### PR TITLE
Removes outdated apidoc build instructions, links to correct ones

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,30 +35,4 @@ This script builds the `possum-docs` Docker image and then runs
 
 ### API Blueprint Docs
 
-TODO: move this section out of `docs/` and into project root or `apidocs/`.
-
-We're using [API Blueprint](https://apiblueprint.org/documentation/) to document the Possum API. There is no Ruby specific implementation, so we're using the [Aglio](https://github.com/danielgtaylor/aglio) package. The final generated docs can be viewed in two ways:
-
-##### Live Preview
-```sh-session
-$ cd docs
-$ ./dev.sh /node_modules/.bin/aglio -i apidocs/src/api.md -s -h 0.0.0.0 -p 4000
-```
-
-The above will make the rendered API docs available on `http://localhost:4000/`.
-
-Please note that the Docs Dockerfile contains the configuration to build both Jekyll and Aglio. This is why we execute commands from the `/docs` folder not the `/apidocs` folder. The API Blueprint reference path (`apidocs/src/api.md`) is from the project root.
-
-##### Generated (Visible from Jekyll)
-
-To compile API docs into the Jekyll project, first, start the Jekyll server:
-
-```sh-session
-$ cd docs && ./dev.sh
-```
-
-Now in a new shell, compile API docs into the running project:
-```sh-session
-$ docker exec possum-web /node_modules/.bin/aglio -i apidocs/src/api.md -o /opt/conjur/_site/apidocs.html
-```
-The above should be run from the root `possum` folder.
+See [Build the API documentation from source](../README.md#build-the-api-documentation-from-source).

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,4 +35,15 @@ This script builds the `possum-docs` Docker image and then runs
 
 ### API Blueprint Docs
 
-See [Build the API documentation from source](../README.md#build-the-api-documentation-from-source).
+Currently, the docker-compose setup described above assumes that the API docs have been rendered to `docs/_includes/api.html`. Without that file, the local server will fail to serve the API docs.
+
+To perform this step, run the following:
+```sh-session
+$ cd "$(git rev-parse --show-toplevel)" # cd to project root
+$ docker-compose build --pull docs
+$ docker-compose up -d docs
+$ apidocs/build.sh
+$ docker run --rm conjurinc/possum-apidocs > docs/_includes/api.html
+```
+
+If you're just working on the API docs and want a live-updating dev server for them, see [Build the API documentation from source](../README.md#build-the-api-documentation-from-source).


### PR DESCRIPTION
Closes #280

#### What does this pull request do?
Links in the "docs" readme to the top level readme, which contains instructions for building the API docs from source.

#### What background context can you provide?
We suggested three methods of building the apidocs, only one of which really works, so it makes sense to settle on that one alone.

#### Where should the reviewer start?
Changes in `docs/README.md`. See the correct instructions in the top-level `README.md`

#### How should this be manually tested?
Follow the link to the correct build instructions.