### PR TITLE
Upgrade developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-docs/.sass-cache/
-
 # Ignore bundler config.
 .bundle
 
@@ -29,6 +27,8 @@ coverage
 demo/run/*.yml
 *~
 apidocs/node_modules
+docs/apidocs.html
 *.config
 docs/_layouts/page-toc.html
 api.html
+*~

--- a/apidocs/Dockerfile.apidocs
+++ b/apidocs/Dockerfile.apidocs
@@ -5,5 +5,6 @@ COPY package.json ./
 RUN npm install
 COPY generate-static-docs ./
 
-# COPY src ./src/
-# ENTRYPOINT /bin/sh /home/node/generate-static-docs
+COPY src ./src/
+ENTRYPOINT [ "/bin/sh", "/home/node/generate-static-docs" ]
+EXPOSE 3000

--- a/apidocs/build.sh
+++ b/apidocs/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -ex
 
-docker build -t conjurinc/possum-apidocs -f Dockerfile.apidocs .
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+docker build -t conjurinc/possum-apidocs -f $DIR/Dockerfile.apidocs $DIR

--- a/apidocs/generate-static-docs
+++ b/apidocs/generate-static-docs
@@ -4,10 +4,8 @@ export PATH="/home/node/node_modules/.bin:$PATH"
 
 aglio_options=""
 
-while getopts 'wh' opt; do
-    case $opt in
-        h)
-            cat <<EOF
+function showhelp() {
+    cat <<EOF
 Usage: generate-static-docs [OPTION]... [FILE]
 Uses Aglio to generate static API documentation for Conjur CE.
 
@@ -16,13 +14,23 @@ Uses Aglio to generate static API documentation for Conjur CE.
 
 The FILE argument specifies where to write output (default stdout).
 EOF
-            exit;;
+    exit
+}
+
+while getopts 'whv' opt; do
+    case $opt in
+        h)
+            showhelp;;
         w)
-            aglio_options="$aglio_options -s";;
+            aglio_options="$aglio_options -s -h 0.0.0.0 -p 3000";;
+        v)
+            aglio_options="$aglio_options --verbose";;
+        *)
+            showhelp;;
     esac
 done
 shift $((OPTIND-1))
 
 file="${1:--}"
 
-aglio $aglio_options -i src/api.md -o "$file" --verbose
+aglio $aglio_options -i src/api.md -o "$file"


### PR DESCRIPTION
#### What does this pull request do?

* .gitignore updated to ignore `apidocs.html` and vim/emacs
backup (`*~`) files
* apidocs/Dockerfile.apidocs updated to use array entrypoint syntax so that
  options like `-w` for live update or `-v` for verbose can be passed
  during `docker run` invocation
* apidocs/build.sh is updated to always use the script directory for
  context
* apidocs/generate-static-docs updated:
  + verbose flag added
  + watch flag now specifies hosting on `0.0.0.0:3000`

#### What background context can you provide?

This PR consolidates various changes I've made to upgrade the
developer experience over the course of the last week so we can get
them merged separately from the individual API doc routes.

