### PR TITLE
Fixed: Added styling for "company" field on eval form

### DIFF
--- a/docs/_sass/_eval.scss
+++ b/docs/_sass/_eval.scss
@@ -9,7 +9,7 @@
 	align-items: center;
 	position: absolute;
 	height: 100vh;
-	width: 100vw;  
+	width: 100vw;
 	max-width: 100%;
 	z-index: 1;
 	text-align:center;
@@ -67,11 +67,20 @@ img {
 	// input field
 	input#email-795e5607-3251-4827-9e88-94db1ef9fa7a {
 		width: 85%;
-		height: 44px; 
+		height: 44px;
 		text-align: center;
 		box-sizing: border-box;
 		font-size: 16px;
 		font-family: 'Open Sans', sans-serif;
+	}
+
+	input#company-795e5607-3251-4827-9e88-94db1ef9fa7a {
+    width: 85%;
+    height: 44px;
+    text-align: center;
+    box-sizing: border-box;
+    font-size: 16px;
+    font-family: 'Open Sans', sans-serif;
 	}
 
 	//error message


### PR DESCRIPTION
Fixes: GH Issue #155 

#### What does this pull request do?
Adds minor styling to a new form field added to the /eval signup form

#### What background context can you provide?
We're receiving submissions from emails not associated w/ any company, so we want to get a bit more info from these users

#### Where should the reviewer start?
/eval.html

#### How should this be manually tested?
Go to /eval.html and see if both forms look identical

#### Screenshots (if appropriate)
![conjur_eval_form_update](https://user-images.githubusercontent.com/123787/28679115-32a15844-72c0-11e7-90d4-456b61bf203c.png)

#### Questions:
> Does this have automated Cucumber tests?
No

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
No

> Does the knowledge base need an update?
No
