### PR TITLE
test fix for iOS rendering of CTA boxes.

### DIFF
--- a/docs/_includes/cta.md
+++ b/docs/_includes/cta.md
@@ -2,26 +2,28 @@
 
 <div class="col-md-6">
   <div class="cta-box">
-    <div class="cta-box-header">
-      {{ section.title }}      
-    </div>
+    <div class="cta-content-wrap">
+      <div class="cta-box-header">
+        {{ section.title }}      
+      </div>
 
-    {% if section.text %}
-      <p>{{ section.text }}</p>
-    {% endif %}
+      {% if section.text %}
+        <p>{{ section.text }}</p>
+      {% endif %}
 
-    <ul class="cta-links list-unstyled">
-      {% for link in section.links %}
-        <li class="link">
-          {% if link[1].icon %}{{ link[1].icon }}{% endif %}          
-          {% if link[1].content %}
-            {{ link[1].content }}
-          {% else %}
-            <a href="{{ link[1].path }}" {% if link[1].target %}target="{{ link[1].target }}"{% endif %}>{{ link[1].title }}</a>
-          {% endif %}          
-        </li>
-      {% endfor %}
-    </ul>
+      <ul class="cta-links list-unstyled">
+        {% for link in section.links %}
+          <li class="link">
+            {% if link[1].icon %}{{ link[1].icon }}{% endif %}          
+            {% if link[1].content %}
+              {{ link[1].content }}
+            {% else %}
+              <a href="{{ link[1].path }}" {% if link[1].target %}target="{{ link[1].target }}"{% endif %}>{{ link[1].title }}</a>
+            {% endif %}          
+          </li>
+        {% endfor %}
+      </ul>
 
+    </div>    
   </div>
 </div>

--- a/docs/_sass/elements.scss
+++ b/docs/_sass/elements.scss
@@ -37,6 +37,10 @@
   display: flex;
   flex-direction: column;
 
+  .cta-content-wrap {
+    flex: 1;
+  }
+
   .cta-box-header {
     font-weight: 400;
     padding: 1em 1.5em;


### PR DESCRIPTION
Testing fix for https://github.com/cyberark/conjur/issues/302

#### What does this pull request do?
Testing a fix for flexbox rendering on iOS.

#### What background context can you provide?
Content rendered OK locally, but when on staging, was not rendering properly on iOS.

#### Where should the reviewer start?
Homepage. 
#### How should this be manually tested?
Check to see that CTA boxes are visible. (can't check locally, needs to be visible on iOS safari to test)
#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/ux-updates/

#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
