### PR TITLE
introduces line wrapping for highlighted code blocks in docs

### DIFF
--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -258,6 +258,10 @@
 // Copy to Clipboard Code Boxes
 // ***********************
 
+.highlight pre {
+  white-space: pre-wrap;
+}
+
 pre > code {
   width: 90%;
   overflow: auto;

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -260,6 +260,7 @@
 
 .highlight pre {
   white-space: pre-wrap;
+  word-break: break-all;
 }
 
 pre > code {

--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -72,7 +72,7 @@ $ docker-compose exec conjur conjurctl account create quick-start
 {% highlight shell %}
 $ conjur init -u conjur -a quick-start # or whatever account you created
 $ conjur authn login -u admin
-Please enter admin's password (it will not be echoed):
+Please enter admin\'s password (it will not be echoed):
 {% endhighlight %}
 
 {% include toc.md key='explore' %}


### PR DESCRIPTION

#### What does this pull request do?

Introduces line wrapping for highlighted code blocks throughout the site.
#### Where should the reviewer start?

The diff is exceedingly small, a single `.scss` file change.
#### How should this be manually tested?

+ Build and serve the `conjur.org` site on your computer` as per https://github.com/cyberark/conjur/blob/master/docs/README.md
+ Visit the running application and confirm that wrapping is consistent within the highlighted code blocks. Below are some suggestions (assuming the site is running on `localhost:4000`). It's worth comparing `localhost:4000` against `conjur.org` to see the value in this change.
  - http://localhost:4000/tutorials/policy/applications.html
  - http://localhost:4000/get-started/install-conjur.html

#### Screenshots (if appropriate)

Below are some comparisons of the changes introduced by this PR **vs** the master branch

![image](https://user-images.githubusercontent.com/8653164/31431396-79d216c2-ae6b-11e7-8bba-b25a9b8f4633.png)

![image](https://user-images.githubusercontent.com/8653164/31431301-2f272d4c-ae6b-11e7-8ed5-875231de2e27.png)

