### PR TITLE
Update CTAs for new webinars

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -90,6 +90,7 @@
   howitworks: How Ansible works with Conjur
   machineidentity: Machine Identity
   workflow: Integration Workflow
+  learnmore: Learn More
 
 "/integrations/puppet.html":
   overview: Overview

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -23,24 +23,28 @@
   <li class="item"><a href="/support.html">Support</a></li>
 </ul>
 
-<div>
-  <div>
-    <p></p>
-    <p></p>
-
-  </div>
-</div>
 <ul class="sidebar-nav list-unstyled">
   <li class="item"><a id="side-nav-button-github" class="event-click" href="https://github.com/cyberark/conjur" target="_blank"><i class="fa fa-github-alt"></i> GitHub</a></li>
   <li class="item"><a id="side-nav-button-dockerhub" class="event-click" href="https://hub.docker.com/r/cyberark/conjur/" target="_blank"><div class="icon-docker-hub"></div> DockerHub</a></li>
   <li class="item"><a id="side-nav-button-cloud-formation" class="event-click" href="https://s3.amazonaws.com/conjur-ci-public/cloudformation/conjur-latest.yml"><i class="fa fa-cloud"></i> AWS CloudFormation</a></li>
   <li class="item"><a id="side-nav-button-slack" class="event-click" href="https://slackin-conjur.herokuapp.com/" target="_blank"><i class="fa fa-slack"></i> Slack</a></li>
 </ul>
+
+<!-- Webinar CTAs -->
 <div class="cta-box-webinar">
   <p class="header">WEBINAR</p>
-  <p class="description">CyberArk Conjur - A library of validated integrations with CI/CD tools</p>
-  <p class="date">October 17 / 2PM EST</p>
+  <p class="description">Orchestrating Trust in Your DevOps Pipeline</p>
+  <p class="date">October 26 / 11AM EST</p>
   <div class="link">
-    <a href="https://www.cyberark.com/resource/explore-cyberarks-weekly-technical-webcast-series/" class="conjur-webinar-btn">Register</a>
+    <a href="https://pages.cloudbees.com/orchestratingtrust-devops-pipeline-webinar-registration" class="conjur-webinar-btn" target="_blank">Register</a>
+  </div>
+</div>
+
+<div class="cta-box-webinar">
+  <p class="header">WEBINAR</p>
+  <p class="description">Delivering Infrastructure and Security Policy as Code with Puppet and CyberArk Conjur</p>
+  <p class="date">November 8 / 11AM EST</p>
+  <div class="link">
+    <a href="http://info.puppet.com/Technical-Partner-Series-CyberArk_Register.html?ls=Outbound&lsd=Email&cid=7010f0000017M8Q&utm_medium=email&utm_campaign=Q3FY18_WW_All_CHANNEL_EM_BLST_CyberArk-Partner-Webinar-Series-Registrations-2017&utm_source=email-2017-11&utm_content=cyberark-partner-webinar-series-registrations" class="conjur-webinar-btn" target="_blank">Register</a>
   </div>
 </div>

--- a/docs/_includes/sidebar.md
+++ b/docs/_includes/sidebar.md
@@ -45,6 +45,6 @@
   <p class="description">Delivering Infrastructure and Security Policy as Code with Puppet and CyberArk Conjur</p>
   <p class="date">November 8 / 11AM EST</p>
   <div class="link">
-    <a href="http://info.puppet.com/Technical-Partner-Series-CyberArk_Register.html?ls=Outbound&lsd=Email&cid=7010f0000017M8Q&utm_medium=email&utm_campaign=Q3FY18_WW_All_CHANNEL_EM_BLST_CyberArk-Partner-Webinar-Series-Registrations-2017&utm_source=email-2017-11&utm_content=cyberark-partner-webinar-series-registrations" class="conjur-webinar-btn" target="_blank">Register</a>
+    <a href="https://www.cyberark.com/puppet-technical-partner-series/" class="conjur-webinar-btn" target="_blank">Register</a>
   </div>
 </div>

--- a/docs/_includes/whatsnew.html
+++ b/docs/_includes/whatsnew.html
@@ -1,17 +1,7 @@
-<h2 class="section-title">Whats New?</h2>
+<h2 class="section-title">Whats Happening</h2>
 
-<div class="row">
-  <div class="col-md-6">
-    <div class="cta-box-webinar">
-      <p class="header">WEBINAR</p>
-      <p class="description">CyberArk Conjur - A library of validated integrations with CI/CD tools</p>
-      <p class="date">October 17 / 2PM EST</p>
-      <div class="link">
-        <a href="https://www.cyberark.com/resource/explore-cyberarks-weekly-technical-webcast-series/" class="conjur-webinar-btn" target="_blank">Register</a>
-      </div>
-    </div>
-  </div>
-  <div class="col-md-6">
+<div class="row full-width-cta">
+
     <div class="cta-box-webinar">
       <p class="header">WEBINAR</p>
       <p class="description">Orchestrating Trust in Your DevOps Pipeline</p>
@@ -20,6 +10,14 @@
         <a href="https://pages.cloudbees.com/orchestratingtrust-devops-pipeline-webinar-registration" class="conjur-webinar-btn" target="_blank">Register</a>
       </div>
     </div>
-  </div>
+
+    <div class="cta-box-webinar">
+      <p class="header">WEBINAR</p>
+      <p class="description">Delivering Infrastructure and Security Policy as Code with Puppet and CyberArk Conjur</p>
+      <p class="date">November 8 / 11AM EST</p>
+      <div class="link">
+        <a href="https://www.cyberark.com/puppet-technical-partner-series/" class="conjur-webinar-btn" target="_blank">Register</a>
+      </div>
+    </div>
 
 </div>

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -84,6 +84,7 @@
   border-radius: 4px;
   padding: 16px;
   border: 4px solid $conjur-softgray;
+  margin-bottom: 1em;
 
   .header {
     margin: 0px;
@@ -208,6 +209,10 @@
       margin-right: 5px;
     }
   }
+}
+
+.cta-video {
+  margin: .5em 0;
 }
 
 @media (max-width: 992px) {

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -80,6 +80,17 @@
 // ***********************
 // CTA Boxes
 // ***********************
+.full-width-cta {
+  display: flex;
+  justify-content: space-between;
+
+  .cta-box-webinar {
+    width: 48%;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 .cta-box-webinar {
   border-radius: 4px;
   padding: 16px;
@@ -99,6 +110,7 @@
     color: $conjur-text;
     margin: 0px;
     padding-bottom: 10px;
+    flex-grow: 1;
   }
 
   .description {
@@ -213,6 +225,18 @@
 
 .cta-video {
   margin: .5em 0;
+}
+
+@media (max-width: 770px) {
+  .full-width-cta {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+
+    .cta-box-webinar {
+      width: 100%;
+    }
+  }
 }
 
 @media (max-width: 992px) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,9 +26,6 @@ description: Conjur is a scalable, flexible, open source security service that s
   <h2 class="section-title">How Conjur Works</h2>
   <p>To use Conjur, you write policy files to enumerate and categorize the things in your infrastructure: hosts, images, containers, web services, databases, secrets, users, groups, etc. You also use the policy files to define role relationships, such as the members of each group, and permissions rules, such as which groups and machines can fetch each secret. The Conjur server runs on top of the policies and provides HTTP services such as authentication, permission checks, secrets, and public keys. You can also perform dynamic updates, such as change secret values and enroll new hosts.</p>
 
-
   {% include whatsnew.html %}
-
-
 
 </div>

--- a/docs/integrations/ansible.md
+++ b/docs/integrations/ansible.md
@@ -61,4 +61,4 @@ in the potential integration approaches.
 {% include toc.md key='learnmore' %}
 <a href="https://www.ansible.com/videos-ansiblefest-sanfran-2017?wvideo=w6f4imkxfn"><strong>AnsibleFest 2017: </strong>Why DevOps Requires Privilege and How to Secure it with Shared Secrets and Ansible</a>
 
-<a href="https://www.ansible.com/videos-ansiblefest-sanfran-2017?wvideo=w6f4imkxfn"><img class="cta-video" src="https://embedwistia-a.akamaihd.net/deliveries/0282894dd8964f197fc8c75ff290f9fce1c23c24.jpg?image_play_button_size=2x&amp;image_crop_resized=960x539&amp;image_play_button=1&amp;image_play_button_color=54bbffe0" width="600" style="width: 600px;"></a>
+<a href="https://www.ansible.com/videos-ansiblefest-sanfran-2017?wvideo=w6f4imkxfn"><img class="cta-video" src="https://embedwistia-a.akamaihd.net/deliveries/0282894dd8964f197fc8c75ff290f9fce1c23c24.jpg?image_play_button_size=2x&amp;image_crop_resized=960x539&amp;image_play_button=1&amp;image_play_button_color=54bbffe0" width="600" style="width: 600px;" alt="AnsibleFest 2017"></a>

--- a/docs/integrations/ansible.md
+++ b/docs/integrations/ansible.md
@@ -58,6 +58,7 @@ See the [Conjur Ansible Role GitHub repo](https://github.com/cyberark/ansible-ro
 for integration instructions and a discussion of the security tradeoffs involved
 in the potential integration approaches.
 
+{% include toc.md key='learnmore' %}
+<a href="https://www.ansible.com/videos-ansiblefest-sanfran-2017?wvideo=w6f4imkxfn"><strong>AnsibleFest 2017: </strong>Why DevOps Requires Privilege and How to Secure it with Shared Secrets and Ansible</a>
 
-
-[ansible integration]: /img/conjur_ansible_map.svg  "Ansible Conjur Integration diagram"
+<a href="https://www.ansible.com/videos-ansiblefest-sanfran-2017?wvideo=w6f4imkxfn"><img class="cta-video" src="https://embedwistia-a.akamaihd.net/deliveries/0282894dd8964f197fc8c75ff290f9fce1c23c24.jpg?image_play_button_size=2x&amp;image_crop_resized=960x539&amp;image_play_button=1&amp;image_play_button_color=54bbffe0" width="600" style="width: 600px;"></a>


### PR DESCRIPTION
Closes [Issue 447](https://github.com/cyberark/conjur/issues/447)

#### What does this pull request do?
Updates webinars with most recent dates.
- October 26: Orchestrating Trust in Your DevOps Pipeline
- November 8: Delivering Infrastructure and Security Policy as Code with Puppet and CyberArk Conjur

#### What background context can you provide?
Content updates. 
Note: These are currently hardcoded, and need to be updated to use data file so we aren't touching markup when updating. Separate Issues coming for that effort.
#### Where should the reviewer start?
Homepage, then inside page afterwards.
#### How should this be manually tested?
**Homepage**
Check that the CTAs are updated with the new content, and are the same height at different screen widths.

**Inside pages**
Check that content is updated with new dates.
#### Screenshots (if appropriate)
*Homepage*
![screenshot 2017-10-19 16 44 58](https://user-images.githubusercontent.com/123787/31793569-9d9b5b76-b4ed-11e7-8608-7cdda2696c36.png)

*Inside*
![screenshot 2017-10-19 16 45 25](https://user-images.githubusercontent.com/123787/31793587-a7ead58e-b4ed-11e7-84da-3fd25f3966b3.png)


#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/cta-updates/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
