### PR TITLE
AWS CloudFormation link

### DIFF
--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -34,7 +34,7 @@
 <ul class="sidebar-nav list-unstyled">
   <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
   <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
-  <li class="item"><a id="side-nav-button-cloud-formation" class="event-click" href="https://s3.amazonaws.com/conjur-ci-public/cloudformation/conjur-latest.yml"><i class="fa fa-amazon"></i> AWS CloudFormation</a></li>
+  <li class="item"><a id="side-nav-button-cloud-formation" class="event-click" href="https://s3.amazonaws.com/conjur-ci-public/cloudformation/conjur-latest.yml"><i class="fa fa-cloud"></i> AWS CloudFormation</a></li>
   <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>
 <div class="cta-box-webinar">

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -34,7 +34,7 @@
 <ul class="sidebar-nav list-unstyled">
   <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
   <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
-  <li class="item coming-soon"><a id="side-nav-button-cloud-formation" class="event-click" href="#"><i class="fa fa-cloud"></i> AWS CloudFormation <span>(Coming Soon)</span></a></li>
+  <li class="item"><a id="side-nav-button-cloud-formation" class="event-click" href="https://s3.amazonaws.com/conjur-ci-public/cloudformation/conjur-latest.yml"><i class="fa fa-amazon"></i> AWS CloudFormation</a></li>
   <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>
 <div class="cta-box-webinar">


### PR DESCRIPTION
Closes:

-  [GH Issue 434](https://github.com/cyberark/conjur/issues/434)
- [Jira - CON-4331](https://conjurinc.atlassian.net/browse/CON-4331)

#### What does this pull request do?
Adds CloudFormation download to sidebar link. 
URL: https://s3.amazonaws.com/conjur-ci-public/cloudformation/conjur-latest.yml
#### What background context can you provide?
Initial step before creating a CloudFormation download page.
#### Where should the reviewer start?
homepage
#### How should this be manually tested?
Click AWS CloudFormation link in sidebar, and confirm that "Coming Soon" text is removed, and that "conjur-latest.yml" downloads.
#### Screenshots (if appropriate)
![aws_cloudformation](https://user-images.githubusercontent.com/123787/31513762-4cc8d40c-af5d-11e7-9657-b2e5fb3ca229.png)

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/AWS-CLoudFormation-ink/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
