### PR TITLE
Documents search, limit, offset query parameters when listing resources

### DIFF
--- a/apidocs/src/list_resources.md
+++ b/apidocs/src/list_resources.md
@@ -4,17 +4,24 @@
 
 Lists resources within an organization account.
 
-If a `kind` query parameter is given, the results will be narrowed to only
-resources of that kind. Likewise, if `search` is given, it will be narrowed to
-only resources with names or annotations containing the search term.
+If a `kind` query parameter is given, narrows results to only resources of that
+kind.
 
-If a `limit` is given, no more than that number of results will be returned.
-Providing an `offset` will skip a number of resources before returning the rest.
-In addition, providing an `offset` will give `limit` a default value of 10 if
-none other is provided. These two parameters can be combined to page through
-results.
+If a `limit` is given, returns no more than that number of results. Providing an
+`offset` skips a number of resources before returning the rest. In addition,
+providing an `offset` will give `limit` a default value of 10 if none other is
+provided. These two parameters can be combined to page through results.
 
-If the parameter `count` is `true`, returns only the number of items in the list.
+If the parameter `count` is `true`, returns only the number of items in the
+list.
+
+#### Text search
+
+If the `search` parameter is provided, narrows results to those pertaining to
+the search query. Search works across resource IDs and annotations. Weights
+results so that those with matching `id` or a matching annotation called `name`
+are first, then those with another matching annotation, and finally those with a
+matching `kind`.
 
 #### Example with `curl` and `jq`
 

--- a/apidocs/src/list_resources.md
+++ b/apidocs/src/list_resources.md
@@ -1,6 +1,6 @@
 ## List resources [/resources]
 
-### List resources [GET /resources/{account}{?kind}{?search}{?limit}{?offset}]
+### List resources [GET /resources/{account}{?kind}{?search}{?limit}{?offset}{?count}]
 
 Lists resources within an organization account.
 
@@ -10,7 +10,11 @@ only resources with names or annotations containing the search term.
 
 If a `limit` is given, no more than that number of results will be returned.
 Providing an `offset` will skip a number of resources before returning the rest.
-These two parameters can be combined to page through results.
+In addition, providing an `offset` will give `limit` a default value of 10 if
+none other is provided. These two parameters can be combined to page through
+results.
+
+If the parameter `count` is `true`, returns only the number of items in the list.
 
 #### Example with `curl` and `jq`
 
@@ -44,6 +48,7 @@ curl -H "$(conjur authn authenticate -H)" \
   + search: password (string, optional) - search term used to narrow results
   + limit: 2 (number, optional) - maximum number of results to return
   + offset: 6 (number, optional) - number of results to skip
+  + count: false (boolean, optional) - if true, return only the number of items in the list
 
 + Request
   <!-- include(partials/auth_header_code.md) -->

--- a/apidocs/src/list_resources.md
+++ b/apidocs/src/list_resources.md
@@ -18,10 +18,10 @@ list.
 #### Text search
 
 If the `search` parameter is provided, narrows results to those pertaining to
-the search query. Search works across resource IDs and annotations. Weights
-results so that those with matching `id` or a matching annotation called `name`
-are first, then those with another matching annotation, and finally those with a
-matching `kind`.
+the search query. Search works across resource IDs and the values of
+annotations. It weights results so that those with matching `id` or a matching
+value of an annotation called `name` appear first, then those with another
+matching annotation value, and finally those with a matching `kind`.
 
 #### Example with `curl` and `jq`
 

--- a/apidocs/src/list_resources.md
+++ b/apidocs/src/list_resources.md
@@ -1,16 +1,37 @@
 ## List resources [/resources]
 
-### List resources [GET /resources/{account}{?kind}]
+### List resources [GET /resources/{account}{?kind}{?search}{?limit}{?offset}]
 
 Lists resources within an organization account.
+
+If a `kind` query parameter is given, the results will be narrowed to only
+resources of that kind. Likewise, if `search` is given, it will be narrowed to
+only resources with names or annotations containing the search term.
+
+If a `limit` is given, no more than that number of results will be returned.
+Providing an `offset` will skip a number of resources before returning the rest.
+These two parameters can be combined to page through results.
+
+#### Example with `curl` and `jq`
+
+Suppose your organization name is "mycorp" and you want to search for the first
+two resources matching the word "db":
+
+```bash
+curl -H "$(conjur authn authenticate -H)" \
+     'https://eval.conjur.org/resources/mycorp?search=db&limit=2' \
+     | jq .
+```
 
 <!-- include(partials/resource_kinds.md) -->
 
 ---
 
+#### Request
+
 <!-- include(partials/auth_header_table.md) -->
 
-**Response**
+#### Response
 
 | Code | Description                       |
 |------|-----------------------------------|
@@ -20,6 +41,9 @@ Lists resources within an organization account.
 + Parameters
   + <!-- include(partials/account_param.md) -->
   + kind: variable (string, optional) - kind of object to list
+  + search: password (string, optional) - search term used to narrow results
+  + limit: 2 (number, optional) - maximum number of results to return
+  + offset: 6 (number, optional) - number of results to skip
 
 + Request
   <!-- include(partials/auth_header_code.md) -->


### PR DESCRIPTION
Closes #165 

#### What does this pull request do?
Explains how to narrow your resource searches using three query parameters.

#### What background context can you provide?
In order to query Conjur more efficiently, API users should use query parameters instead of asking for the whole list and filtering client-side. This PR documents those useful query parameters.

#### Where should the reviewer start?
`apidocs/src/list_resources.md`

#### How should this be manually tested?
Build the apidocs as per README.md and view them in your browser. Check the "List resources" subheading.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/doc%252Fresource-show-limit-offset-search%252F165/
