### PR TITLE
Fixing the front matter for /start/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@ title: Conjur
 layout: page
 section: welcome
 id: index
-redirect_from: "/start"
 ---
 
 <div class="row equal">

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -1,0 +1,4 @@
+---
+permalink: "/start"
+redirect_to: "/"
+---

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -1,4 +1,5 @@
 ---
-permalink: "/start"
+title: Get Started
+layout: page
 redirect_to: "/"
 ---


### PR DESCRIPTION
Fixing the front matter for the /start/index.md file so it generates correctly.  Apparently, Jekyll fails silently and generates the old, incorrect files when certain values are missing.  Thanks, Jekyll.