### PR TITLE
Moves API doc link from "reference" subheading to top-level

### DIFF
--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -67,14 +67,13 @@ main:
             title: Custom Authentication
             path: /tutorials/integrations/authenticators.html
 
-
+  apidocs:
+    title: API Documentation
+    path: /apidocs.html
   reference:
     title: Reference
     path: /reference/
     items:
-      apidocs:
-        title: API Documentation
-        path: /apidocs.html
       policies:
         title: Policies
         path: /reference/policy.html


### PR DESCRIPTION
Closes #158 

#### What does this pull request do?
It moves the API docs link in the side navigation from under the "reference" heading to the top-level.

#### What background context can you provide?
@dustinmm80 and @typaulhus suggested that providing a more prominent link will help us improve engagement with interested developers and get more feedback on the API docs.

#### Where should the reviewer start?
The change is in `docs/_data/sidebar.yml`

#### How should this be manually tested?
Generate the site (instructions in `docs/README.md`) and verify that the link is appropriately placed on the top level.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/possum/job/doc%252Fmove-apidocs-to-top-level%252F158/

#### Questions:
> Does this have automated Cucumber tests?

I don't believe we do any route testing for the sidebar nav

> Can we make a blog post, video, or animated GIF out of this?

yes, an API docs blog post would be a nice accompaniment in the spirit of this PR