### PR TITLE
Reject account names with invalid characters

### DIFF
--- a/cucumber/api/features/account_create.feature
+++ b/cucumber/api/features/account_create.feature
@@ -82,3 +82,37 @@ Feature: Create a new account
     id=new_account@example.com
     """
     And I can authenticate with the admin API key for the account "new_account@example.com"
+
+  Scenario: Creating account with : or space in the name fails
+    Given I create a new user "admin" in account "!"
+    And I permit role "!:user:admin" to "execute" resource "!:webservice:accounts"
+    And I login as "!:user:admin"
+    Then I POST "/accounts" with body:
+    """
+    id=test:bad
+    """
+    Then the HTTP response status code is 422
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "argument_error",
+        "message": "account name \"test:bad\" contains invalid characters (:)"
+      }
+    }
+    """
+
+    When I POST "/accounts" with body:
+    """
+    id=test+bad
+    """
+    Then the HTTP response status code is 422
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "argument_error",
+        "message": "account name \"test bad\" contains invalid characters ( )"
+      }
+    }
+    """


### PR DESCRIPTION
Closes #75.

#### What does this pull request do?

Checks the account name on creation to ensure it doesn't contain funny characters (`[ :]`).
Also create the new account in a transaction; this way if anything goes awry it won't be left half-created.

#### What background context can you provide?

Creating accounts with especially `:` in the name breaks all sorts of implicit assumptions and used to leave the account in half-created, unusable form.

Note this problem is IMO a symptom of a more significant underlying issue; I've put some time into resolving it, but finally decided it needs discussion; see #181 for that.

#### How should this be manually tested?

`possum account create foo:bar`

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/possum/job/bugfix%252Fbad-account-names/1/

#### Questions:
> Does this have automated Cucumber tests?

Yes.

> Can we make a blog post, video, or animated GIF out of this?

No.

> Is this explained in documentation?

There is currently no documentation (that I could find) regarding the account functionality. If there is or was, a note could be added to document the exceptions; however, I think it's not necessarily a good idea: this is only for corner cases, the error message is self-explanatory, and if we ever change the blacklist, the doc and code can become out-of-sync.

> Does the knowledge base need an update?

Not that I know of.