### PR TITLE
fixes production conjur server static asset compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'rack-rewrite'
 gem 'simplecov', require: false
 
 gem 'sass-rails'
-#gem 'uglifier'
+gem 'uglifier'
 gem 'therubyracer'
 #gem 'coffee-rails'
 gem 'bootstrap-sass', '~> 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,8 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
+    uglifier (3.2.0)
+      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -408,6 +410,7 @@ DEPENDENCIES
   spring-commands-rspec
   table_print
   therubyracer
+  uglifier
 
 BUNDLED WITH
    1.15.4

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -11,9 +11,9 @@
 
     <strong>More Info:</strong>
     <ul class="note">
-      <li><a href="https://try.conjur.org/reference/" target="_blank">Documentation</a></li>
-      <li><a href="https://try.conjur.org/try-conjur-enterprise.html" target="_blank">Conjur Enterprise</a></li>
-      <li><a href="https://www.conjur.com/" target="_blank">Conjur.com</a></li>
+      <li><a href="https://www.conjur.org/reference/" target="_blank">Documentation</a></li>
+      <li><a href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">Conjur Enterprise</a></li>
+      <li><a href="https://www.conjur.org/" target="_blank">Conjur.org</a></li>
     </ul>
   </div>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,6 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   #Add support for asset compression in production
-  config.assets.css_compressor = :yui
+  config.assets.css_compressor = :sass
   config.assets.js_compressor = :uglifier
 end

--- a/cucumber/api/features/status_page.feature
+++ b/cucumber/api/features/status_page.feature
@@ -2,8 +2,7 @@ Feature: Status page
 
   The root route is a simple "status page" that can be used to verify that the API is reachable
 
-  Scenario: GET / returns 200.
+  Scenario: GET / should be reachable.
 
-    When I GET "/"
-    Then the HTTP response status code is 200
-    And the html result contains "Conjur CE Status"
+    When I GET the root route
+    Then the status page should be reachable

--- a/cucumber/api/features/status_page.feature
+++ b/cucumber/api/features/status_page.feature
@@ -1,0 +1,9 @@
+Feature: Status page
+
+  The root route is a simple "status page" that can be used to verify that the API is reachable
+
+  Scenario: GET / returns 200.
+
+    When I GET "/"
+    Then the HTTP response status code is 200
+    And the html result contains "Conjur CE Status"

--- a/cucumber/api/features/status_page.feature
+++ b/cucumber/api/features/status_page.feature
@@ -1,8 +1,8 @@
 Feature: Status page
 
-  The root route is a simple "status page" that can be used to verify that the API is reachable
+  The root route is a simple "status page" that verifies that the API is reachable
 
-  Scenario: GET / should be reachable.
+  Scenario: GET / is reachable.
 
     When I GET the root route
-    Then the status page should be reachable
+    Then the status page is reachable

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -44,12 +44,6 @@ Then(/^the text result is:$/) do |value|
   expect(@result).to eq(value)
 end
 
-Then(/^the html result contains "([^"]*)"$/) do |value|
-  expect(@result).to be
-  expect(@result.headers[:content_type]).to include("text/html")
-  expect(@result).to include(value)
-end
-
 Then(/^the binary result is "([^"]*)"$/) do |value|
   expect(@result).to be
   expect(@result.headers[:content_type]).to eq("application/octet-stream")

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -44,6 +44,12 @@ Then(/^the text result is:$/) do |value|
   expect(@result).to eq(value)
 end
 
+Then(/^the html result contains "([^"]*)"$/) do |value|
+  expect(@result).to be
+  expect(@result.headers[:content_type]).to include("text/html")
+  expect(@result).to include(value)
+end
+
 Then(/^the binary result is "([^"]*)"$/) do |value|
   expect(@result).to be
   expect(@result.headers[:content_type]).to eq("application/octet-stream")

--- a/cucumber/api/features/step_definitions/status_page_steps.rb
+++ b/cucumber/api/features/step_definitions/status_page_steps.rb
@@ -2,7 +2,7 @@ When(/^I GET the root route$/) do
   @response = RestClient.get(Conjur.configuration.appliance_url)
 end
 
-Then(/^the status page should be reachable$/) do
+Then(/^the status page is reachable$/) do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to include("text/html")
   expect(@response.body).to include("Your Conjur CE server is running!")

--- a/cucumber/api/features/step_definitions/status_page_steps.rb
+++ b/cucumber/api/features/step_definitions/status_page_steps.rb
@@ -1,0 +1,9 @@
+When(/^I GET the root route$/) do
+  @response = RestClient.get(Conjur.configuration.appliance_url)
+end
+
+Then(/^the status page should be reachable$/) do
+  expect(@response.code).to eq(200)
+  expect(@response.headers[:content_type]).to include("text/html")
+  expect(@response.body).to include("Your Conjur CE server is running!")
+end


### PR DESCRIPTION
Closes #292

#### What does this pull request do?
Fixes missing (commented out) dependencies for `js_compressor` and misconfigured `css_compressor` for production Conjur server.
Incidentally, this also fixes the status page which has no been loading and returning HTTP Status 500 in production. 
#### Where should the reviewer start?
The diff is pretty small so that's a good place to start, followed by confirming the new cucumber tests are passing.
#### How should this be manually tested?
Run the Conjur server in production mode and verify that the status page is reachable.
