### PR TITLE
Removes Custom Authentication from tutorials

### DIFF
--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -77,9 +77,6 @@ main:
           #   title: Custom Authentication
           #   path: /tutorials/integrations/authenticators.html
 
-  apidocs:
-    title: API Documentation
-    path: /apidocs.html
   reference:
     title: Reference
     path: /reference/


### PR DESCRIPTION
Fixes #263 

#### What does this pull request do?

Removes a tutorial from the menu

#### What background context can you provide?

This tutorial is outdated.

#### Where should the reviewer start?

#### How should this be manually tested?

Run the doc site and verify that the tutorial is not listed.

Navigate to the tutorial URL manually and ensure that it's still there.

#### Screenshots (if appropriate)

#### Link to build in Jenkins (if appropriate)

#### Questions:

> Does this have automated Cucumber tests?


> Can we make a blog post, video, or animated GIF out of this?


> Is this explained in documentation?


> Does the knowledge base need an update?

