### PR TITLE
Adding Integrations to top-nav

### DIFF
--- a/app/assets/stylesheets/resets.scss
+++ b/app/assets/stylesheets/resets.scss
@@ -139,7 +139,7 @@ p {
 	padding: 5px 0;
 	border-radius: 6px;
 	position: absolute;
-  right: 43px;
+  right: -5px;
 	z-index: 1;
 	margin-top: 30px;
 }

--- a/docs/_data/cta.yml
+++ b/docs/_data/cta.yml
@@ -28,17 +28,17 @@ operations:
       icon: <i class="fa fa-arrow-down"></i>
 
 local:
-  title: Run Conjur
+  title: Run Your Own Conjur Server
   text: "Running your own Conjur server gives you total control over the software and doesn't require you to connect to the Internet."
   links:
     self-host:
       title: Install Conjur
-      content: <a href="/get-started/install-conjur.html" class="conjur-cta-primary">Get Started</a>
+      content: <a href="/get-started/install-conjur.html" class="conjur-cta-primary">Install Conjur</a>
 
 hosted:
-  title: Demo Conjur
+  title: Evaluate Conjur in the Cloud
   text: "The quickest way to get started using Conjur. Get immediate access to a running server in the cloud. Not for production secrets."
   links:
     hosted:
       title: Start your evaluation
-      content: <a href="/get-started/evaluate-conjur.html" class="conjur-cta-secondary">Start Evaluation</a>
+      content: <a href="/get-started/evaluate-conjur.html" class="conjur-cta-secondary">Request Access</a>

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -19,6 +19,31 @@ main:
       evaluate-conjur:
         title: Evaluate Conjur
         path: /get-started/evaluate-conjur.html
+  integrations:
+    title: Integrations
+    path: /integrations/
+    items:
+      ruby:
+        title: Ruby
+        path: https://github.com/cyberark/conjur-api-ruby
+      go:
+        title: Go
+        path: https://github.com/cyberark/conjur-api-go
+      ansible:
+        title: Ansible
+        path: https://github.com/cyberark/ansible-role-conjur
+      puppet:
+        title: Puppet
+        path: https://github.com/cyberark/conjur-puppet
+      summon:
+        title: Summon
+        path: https://github.com/cyberark/summon
+      java:
+        title: Java
+        path: https://github.com/cyberark/conjur-api-java
+      dotnet:
+        title: .NET
+        path: https://github.com/cyberark/conjur-api-dotnet
   tutorials:
     title: Tutorials
     path: /tutorials/

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -23,27 +23,36 @@ main:
     title: Integrations
     path: https://github.com/cyberark
     items:
+      kubernetes:
+        title: Kubernetes
+        path: https://github.com/conjurdemos/scalability-k8s
       ansible:
         title: Ansible
         path: https://github.com/cyberark/ansible-role-conjur
-      dotnet:
-        title: .NET
-        path: https://github.com/cyberark/conjur-api-dotnet
-      go:
-        title: Go
-        path: https://github.com/cyberark/conjur-api-go
-      java:
-        title: Java
-        path: https://github.com/cyberark/conjur-api-java
       puppet:
         title: Puppet
         path: https://github.com/cyberark/conjur-puppet
-      ruby:
-        title: Ruby
-        path: https://github.com/cyberark/conjur-api-ruby
+      jenkins:
+        title: Jenkins
+        path: https://github.com/conjur/jenkins-e2e-example
+      chef:
+        title: Chef
+        path: https://github.com/conjur/chef-demo
       summon:
         title: Summon
         path: https://github.com/cyberark/summon
+      go:
+        title: Go
+        path: https://github.com/cyberark/conjur-api-go
+      ruby:
+        title: Ruby
+        path: https://github.com/cyberark/conjur-api-ruby
+      dotnet:
+        title: .NET
+        path: https://github.com/cyberark/conjur-api-dotnet
+      java:
+        title: Java
+        path: https://github.com/cyberark/conjur-api-java
   tutorials:
     title: Tutorials
     path: /tutorials/

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -21,7 +21,7 @@ main:
         path: /get-started/evaluate-conjur.html
   integrations:
     title: Integrations
-    path: /integrations/
+    path: https://github.com/cyberark
     items:
       ansible:
         title: Ansible

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -23,27 +23,27 @@ main:
     title: Integrations
     path: /integrations/
     items:
-      ruby:
-        title: Ruby
-        path: https://github.com/cyberark/conjur-api-ruby
-      go:
-        title: Go
-        path: https://github.com/cyberark/conjur-api-go
       ansible:
         title: Ansible
         path: https://github.com/cyberark/ansible-role-conjur
-      puppet:
-        title: Puppet
-        path: https://github.com/cyberark/conjur-puppet
-      summon:
-        title: Summon
-        path: https://github.com/cyberark/summon
-      java:
-        title: Java
-        path: https://github.com/cyberark/conjur-api-java
       dotnet:
         title: .NET
         path: https://github.com/cyberark/conjur-api-dotnet
+      go:
+        title: Go
+        path: https://github.com/cyberark/conjur-api-go
+      java:
+        title: Java
+        path: https://github.com/cyberark/conjur-api-java
+      puppet:
+        title: Puppet
+        path: https://github.com/cyberark/conjur-puppet
+      ruby:
+        title: Ruby
+        path: https://github.com/cyberark/conjur-api-ruby
+      summon:
+        title: Summon
+        path: https://github.com/cyberark/summon
   tutorials:
     title: Tutorials
     path: /tutorials/

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -45,6 +45,7 @@
   install: Install and Configure
   connect: Connect
   explore: Explore
+  next-steps: Next Steps
 
 "/reference/policy.html":
   introduction: What is a Policy?

--- a/docs/_sass/_resets.scss
+++ b/docs/_sass/_resets.scss
@@ -142,7 +142,7 @@ p {
 	padding: 5px 0;
 	border-radius: 6px;
 	position: absolute;
-        right: 43px;
+        right: -5px;
 	z-index: 1;
 	margin-top: 30px;
 }

--- a/docs/get-started/evaluate-conjur.md
+++ b/docs/get-started/evaluate-conjur.md
@@ -157,5 +157,5 @@ fde5c4a45ce573f9768987cd
 
 {% include toc.md key='next-steps' %}
 
+* Run your own [Conjur Server](/get-started/install-conjur.html)
 * Go through the [Conjur Tutorials](/tutorials/)
-* Talk to the Conjur team on our [Slack channel](https://slackin-conjur.herokuapp.com/)

--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -70,5 +70,11 @@ conjur help
 conjur help policy load
 ```
 
+
+{% include toc.md key='next-steps' %}
+
+* Go through the [Conjur Tutorials](/tutorials/)
+* View Conjur's [API Documentation](/api.html)
+
 [get-docker]: https://docs.docker.com/engine/installation
 [get-docker-compose]: https://docs.docker.com/compose/install

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,4 @@ Containers come with their own security challenges and Conjur is specifically bu
 
 {% include toc.md key='integrations' %}
 
-CyberArk officially provides and supports integration libraries between Conjur and external tools such as Active Directory, Puppet, Ansible, Chef, Jenkins, Salt Stack, Docker, Kubernetes, OpenShift, and CloudFoundry. CyberArk has officially partnered with Puppet to provide joint support for the Conjur Puppet Module. CyberArk is extending this partnering relationship to other major tool vendors in the DevOps space.
+CyberArk officially provides and supports integration libraries between Conjur and external tools such as Puppet, Ansible, Chef, Jenkins, Salt Stack, Docker, Kubernetes, OpenShift, and CloudFoundry. CyberArk has officially partnered with Puppet to provide joint support for the Conjur Puppet Module. CyberArk is extending this partnering relationship to other major tool vendors in the DevOps space.


### PR DESCRIPTION
Closes [GH Issue 308](https://github.com/cyberark/conjur/issues/308) & [GH Issue 296](https://github.com/cyberark/conjur/issues/296)

#### What does this pull request do?
- Moves Integrations to it's own top-level navigation, linking directly to GitHub repos.
- Updates some Next Steps links
- Removes AD name from Integrations section on homepage
- Fixes "copy to clipboard" hover
#### What background context can you provide?
IA reorganization where we want to move users from guided to expert content: Evaluation -> Installation, and then Next Steps to guide through Integrations -> tutorials -> Reference -> API
#### Where should the reviewer start?
Homepage.
#### How should this be manually tested?
- Confirm that there is an Integrations top-nav item, and the links go to GitHub (will be following this up w landing pages for each integration)
- Check that Next Steps links (at bottom of page) work on /get-started/evaluate-conjur.html & /get-started/install-conjur.html
- Check that "copy to clipboard" hover is properly aligned in code blocks
#### Screenshots (if appropriate)
![screenshot 2017-08-29 14 55 51](https://user-images.githubusercontent.com/123787/29838801-352b9434-8cca-11e7-8f50-6a6e4c6a34a2.png)

![screenshot 2017-08-29 14 33 51](https://user-images.githubusercontent.com/123787/29837767-1e96d8c6-8cc7-11e7-820b-9668776e6d67.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/ux-updates-02/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
