### PR TITLE
CTA Webinar Left Sidebar

### DIFF
--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -43,6 +43,6 @@
     <p class= "cta-box-webinar-date">October 17 / 2PM EST</p>
   </div>
   <div class = "cta-webinar-link">
-    <a href= "http://lp.cyberark.com/On-The-Front-Lines.html" class="conjur-webinar-btn">Register</a> 
+    <a href= "https://www.cyberark.com/resource/explore-cyberarks-weekly-technical-webcast-series/" class="conjur-webinar-btn">Register</a>
   </div>
 </div>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -23,7 +23,25 @@
   <li class="item"><a href="/support.html">Support</a></li>
 </ul>
 
-<hr/>
+<div>
+  <div>
+    <p></p>
+    <p></p>
+
+  </div>
+</div>
+<div class="cta-box-webinar">
+  <div class="cta-box-webinar-wrapper">
+    <p class= "cta-box-webinar-header">WEBINAR</p>
+    <p class= "cta-box-webinar-description">CyberArk Conjur - A library of validated integrations with CI/CD tools</p>
+    <p class= "cta-box-webinar-date">October 17 / 2PM EST</p>
+  </div>
+  <div class = "cta-webinar-link">
+    <a href= "http://lp.cyberark.com/On-The-Front-Lines.html" class="conjur-webinar-btn">Register</a> 
+  </div>
+</div>
+
+ 
 
 <ul class="sidebar-nav list-unstyled">
   <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -30,6 +30,12 @@
 
   </div>
 </div>
+<ul class="sidebar-nav list-unstyled">
+  <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
+  <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
+  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> AWS CloudFormation <span>(Coming Soon)</span></a></li>
+  <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
+</ul>
 <div class="cta-box-webinar">
   <div class="cta-box-webinar-wrapper">
     <p class= "cta-box-webinar-header">WEBINAR</p>
@@ -40,12 +46,3 @@
     <a href= "http://lp.cyberark.com/On-The-Front-Lines.html" class="conjur-webinar-btn">Register</a> 
   </div>
 </div>
-
- 
-
-<ul class="sidebar-nav list-unstyled">
-  <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
-  <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
-  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> AWS CloudFormation <span>(Coming Soon)</span></a></li>
-  <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
-</ul>

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -41,6 +41,7 @@
   padding: 16px;
   border: 4px solid $conjur-softgray;
 }
+
 .cta-box-webinar-header{
   margin: 0px;
   font-size: 14px;
@@ -57,19 +58,17 @@
 .cta-box-webinar-wrapper{
   padding-bottom:10px;
 }
-.conjur-webinar-btn a:hover{
-  text-decoration:none;
-}
 .cta-webinar-link a:hover{
   text-decoration:none;
   color:white;
 }
 .conjur-webinar-btn{
     text-decoration: none;
+    display: block;
     transition: all 0.4s;
     color: #fff;
     background: $conjur-teal;
-    padding: 0.5em 4.4em;
+    padding: 0.4em;
     text-transform: uppercase;
     font-weight: bold;
     text-align: center;
@@ -173,6 +172,7 @@
     }
 
   }
+
 
   .cta-box ul.cta-links a.conjur-cta-primary, .cta-box ul.cta-links a.conjur-cta-secondary {
     position: relative;

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -61,6 +61,8 @@
 .cta-webinar-link a:hover{
   text-decoration:none;
   color:white;
+  transition: all 0.4s;
+  background-color: darken($conjur-teal,08);
 }
 .conjur-webinar-btn{
     text-decoration: none;
@@ -70,7 +72,7 @@
     background: $conjur-teal;
     padding: 0.4em;
     text-transform: uppercase;
-    font-weight: bold;
+    font-weight: regular;
     text-align: center;
 }
 .cta-box-webinar-description {

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -29,7 +29,57 @@
 // ***********************
 // CTA Boxes
 // ***********************
-
+.cta-box-webinar{
+  border-radius: 4px;
+  color: $conjur-text;
+  height: 100%;
+  width: 102%;
+  flex: 0 0 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 228px;
+  padding: 16px;
+  border: 4px solid $conjur-softgray;
+}
+.cta-box-webinar-header{
+  margin: 0px;
+  font-size: 14px;
+  font-family:"Open Sans";
+  color: $conjur-dark;
+  font-weight: bold;
+}
+.cta-box-webinar-date{
+  font-size: 14px;
+  color: $conjur-text;
+  margin: 0px;
+  font-weight: regular;
+}
+.cta-box-webinar-wrapper{
+  padding-bottom:10px;
+}
+.conjur-webinar-btn a:hover{
+  text-decoration:none;
+}
+.cta-webinar-link a:hover{
+  text-decoration:none;
+  color:white;
+}
+.conjur-webinar-btn{
+    text-decoration: none;
+    transition: all 0.4s;
+    color: #fff;
+    background: $conjur-teal;
+    padding: 0.5em 4.4em;
+    text-transform: uppercase;
+    font-weight: bold;
+    text-align: center;
+}
+.cta-box-webinar-description {
+  color: $conjur-teal;
+  margin: 0px;
+  font-size: 18px;
+  font-weight: regular;
+}
 .cta-box {
   //background-color: $conjur-softgray;
   border-radius: 4px;
@@ -45,12 +95,12 @@
   .cta-content-wrap {
     flex: 1;
   }
-
   .cta-box-header {
     font-weight: 400;
     padding: 1em 1.5em;
     font-size: 140%;
   }
+
 
   hr {
     border-bottom: 1px solid $conjur-medgray;


### PR DESCRIPTION
Closes [relevant GitHub issues, eg #411]

#### What does this pull request do?
Adds CTA Webinar to Sidebar for the October 17 webinar
#### What background context can you provide?
A webinar will be held on October 17 and this CTA will advertise for this event on the conjur site.
#### Where should the reviewer start?
Left Sidebar
#### How should this be manually tested?
N/A
#### Screenshots (if appropriate)
![ctawebinaroct17](https://user-images.githubusercontent.com/19418506/31196454-cf6139b0-a91b-11e7-92d4-92f6866a1224.png)

#### Link to build in Jenkins (if appropriate)
#### Questions:
> Does this have automated Cucumber tests?
N/A

> Can we make a blog post, video, or animated GIF out of this?
N/A

> Is this explained in documentation?
N/A

> Does the knowledge base need an update?

