### PR TITLE
Sitemap & Google Console for .org Site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :website do
   gem 'jekyll-coffeescript'
   gem 'jekyll-paginate'
   gem 'jekyll-redirect-from'
+  gem 'jekyll-sitemap'
   gem 'rack-jekyll'
   gem 'html-proofer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
+    jekyll-sitemap (1.1.1)
+      jekyll (~> 3.3)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     json (2.1.0)
@@ -375,6 +377,7 @@ DEPENDENCIES
   jekyll-coffeescript
   jekyll-paginate
   jekyll-redirect-from
+  jekyll-sitemap
   json_spec
   listen
   parallel

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,5 +6,6 @@ gems:
   - jekyll-coffeescript
   - jekyll-paginate
   - jekyll-redirect-from
+  - jekyll-sitemap
 title: CyberArk Conjur
 plugins_dir: ./_plugins

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -26,6 +26,8 @@
   })(window,document,'script','dataLayer','GTM-PGRNZ3V');</script>
   <!-- End Google Tag Manager -->
 
+  <meta name="google-site-verification" content="tKrGG7RbZKF8fJZ5tz45n2JFwaeYj-QGGhdGXLAbkHQ" />
+
   <!-- favicon -->
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">


### PR DESCRIPTION
Adding a plugin to generate a sitemaps.org compliant sitemap for use in SEO, and adding Google Site Console access.

#### What does this pull request do?

This PR adds a plugin for Jekyll that generates an xml sitemaps.org compliant sitemap file automatically on site generation.  The plugin is at: https://github.com/jekyll/jekyll-sitemap

#### What background context can you provide?

The site does not currently have a sitemaps.org compliant sitemap for search engines to use for spidering and cataloging purposes.

#### Where should the reviewer start?

The reviewer should start by testing the site locally - there should be a file generated at _\conjur\docs\_site\sitemap.xml_.

#### How should this be manually tested?

Pull this branch down locally to your conjur local environment and build it according to the instructions listed here:  https://github.com/cyberark/conjur/blob/webmaster-tools-plus-sitemap/docs/README.md

If you do not see the changes locally, you can forcibly re-generate the site as follows:

Start in the root directory (_/conjur/_):

```
$ bundle
$ cd docs
$ jekyll build 
```

Windows, Vagrant, or VM users should use these commands instead if they wish to regenerate the site on the fly as files change:

```
$ bundle
$ cd docs
$ jekyll build --watch --force_polling
```

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4164335/30331923-07eb9e46-97a7-11e7-8ef5-7f83088a32bf.png)

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/webmaster-tools-plus-sitemap/