### PR TITLE
Stale clipboard copy text

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -17,7 +17,7 @@ RUN bundle --with website
 
 COPY ./docs /usr/src/docs
 WORKDIR /usr/src/docs
-RUN jekyll build --source /usr/src/docs --destination /usr/src/docs/_site
+RUN jekyll build --source /usr/src/docs --destination /usr/src/docs/_site --plugins /usr/src/docs/_plugins
 
 EXPOSE 4000
 

--- a/docs/javascript/clipboard-buttons.js
+++ b/docs/javascript/clipboard-buttons.js
@@ -82,7 +82,6 @@ function createClipboardButtons() {
 
   for(var i = 0; i < codeBlocks.length; i++) {
     var block = codeBlocks[i];
-    
     createClipboardButton(block, getClipboardText(block));
   }
 }

--- a/docs/javascript/clipboard-buttons.js
+++ b/docs/javascript/clipboard-buttons.js
@@ -1,3 +1,7 @@
+---
+---
+//
+
 function extractShellCommand(shellBlock) {
   var blockLines = shellBlock.innerText.split("\n");
   var command = "";
@@ -16,11 +20,11 @@ function extractShellCommand(shellBlock) {
     if(cmdStart && command != "") {
       command += " && ";
     }
-    
+
     if(cmdStart || includeNextLine) {
       command += line.substring(lineBegin, lineEnd);
     }
-    
+
     includeNextLine = lineBroken;
   }
 
@@ -33,7 +37,7 @@ function extractIrbCommands(irbBlock) {
 
   for(var j = 0; j < blockLines.length; j++) {
     var line = blockLines[j];
-    
+
     if(line.startsWith("irb")) {
       if(command != "") {
         command += "; ";
@@ -55,7 +59,7 @@ function createClipboardButton(block, clipboardText) {
   tooltip.setAttribute("class", "tooltip-text arrow_box");
   tooltip.innerHTML = "Copy to clipboard";
   btn.appendChild(tooltip);
-  
+
   new Clipboard(btn);
 }
 

--- a/docs/javascript/clipboard-buttons.js
+++ b/docs/javascript/clipboard-buttons.js
@@ -47,7 +47,7 @@ function extractIrbCommands(irbBlock) {
 
 function createClipboardButton(block, clipboardText) {
   var btn = document.createElement("button");
-  btn.setAttribute("class", "hover-button");
+  btn.setAttribute("class", "clipboard-button hover-button");
   btn.setAttribute("data-clipboard-text", clipboardText);
   block.parentNode.insertBefore(btn, block);
 
@@ -59,23 +59,41 @@ function createClipboardButton(block, clipboardText) {
   new Clipboard(btn);
 }
 
-var codeBlocks = document.querySelectorAll("pre code");
-
-for(var i = 0; i < codeBlocks.length; i++) {
-  var block = codeBlocks[i];
+function getClipboardText(block) {
   var codeType = block.getAttribute("data-lang");
 
   if(codeType == "shell") {
-    var text = extractShellCommand(block);
+    return extractShellCommand(block);
   } else if(codeType == "ruby") {
     if(block.innerText.startsWith("irb")) {
-      var text = extractIrbCommands(block);
+      return extractIrbCommands(block);
     } else {
-      var text = block.innerText;
+      return block.innerText;
     }
   } else {
-    var text = block.innerText;
+    return block.innerText;
   }
-  
-  createClipboardButton(block, text);
+
+  return null;
 }
+
+function createClipboardButtons() {
+  var codeBlocks = document.querySelectorAll("pre code");
+
+  for(var i = 0; i < codeBlocks.length; i++) {
+    var block = codeBlocks[i];
+    
+    createClipboardButton(block, getClipboardText(block));
+  }
+}
+
+function updateClipboardButtons() {
+  var buttons = document.getElementsByClassName("clipboard-button");
+
+  [].forEach.call(buttons, function(btn) {
+    var clipboardText = getClipboardText(btn.nextSibling);
+    btn.setAttribute("data-clipboard-text", clipboardText);
+  });
+}
+
+createClipboardButtons();

--- a/docs/javascript/conjur-account.js
+++ b/docs/javascript/conjur-account.js
@@ -40,6 +40,8 @@ function displayAccountCredentials(email, account_id, api_key) {
       s.innerText = '"' + account_id + '"';
     }
   });
+
+  updateClipboardButtons();
 }
 
 function displayError(formField, message) {


### PR DESCRIPTION
Closes #368 

Error repro steps
1) Check out `master`
1) Add `displayAccountCredentials("email@email.com", "my-account-id", "my-api-key")` to the bottom of `docs/javascript/conjur-account.js`
1) Click copy-to-clipboard button on a field that shows `my-account-id`
1) Paste the text somewhere and observe that it does not match the code block

Solution test steps
1) Check out `stale-clipboard-copy-text--368` branch
1) Add `displayAccountCredentials("email@email.com", "my-account-id", "my-api-key")` to the bottom of `docs/javascript/conjur-account.js`
1) Click copy-to-clipboard button on a field that shows `my-account-id`
1) Paste the text somewhere and observe that it does match the code block