### PR TITLE
Enhances conjurctl behavior

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -44,7 +44,7 @@ class Role < Sequel::Model
     end
     
     def username_from_roleid roleid
-      account, kind, id = roleid.split(":", 3)
+      _, kind, id = roleid.split(":", 3)
       if kind == 'user'
         id
       else
@@ -61,7 +61,7 @@ class Role < Sequel::Model
   
   def api_key
     unless self.credentials
-      account, kind, id = self.id.split(":", 3)
+      _, kind, id = self.id.split(":", 3)
       if %w(user host deputy).member?(kind)
         self.credentials = Credentials.create(role: self)
       else

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -34,21 +34,21 @@ end
 desc 'Run the application server'
 command :server do |c|
   c.desc 'Account to initialize'
-  c.arg :account
+  c.arg_name :name
   c.flag [ :a, :account ]
 
   c.desc 'Policy file to load into the server'
-  c.arg :file_name
+  c.arg_name :path
   c.flag [ :f, :file ]
 
   c.desc 'Server listen port'
-  c.arg :port
+  c.arg_name :port
   c.default_value ENV['PORT'] || '80'
   c.flag [ :p, :port ]
 
   c.desc 'Server bind address'
   c.default_value ENV['BIND_ADDRESS'] || '0.0.0.0'
-  c.arg :address
+  c.arg_name :ip
   c.flag [ :b, :'bind-address' ]
 
   c.action do |global_options,options,args|
@@ -75,16 +75,15 @@ desc "Manage the policy"
 command :policy do |cgrp|
   cgrp.desc "Load MAML policy from file(s)"
   cgrp.arg :account
-  cgrp.arg_name "filename"
-  cgrp.arg :file_name, :multiple
+  cgrp.arg :filename, :multiple
   cgrp.command :load do |c|
     c.action do |global_options,options,args|
       account, *file_names = args
       connect
 
-      file_names.each do |file_name|
-        exec "rake policy:load[#{account},#{file_name}]"
-      end
+      file_names.map { |file_name|
+        system "rake policy:load[#{account},#{file_name}]"
+      }.all?
     end
   end
 
@@ -103,8 +102,7 @@ $ conjurctl watch /run/conjur/policy/load)"
   DESC
 
   cgrp.arg :account
-  cgrp.arg_name "filename"
-  cgrp.arg :file_name
+  cgrp.arg :filename
   cgrp.command :watch do |c|
     c.action do |global_options,options,args|
       account, file_name = args
@@ -195,9 +193,9 @@ command :role do |cgrp|
 
       connect
 
-      args.each do |id|
+      args.map { |id|
         print `rake role:retrieve-key[#{id}]`
-      end
+      }.all?
     end
   end
 end

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -81,7 +81,7 @@ command :policy do |cgrp|
       account, *file_names = args
       connect
 
-      fail unless file_names.map { |file_name|
+      fail 'policy load failed' unless file_names.map { |file_name|
         system "rake policy:load[#{account},#{file_name}]"
       }.all?
     end
@@ -163,7 +163,7 @@ $ conjurctl account create myorg
   cgrp.arg :account
   cgrp.command :delete do |c|
     c.action do |global_options,options,args|
-      account=args.first
+      account = args.first
       connect
 
       exec "rake account:delete[#{account}]"
@@ -193,7 +193,7 @@ command :role do |cgrp|
 
       connect
 
-      fail unless args.map { |id|
+      fail 'key retrieval failed' unless args.map { |id|
         system "rake role:retrieve-key[#{id}]"
       }.all?
     end

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -81,7 +81,7 @@ command :policy do |cgrp|
       account, *file_names = args
       connect
 
-      file_names.map { |file_name|
+      fail unless file_names.map { |file_name|
         system "rake policy:load[#{account},#{file_name}]"
       }.all?
     end
@@ -193,8 +193,8 @@ command :role do |cgrp|
 
       connect
 
-      args.map { |id|
-        print `rake role:retrieve-key[#{id}]`
+      fail unless args.map { |id|
+        system "rake role:retrieve-key[#{id}]"
       }.all?
     end
   end

--- a/lib/tasks/role.rake
+++ b/lib/tasks/role.rake
@@ -6,9 +6,11 @@ namespace :role do
       puts role.api_key
     rescue Sequel::NoMatchingRow
       # If no such role exists, print an error to stderr and a blank line to
-      # stdout so that you always get one line of output per role.
+      # stdout so that a script using conjurctl always gets one line of output
+      # per role. If stdout is a TTY, skip printing the blank line so it's not
+      # confusing for humans.
       $stderr.puts "error: role does not exist: #{args[:role_id]}"
-      puts
+      puts unless $stdout.isatty
       exit 1
     end
   end

--- a/lib/tasks/role.rake
+++ b/lib/tasks/role.rake
@@ -1,11 +1,12 @@
-namespace :"role" do
+namespace :role do
   desc "Retrieve the API key for the given role"
   task :"retrieve-key", [:role_id] => [:environment] do |t, args|
     begin
       creds = Credentials.first!(role_id: args[:role_id])
-      $stderr.puts creds.api_key
+      puts creds.api_key
     rescue Sequel::NoMatchingRow
-      $stderr.puts "Role '#{args[:role_id]}' not found"
+      $stderr.puts "error: #{args[:role_id]} is not a role"
+      puts
       exit 1
     end
   end

--- a/lib/tasks/role.rake
+++ b/lib/tasks/role.rake
@@ -2,10 +2,12 @@ namespace :role do
   desc "Retrieve the API key for the given role"
   task :"retrieve-key", [:role_id] => [:environment] do |t, args|
     begin
-      creds = Credentials.first!(role_id: args[:role_id])
-      puts creds.api_key
+      role = Role.first!(role_id: args[:role_id])
+      puts role.api_key
     rescue Sequel::NoMatchingRow
-      $stderr.puts "error: #{args[:role_id]} is not a role"
+      # If no such role exists, print an error to stderr and a blank line to
+      # stdout so that you always get one line of output per role.
+      $stderr.puts "error: role does not exist: #{args[:role_id]}"
       puts
       exit 1
     end


### PR DESCRIPTION
#### What does this pull request do?
* `role retrieve-key` can handle one or more arguments, errors if any retrievals fail
* `policy load` can handle one or more arguments, errors if any loads fail
* retrieve-key prints keys to stdout instead of stderr
* incorrect arguments to a command shows help (use strict GLI arguments)

#### What background context can you provide?
In reviewing the recent addition of "retrieve-key" to conjurctl, I noticed a few things I'm inclined to change about how conjurctl works.

#### How should this be manually tested?
1. Use the dev environment instructions in readme.
1. `conjurctl role retrieve-key [some-role] [some-other-role]` and notice this retrieves each role's key
1. `conjurctl role retrieve-key` and notice this prints help for "role retrieve-key"
1. `conjurctl data-key generate lol wat` and notice this prints help for "data-key generate"

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/enhance-conjurctl-behavior/
