### PR TITLE
Fixes: Broken links on tutorial pages

### DIFF
--- a/docs/_sass/_sidebar.scss
+++ b/docs/_sass/_sidebar.scss
@@ -177,7 +177,7 @@
 		}
 
 		.nav.navbar-nav > li {
-			border-bottom: 1px solid rgba(255,255,255,.1);
+			//border-bottom: 1px solid rgba(255,255,255,.1);
 			position: relative;
 		}
 
@@ -249,8 +249,6 @@
 		}
 
 		.navbar-toggle {
-			//background-color: #ffffff;
-
 			span {
 				background-color: #fff;
 			}

--- a/docs/tutorials/integrations/ruby.md
+++ b/docs/tutorials/integrations/ruby.md
@@ -9,7 +9,7 @@ The [Conjur API for Ruby](https://github.com/conjurinc/api-ruby) provides a robu
 
 {% include toc.md key='prerequisites' %}
 
-* A [Conjur server](/conjur/installation/server.html) endpoint.
+* A [Conjur server](/installation/server.html) endpoint.
 * The [Conjur API for Ruby](https://github.com/conjurinc/api-ruby), version 5.0 or later.
 
 {% include toc.md key='setup' %}

--- a/docs/tutorials/policy/applications.md
+++ b/docs/tutorials/policy/applications.md
@@ -19,15 +19,15 @@ Step (4) has a special name, "entitlement", because in this step existing object
 * Grant a policy Group to a Layer.
 * Grant a policy Group to a different Group (usually a group of Users).
 
-Organizing policy management into three categories - protected resources, applications, and entitlements - helps to keep the workflow organized and clear. It also satisfies the essential security requirements of separation of duties and least privilege. 
+Organizing policy management into three categories - protected resources, applications, and entitlements - helps to keep the workflow organized and clear. It also satisfies the essential security requirements of separation of duties and least privilege.
 
 * **Separation of duties** Management of protected resources is separated from management of client applications. Different teams can be responsible for each of these tasks. In addition, policy management can also be delegated to machine roles if desired.
 * **Least privilege** The client applications are granted exactly the privileges that they need to perform their work. And policy managers (whether humans or machines) have management privileges only on the objects that rightfully belong under their control.
 
 {% include toc.md key='prerequisites' %}
 
-* A [Conjur server](/conjur/installation/server.html) endpoint.
-* The [Conjur CLI](/conjur/installation/client.html).
+* A [Conjur server](/installation/server.html) endpoint.
+* The [Conjur CLI](/installation/client.html).
 
 {% include toc.md key='setup' %}
 
@@ -91,7 +91,7 @@ For this example, the "frontend" policy will simply define a Layer and a Host. C
 {% include policy-file.md policy='application_frontend' %}
 
 <div class="note">
-<strong>Note</strong> Statically defining the hosts in a policy is appropriate for fairly static infrastructure. More dynamic systems such as auto-scaling groups and containerized deployments can be managed with Conjur as well. The details of these topics are covered elsewhere. 
+<strong>Note</strong> Statically defining the hosts in a policy is appropriate for fairly static infrastructure. More dynamic systems such as auto-scaling groups and containerized deployments can be managed with Conjur as well. The details of these topics are covered elsewhere.
 </div>
 <p/>
 
@@ -194,7 +194,7 @@ $ conjur resource permitted_roles variable:db/password execute
 ]
 {% endhighlight %}
 
-The important line here is **dev:host:frontend/frontend-01**. 
+The important line here is **dev:host:frontend/frontend-01**.
 
 Now we can finish the tutorial by fetching the password while authenticated as the host:
 
@@ -216,4 +216,3 @@ This pattern can be extended in the following ways:
 * Automatically enroll hosts into the `frontend` layer by adding a Host Factory.
 * Add more applications that need access to the database password, and grant them access by adding entitlements to the `db` policy.
 * Create user groups such as `database-administrators` and `frontend-developers`, and give them management rights on their respective policies. In this way, policy management can be federated and scaled.
-

--- a/docs/tutorials/policy/delegation.md
+++ b/docs/tutorials/policy/delegation.md
@@ -11,14 +11,14 @@ But when Conjur is used in a large organization, it's important that the securit
 
 {% include toc.md key='prerequisites' %}
 
-* A [Conjur server](/conjur/installation/server.html) endpoint.
-* The [Conjur CLI](/conjur/installation/client.html).
+* A [Conjur server](/installation/server.html) endpoint.
+* The [Conjur CLI](/installation/client.html).
 
 It's advisable, but not required, to step through the [Enrolling an Application](./applications.html) tutorial before this one.
 
 {% include toc.md key='setup' %}
 
-Most Conjur deployments will begin with a small number of users working as administrators, loading all the policy data. All the policies can be kept in a single source control repository. Let's set up a simple example of this. 
+Most Conjur deployments will begin with a small number of users working as administrators, loading all the policy data. All the policies can be kept in a single source control repository. Let's set up a simple example of this.
 
 First, a top-level policy defines two empty policies: `db` and `frontend`. Save this policy as "conjur.yml":
 
@@ -88,7 +88,7 @@ Ownership of any object can be changed by using the `owner` field in policy YAML
   owner: !group dba
 {% endhighlight %}
 
-Ownership of the "db" policy is assigned to the role "group:dba". 
+Ownership of the "db" policy is assigned to the role "group:dba".
 
 Now any role which has the role "group:dba" can fully manage the "db" policy. Policy owners can do all of the following:
 
@@ -96,7 +96,7 @@ Now any role which has the role "group:dba" can fully manage the "db" policy. Po
 * Fully manage all objects in the policy, including variables and host factories.
 * Grant privileges on policy objects to other roles (e.g. application layers).
 
-So what does it mean to be "in the policy"? Each object and annotation has a `policy` attribute which indicates which policy that data belongs to. When you create an object, the `policy` attribute is set to the policy that created the data. 
+So what does it mean to be "in the policy"? Each object and annotation has a `policy` attribute which indicates which policy that data belongs to. When you create an object, the `policy` attribute is set to the policy that created the data.
 
 <div class="note">
 <strong>Note</strong> The <tt>policy</tt> attribute is a little different than resource ownership. The <tt>policy</tt> attribute is used when a policy is being loaded to determine which data the policy update is allowed to effect.
@@ -151,7 +151,7 @@ $ CONJUR_AUTHN_LOGIN=donna CONJUR_AUTHN_API_KEY=$api_key_donna conjur policy loa
 error: 403 Forbidden
 {% endhighlight %}
 
-This is not a bug! We've created the users and groups, but we haven't changed the ownership of the policies. 
+This is not a bug! We've created the users and groups, but we haven't changed the ownership of the policies.
 
 Update the `owner` fields in "conjur.yml":
 
@@ -189,5 +189,3 @@ In this tutorial, we showed how to assign the `owner` attribute of a policy to a
 In this way, users can be empowered to manage their own machines, variables, and web services without weakening the security of the overall system.
 
 This type of delegated / federated workflow can allow for superior velocity in a development organization, without compromising on security and compliance controls.
-
-


### PR DESCRIPTION
Closes #105 

#### What does this pull request do?
- fixes the broken links on Tutorial pages.
- fixes some styling issues on the responsive navigation (links inconsistent sizes)

#### Where should the reviewer start?
- docs/tutorials/integrations/ruby.md
- docs/tutorials/policy/delegation.md
- docs/tutorials/policy/applications.md

#### How should this be manually tested?
Navigate to these pages and click on the links in the "Prerequisite" sections (near the top of the page):
- https://try.conjur.org/tutorials/policy/applications.html
- https://try.conjur.org/tutorials/policy/delegation.html
- https://try.conjur.org/tutorials/integrations/ruby.html 

#### Screenshots (if appropriate)
n/a

#### Link to build in Jenkins (if appropriate)
n/a

#### Questions:
> Does this have automated Cucumber tests?  **No**
> Can we make a blog post, video, or animated GIF out of this? **No**
> Is this explained in the documentation? **No**
> Does the knowledge base need an update? **No**

