### PR TITLE
remove CTA from sidebar

### DIFF
--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -28,5 +28,3 @@
   <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> AWS CloudFormation <span>(Coming Soon)</span></a></li>
   <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>
-
-<a href="https://www.cyberark.com/devops-webinar/"><img src="/img/cta/cybr_webinar_cta.svg" alt="Open Source Webinar CTA"></a>


### PR DESCRIPTION
Closes [380](https://github.com/cyberark/conjur/issues/380)

#### What does this pull request do?
Removes webinar CTA from sidebar
#### What background context can you provide?
The webinar happened this morning, so CTA needs to be taken down.
#### Where should the reviewer start?
Homepage.
#### How should this be manually tested?
Confirm that there is no CTA in the left sidebar.
#### Screenshots (if appropriate)
![conjur_org_nocta](https://user-images.githubusercontent.com/123787/30610706-0f3c4078-9d4d-11e7-9b2a-97e5d6634aad.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/remove-sidebar-cta/
#### Questions:
> Does this have automated Cucumber tests?
no
> Can we make a blog post, video, or animated GIF out of this?
no
> Is this explained in documentation?
no
> Does the knowledge base need an update?
no