### PR TITLE
fixes for first-time usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
       rest-client (>= 1.4.2)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     concurrent-ruby (1.0.2)
     conjur-api (4.25.1)
       activesupport
@@ -264,6 +269,7 @@ DEPENDENCIES
   base32-crockford
   bcrypt-ruby (~> 3.0.0)
   byebug
+  ci_reporter_rspec
   conjur-appliance-logging!
   conjur-cli
   conjur-debify

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -4,7 +4,7 @@ docker-compose build
 
 if [ ! -f data_key ]; then
 	echo "Generating data key"
-	docker-compose run --rm --entrypoint possum possum data-key generate > data_key
+	docker-compose run --no-deps --rm --entrypoint possum possum data-key generate > data_key
 fi
 
 export POSSUM_DATA_KEY="$(cat data_key)"

--- a/lib/tasks/generate-data-key.rake
+++ b/lib/tasks/generate-data-key.rake
@@ -3,5 +3,5 @@ task :"generate-data-key" do
   require 'slosilo'
   require 'base64'
   key = Base64.strict_encode64(Slosilo::Symmetric.new.random_key)
-  puts key
+  print key
 end


### PR DESCRIPTION
Don't start pg when generating the data key. Make sure the output from 'possum data-key generate' doesn't end in a newline (for easier scripting). Update gems.
