### PR TITLE
feat: add apidocs for "show public keys"

### DIFF
--- a/apidocs/Dockerfile.apidocs
+++ b/apidocs/Dockerfile.apidocs
@@ -6,5 +6,5 @@ RUN npm install
 COPY generate-static-docs ./
 
 COPY src ./src/
-CMD [ "/bin/sh", "/home/node/generate-static-docs" ]
+ENTRYPOINT [ "/bin/sh", "/home/node/generate-static-docs" ]
 EXPOSE 3000

--- a/apidocs/dev.sh
+++ b/apidocs/dev.sh
@@ -1,13 +1,14 @@
 #!/bin/bash -ex
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 source build.sh
 
 docker run \
         -it \
         --rm \
-        -v $PWD/:/apidocs \
-        -p 4000:4000 \
-        -w /apidocs \
+        -v $DIR/src:/home/node/src \
+        -p 3000:3000 \
         --name possum-apidocs \
         conjurinc/possum-apidocs \
-        sh -c "/home/node/node_modules/.bin/aglio -i src/api.md -s -h 0.0.0.0 -p 4000"
+        -w

--- a/apidocs/generate-static-docs
+++ b/apidocs/generate-static-docs
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export PATH="/home/node/node_modules/.bin:$PATH"
-
 aglio_options=""
 
 function showhelp() {
@@ -33,4 +31,5 @@ shift $((OPTIND-1))
 
 file="${1:--}"
 
-aglio $aglio_options -i src/api.md -o "$file"
+env PATH="/home/node/node_modules/.bin:$PATH" \
+    sh -c "aglio $aglio_options -i src/api.md -o \"$file\""

--- a/apidocs/src/show_public_keys.md
+++ b/apidocs/src/show_public_keys.md
@@ -2,11 +2,9 @@
 
 ### Show public keys  [GET /public_keys/{account}/{kind}/{identifier}]
 
-The response to this method is all public keys for a resource as a newline delimited string for compatibility with the authorized_keys SSH format.
+Shows all public keys for a resource as newline delimited string for compatibility with [the authorized_keys SSH format](https://en.wikibooks.org/wiki/OpenSSH/Client_Configuration_Files#.7E.2F.ssh.2Fauthorized_keys).
 
-If the given resource does not exist, an empty string will be returned. This is to prevent attackers from determining whether a resource exists.
-
-**Permissions Required**: No special permissions are required to call this method, since public keys are, well, public.
+Returns an empty string if the resource does not exist, to prevent attackers from determining whether a resource exists.
 
 <!-- include(partials/resource_kinds.md) -->
 
@@ -24,11 +22,11 @@ curl https://eval.conjur.org/public_keys/mycorp/user/alice
 |------|-----------------------------------------------------|
 |  200 | Public keys returned as newline delimited string            |
 
-For example, to fetch all the public keys for the user "alice":
+For example, to show all the public keys for the user "alice":
 
 + Parameters
   + <!-- include(partials/account_param.md) -->
-  + kind: user (string) - kind of resource of which to fetch public keys
+  + kind: user (string) - kind of resource of which to show public keys
   + identifier: alice (string)  - the identifier of the object
 
 + Response 200 (text/plain)


### PR DESCRIPTION
Closes #179 

#### What does this pull request do?
It add a section in the documentation for public keys and a subsection for `show public keys`

#### Where should the reviewer start?

The changes are in `apidocs/src/show_public_keys.md`

#### How should this be manually tested?

Replace the account, kind and identifier in the example with some from your own Conjur setup and try running the commands.
