### PR TITLE
Add build.ps1 for Windows users

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,16 @@
+$tag = "$(git rev-parse --short HEAD)"
+$run_dev = $true
+
+Write-Host "Building Conjur Docker image"
+& docker build -t conjur .
+
+Write-Host "Tagging conjur:${tag}"
+& docker tag conjur "conjur:${tag}"
+
+Write-Host "Building test container"
+& docker build -t conjur-test -f Dockerfile.test . 
+
+if ($run_dev) {
+    Write-Host "Building dev container"
+    & docker build -t conjur-dev -f Dockerfile.dev . 
+}


### PR DESCRIPTION
Closes #356 

#### What does this pull request do?

Adds [build.ps1](build.ps1) for Docker for Windows users to be able to build the image and container for Conjur.

#### What background context can you provide?

Currently, only build.sh is provided with cyberark/conjur and alienates Windows-centric users and enterprises.

#### Where should the reviewer start?

Compare [build.sh](build.sh) to [build.ps1](build.ps1) line-by-line.

#### How should this be manually tested?

Will require Docker for Windows, Docker Compose for Windows, and Hyper-V.  Hyper-V is a requirement of Docker for Windows.  Docker Toolbox is considered legacy and rarely used anymore.

#### Screenshots (if appropriate)

N/A

#### Link to build in Jenkins (if appropriate)

N/A

#### Questions:
> Does this have automated Cucumber tests?

No.

> Can we make a blog post, video, or animated GIF out of this?

Yes.

> Is this explained in documentation?

No.

> Does the knowledge base need an update?

The knowledge base does not currently provide Windows commands with the current Linux ones.  So, I would say yes.