### PR TITLE
Missing hubspot token is submitted as empty string

### DIFF
--- a/docs/javascript/conjur-account.js
+++ b/docs/javascript/conjur-account.js
@@ -78,13 +78,13 @@ function submitAccountSignup() {
   }
 
   var hutk = getCookieValue("hubspotutk");
-  
+
   var payload =
       "email=" + $("#email-address").val() +
       "&organization=" + $("#organization").val() +
       "&recaptcha_token=" + recaptchaToken +
-      "&hutk=" + hutk;
-  
+      "&hutk=" + (hutk === null ? '' : hutk);
+
   $.ajax({
     context: this,
     type: "POST",


### PR DESCRIPTION
Closes #438.

#### What does this pull request do?

Prevents hosted Conjur signup from submitting the string "null" for the hutk param.

#### How should this be manually tested?

I would just throw a console.log in conjur-account.js and confirm that the URL params are getting created with a blank string for hutk instead of "null".