### PR TITLE
Adding --delete-removed flag to s3 command

### DIFF
--- a/website.sh
+++ b/website.sh
@@ -19,5 +19,5 @@ jekyll build --destination /output/_site
 
 echo "${POSSUM_WEB_USER}:$(openssl passwd -apr1 ${POSSUM_WEB_PASSWORD})" | aws s3 cp - s3://${POSSUM_WEB_CFG_BUCKET}/htpasswd
 
-aws s3 sync /output/_site s3://${POSSUM_WEB_BUCKET}
+aws s3 sync --delete-removed /output/_site s3://${POSSUM_WEB_BUCKET}
 '


### PR DESCRIPTION
`--delete-removed` in the sync command should remove old files that are no longer built out rather than let them lay around.