### PR TITLE
fixed Google Tag Manager classes & IDs

### DIFF
--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -25,6 +25,6 @@
 <ul class="sidebar-nav list-unstyled">
   <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
   <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
-  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> Cloud Formation <span>(Coming Soon)</span></a></li>
+  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> AWS CloudFormation <span>(Coming Soon)</span></a></li>
   <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -23,8 +23,8 @@
 <hr/>
 
 <ul class="sidebar-nav list-unstyled">
-  <li class="item"><a id=”side-nav-button-github” class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
-  <li class="item"><a id=”side-nav-button-dockerhub” class=“event-click” href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
-  <li class="item coming-soon"><a id=”side-nav-button-cloud-formation” class=“event-click” href="#"><i class="fa fa-cloud"></i> Cloud Formation <span>(Coming Soon)</span></a></li>
-  <li class="item"><a id=”side-nav-button-slack” class=“event-click” href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
+  <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
+  <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
+  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> Cloud Formation <span>(Coming Soon)</span></a></li>
+  <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>

--- a/docs/_includes/top_nav.html
+++ b/docs/_includes/top_nav.html
@@ -16,11 +16,11 @@
     			{% include top_nav_menu.html item=value section=key %}
     		{% endfor %}
         <li class="nav-item">
-          <a id="top-nav-button-github" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i></a>
+          <a id="top-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i></a>
         </li>
 
         <li class="nav-item">
-          <a id="top-nav-button-slack" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i></a>
+          <a id="top-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i></a>
         </li>
       </ul>
 


### PR DESCRIPTION
#### What does this pull request do?
Fixes quotemarks around class names for Google Tag Manager
#### What background context can you provide?
Integrations with Marketing's tracking of metrics.
#### Where should the reviewer start?
homepage
#### How should this be manually tested?
Using the web inspector, confirm that the class names for GitHub, DockerHub, Slack, and CloudFormation don't have quote marks around class names (should be the straight inch marks)
#### Screenshots (if appropriate)
<img width="1265" alt="screenshot 2017-09-06 12 59 17" src="https://user-images.githubusercontent.com/123787/30124456-3b6a4a22-9303-11e7-9262-ecdbf632ec60.png">

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/marketing-updates/
