### PR TITLE
centers each code-block clipboard's tooltip to the clipboard icon

### DIFF
--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -226,7 +226,7 @@
   padding: 5px 0;
   border-radius: 6px;
   position: absolute;
-  right: -35px;
+  right: -45px;
   z-index: 1;
   margin-top: 30px;
 }


### PR DESCRIPTION
#### What does this pull request do?

Centres each code-block clipboard's tooltip to the clipboard icon

#### Where should the reviewer start?

The diff is exceedingly small! Value change.

#### How should this be manually tested?

+ Build and serve the `conjur.org` site on your machine as per https://github.com/cyberark/conjur/blob/master/docs/README.md
+ Visit the running application and confirm that code-block clipboard tooltips are centered to the clipboard icon. Below are some suggestions (assuming the site is running on `localhost:4000`). It's worth comparing `localhost:4000` against `conjur.org` to see the value in this change.
  - http://localhost:4000/tutorials/policy/applications.html
  - http://localhost:4000/get-started/install-conjur.html

#### Screenshots

 - PR vs master branch
![image](https://user-images.githubusercontent.com/8653164/31507129-86c6918a-af71-11e7-95a7-296e2c795f6f.png)
