### PR TITLE
Docs Site SEO Tweaks

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,5 +6,5 @@ gems:
   - jekyll-coffeescript
   - jekyll-paginate
   - jekyll-redirect-from
-title: Conjur
+title: CyberArk Conjur
 plugins_dir: ./_plugins

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,6 +3,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE9">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
+  {% if page.description != null %}
+    <meta name="description" content="{{ page.description }}">
+  {% endif %}
+
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,5 @@
 ---
-title: CyberArk Conjur API Docs
+title: Conjur API Documentation
 layout: apidocs
+description: API documentation for CyberArk Conjur
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,0 @@
----
-title: Contributing
-layout: page
-section: support
----
-
-TBD

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -2,6 +2,7 @@
 title: Get Started
 layout: page
 section: get-started
+description: Get started quickly with Conjur by test-driving a cloud server instantly, or download and run your own Conjur server
 ---
 
 Thanks for your interest in Conjur. To get started, we have a few options available for you.

--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -2,6 +2,7 @@
 title: Install Conjur
 layout: page
 section: get-started
+description: Install Conjur locally yourself using Docker and the official Conjur containers on DockerHub
 ---
 
 You can easily download and run the Conjur software using Docker and the

--- a/docs/get-started/install-docker-on-gnu-linux.md
+++ b/docs/get-started/install-docker-on-gnu-linux.md
@@ -2,6 +2,7 @@
 title: Install Docker on GNU/Linux
 layout: page
 section: get-started
+description: Getting started with Conjur - install Docker and Docker Compose
 ---
 
 To get started with Conjur, you need to install Docker and Docker Compose using

--- a/docs/get-started/try-conjur.md
+++ b/docs/get-started/try-conjur.md
@@ -2,6 +2,7 @@
 title: Try Conjur
 layout: page
 section: get-started
+description: Try Conjur out quickly with instant access to a hosted Conjur server in the cloud 
 custom_js:
 - https://www.google.com/recaptcha/api.js
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
 ---
-title: Conjur
+title: Open Source Secrets Management & Machine Identity
 layout: page
 section: welcome
 id: index
+description: CyberArk Conjur is a scalable, flexible, open source security service that stores secrets, provides machine identity based authorization, and more.
 ---
 
 <div class="row equal">

--- a/docs/integrations/ansible.md
+++ b/docs/integrations/ansible.md
@@ -2,6 +2,7 @@
 title: Conjur Ansible Role
 layout: page
 section: integrations
+description: Conjur Integrations - Ansible Role
 ---
 
 The [Conjur Ansible Role](https://github.com/cyberark/ansible-role-conjur)

--- a/docs/integrations/conjur-api-dotnet.md
+++ b/docs/integrations/conjur-api-dotnet.md
@@ -2,6 +2,7 @@
 title: Conjur .NET API
 layout: page
 section: integrations
+description: Conjur Integrations - .NET API
 ---
 
 The [Conjur .NET API](https://github.com/cyberark/conjur-api-dotnet) provides a

--- a/docs/integrations/conjur-api-go.md
+++ b/docs/integrations/conjur-api-go.md
@@ -2,6 +2,7 @@
 title: Conjur Go API
 layout: page
 section: integrations
+description: Conjur Integrations - Go API
 ---
 
 The [Conjur Go API](https://github.com/cyberark/conjur-api-go) provides a robust

--- a/docs/integrations/conjur-api-java.md
+++ b/docs/integrations/conjur-api-java.md
@@ -2,6 +2,7 @@
 title: Conjur Java API
 layout: page
 section: integrations
+description: Conjur Integrations - Java API
 ---
 
 The [Conjur Java API](https://github.com/cyberark/conjur-api-java) provides a

--- a/docs/integrations/conjur-api-ruby.md
+++ b/docs/integrations/conjur-api-ruby.md
@@ -2,6 +2,7 @@
 title: Conjur Ruby API
 layout: page
 section: integrations
+description: Conjur Integrations - Ruby API
 ---
 
 The [Conjur Ruby API](https://github.com/cyberark/conjur-api-ruby) provides a

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -2,6 +2,7 @@
 title: Integrations
 layout: page
 section: integrations
+description: Conjur Integrations - Working with various tools, platforms, and languages
 ---
 
 Conjur makes tools and integrations available on a variety of platforms

--- a/docs/integrations/puppet.md
+++ b/docs/integrations/puppet.md
@@ -2,6 +2,7 @@
 title: Conjur Puppet Module
 layout: page
 section: integrations
+description: Conjur Integrations - Puppet Module
 ---
 
 The [Conjur Puppet Module](https://forge.puppet.com/conjur/conjur) simplifies

--- a/docs/integrations/summon.md
+++ b/docs/integrations/summon.md
@@ -2,6 +2,7 @@
 title: Summon CLI Tool
 layout: page
 section: integrations
+description: Conjur Integrations - Summon CLI Tool
 ---
 
 The [Summon CLI tool](https://github.com/cyberark/summon) provides an interface

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -1,6 +1,7 @@
 ---
 title: Reference - Authentication
 layout: page
+description: Conjur Reference - Authentication
 ---
 
 ## API Routes
@@ -38,11 +39,10 @@ If you omit the `-H` option, you get the token as JSON.
 
 ## Whoami
 
-Once you are logged in, you can print your current logged-in identity 
+Once you are logged in, you can print your current logged-in identity
 with the command `conjur authn whoami`.
 
 {% highlight shell %}
 $ conjur authn whoami
 {"account":"mycorp","username":"joe-tester"}
 {% endhighlight %}
-

--- a/docs/reference/cryptography.md
+++ b/docs/reference/cryptography.md
@@ -1,6 +1,7 @@
 ---
 title: Reference - Cryptography
 layout: page
+description: Conjur Reference - Cryptography
 ---
 
 Conjur uses industry-standard cryptography to protect your data.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,7 @@
 ---
 title: Reference
 layout: page
+description: Conjur Reference Index
 ---
 
 {% include nav-items.md items=site.data.sidebar.main.reference.items %}

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -1,6 +1,7 @@
 ---
 title: Reference - Policies
 layout: page
+description: Conjur Reference - Policies
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/support.md
+++ b/docs/support.md
@@ -2,6 +2,7 @@
 title: Support
 layout: page
 section: support
+description: Need support for Conjur? Join us in our Slack channel or drop us a support email!
 ---
 
 Our primary channel for support is through our [Slack](https://slackin-conjur.herokuapp.com/){:target="_blank"} community, which you can join below.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,6 +2,7 @@
 title: Tutorials
 layout: page
 section: tutorials
+description: Tutorials to get you started quickly with writing Conjur policy files and integrating Conjur with your runtime environment.
 ---
 
 Tutorials are organized into the following general categories:

--- a/docs/tutorials/integrations/authenticators.md
+++ b/docs/tutorials/integrations/authenticators.md
@@ -2,6 +2,7 @@
 title: Tutorial - Custom Authentication
 layout: page
 section: tutorials
+description: Conjur Tutorial - Custom Authentication
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/tutorials/integrations/index.md
+++ b/docs/tutorials/integrations/index.md
@@ -2,6 +2,7 @@
 title: Runtime Solutions
 layout: page
 section: tutorials
+description: Index of Conjur Runtime Solution tutorials
 ---
 
 {% include nav-items.md items=site.data.sidebar.main.tutorials.items.runtime.items %}

--- a/docs/tutorials/integrations/puppet.md
+++ b/docs/tutorials/integrations/puppet.md
@@ -2,6 +2,7 @@
 title: Tutorial - Puppet
 layout: page
 section: tutorials
+description: Conjur Tutorial - Puppet
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/tutorials/integrations/ruby.md
+++ b/docs/tutorials/integrations/ruby.md
@@ -2,6 +2,7 @@
 title: Tutorial - Ruby API
 layout: page
 section: tutorials
+description: Conjur Tutorial - Ruby API
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/tutorials/policy/applications.md
+++ b/docs/tutorials/policy/applications.md
@@ -2,6 +2,7 @@
 title: Tutorial - Enrolling an Application
 layout: page
 section: tutorials
+description: Conjur Tutorial - Enrolling an Application
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/tutorials/policy/delegation.md
+++ b/docs/tutorials/policy/delegation.md
@@ -2,6 +2,7 @@
 title: Tutorial - Delegating Policy Management
 layout: page
 section: tutorials
+description: Conjur Tutorial - Delegating Policy Management
 ---
 
 {% include toc.md key='introduction' %}

--- a/docs/tutorials/policy/index.md
+++ b/docs/tutorials/policy/index.md
@@ -2,6 +2,7 @@
 title: Policy Tutorials
 layout: page
 section: tutorials
+description: Index of Conjur Policy tutorials
 ---
 
 {% include nav-items.md items=site.data.sidebar.main.tutorials.items.policy.items %}

--- a/docs/usage-agreement.md
+++ b/docs/usage-agreement.md
@@ -2,6 +2,7 @@
 title: Usage Agreement
 layout: page
 section: get-started
+description: Conjur Usage Agreement
 ---
 
 

--- a/docs/welcome/how-conjur-works.md
+++ b/docs/welcome/how-conjur-works.md
@@ -2,6 +2,7 @@
 title: How Conjur Works
 layout: page
 section: welcome
+description: Conjur works by leveraging policy files - infrastructure as code (IaC) - to enumerate and categorize your infrastructure.
 ---
 
 To use Conjur, you write policy files to enumerate and categorize the things in your infrastructure: hosts, images, containers, web services, databases, secrets, users, groups, etc. You also use the policy files to define role relationships, such as the members of each group, and permissions rules, such as which groups and machines can fetch each secret. The Conjur server runs on top of the policies and provides HTTP services such as authentication, permission checks, secrets, and public keys. You can also perform dynamic updates, such as change secret values and enroll new hosts.


### PR DESCRIPTION
Updating the docs site structure and files to support custom meta descriptions per page.  Also updated a few important page titles for better SEO.

**NOTE:**  These are just suggestions for titles and descriptions based on moderate research and SEO tool testing.  Input is greatly appreciated!

#### What does this pull request do?

This PR adds in per-page custom meta descriptions and updated/tweaked page titles in some cases for better SEO coverage.

#### What background context can you provide?

Our existing pages do not currently have any meta descriptions and in many cases the page titles were horribly lacking, such as "Conjur - Conjur"

#### Where should the reviewer start?

These are primarily all content updates, but there was a template change to add the meta description tag to the head if it exists.  

#### How should this be manually tested?

Pull down this branch locally and follow the instructions to run the docs site and re-generate the API docs here:  https://github.com/cyberark/conjur/blob/docs-site-meta/docs/README.md

#### Screenshots (if appropriate)
**BEFORE:**

![image](https://user-images.githubusercontent.com/4164335/30289635-ce531ac6-96fa-11e7-9368-71975bdc75a1.png)

**AFTER:**

![image](https://user-images.githubusercontent.com/4164335/30289669-ec41279e-96fa-11e7-8062-73926c069000.png)

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/docs-site-meta/