### PR TITLE
Update prereq install instructions in install quick-start doc

### DIFF
--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -4,18 +4,21 @@ layout: page
 section: get-started
 ---
 
-You can easily download and run the Conjur software using the [official containers on DockerHub](https://hub.docker.com/r/cyberark/conjur/).
+You can easily download and run the Conjur software using Docker and the
+official Conjur containers on DockerHub.
 
 {% include toc.md key='prereq' %}
 
-The easiest way to install and configure Conjur quickly is using Docker and Docker Compose.
+1. [Install Docker Toolbox][get-docker], available for Windows and macOS.
 
-1. [Install Docker][get-docker]
-1. [Install Docker Compose][get-docker-compose]
+   If you're using GNU/Linux, [follow instructions here][get-docker-gnu].
+
+1. Install a terminal application if you don't have one already.
+   [Hyper](https://hyper.is) is nice.
 
 {% include toc.md key='launch' %}
 
-1. Download the Conjur quick-start configuration:
+1. In your terminal, download the Conjur quick-start configuration:
 
    ```sh-session
    $ curl -o docker-compose.yml https://www.conjur.org/get-started/docker-compose.quickstart.yml
@@ -76,5 +79,5 @@ conjur help policy load
 * Go through the [Conjur Tutorials](/tutorials/)
 * View Conjur's [API Documentation](/api.html)
 
-[get-docker]: https://docs.docker.com/engine/installation
-[get-docker-compose]: https://docs.docker.com/compose/install
+[get-docker]: https://www.docker.com/products/docker-toolbox
+[get-docker-gnu]: install-docker-on-gnu-linux.html

--- a/docs/get-started/install-docker-on-gnu-linux.md
+++ b/docs/get-started/install-docker-on-gnu-linux.md
@@ -1,0 +1,19 @@
+---
+title: Install Docker on GNU/Linux
+layout: page
+section: get-started
+---
+
+# Installing Docker on GNU/Linux
+
+To get started with Conjur, you need to install Docker and Docker Compose using
+your distro's package system.
+
+## On Ubuntu 16.04+
+
+```sh-session
+$ sudo apt update
+$ sudo apt install docker.io docker-compose
+# suggested: install the documentation
+$ sudo apt install docker-doc
+```


### PR DESCRIPTION
#### What does this pull request do?
Where we linked to Docker's big wordy "install Docker" document before which covered every possible angle, now we link to the relatively straightforward Docker Toolbox page.

We also suggest downloading a terminal app for users who don't often use a terminal but want to try installing Conjur.

#### What background context can you provide?
In [my user test with Steve](https://gist.github.com/ryanprior/bd1bf90dcf7df9f1a597f03bb77edee8), we got hung up on installing the prerequisites. The page we linked to before didn't have a clear "install button" which he was looking for and it took a lot of reading to get to that stage. Then, when he installed Docker for Windows it didn't work on Windows 10, which other people on the Conjur team have also experienced.

Finally, he thought that he should type the terminal commands into the Docker app, which I don't believe will work (although I'm not a Kitematic expert and maybe there's some way to get a shell in there?)

#### Where should the reviewer start?
`docs/get-started/install-conjur.md`

#### How should this be manually tested?
Ideally, start with a Windows or Mac machine that doesn't have Docker installed and run through those prerequisite instructions.