### PR TITLE
Ansible graphic reloaction

### DIFF
--- a/docs/_sass/_global.scss
+++ b/docs/_sass/_global.scss
@@ -48,6 +48,10 @@ img {
 	&.no-margin {
 		margin: 0;
 	}
+	&.integration-diagram {
+		margin-top: 0;
+		margin-bottom: 1em;
+	}
 }
 
 figure {

--- a/docs/integrations/ansible.md
+++ b/docs/integrations/ansible.md
@@ -8,6 +8,11 @@ description: Conjur Integrations - Ansible Role
 ## What is Ansible?
 Ansible is an automation language and automation engine that lets you describe end-to-end IT application environments with a “playbook.” Ansible’s simple, human-readable language allows orchestration of your application lifecycle no matter where it’s deployed.
 
+{% include toc.md key='howitworks' %}
+
+<img class="integration-diagram" src="/img/conjur_ansible_map.svg" alt="Conjur Ansible integration diagram">
+Instead of all secrets moving through the Ansible Controller, each Ansible managed remote node is responsible using its own identity to retrieving its own secrets from the secret store.
+
 {% include toc.md key='integration' %}
 
 The [Conjur Ansible integration](https://github.com/cyberark/ansible-role-conjur) can be used to configure a host with a Conjur machine identity. Through integration with Conjur, the machine can be granted least-privilege
@@ -32,11 +37,6 @@ Moving secret retrieval to the node provides a maximum level of security. This a
 The module receives variables and a command as arguments and, similar to [Conjur's Summon CLI](https://conjur.org/tools/summon.html), provides an interface for fetching secrets from a provider and exporting them to a sub-process environment.
 
 Note that you can provide both Conjur variables and non-Conjur variables, where in Conjur variables a `!var` prefix is required.
-
-{% include toc.md key='howitworks' %}
-
-<img src="/img/conjur_ansible_map.svg" alt="Conjur Ansible integration diagram">
-Instead of all secrets moving through the Ansible Controller, each Ansible managed remote node is responsible using its own identity to retrieving its own secrets from the secret store.
 
 {% include toc.md key='machineidentity' %}
 


### PR DESCRIPTION
#### What does this pull request do?
Simple PR, this moves the Ansible integration graphic further up the page, so users it's more prominent on the page. (I will NOT say "above the fold"!)
#### What background context can you provide?
#### Where should the reviewer start?
/integrations/ansible.html
#### How should this be manually tested?
Check that graphic (in How Ansible works with Conjur section) is the 2nd section on the page, after "What is ansible?"
#### Screenshots (if appropriate)
![screenshot 2017-09-29 15 41 45](https://user-images.githubusercontent.com/123787/31033092-c7834050-a52c-11e7-8a6c-8989028103e3.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/ansible-graphic/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
