### PR TITLE
Changes to disclaimer in mobile footer

### DIFF
--- a/docs/_sass/_footer.scss
+++ b/docs/_sass/_footer.scss
@@ -59,6 +59,11 @@
     justify-content: center;
   }
 
+  .disclaimer {
+    padding:20px;
+    padding-right:0px;
+  }
+
   .list-unstyled {
     text-align: center;
   }


### PR DESCRIPTION
Closes #385

#### What does this pull request do?
Fixes footer padding when viewing on mobile devices
#### What background context can you provide?
When on mobile devices, the disclaimer and CyberArk logo were very close to one another.
#### Where should the reviewer start?
The footer of the page
#### How should this be manually tested?
#### Screenshots (if appropriate)
Before:
![mobilebefore](https://user-images.githubusercontent.com/19418506/30932033-50e5a616-a394-11e7-9ba6-07a8dfad941f.png)
After:
![mobile](https://user-images.githubusercontent.com/19418506/30932158-ac8a47ba-a394-11e7-8960-38bfaee5ad07.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/385-mobile-footer/

#### Questions:
> Does this have automated Cucumber tests?
N/A

> Can we make a blog post, video, or animated GIF out of this?
N/A

> Is this explained in documentation?
N/A

> Does the knowledge base need an update?
N/A
