### PR TITLE
Builds conjur-apidocs image before using it in website.sh

### DIFF
--- a/website.sh
+++ b/website.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -ex
 
-docker-compose build apidocs # make sure we build first so that the
-                             # build output doesn't make it into
-                             # `docs/_includes/api.html`
-docker-compose run --rm apidocs > docs/_includes/api.html
+docker-compose build apidocs # builds conjur-apidocs image
+docker run --rm conjur-apidocs > docs/_includes/api.html
 
 docker-compose run --rm  \
   -e AWS_ACCESS_KEY_ID \

--- a/website.sh
+++ b/website.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+docker-compose build apidocs # make sure we build first so that the
+                             # build output doesn't make it into
+                             # `docs/_includes/api.html`
 docker-compose run --rm apidocs > docs/_includes/api.html
 
 docker-compose run --rm  \


### PR DESCRIPTION
This is a proposal to fix a problem where, when the `conjur-apidocs` image needs to be built before being used in `website.sh`, the build logs were getting prepended to `api.html` instead of being logged.