### PR TITLE
Pushes static API doc as part of website

### DIFF
--- a/website.sh
+++ b/website.sh
@@ -10,6 +10,7 @@ docker run -i -v $PWD:/opt/conjur --rm  \
   possum-web bash -ec '
 mkdir /output
 jekyll build --source docs --destination /output/_site
+cp api.html /output/_site/api.html
 
 echo "${POSSUM_WEB_USER}:$(openssl passwd -apr1 ${POSSUM_WEB_PASSWORD})" | aws s3 cp - s3://${POSSUM_WEB_CFG_BUCKET}/htpasswd
 


### PR DESCRIPTION
This PR copies the `api.html` file, already generated by Jenkins, into the site generated by Jekyll so it will be pushed to S3 with the rest of the site.