### PR TITLE
Adding Usage Agreement to Eval form

### DIFF
--- a/docs/_includes/sign-up/sign-up-form.html
+++ b/docs/_includes/sign-up/sign-up-form.html
@@ -17,7 +17,7 @@
     <div class="form-group form-check required">
         <label class="form-check-label">
           <input type="checkbox" id="terms" id="terms" name="terms" data-error="You must read and agree to the Terms of Use and Usage Agreement to continue." required>
-          By checking this box, I agree to the <a href="/usage-agreement">Usage Agreement</a>
+          By checking this box, I agree to the <a href="/usage-agreement.html">Usage Agreement</a>
         </label>
         <div class="help-block with-errors"></div>
     </div>

--- a/docs/_includes/sign-up/sign-up-form.html
+++ b/docs/_includes/sign-up/sign-up-form.html
@@ -17,7 +17,7 @@
     <div class="form-group form-check required">
         <label class="form-check-label">
           <input type="checkbox" id="terms" id="terms" name="terms" data-error="You must read and agree to the Terms of Use and Usage Agreement to continue." required>
-          By checking this box, I agree to the <a href="#">Terms of Use</a>, and <a href="#">Usage Agreement</a>
+          By checking this box, I agree to the <a href="/usage-agreement">Usage Agreement</a>
         </label>
         <div class="help-block with-errors"></div>
     </div>

--- a/docs/usage-agreement.md
+++ b/docs/usage-agreement.md
@@ -1,0 +1,10 @@
+---
+title: Usage Agreement
+layout: page
+section: get-started
+---
+
+
+The Conjur hosted service is offered for evaluation purposes only, and is not warranted for production deployments. The Conjur hosted service is provided "as is" without any warranties or representations of any kind. To the extent permitted by law, Conjur disclaims all implied warranties and representations, including, without limitation, any implied warranty of merchantability, fitness for a particular purpose and non-infringement. You assume all risks and all costs associated with its use of this hosted service. Your sole and exclusive remedy in case of any dissatisfaction or damage is termination of the service.
+
+Do not store sensitive data within the Conjur hosted service. CyberArk is not responsible or liable for the deletion of or failure to store any of Customer’s data and other information maintained as part of the Conjur hosted service. All data entered into the hosted service by or for Customer may be permanently lost or inaccessible. You are solely responsible for securing and backing up such data and information. Instead, download the Conjur server and deploy it within your own environment. Your account on the Conjur hosted service may be re-initialized at any time (although we will strive to avoid doing so).


### PR DESCRIPTION
Closes [GH Issue 297](https://github.com/cyberark/conjur/issues/297)

#### What does this pull request do?
Adds Usage Agreement to Conjur Evaluation form
#### What background context can you provide?
Adding legalese
#### Where should the reviewer start?
/get-started/evaluate-conjur.html
#### How should this be manually tested?
In the sign-up form, check that the Usage Agreement page exists, and is styled like other pages.
#### Screenshots (if appropriate)
![usage agreement conjur](https://user-images.githubusercontent.com/123787/29842341-8faad51c-8cd6-11e7-8678-0cf3be0e370c.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/ux-updates-03/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
