### PR TITLE
Documents API route to show permitted roles and check permissions on resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ Conjur provides:
 
 # Development
 
-We use Jenkins as our Continuous Integration server. CyberArk employees and
-approved developers can view the current status here:
-https://jenkins.conjur.net/job/possum/
-
 To get access to Jenkins, ask in our Slack community. (You can
 join [here][join-slack].)
 

--- a/apidocs/src/api.md
+++ b/apidocs/src/api.md
@@ -66,6 +66,8 @@ Only the twenty most recent values in a Variable are retained; this prevents the
 
 <!-- include(show_permitted_roles.md) -->
 
+<!-- include(check_permission.md) -->
+
 # Group Host Factory
 
 <!-- include(host_factory_create_tokens.md) -->

--- a/apidocs/src/api.md
+++ b/apidocs/src/api.md
@@ -64,6 +64,8 @@ Only the twenty most recent values in a Variable are retained; this prevents the
 
 <!-- include(show_resource.md) -->
 
+<!-- include(show_permitted_roles.md) -->
+
 # Group Host Factory
 
 <!-- include(host_factory_create_tokens.md) -->

--- a/apidocs/src/check_permission.md
+++ b/apidocs/src/check_permission.md
@@ -1,0 +1,50 @@
+## Check permission [/resources/{account}/{kind}/{identifier}?check=true&role={role}&privilege={privilege}]
+
+### Check permission [GET]
+
+Checks whether a role has a privilege on a resource. For example: is this Host
+authorized to `execute` (fetch the value of) this Secret?
+
+<!-- include(partials/resource_kinds.md) -->
+
+#### Example with `curl`
+
+Suppose your account name is "mycorp" and you want to check whether Host "application" can `execute` (fetch the value of) Variable "db-password":
+
+This request has a long URL, so I break it up for you with some variables.
+
+```bash
+endpoint='https://eval.conjur.org/resources'
+account='mycorp'
+var_id='db-password'
+host_id='application'
+
+curl -i -H "$(conjur authn authenticate -H)" \
+     '$endpoint/$account/variable/$var_id?check=true&role=$account:host:$host_id&privilege=execute'
+```
+
+---
+
+#### Request
+
+<!-- include(partials/auth_header_table.md) -->
+
+#### Response
+
+| Code | Description                                                                            |
+|------|----------------------------------------------------------------------------------------|
+|  204 | The role has the specified privilege on the resource                                   |
+|<!-- include(partials/http_401.md) -->|
+|  404 | The role or resource was not found; or the role does not have the specified permission |
+
++ Parameters
+  + <!-- include(partials/account_param.md) -->
+  + kind: variable (string) - kind of resource to test
+  + identifier: db-password (string) - the identifier of the resource to test
+  + role: mycorp:host:application (string) - the fully qualified identifier of the role to test
+  + privilege: execute (string) - the privilege to test on the resource
+
++ Request
+  <!-- include(partials/auth_header_code.md) -->
+
++ Response 204

--- a/apidocs/src/check_permission.md
+++ b/apidocs/src/check_permission.md
@@ -2,14 +2,15 @@
 
 ### Check permission [GET]
 
-Checks whether a role has a privilege on a resource. For example: is this Host
+Checks whether a role has a privilege on a resource. For example, is this Host
 authorized to `execute` (fetch the value of) this Secret?
 
 <!-- include(partials/resource_kinds.md) -->
 
 #### Example with `curl`
 
-Suppose your account name is "mycorp" and you want to check whether Host "application" can `execute` (fetch the value of) Variable "db-password":
+Suppose your account name is "mycorp" and you want to check whether Host
+"application" can `execute` (fetch the value of) Variable "db-password":
 
 This request has a long URL, so I break it up for you with some variables.
 
@@ -41,7 +42,8 @@ curl -i -H "$(conjur authn authenticate -H)" \
   + <!-- include(partials/account_param.md) -->
   + kind: variable (string) - kind of resource to test
   + identifier: db-password (string) - the identifier of the resource to test
-  + role: mycorp:host:application (string) - the fully qualified identifier of the role to test
+  + role: mycorp:host:application (string) - the fully qualified identifier of
+    the role to test
   + privilege: execute (string) - the privilege to test on the resource
 
 + Request

--- a/apidocs/src/show_permitted_roles.md
+++ b/apidocs/src/show_permitted_roles.md
@@ -12,7 +12,9 @@ Lists the roles which have the named permission on a resource.
 
 #### Example with `curl` and `jq`
 
-Suppose your organization name is "mycorp" and you want to find out which roles have `execute` privileges on the Variable `db-password`, and can thus fetch the secret:
+Suppose your organization name is "mycorp" and you want to find out which roles
+have `execute` privileges on the Variable `db-password`, and can thus fetch the
+secret:
 
 ```bash
 curl -H "$(conjur authn authenticate -H)" \
@@ -39,8 +41,9 @@ curl -H "$(conjur authn authenticate -H)" \
 + Parameters
   + <!-- include(partials/account_param.md) -->
   + kind: variable (string) - kind of resource requested
-  + id: db-password (string)  - the identifier of the resource
-  + privilege: execute (string) - roles permitted to exercise this privilege are shown
+  + id: db-password (string) - the identifier of the resource
+  + privilege: execute (string) - roles permitted to exercise this privilege are
+    shown
 
 + Request
   <!-- include(partials/auth_header_code.md) -->

--- a/apidocs/src/show_permitted_roles.md
+++ b/apidocs/src/show_permitted_roles.md
@@ -33,8 +33,8 @@ curl -H "$(conjur authn authenticate -H)" \
 |  200 | Permitted roles returned as a JSON list |
 |<!-- include(partials/http_401.md) -->|
 |<!-- include(partials/http_403.md) -->|
+|  404 | The specified resource does not exist   |
 |<!-- include(partials/http_422.md) -->|
-|  400 | The requested resource does not exist   |
 
 For example, to get roles permitted to `execute` the Variable "db-password":
 

--- a/apidocs/src/show_permitted_roles.md
+++ b/apidocs/src/show_permitted_roles.md
@@ -1,0 +1,58 @@
+## Show permitted roles [/resources/{account}/{kind}/{id}?permitted_roles=true&privilege={privilege}]
+
+### Show permitted roles [GET]
+
+Lists the roles which have the named permission on a resource.
+
+**Permissions Required**
+
+`read` privilege on the resource.
+
+<!-- include(partials/resource_kinds.md) -->
+
+#### Example with `curl` and `jq`
+
+Suppose your organization name is "mycorp" and you want to find out which roles have `execute` privileges on the Variable `db-password`, and can thus fetch the secret:
+
+```bash
+curl -H "$(conjur authn authenticate -H)" \
+     'https://eval.conjur.org/resources/mycorp/variable/db-password?permitted_roles=true&privilege=execute' \
+     | jq .
+```
+
+---
+
+#### Request
+
+<!-- include(partials/auth_header_table.md) -->
+
+#### Response
+
+| Code | Description                             |
+|------|-----------------------------------------|
+|  200 | Permitted roles returned as a JSON list |
+|<!-- include(partials/http_401.md) -->|
+|<!-- include(partials/http_403.md) -->|
+|<!-- include(partials/http_422.md) -->|
+|  400 | The requested resource does not exist   |
+
+For example, to get roles permitted to `execute` the Variable "db-password":
+
++ Parameters
+  + <!-- include(partials/account_param.md) -->
+  + kind: variable (string) - kind of resource requested
+  + id: db/password (string)  - the identifier of the resource
+  + privilege: execute (string) - roles permitted to exercise this privilege are shown
+
++ Request
+  <!-- include(partials/auth_header_code.md) -->
+
++ Response 200 (application/json)
+
+    ```json
+    [
+      "mycorp:policy:database",
+      "mycorp:user:db-admin",
+      "mycorp:host:database/db-host"
+    ]
+    ```

--- a/apidocs/src/show_permitted_roles.md
+++ b/apidocs/src/show_permitted_roles.md
@@ -36,12 +36,10 @@ curl -H "$(conjur authn authenticate -H)" \
 |  404 | The specified resource does not exist   |
 |<!-- include(partials/http_422.md) -->|
 
-For example, to get roles permitted to `execute` the Variable "db-password":
-
 + Parameters
   + <!-- include(partials/account_param.md) -->
   + kind: variable (string) - kind of resource requested
-  + id: db/password (string)  - the identifier of the resource
+  + id: db-password (string)  - the identifier of the resource
   + privilege: execute (string) - roles permitted to exercise this privilege are shown
 
 + Request

--- a/apidocs/src/show_resource.md
+++ b/apidocs/src/show_resource.md
@@ -1,6 +1,6 @@
 ## Show a resource [/resources/{account}/{kind}/{identifier}]
 
-### Show a resource [GET /resources/{account}/{kind}/{identifier}]
+### Show a resource [GET]
 
 The response to this method is a JSON document describing a single resource.
 
@@ -53,60 +53,5 @@ For example, to show the variable "db/password":
         "annotations": [],
         "policy_versions": []
       }
-    ]
-    ```
-
-### Show permitted roles [GET /resources/{account}/{kind}/{id}?permitted_roles=true&privilege={privilege}]
-
-Lists the roles which have the named permission on a resource.
-
-**Permissions Required**
-
-`read` privilege on the resource.
-
-#### Example with `curl` and `jq`
-
-Suppose your organization name is "mycorp" and you want to find out which roles have `execute` privileges on the Variable `db-password`, and can thus fetch the secret:
-
-```bash
-curl -H "$(conjur authn authenticate -H)" \
-     'https://eval.conjur.org/resources/mycorp/variable/db-password?permitted_roles=true&privilege=execute' \
-     | jq .
-```
-
----
-
-#### Request
-
-<!-- include(partials/auth_header_table.md) -->
-
-#### Response
-
-| Code | Description                             |
-|------|-----------------------------------------|
-|  200 | Permitted roles returned as a JSON list |
-|<!-- include(partials/http_401.md) -->|
-|<!-- include(partials/http_403.md) -->|
-|<!-- include(partials/http_422.md) -->|
-|  400 | The requested resource does not exist   |
-
-For example, to get roles permitted to `execute` the Variable "db-password":
-
-+ Parameters
-  + <!-- include(partials/account_param.md) -->
-  + kind: variable (string) - kind of resource requested
-  + id: db/password (string)  - the identifier of the resource
-  + privilege: execute (string) - roles permitted to exercise this privilege are shown
-
-+ Request
-  <!-- include(partials/auth_header_code.md) -->
-
-+ Response 200 (application/json)
-
-    ```json
-    [
-      "mycorp:policy:database",
-      "mycorp:user:db-admin",
-      "mycorp:host:database/db-host"
     ]
     ```

--- a/apidocs/src/show_resource.md
+++ b/apidocs/src/show_resource.md
@@ -55,3 +55,58 @@ For example, to show the variable "db/password":
       }
     ]
     ```
+
+### Show permitted roles [GET /resources/{account}/{kind}/{id}?permitted_roles=true&privilege={privilege}]
+
+Lists the roles which have the named permission on a resource.
+
+**Permissions Required**
+
+`read` privilege on the resource.
+
+#### Example with `curl` and `jq`
+
+Suppose your organization name is "mycorp" and you want to find out which roles have `execute` privileges on the Variable `db-password`, and can thus fetch the secret:
+
+```bash
+curl -H "$(conjur authn authenticate -H)" \
+     'https://eval.conjur.org/resources/mycorp/variable/db-password?permitted_roles=true&privilege=execute' \
+     | jq .
+```
+
+---
+
+#### Request
+
+<!-- include(partials/auth_header_table.md) -->
+
+#### Response
+
+| Code | Description                             |
+|------|-----------------------------------------|
+|  200 | Permitted roles returned as a JSON list |
+|<!-- include(partials/http_401.md) -->|
+|<!-- include(partials/http_403.md) -->|
+|<!-- include(partials/http_422.md) -->|
+|  400 | The requested resource does not exist   |
+
+For example, to get roles permitted to `execute` the Variable "db-password":
+
++ Parameters
+  + <!-- include(partials/account_param.md) -->
+  + kind: variable (string) - kind of resource requested
+  + id: db/password (string)  - the identifier of the resource
+  + privilege: execute (string) - roles permitted to exercise this privilege are shown
+
++ Request
+  <!-- include(partials/auth_header_code.md) -->
+
++ Response 200 (application/json)
+
+    ```json
+    [
+      "mycorp:policy:database",
+      "mycorp:user:db-admin",
+      "mycorp:host:database/db-host"
+    ]
+    ```


### PR DESCRIPTION
Closes #250

#### What does this pull request do?
Shows how to list the roles with a certain permission on a given resource, or to check whether a role has a given permission on a resource.

#### What background context can you provide?
This is useful if you want to know who can execute a variable, or who can update a webservice, etc.

#### Where should the reviewer start?
`apidocs/src/check_permission.md`
`apidocs/src/show_permitted_roles.md`

#### How should this be manually tested?
Build the apidocs as per README.md, then visit the "Show permitted roles" and "Check permission" subheadings.

#### Screenshots (if appropriate)
Show permitted roles:
<img width="516" alt="screen shot 2017-08-15 at 5 51 48 pm" src="https://user-images.githubusercontent.com/4389854/29339988-77704cba-81e2-11e7-8c45-78a719fa3be0.png">

Check permission:
<img width="351" alt="screen shot 2017-08-17 at 6 24 44 pm" src="https://user-images.githubusercontent.com/4389854/29437960-7365f938-8379-11e7-8acf-2bfc9e31e900.png">


#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/doc%252Fpermitted-roles-&-check-permissions%252F250/