### PR TITLE
Fixed: CyberArk logo area ends up overlapping TOC when browser is resized

### DIFF
--- a/docs/_sass/_sidebar.scss
+++ b/docs/_sass/_sidebar.scss
@@ -16,30 +16,30 @@
 
 	hr {
 		position: relative;
-    margin: 1.5rem 0;
-    border: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.5);;
+		margin: 1.5rem 0;
+		border: 0;
+		border-bottom: 1px solid rgba(255, 255, 255, 0.5);
 	}
 
 	a {
 		color: #ffffff;
 		display: block;
 		font-size: 16px;
-    padding: .1em 0;
+		padding: .1em 0;
 	}
 
 	.sidebar-nav {
 		padding-left: 10px;
 		ul {
-	  	padding-left: 1rem;
+	  		padding-left: 1rem;
 			margin: .1em 0;
 		}
 	}
 }
 
 .sidebar-disclaimer {
-  margin-top: 2em;
-  bottom: 25px;
+	margin-top: 2em;
+	bottom: 25px;
 	text-align: center;
 	width: 90%;
 
@@ -49,14 +49,14 @@
 		display: inline-block;
 	}
 
-  img.cyberark-sidebar-logo {
-  	width: 100px;
-  	margin: 0 auto;
+	img.cyberark-sidebar-logo {
+		width: 100px;
+		margin: 0 auto;
 	}
 }
 
 .slack-signup {
-  margin-top: 1.5em;
+	margin-top: 1.5em;
 }
 
 .disclaimer {


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug in the doc site where the CyberArk logo area ends up overlapping TOC when browser is resized

#### Where should the reviewer start?
docs/_sass/_sidebar.scss

#### How should this be manually tested?
Click around the site, expand some sections, resize window.

#### What are the relevant tickets?
#142 

#### Reviewers
@mizziness 

#### Questions:
- Can we make a blog post, a video, an animated GIF out of this?
No
- Is this explained in a training tutorial?
No
- Does the knowledge base need an update?
No
- Is there a demo?
No