### PR TITLE
IE 11 and older fallback fix for flexbox

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
   <link href="https://gmpg.org/xfn/11" rel="profile">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE9">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
   <!-- Enable responsiveness on mobile devices-->


### PR DESCRIPTION
Force IE to emulate IE9 via meta tag which displays flexbox elements via table-like display fallbacks.  Probably the fastest and safest fix.

#### What does this pull request do?

This PR changes the meta tag in the header include to enforce IE to emulate IE9, which fixes the broken flexbox bugs.

#### What background context can you provide?
Microsoft Edge supports flexbox, but other older IEs (11 and under) do not.  IE9 falls back on table display, though, so that is the likely the cleanest and lowest risk fix.

#### Where should the reviewer start?
This is a very tiny change - just one line in one file.

#### How should this be manually tested?

A reviewer will need to test in Windows using IE 11 and 10, and Microsoft Edge.  Side-by-side comparison can be done with Chrome.

#### Screenshots (if appropriate)
**BEFORE FIX:**

Edge:

![image](https://user-images.githubusercontent.com/4164335/30130345-ccee0e12-9316-11e7-99b2-bae5826cdc2c.png)

IE 11:

![image](https://user-images.githubusercontent.com/4164335/30130357-d7c811ac-9316-11e7-9dc9-8e978b9f3fed.png)

**AFTER FIX:**

Edge:

![image](https://user-images.githubusercontent.com/4164335/30130231-80b3a9d0-9316-11e7-9384-d8257fe51a40.png)

IE 11:
![image](https://user-images.githubusercontent.com/4164335/30130252-903c03e8-9316-11e7-9b33-96c878459028.png)

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/ie-flexbox-fallback/