### PR TITLE
Conjur uses rubygems CLI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'cucumber'
   gem 'aruba'
   gem 'rake_shared_context'
-  gem 'conjur-cli', '= 6.0.0.rc1'
+  gem 'conjur-cli', '~> 6.0'
   gem 'rails_layout'
   gem 'rspec-core', '~> 3.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'cucumber'
   gem 'aruba'
   gem 'rake_shared_context'
-  gem 'conjur-cli', github: 'conjurinc/cli-ruby', branch: 'possum'
+  gem 'conjur-cli', '= 6.0.0.rc1'
   gem 'rails_layout'
   gem 'rspec-core', '~> 3.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'cucumber'
   gem 'aruba'
   gem 'rake_shared_context'
-  gem 'conjur-cli', '~> 6.0'
+  gem 'conjur-cli', '~> 6'
   gem 'rails_layout'
   gem 'rspec-core', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   ci_reporter_rspec
   conjur-api!
-  conjur-cli (~> 6.0)
+  conjur-cli (~> 6)
   conjur-debify
   conjur-policy-parser!
   conjur-rack!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,4 @@
 GIT
-  remote: https://github.com/conjurinc/cli-ruby.git
-  revision: a30d685c1ec255beffd3f42a48e66c1c31cd2b53
-  branch: possum
-  specs:
-    conjur-cli (6.0.0beta.1)
-      activesupport
-      conjur-api (~> 5.0.0.beta)
-      deep_merge (~> 1.0)
-      gli (>= 2.8.0)
-      highline (~> 1.7)
-      netrc (~> 0.10)
-      table_print (~> 1.5)
-      xdg (~> 2.2)
-
-GIT
   remote: https://github.com/conjurinc/conjur-policy-parser.git
   revision: b92854c1a0db5afb6a2294b77d96fcd9831cc59e
   branch: possum
@@ -109,6 +94,15 @@ GEM
     colorator (1.1.0)
     colored (1.2)
     concurrent-ruby (1.0.5)
+    conjur-cli (6.0.0.rc1)
+      activesupport
+      conjur-api (~> 5.0.0.beta)
+      deep_merge (~> 1.0)
+      gli (>= 2.8.0)
+      highline (~> 1.7)
+      netrc (~> 0.10)
+      table_print (~> 1.5)
+      xdg (~> 2.2)
     conjur-debify (1.5.3)
       conjur-cli
       docker-api (~> 1.33)
@@ -365,7 +359,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   ci_reporter_rspec
   conjur-api!
-  conjur-cli!
+  conjur-cli (= 6.0.0.rc1)
   conjur-debify
   conjur-policy-parser!
   conjur-rack!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/api-ruby.git
-  revision: 6606bbdb845024918ff8560b5aad3fd978c347b5
+  revision: 957b2063c37c6c94b789dca1004d57ce25f6becf
   specs:
-    conjur-api (5.0.0.pre)
+    conjur-api (5.0.0)
       activesupport
       rest-client
 
@@ -94,7 +94,7 @@ GEM
     colorator (1.1.0)
     colored (1.2)
     concurrent-ruby (1.0.5)
-    conjur-cli (6.0.0.rc1)
+    conjur-cli (6.0.0)
       activesupport
       conjur-api (~> 5.0.0.beta)
       deep_merge (~> 1.0)
@@ -140,7 +140,7 @@ GEM
       sass (>= 3.2)
     forwardable-extended (2.6.0)
     gherkin (4.1.1)
-    gli (2.16.0)
+    gli (2.16.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     highline (1.7.8)
@@ -359,7 +359,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   ci_reporter_rspec
   conjur-api!
-  conjur-cli (= 6.0.0.rc1)
+  conjur-cli (~> 6.0)
   conjur-debify
   conjur-policy-parser!
   conjur-rack!


### PR DESCRIPTION
Closes #431 

#### What does this pull request do?

Update Conjur to use the CLI gem from RubyGems instead of the possum git branch.

#### How should this be manually tested?

I tested by running `dev/start.sh` then manually installing the 6.0.0 CLI gem on the client container and executing CLI commands from there.