### PR TITLE
Added Conjur Enterprise to top nav

### DIFF
--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -80,7 +80,6 @@
 		}
 
 		.nav.navbar-nav > li {
-			//border-bottom: 1px solid rgba(255,255,255,.1);
 			position: relative;
 		}
 

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -103,3 +103,7 @@ main:
   api:
     title: API
     path: /api.html
+
+  enterprise:
+    title: Conjur Enterprise
+    path: https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/

--- a/docs/_sass/_navigation.scss
+++ b/docs/_sass/_navigation.scss
@@ -26,6 +26,10 @@
     float: right;
   }
 
+  // .nav > li > a {
+  //   padding: 0px 10px;
+  // }
+
   #top-search {
     margin: 15px 0;
     padding: 8px 0;
@@ -35,7 +39,6 @@
     &:hover {
       > ul.dropdown-menu {
         display: block;
-        //background-color: $conjur-dark;
         background-color: darken($cybr-dkblue,04);
         color: #ffffff;
 
@@ -49,7 +52,6 @@
             font-weight: 300;
 
             &:hover {
-              //background-color: rgba(0,0,0,0.15);
               background-color: darken($cybr-dkblue,04);
             }
           }
@@ -83,15 +85,13 @@
 
 }
 
-
-
 @media (max-width: 1200px) {
   #top-navigation {
     .navbar-header {
       a.navbar-brand {
         box-sizing: content-box;
-        width: 256px;
-        margin: 13px 0 0 0;
+        width: 150px;
+        margin: 25px 0 0 0;
       }
     }
   }
@@ -102,16 +102,19 @@
     a.navbar-brand {
       color: #ffffff;
       font-size: 2rem;
-      margin: 18px 0 0px 33px;
+      margin: 18px 0 0px 0px;
       display: inline-block;
-      width: 35px;
+      width: 30px;
       background: url("/img/cybr_icon_sq.svg") no-repeat top left;
       padding: 0px;
     }
   }
+
+  .nav > li > a {
+    padding: 10px;
+  }
+
 }
-
-
 
 @media (max-width: 767px) {
   #top-navigation {


### PR DESCRIPTION
fixed RWD styling at tablet breakpoints.

Closes [GI 369](https://github.com/cyberark/conjur/issues/369)

#### What does this pull request do?
Adds "Conjur Enterprise" to top navigation
#### What background context can you provide?
Link in sidebar is useful, but on mobile, you need to scroll to bottom of the page to access. Want to integrate this into main navigation.
#### Where should the reviewer start?
Homepage
#### How should this be manually tested?
Confirm that "Conjur Enterprise" link exists. Resize browser widths to confirm that navigation doesnt break at tablet/mobile sizes.

#### Screenshots (if appropriate)
![conjur_enterprise_navigation](https://user-images.githubusercontent.com/123787/30337967-032d1702-97b8-11e7-9c36-358cfcef7667.png)


#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/enterprise-nav-link/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
