### PR TITLE
CON-4272 Account Info Display

### DIFF
--- a/docs/_includes/sign-up/credentials.html
+++ b/docs/_includes/sign-up/credentials.html
@@ -1,0 +1,11 @@
+<div class="hosted-confirmation">
+  <h2>Thank you for evaluating Conjur!</h2>
+
+  <p>Your account details and API key for use in your trial tour are below:</p>
+
+  <div class="hosted-account-credentials">
+    <p><strong>Email:</strong> {{ "your@emailaddress.com" }}</p>
+    <p><strong>Account ID:</strong> {{ "your-conjur-account-id" }}</p>
+    <p><strong>API Key:</strong> {{ "oauhdfiuagfiaubgflasvfYSEVFLivfliegfiwevbfhsdbjhdbvjshdbvsjhdbvsjhdbv" }}</p>
+  </div>
+</div>

--- a/docs/_includes/sign-up/sign-up-form.html
+++ b/docs/_includes/sign-up/sign-up-form.html
@@ -13,3 +13,5 @@
     <button type="submit" class="btn btn-primary">Create Account</button>
   </div>
 </form>
+
+{% include sign-up/credentials.html %}

--- a/docs/_sass/_eval.scss
+++ b/docs/_sass/_eval.scss
@@ -1,128 +1,41 @@
 // ***********************
-// Eval Signup Page
+// Eval Signup
 // ***********************
 
-.container.eval {
-	display:flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	position: absolute;
-	height: 100vh;
-	width: 100vw;
-	max-width: 100%;
-	z-index: 1;
-	text-align:center;
-	color: rgba(255,255,255,.5);
-	background: #0071c7; /* Old browsers */
-	background: -moz-linear-gradient(top, #0071c7 0%, #11b5e4 100%); /* FF3.6-15 */
-	background: -webkit-linear-gradient(top, #0071c7 0%,#11b5e4 100%); /* Chrome10-25,Safari5.1-6 */
-	background: linear-gradient(to bottom, #0071c7 0%,#11b5e4 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#0071c7', endColorstr='#11b5e4',GradientType=0 ); /* IE6-9 */
-	.row {
-		width: 900px;
-		max-width: 90%;
-	}
-}
-
-h1#conjur-community-edition {
-	color: #fff;
-}
-
-.submitted-message {
-	color: #fff;
-}
-
-img {
-	margin: 0 0 3rem 0;
-}
-
-.logos {
-	width: 100%;
-	max-width: 500px;
-	&.cyberark-logo {
-		width: 100%;
-		max-width: 150px;
-		margin-top: 3rem;
-		margin-bottom: 0;
-	}
-	&.conjur-logo {
-		width: 300px;
-		max-width: 80%;
-		margin-bottom: 4rem;
-	}
-}
-
-/*  Hubspot Form  */
-.hbspt-form {
-	label {
-		span {
-			display: none;
-			font-family: 'Open Sans', sans-serif;
-			font-weight: 300;
-			color: #fff;
+form {
+	.form-group.required,
+	.form-check.required {
+		label {
+			&:after {
+				content: " *";
+	   		color: red;
+			}
 		}
 	}
 
-	// input field
-	input#email-795e5607-3251-4827-9e88-94db1ef9fa7a {
-		width: 85%;
-		height: 44px;
-		text-align: center;
-		box-sizing: border-box;
-		font-size: 16px;
-		font-family: 'Open Sans', sans-serif;
-	}
+	&.hosted-account-signup {
+		background-color: $conjur-softgray;
+		padding: 1.5em 2em;
+		border-radius: 4px;
+		border: 1px solid $conjur-ltgray;
 
-	input#company-795e5607-3251-4827-9e88-94db1ef9fa7a {
-    width: 85%;
-    height: 44px;
-    text-align: center;
-    box-sizing: border-box;
-    font-size: 16px;
-    font-family: 'Open Sans', sans-serif;
-	}
-
-	//error message
-	ul.hs-error-msgs.inputs-list li label {
-		text-align: center;
-		color: #c30;
-		font-size: .8rem;
-	}
-
-	input.hs-button {
-		color: #fff;
-		background-color: $conjur-blue;
-		background-image: none;
-		border: none;
-		text-shadow: none;
-		box-shadow: none;
-		font-family: 'Open Sans', sans-serif;
-		font-weight: 300;
-		font-size: 1rem;
-		padding: 1em 2em;
-		max-width: 90%;
-		&.hs-button:hover:not(.inactive) {
-			color: #fff;
-			background-color: darken($conjur-blue,05);
-			background-image: none;
-			border: none;
-			text-shadow: none;
-			box-shadow: none;
-			font-family: 'Open Sans', sans-serif;
-			font-weight: 300;
-			font-size: 1rem;
-			padding: 1em 2em;
-			max-width: 90%;
-		}
-		.hs_submit .actions {
-			margin: 0;
-			padding: 0;
+		label {
+			font-weight: 400;
 		}
 	}
+}
 
-	form .actions {
-		margin: 0;
-		padding: 0;
+.hosted-confirmation {
+	display: none;
+
+	.hosted-account-credentials {
+		background-color: $conjur-softgray;
+		padding: 1.5em 2em;
+		border-radius: 4px;
+		border: 1px solid $conjur-ltgray;
+
+		strong {
+			font-weight: bold;
+		}
 	}
 }

--- a/docs/_sass/_resets.scss
+++ b/docs/_sass/_resets.scss
@@ -66,33 +66,6 @@ img {
 }
 
 // ***********************
-// Form Stuff
-// ***********************
-
-form {
-	.form-group.required,
-	.form-check.required {
-		label {
-			&:after {
-				content: " *";
-	   		color: red;
-			}
-		}
-	}
-
-	&.hosted-account-signup {
-		background-color: $conjur-softgray;
-		padding: 1.5em 2em;
-		border-radius: 4px;
-		border: 1px solid $conjur-ltgray;
-
-		label {
-			font-weight: 400;
-		}
-	}
-}
-
-// ***********************
 // Container
 // ***********************
 

--- a/docs/javascript/conjur-account.js
+++ b/docs/javascript/conjur-account.js
@@ -1,3 +1,6 @@
+---
+---
+//
 
 var cookies = document.cookie.split('; ');
 var account = null;
@@ -19,3 +22,14 @@ if (account) {
     }
   });
 }
+
+$(document).ready(function() {
+
+  $("form.hosted-account-signup").on("submit", function(event){
+    event.preventDefault();
+    $(this).fadeOut("normal", function(){
+      $(this).next(".hosted-confirmation").slideDown("normal");
+    });
+  });
+
+});

--- a/docs/try-conjur.md
+++ b/docs/try-conjur.md
@@ -1,14 +1,15 @@
 ---
-title: Try Conjur
+title: Evaluate Conjur
 layout: page
 ---
-
 
 {% include toc.md key='introduction' %}
 
 This document will use the Conjur command-line interface (CLI) to show you how to use Conjur to perform some common tasks such as loading and retrieving secrets from Conjur, creating security policies, logging in as a machine, and fetching a secret while logged in as a machine.
 
 For this tour, we will use a Conjur server that is running in the cloud, where an account has already been created for you. Please note that this cloud-based Conjur server is for evaluation purposes only, and therefore you should make sure **not** to store any sensitive information in it. For production scenarios, the Conjur server would be deployed within your own private environment.
+
+{% include sign-up/sign-up-form.html %}
 
 {% include toc.md key='docker' %}
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -3,8 +3,6 @@ title: Tutorials
 layout: page
 ---
 
-{% include sign-up-form.html %}
-
 Tutorials are organized into the following general categories:
 
 * [Policy](./policy) How to use the Conjur policy language to describe and control your infrastructure.


### PR DESCRIPTION
https://conjurinc.atlassian.net/browse/CON-4272

#### What does this pull request do?

This PR stubs out the form switching to showing account credentials.

#### What background context can you provide?

This form partial will replace, for now, the Hubspot form we currently use for evaluation.  Note that this PR does not merge into master, but into the `api-docs-ui-revamp` branch as it requires changes made in that branch.

#### Where should the reviewer start?

This is a pretty small PR - the new partials are in at `docs/_includes/sign-up/credentials.html`.  This also moves the original partial into a subfolder for better organization and removes / replaces old eval page styles.

#### How should this be manually tested?

The steps are the same as in the parent branch's PR except that you do not need to build the apidocs partial:  https://github.com/cyberark/conjur/pull/222 

#### Screenshots (if appropriate)

![trial-form-transition](https://user-images.githubusercontent.com/4164335/29284875-7517a654-80fa-11e7-8b1e-bdfece39df66.gif)
