### PR TITLE
Pull before generating master key

### DIFF
--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -34,9 +34,9 @@ official Conjur containers on DockerHub.
 
 1. Generate your master data key and load it into the environment:
 
-   ```shell
-   docker-compose run --no-deps --rm conjur data-key generate > data_key
-   export CONJUR_DATA_KEY="$(< data_key)"
+   ```sh-session
+   $ docker-compose run --no-deps --rm conjur data-key generate > data_key
+   $ export CONJUR_DATA_KEY="$(< data_key)"
    ```
 
 <div class="alert alert-info" role="alert"> <strong>Prevent data loss:</strong><br>
@@ -49,8 +49,8 @@ official Conjur containers on DockerHub.
 1. Run `docker-compose up -d` to run the Conjur server, database and client
 1. Create a default account (eg. `quick-start`):
 
-   ```shell
-   docker-compose exec conjur conjurctl account create quick-start
+   ```sh-session
+   $ docker-compose exec conjur conjurctl account create quick-start
    ```
 
  <div class="alert alert-info" role="alert"> <strong>Prevent data loss:</strong><br>
@@ -75,10 +75,10 @@ official Conjur containers on DockerHub.
 
 Conjur is installed and ready for use! Ready to do more?  Here are some suggestions:
 
-```shell
-conjur authn whoami
-conjur help
-conjur help policy load
+```sh-session
+$ conjur authn whoami
+$ conjur help
+$ conjur help policy load
 ```
 
 

--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -24,6 +24,14 @@ official Conjur containers on DockerHub.
    $ curl -o docker-compose.yml https://www.conjur.org/get-started/docker-compose.quickstart.yml
    ```
 
+1. pull all the required Docker images from DockerHub
+
+   `docker-compose` can do this for you automatically:
+
+   ```sh-session
+   $ docker-compose pull
+   ```
+
 1. Generate your master data key and load it into the environment:
 
    ```shell


### PR DESCRIPTION
#### What does this pull request do?
Removes an opportunity for the install process to fail when images aren't pulled before beginning

#### What background context can you provide?
When I switched from Docker for Mac to Docker Toolbox, I noticed when running through the install instructions that this step behaved unexpectedly:

```sh-session
$ docker-compose run --no-deps --rm conjur data-key generate > data_key
```

This is because it hadn't pulled that image yet:

```sh-session
$ cat data_key 
latest: Pulling from cyberark/conjur
Digest: sha256:0ff0638752328710cac84db8a08b67cf31393758fb398ebc01e08841473e7fbe
Status: Downloaded newer image for cyberark/conjur:latest
IsjFOg3l4HNv7qv608B1m0L1gKgl/1BihGdZ19cIdbA=
```

I remedied the problem by explicitly telling the user to `docker-compose pull` first.

#### Where should the reviewer start?
`docs/get-started/install-conjur.md`

#### How should this be manually tested?
First:
```sh-session
$ docker rmi cyberark/conjur
```

Then follow the install instructions and make sure they still work.