### PR TITLE
Added click-tracking to nav items

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -113,7 +113,3 @@ main:
       cryptography:
         title: Cryptography
         path: /reference/cryptography.html
-
-  enterprise:
-    title: Conjur Enterprise
-    path: https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -24,6 +24,7 @@
           <ul class="footer-links list-unstyled">
             <li><a href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
             <li><a href="https://github.com/cyberark/conjur/blob/master/CONTRIBUTING.md">Contributing</a></li>
+            <li><a href="https://www.conjur.com/careers/engineering/puzzle">Careers</a></li>
             <li><a href="/support.html">Support</a></li>
           </ul>
         </div>

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -20,7 +20,7 @@
           <a class="pull-left" href="https://www.cyberark.com/"><img class="cyberark-sidebar-logo" src="{{ site.baseurl }}/img/cybr_logo_white_horiz.svg" alt="CyberArk Logo"></a>
           <p class="disclaimer">&copy; {{ site.time | date: '%Y' }} CyberArk. All rights reserved.</p>
         </div>
-        <div class="col-md-6 ">
+        <div class="col-md-6">
           <ul class="footer-links list-unstyled">
             <li><a href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
             <li><a href="https://github.com/cyberark/conjur/blob/master/CONTRIBUTING.md">Contributing</a></li>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -18,8 +18,8 @@
 {% endif %}
 
 <ul class="sidebar-nav list-unstyled">
-  <li class="item"><a class=“event-click”
-  id=”side-nav-button-enterprise” href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
+  <li class="item"><a class="event-click"
+  id="side-nav-button-enterprise" href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
   <li class="item"><a href="https://github.com/cyberark/conjur/blob/master/CONTRIBUTING.md">Contributing</a></li>
   <li class="item"><a href="/support.html">Support</a></li>
 </ul>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -18,7 +18,8 @@
 {% endif %}
 
 <ul class="sidebar-nav list-unstyled">
-  <li class="item"><a href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
+  <li class="item"><a class=“event-click”
+  id=”side-nav-button-enterprise” href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">CyberArk Conjur Enterprise</a></li>
   <li class="item"><a href="https://github.com/cyberark/conjur/blob/master/CONTRIBUTING.md">Contributing</a></li>
   <li class="item"><a href="/support.html">Support</a></li>
 </ul>

--- a/docs/_includes/top_nav.html
+++ b/docs/_includes/top_nav.html
@@ -10,11 +10,17 @@
     </div>
     <div class="collapse navbar-collapse" id="mobileNav">
       <ul class="nav navbar-nav">
+
         {% for item_hash in site.data.navigation.main %}
           {% assign key = item_hash[0] %}
     			{% assign value = item_hash[1] %}
     			{% include top_nav_menu.html item=value section=key %}
     		{% endfor %}
+
+        <li class="nav-item">
+          <a id="top-nav-button-enterprise" class="event-click" href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">Conjur Enterprise</a>
+        </li>
+
         <li class="nav-item">
           <a id="top-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i></a>
         </li>


### PR DESCRIPTION
Closes: 
- [CON-4323](https://conjurinc.atlassian.net/browse/CON-4323)
- [GitHub issue 421](https://github.com/cyberark/conjur/issues/421)

#### What does this pull request do?

- Adds analytics tracking info to nav items for Enterprise Edition
- Adds link to engineering hiring puzzle in footer

#### What background context can you provide?
Updating analytics information
#### Where should the reviewer start?
homepage
#### How should this be manually tested?
Using web inspector check that:
- Top-nav link for Conjur Enterprise has a class of "event-click", and an ID of "top-nav-button-enterprise"
- Sidebar nav item for CyberArk Conjur Enterprise has a class of "event-click", and an ID of "side-nav-button-enterprise"
- Link to engineering hiring puzzle exists (and works) in footer.
#### Screenshots (if appropriate)
Top-nav:
![screenshot 2017-10-10 16 59 31](https://user-images.githubusercontent.com/123787/31410379-6d4b2c3e-addc-11e7-8736-1f6d30718244.png)

Sidebar:
![screenshot 2017-10-10 16 58 43](https://user-images.githubusercontent.com/123787/31410394-75d88158-addc-11e7-82cd-46dc0178043a.png)

Careers link:
![screenshot 2017-10-10 17 00 17](https://user-images.githubusercontent.com/123787/31410434-95bd3cde-addc-11e7-9e43-dc030d0bd760.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/click-tracking/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
