### PR TITLE
Live reloading

### DIFF
--- a/apidocs/Dockerfile.apidocs
+++ b/apidocs/Dockerfile.apidocs
@@ -4,5 +4,6 @@ WORKDIR /home/node
 COPY package.json ./
 RUN npm install
 COPY generate-static-docs ./
-COPY src ./src/
-ENTRYPOINT /bin/sh /home/node/generate-static-docs
+
+# COPY src ./src/
+# ENTRYPOINT /bin/sh /home/node/generate-static-docs

--- a/apidocs/build.sh
+++ b/apidocs/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker build -t conjurinc/possum-apidocs -f apidocs/Dockerfile.apidocs apidocs
+docker build -t conjurinc/possum-apidocs -f Dockerfile.apidocs .

--- a/apidocs/dev.sh
+++ b/apidocs/dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -ex
+
+source build.sh
+
+docker run \
+        -it \
+        --rm \
+        -v $PWD/:/apidocs \
+        -p 4000:4000 \
+        -w /apidocs \
+        --name possum-apidocs \
+        conjurinc/possum-apidocs \
+        /home/node/node_modules/.bin/aglio -i src/api.md -s -h 0.0.0.0 -p 4000


### PR DESCRIPTION
@ryanprior: this is a PR to simplify running the server for local development.  It behaves just like `/docs` project:

```bash
$ cd apidocs
$ ./dev.sh
```
Which is accessible via `http://localhost:4000`.  It runs the Aglio server (which gives us hot reloading).

The server does not appear to respond to `ctr-c` :(

Pull it in if you'd like.  I used it to check out the documentation PR.