### PR TITLE
Updates CTA with new webinar content

### DIFF
--- a/docs/_data/cta.yml
+++ b/docs/_data/cta.yml
@@ -53,18 +53,6 @@ hosted:
 
 cta1:
   type: Webinar
-  title: Orchestrating Trust in Your DevOps Pipeline
-  text: ""
-  text-secondary: October 26 / 11AM EST
-  link:
-    button:
-      button-text: Register
-      class: tertiary
-      target: _blank
-      url: https://pages.cloudbees.com/orchestratingtrust-devops-pipeline-webinar-registration
-
-cta2:
-  type: Webinar
   title: Delivering Infrastructure and Security Policy as Code with Puppet and CyberArk Conjur
   text: ""
   text-secondary: November 8 / 11AM EST
@@ -74,3 +62,15 @@ cta2:
       class: tertiary
       target: _blank
       url: https://www.cyberark.com/puppet-technical-partner-series/
+
+cta2:
+  type: Webinar
+  title: Best Practices for Securing Containerised Applications
+  text: ""
+  text-secondary: November 30
+  link:
+    button:
+      button-text: Register
+      class: tertiary
+      target: _blank
+      url: https://www.isc2.org/News-and-Events/Webinars/EMEA-Webinars/Focused-Webinars?commid=287129&cyberark


### PR DESCRIPTION
Closes [GH Issue 472](https://github.com/cyberark/conjur/issues/472)

## What does this pull request do?
This is a small update that updates the CTAs with newest webinar details
## What background context can you provide?
Ongoing updates to keep CTAs current
## Where should the reviewer start?
Homepage, then subpages.
## How should this be manually tested?
**Homepage** - Scroll to bottom of the page, and confirm that CTA content is updated, and links to correct page.
**Internal** - Sidebar CTAs content is updated, and links to correct page.

**11/8** links [here](http://info.puppet.com/Technical-Partner-Series-CyberArk_Register.html)
**11/26** links [here](https://www.isc2.org/News-and-Events/Webinars/EMEA-Webinars/Focused-Webinars?commid=287129&cyberark).
## Screenshots (if appropriate)
![screenshot 2017-10-31 10 25 51](https://user-images.githubusercontent.com/123787/32229023-3893bcd6-be26-11e7-8adb-fec76c59df7c.png)
![screenshot 2017-10-31 10 28 04](https://user-images.githubusercontent.com/123787/32229032-3c784f9c-be26-11e7-961e-c72fec6636e8.png)
## Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/cta-update-103117/
## Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
