### PR TITLE
Rename possum data key env variable  209

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Data is encrypted in and out of the database using [Slosilo](https://github.com/
 
 The Slosilo project has been verified by a professional cryptographic audit. Contact Conjur Inc for more details.
 
-When you start Possum, you must provide a Base64-encoded master data key in the environment variable `POSSUM_DATA_KEY`. You can generate a data key using the following command:
+When you start Possum, you must provide a Base64-encoded master data key in the environment variable `CONJUR_DATA_KEY`. You can generate a data key using the following command:
 
 ```
 $ docker run --rm possum data-key generate

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -127,7 +127,7 @@ database, including the token-signing private key.
 Example:
 
 
-$ export POSSUM_DATA_KEY="$(conjurctl data-key generate)"
+$ export CONJUR_DATA_KEY="$(conjurctl data-key generate)"
   DESC
   cgrp.command :generate do |c|
     c.action do |global_options,options,args|
@@ -144,7 +144,7 @@ command :"account" do |cgrp|
   cgrp.long_desc <<-DESC
 Use this command to generate and store a new account, along with its 2048-bit RSA private key, 
 used to sign auth tokens, as well as the "admin" user API key. 
-The POSSUM_DATA_KEY must be available in the environment
+The CONJUR_DATA_KEY must be available in the environment
 when this command is called, since it's used to encrypt the token-signing key
 in the database.
 

--- a/config/initializers/authenticator.rb
+++ b/config/initializers/authenticator.rb
@@ -12,12 +12,12 @@ Possum::Application.config.middleware.use Conjur::Rack::Authenticator,
   except: [ /^\/authn\/.*\/authenticate$/, /^\/host_factories\/hosts$/ ]
 
 if %w(test development cucumber).member?(Rails.env)
-  ENV['POSSUM_DATA_KEY'] ||= '4pSuk1rAQyuHA5uUYaj0X0BsiPCFb9Nc8J03XA6V5/Y='
+  ENV['CONJUR_DATA_KEY'] ||= '4pSuk1rAQyuHA5uUYaj0X0BsiPCFb9Nc8J03XA6V5/Y='
 end
 
-if data_key = ENV['POSSUM_DATA_KEY']
+if data_key = ENV['CONJUR_DATA_KEY']
   Slosilo::encryption_key = Base64.strict_decode64 data_key.strip
   Slosilo::adapter = Slosilo::Adapters::SequelAdapter.new
 else
-  raise "No POSSUM_DATA_KEY"
+  raise "No CONJUR_DATA_KEY"
 end

--- a/dev/cucumber.sh
+++ b/dev/cucumber.sh
@@ -9,6 +9,6 @@ if [ ! -f data_key ]; then
 	docker-compose run --rm --entrypoint conjurctl possum data-key generate > data_key
 fi
 
-export POSSUM_DATA_KEY="$(cat data_key)"
+export CONJUR_DATA_KEY="$(cat data_key)"
 
 docker-compose run --no-deps cucumber

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -8,7 +8,7 @@ possum:
     DATABASE_URL: postgres://postgres@pg/postgres
     POSSUM_ADMIN_PASSWORD: admin
     CONJUR_PASSWORD_ALICE: secret
-    POSSUM_DATA_KEY:
+    CONJUR_DATA_KEY:
     RAILS_ENV:
   volumes:
   - ..:/src/possum
@@ -23,7 +23,7 @@ cucumber:
     CONJUR_APPLIANCE_URL: http://possum:3000
     DATABASE_URL: postgres://postgres@pg/postgres
     POSSUM_ADMIN_PASSWORD: admin
-    POSSUM_DATA_KEY:
+    CONJUR_DATA_KEY:
     RAILS_ENV:
   volumes:
   - ..:/src/possum

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -9,7 +9,7 @@ if [ ! -f data_key ]; then
 	docker-compose run --no-deps --rm --entrypoint conjurctl possum data-key generate > data_key
 fi
 
-export POSSUM_DATA_KEY="$(cat data_key)"
+export CONJUR_DATA_KEY="$(cat data_key)"
 
 docker-compose up -d
 docker-compose exec possum conjurctl db migrate

--- a/docs/tutorials/integrations/authenticators.md
+++ b/docs/tutorials/integrations/authenticators.md
@@ -71,7 +71,7 @@ What you need to do is use the signing key for the organization account for whic
 
 The Possum server stores the signing keys encrypted in the database. If your custom authenticator is configured with a database connection, you can fetch the signing key using SQL (or the Ruby object-relational helper code).
 
-Since the signing keys are encrypted, connecting to the database is not sufficient to read one. You also need to have the encryption key, which you provide to the Conjur server using the environment variable `POSSUM_DATA_KEY`.
+Since the signing keys are encrypted, connecting to the database is not sufficient to read one. You also need to have the encryption key, which you provide to the Conjur server using the environment variable `CONJUR_DATA_KEY`.
 
 In Ruby code, it looks like this:
 
@@ -82,7 +82,7 @@ require 'slosilo'
 require 'slosilo/adapters/sequel_adapter'
 
 # Establish the encryption key
-data_key = ENV['POSSUM_DATA_KEY']
+data_key = ENV['CONJUR_DATA_KEY']
 Slosilo::encryption_key = Base64.strict_decode64 data_key.strip
 
 # Configure the database connection
@@ -141,7 +141,7 @@ require 'slosilo'
 require 'slosilo/adapters/sequel_adapter'
 
 # Establish the encryption key
-data_key = ENV['POSSUM_DATA_KEY']
+data_key = ENV['CONJUR_DATA_KEY']
 Slosilo::encryption_key = Base64.strict_decode64 data_key.strip
 
 # Configure the database connection

--- a/lib/tasks/data-key.rake
+++ b/lib/tasks/data-key.rake
@@ -1,5 +1,5 @@
 namespace :"data-key" do
-  desc "Create a data encryption key, which should be placed in the environment as POSSUM_DATA_KEY"
+  desc "Create a data encryption key, which should be placed in the environment as CONJUR_DATA_KEY"
   task :generate do
     require 'slosilo'
     require 'base64'

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ function finish {
 }
 trap finish EXIT
 
-export POSSUM_DATA_KEY="$(docker run --rm possum data-key generate)"
+export CONJUR_DATA_KEY="$(docker run --rm possum data-key generate)"
 
 pg_cid=$(docker run -d postgres:9.3)
 


### PR DESCRIPTION
Closes #209.

#### What does this pull request do?

Renames the POSSUM_DATA_KEY env variable.

#### Where should the reviewer start?

`/config/initializers/authenticator.rb`

#### How should this be manually tested?

Running the dev containers with `dev/start.sh` should exercise the initializer. You'll need to rebuild the dev container first I believe.

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/view/V5%20Possum%20Jobs/job/possum/job/rename-possum_data_key-env-variable--209/