### PR TITLE
Fixes /start/ redirect legacy url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@ title: Conjur
 layout: page
 section: welcome
 id: index
-redirect_from: "/start"
 ---
 
 <div class="row equal">

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -1,0 +1,4 @@
+---
+permalink: "/start"
+redirect_to: "/"
+---


### PR DESCRIPTION
Fixes an issue where the start.html was being generated for redirect, but it was not being mapped properly to the old /start/ url.

#### What does this pull request do?

The file is being generated and hosted in s3 correctly, but the endpoint /start/ is not loading the /start.html file.  This PR includes changes to make that happen.

#### What background context can you provide?

The /start url is required for legacy try.conjur.org users and should redirect those users properly.

#### Where should the reviewer start?

Very tiny change.

#### How should this be manually tested?

Start by pulling and building this branch locally and testing that localhost:4000/start, localhost:4000/start/, and localhost:4000/start.html all redirect to localhost:4000.

#### Screenshots (if appropriate)

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/redirects-for-old-endpoints/
