### PR TITLE
replace embed w screenshot that links to asciicinema page

### DIFF
--- a/docs/try-conjur.md
+++ b/docs/try-conjur.md
@@ -61,7 +61,7 @@ Here is a typical policy file. Save this file as `conjur.yml`:
 
 Here's a screencast of the first part of this tour, showing how to start the container, setup the environment, and create a file in the container using `nano`:
 
-<script type="text/javascript" src="https://asciinema.org/a/128514.js" id="asciicast-128514" async></script>
+[![asciicast](https://asciinema.org/a/128514.png)](https://asciinema.org/a/128514)
 
 {% include toc.md key='loading' %}
 


### PR DESCRIPTION
Closes GH Issue https://github.com/conjurinc/possum/issues/198

#### What does this pull request do?
Replaces embed of asciicinema video with screenshot of video that links to asciicinema site.

#### What background context can you provide?
Jenkins builds were failing due to broken links from asciicinema.

#### Where should the reviewer start?
/try-conjur.html

#### How should this be manually tested?
Check to see if the screenshot of the video is visible.

#### Screenshots (if appropriate)
![asciicinema-screenshot](https://user-images.githubusercontent.com/123787/28895045-cd4ec776-77a4-11e7-8e92-a6e165d2eab5.png)

#### Link to build in Jenkins (if appropriate)
n/a

#### Questions:
> Does this have automated Cucumber tests?
No

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
No

> Does the knowledge base need an update?
No
