### PR TITLE
Nginx proxy tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ api.html
 /public/stylesheets/*
 /public/assets/*
 *~
+/docs/tutorials/integrations/nginx/test.out

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ apidocs/node_modules
 docs/apidocs.html
 *.config
 docs/_layouts/page-toc.html
+/docs/tutorials/integrations/nginx/tls/nginx.crt
+/docs/tutorials/integrations/nginx/tls/nginx.key
 api.html
 
 # Generated js bundles

--- a/docs/tutorials/integrations/nginx.md
+++ b/docs/tutorials/integrations/nginx.md
@@ -1,0 +1,9 @@
+---
+title: Tutorial - Nginx Proxy
+layout: page
+section: tutorials
+description: Conjur Tutorial - Nginx
+---
+
+If you're deploying Conjur in production, you need to set up Transport Layer
+Security (TLS) so that requests made to the server are encrypted in transit.

--- a/docs/tutorials/integrations/nginx.md
+++ b/docs/tutorials/integrations/nginx.md
@@ -1,8 +1,8 @@
 ---
-title: Tutorial - Nginx Proxy
+title: Tutorial - NGINX Proxy
 layout: page
 section: tutorials
-description: Conjur Tutorial - Nginx
+description: Conjur Tutorial - NGINX
 ---
 
 If you're deploying Conjur in production, you need to set up Transport Layer
@@ -32,7 +32,7 @@ is called a **man in the middle attack**.
 
 Even if I'm not able to impersonate the Conjur server, I could still learn your
 secrets by joining your network and listening for traffic coming and going from
-the Conjur server. This is called **passive survillance**.
+the Conjur server. This is called **passive surveillance**.
 
 ### TLS defeats passive and active attacks
 
@@ -56,17 +56,17 @@ Do not leave this to chance: even a small flaw can totally compromise your
 secrets. Setting up Conjur and TLS without the appropriate expertise is like
 packing your own parachute and jumping out of a plane.
 
-That doesn't mean you shoud close the tab and walk away. It means you should get
+That doesn't mean you should close the tab and walk away. It means you should get
 in touch with us and your own security team so we can ensure that you can employ
 Conjur successfully.
 
 [authn]: https://www.conjur.org/api.html#authentication-authenticate-post
 [secret-get]: https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
 
-## Using Nginx To Proxy Traffic With TLS To Conjur
+## Using NGINX To Proxy Traffic With TLS To Conjur
 
-[Nginx][nginx] is a web proxy that's Free Software and easy to configure. This
-tutorial will show you how to use Docker to install Conjur and Nginx and
+[NGINX][NGINX] is a web proxy that's Free Software and easy to configure. This
+tutorial will show you how to use Docker to install Conjur and NGINX and
 configure them to provide Conjur with TLS.
 
 ### Prerequisites
@@ -80,7 +80,7 @@ repository. Here's how you get them:
 1. Install Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 1. Clone the Conjur repository
    
-   In your terminal applicaton, run:
+   In your terminal application, run:
    ```sh-session
    $ git clone git@github.com:cyberark/conjur.git
    ```
@@ -88,18 +88,18 @@ repository. Here's how you get them:
 
 ### The Good Part
 
-The tutorial script will install Conjur and Nginx, configure them to work
+The tutorial script will install Conjur and NGINX, configure them to work
 together, and connect a Conjur client to the running server. This is a full
 end-to-end working installation to allow you to see how the pieces connect
 together.
 
 ```sh-session
-$ # start the Conjur+nginx tutorial servers
+$ # start the Conjur+NGINX tutorial servers
 $ cd conjur/docs/tutorials/integrations/nginx
 $ ./start.sh
 ```
 
-Take a look at the logs for the Conjur or nginx servers:
+Take a look at the logs for the Conjur or NGINX servers:
 
 ```sh-session
 $ docker-compose logs conjur
@@ -117,7 +117,7 @@ $ docker-compose exec client bash
 These files show how the proxy setup works:
 
 * `docker-compose.yml` declares services and the connections between them
-* `default.conf` configures nginx to use a self-signed certificate for TLS and
+* `default.conf` configures NGINX to use a self-signed certificate for TLS and
   sets up a proxy to Conjur
 * `tls/tls.conf` sets the parameters of the self-signed certificate
 * `start.sh` shows the installation flow
@@ -128,8 +128,8 @@ In production, don't use a self-signed certificate. It's better than nothing,
 but it's not a sustainable security practice because you're going to have to
 manually verify that you're not talking to a man in the middle.
 
-Instead, ask your secuirty team to provide a certificate signed by a trusted
+Instead, ask your security team to provide a certificate signed by a trusted
 root and modify `default.conf` to use that certificate instead.
 
-[nginx]: https://www.nginx.com
+[NGINX]: https://www.nginx.com
 [prerequisites]: /get-started/install-conjur.html#prerequisites

--- a/docs/tutorials/integrations/nginx.md
+++ b/docs/tutorials/integrations/nginx.md
@@ -6,4 +6,130 @@ description: Conjur Tutorial - Nginx
 ---
 
 If you're deploying Conjur in production, you need to set up Transport Layer
-Security (TLS) so that requests made to the server are encrypted in transit.
+Security so that requests made to the server are encrypted in transit.
+
+*Note: if you use Conjur Enterprise, we handle this for you using an audited
+implementation that works similar to the technique described here.*
+
+## First: A Brief Primer On Transport Layer Security (TLS)
+
+This gets at the heart of the issue we're trying to address with this tutorial.
+
+Suppose you install Conjur and make it available at `http://conjur.local`. Then
+you configure clients to fetch secrets from that address. When they
+[authenticate][authn] using the API, they provide their identity by sending
+their API key to the Conjur server. The Conjur server validates that the
+identity is authentic, then checks that the provided ID is authorized to
+[retrieve the secret][secret-get]. Assuming this check passes, the Conjur server
+returns the secret value to the client.
+
+However, this flow would be vulnerable in two ways. Suppose I were to
+impersonate the Conjur server and listen with my own illegitimate server on
+`http://conjur.local`. Then when your client goes to fetch a secret, I can take
+the API key you send and impersonate you to the real Conjur server. Now I
+control your identity and can learn your secrets without you finding out. This
+is called a **man in the middle attack**.
+
+Even if I'm not able to impersonate the Conjur server, I could still learn your
+secrets by joining your network and listening for traffic coming and going from
+the Conjur server. This is called **passive survillance**.
+
+### TLS defeats passive and active attacks
+
+Transport Layer Security allows your client to verify that it's talking to the
+real Conjur server, and it uses standard secure technology to encrypt your
+secrets in transit. This means:
+
+* Your Conjur server will be `https:` instead of `http:`, just like a secure
+  website
+* Because the client knows it's talking to the real server, the "man in the
+  middle" will be exposed and the client won't leak any secret information
+* Since the traffic to and from Conjur is scrambled using secure encryption,
+  passive listeners on your network can't learn anything about the contents of
+  your secrets
+
+For these reasons, it is crucial to set up TLS correctly when you deploy Conjur.
+
+### Protect Your Secrets
+
+Do not leave this to chance: even a small flaw can totally compromise your
+secrets. Setting up Conjur and TLS without the appropriate expertise is like
+packing your own parachute and jumping out of a plane.
+
+That doesn't mean you shoud close the tab and walk away. It means you should get
+in touch with us and your own security team so we can ensure that you can employ
+Conjur successfully.
+
+[authn]: https://www.conjur.org/api.html#authentication-authenticate-post
+[secret-get]: https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
+
+## Using Nginx To Proxy Traffic With TLS To Conjur
+
+[Nginx][nginx] is a web proxy that's Free Software and easy to configure. This
+tutorial will show you how to use Docker to install Conjur and Nginx and
+configure them to provide Conjur with TLS.
+
+### Prerequisites
+
+This tutorial requires Docker and a terminal application. Prepare by following
+the prerequisite instructions found on [Install Conjur][prerequisites].
+
+Additionally, you will need the tutorial files from the Conjur source code
+repository. Here's how you get them:
+
+1. Install Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+1. Clone the Conjur repository
+   
+   In your terminal applicaton, run:
+   ```sh-session
+   $ git clone git@github.com:cyberark/conjur.git
+   ```
+   This will create a folder called `conjur` in the current directory.
+
+### The Good Part
+
+The tutorial script will install Conjur and Nginx, configure them to work
+together, and connect a Conjur client to the running server. This is a full
+end-to-end working installation to allow you to see how the pieces connect
+together.
+
+```sh-session
+$ # start the Conjur+nginx tutorial servers
+$ cd conjur/docs/tutorials/integrations/nginx
+$ ./start.sh
+```
+
+Take a look at the logs for the Conjur or nginx servers:
+
+```sh-session
+$ docker-compose logs conjur
+$ docker-compose logs proxy
+```
+
+Run some commands in the Conjur client:
+
+```sh-session
+$ docker-compose exec client bash
+# conjur authn whoami
+# conjur list
+```
+
+These files show how the proxy setup works:
+
+* `docker-compose.yml` declares services and the connections between them
+* `default.conf` configures nginx to use a self-signed certificate for TLS and
+  sets up a proxy to Conjur
+* `tls/tls.conf` sets the parameters of the self-signed certificate
+* `start.sh` shows the installation flow
+
+### About that self-signed certificate
+
+In production, don't use a self-signed certificate. It's better than nothing,
+but it's not a sustainable security practice because you're going to have to
+manually verify that you're not talking to a man in the middle.
+
+Instead, ask your secuirty team to provide a certificate signed by a trusted
+root and modify `default.conf` to use that certificate instead.
+
+[nginx]: https://www.nginx.com
+[prerequisites]: /get-started/install-conjur.html#prerequisites

--- a/docs/tutorials/integrations/nginx.md
+++ b/docs/tutorials/integrations/nginx.md
@@ -208,8 +208,8 @@ gateway for Conjur.
 
 This service defines three volumes: the NGINX config file, a self-signed
 certificate, and a private key related to the certificate. Explanation of those
-files follows below. The files are made accessible from the local filesystem for
-read-only access by the container.
+files follows below. The files are made accessible from the local file system
+for read-only access by the container.
 
 #### Production tip
 
@@ -221,7 +221,7 @@ deployments.
 You can use your own certificate here by providing it to the container as a
 volume. This allows your clients to verify that they are talking to the
 authentic Conjur server. Your security team can provide certificates for your
-organization, or you can create a certificate for any domain or subdomain you
+organization, or you can create a certificate for any domain or sub-domain you
 control with [certbot][certbot], which uses [Let's Encrypt][lets-encrypt] to
 provide certificates for no cost.
 
@@ -273,11 +273,11 @@ ssl_certificate_key /etc/nginx/nginx.key;
 ```
 
 This block gives NGINX its directions on how to perform TLS. ("ssl" is a name
-for an older standard for TLS and is still often used synomymously.)
+for an older standard for TLS and is still often used interchangeably.)
 
 The `certificate` is a public key, and the `certificate_key` is the
 corresponding private key. NGINX maintains [documentation][nginx-https] about
-how to configure the server for HTTPS, including production optmization
+how to configure the server for HTTPS, including production optimization
 guidelines and the values of many default settings, so that is worth reading.
 
 [nginx-https]: https://nginx.org/en/docs/http/configuring_https_servers.html

--- a/docs/tutorials/integrations/nginx/default.conf
+++ b/docs/tutorials/integrations/nginx/default.conf
@@ -1,33 +1,12 @@
 server {
-    listen 80;
-    return 301 https://conjur$request_uri;
-}
+    listen              443 ssl;
+    server_name         proxy;
+    access_log          /var/log/nginx/access.log;
 
-server {
-    listen       443;
-    server_name  localhost;
-    ssl_certificate           /etc/nginx/nginx.crt;
-    ssl_certificate_key       /etc/nginx/nginx.key;
-
-    ssl on;
-    ssl_session_cache  builtin:1000  shared:SSL:10m;
-    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-    ssl_prefer_server_ciphers on;
-
-    access_log            /var/log/nginx/access.log;
+    ssl_certificate     /etc/nginx/nginx.crt;
+    ssl_certificate_key /etc/nginx/nginx.key;
 
     location / {
       proxy_pass http://conjur;
     }
-
-    #error_page  404              /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-
 }

--- a/docs/tutorials/integrations/nginx/default.conf
+++ b/docs/tutorials/integrations/nginx/default.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    return 301 https://conjur$request_uri;
+}
+
+server {
+    listen       443;
+    server_name  localhost;
+    ssl_certificate           /etc/nginx/nginx.crt;
+    ssl_certificate_key       /etc/nginx/nginx.key;
+
+    ssl on;
+    ssl_session_cache  builtin:1000  shared:SSL:10m;
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers on;
+
+    access_log            /var/log/nginx/access.log;
+
+    location / {
+      proxy_pass http://conjur;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}

--- a/docs/tutorials/integrations/nginx/docker-compose.yml
+++ b/docs/tutorials/integrations/nginx/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - "443:443"
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./tls/nginx.key:/etc/nginx/nginx.key
-      - ./tls/nginx.crt:/etc/nginx/nginx.crt
+      - ./tls/nginx.key:/etc/nginx/nginx.key:ro
+      - ./tls/nginx.crt:/etc/nginx/nginx.crt:ro
     depends_on: [ conjur ]
 
   client:

--- a/docs/tutorials/integrations/nginx/docker-compose.yml
+++ b/docs/tutorials/integrations/nginx/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  database:
+    image: postgres:9.3
+
+  conjur:
+    image: cyberark/conjur
+    command: server
+    environment:
+      DATABASE_URL: postgres://postgres@database/postgres
+      CONJUR_DATA_KEY:
+    depends_on: [ database ]
+
+  proxy:
+    image: nginx:1.13.6-alpine
+    ports:
+      - "443:443"
+    volumes:
+      - ./default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./tls/nginx.key:/etc/nginx/nginx.key
+      - ./tls/nginx.crt:/etc/nginx/nginx.crt
+    depends_on: [ conjur ]
+
+  client:
+    image: conjurinc/cli5
+    depends_on: [ proxy ]
+    entrypoint: sleep
+    command: infinity

--- a/docs/tutorials/integrations/nginx/docker-compose.yml
+++ b/docs/tutorials/integrations/nginx/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   proxy:
     image: nginx:1.13.6-alpine
     ports:
-      - "443:443"
+      - "8443:443"
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./tls/nginx.key:/etc/nginx/nginx.key:ro

--- a/docs/tutorials/integrations/nginx/start.sh
+++ b/docs/tutorials/integrations/nginx/start.sh
@@ -3,6 +3,9 @@
 # docker-compose pull
 # docker pull svagi/openssl
 
+rm -f tls/nginx.key tls/nginx.crt
+docker-compose down
+
 docker run --rm -it \
        -w /home -v $PWD/tls:/home \
        svagi/openssl req\
@@ -18,3 +21,11 @@ docker run --rm -it \
 docker-compose run --no-deps --rm conjur data-key generate > data_key
 export CONJUR_DATA_KEY="$(< data_key)"
 docker-compose up -d
+
+sleep 6
+
+docker-compose exec conjur conjurctl account create test | tee test.out
+api_key="$(grep API test.out | cut -d: -f2 | tr -d ' \r\n')"
+
+docker-compose exec client bash -c "echo yes | conjur init -u https://proxy -a test"
+docker-compose exec client conjur authn login -u admin -p "$api_key"

--- a/docs/tutorials/integrations/nginx/start.sh
+++ b/docs/tutorials/integrations/nginx/start.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# docker-compose pull
+# docker pull svagi/openssl
+
+docker run --rm -it \
+       -w /home -v $PWD/tls:/home \
+       svagi/openssl req\
+       -x509 \
+       -nodes \
+       -days 365 \
+       -newkey rsa:2048 \
+       -config /home/tls.conf \
+       -extensions v3_ca \
+       -keyout nginx.key \
+       -out nginx.crt
+
+docker-compose run --no-deps --rm conjur data-key generate > data_key
+export CONJUR_DATA_KEY="$(< data_key)"
+docker-compose up -d

--- a/docs/tutorials/integrations/nginx/start.sh
+++ b/docs/tutorials/integrations/nginx/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Pull required containers from Docker Hub
+# Pull required container images from Docker Hub
 docker-compose pull
 docker pull svagi/openssl
 

--- a/docs/tutorials/integrations/nginx/start.sh
+++ b/docs/tutorials/integrations/nginx/start.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-# docker-compose pull
-# docker pull svagi/openssl
+# Pull required containers from Docker Hub
+docker-compose pull
+docker pull svagi/openssl
 
+# Remove containers, certs and keys created in earlier tutorial runs (if any)
 rm -f tls/nginx.key tls/nginx.crt
 docker-compose down
 
+# Create a self-signed certificate and key for TLS
 docker run --rm -it \
        -w /home -v $PWD/tls:/home \
        svagi/openssl req\
@@ -18,14 +21,22 @@ docker run --rm -it \
        -keyout nginx.key \
        -out nginx.crt
 
+# Generate a data key for Conjur encryption of data at rest.
+# *** Prevent data loss: ***
+# Move this key to a safe place before deploying in production!
 docker-compose run --no-deps --rm conjur data-key generate > data_key
 export CONJUR_DATA_KEY="$(< data_key)"
-docker-compose up -d
 
+# Start services and wait a little while for them to become responsive
+docker-compose up -d
 sleep 6
 
+# Create a new account in Conjur and fetch its API key
+# *** Protect your secrets: ***
+# Rotate the admin's API key regularly!
 docker-compose exec conjur conjurctl account create test | tee test.out
 api_key="$(grep API test.out | cut -d: -f2 | tr -d ' \r\n')"
 
+# Configure the Conjur client and log in as admin
 docker-compose exec client bash -c "echo yes | conjur init -u https://proxy -a test"
 docker-compose exec client conjur authn login -u admin -p "$api_key"

--- a/docs/tutorials/integrations/nginx/tls/tls.conf
+++ b/docs/tutorials/integrations/nginx/tls/tls.conf
@@ -12,8 +12,8 @@ x509_extensions = usr_cert
 C=US
 ST=Wisconsin
 L=Madison
-O=Onyx
-OU=CyberArk
+O=CyberArk
+OU=Onyx
 CN=proxy
 
 [ usr_cert ]

--- a/docs/tutorials/integrations/nginx/tls/tls.conf
+++ b/docs/tutorials/integrations/nginx/tls/tls.conf
@@ -1,0 +1,39 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+x509_extensions = v3_ca # The extentions to add to the self signed cert
+req_extensions  = v3_req
+x509_extensions = usr_cert
+
+[ dn ]
+C=US
+ST=Wisconsin
+L=Madison
+O=Onyx
+OU=CyberArk
+CN=proxy
+
+[ usr_cert ]
+basicConstraints=CA:FALSE
+nsCertType                      = client, server, email
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+nsComment                       = "OpenSSL Generated Certificate"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+[ v3_req ]
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = proxy
+IP.1 = 127.0.0.1


### PR DESCRIPTION
Closes CON-4461 (Example exists for using an nginx container to serve Conjur securely with TLS)

#### What does this pull request do?
Provides an example of using Conjur with nginx to provide TLS for Conjur traffic.

#### What background context can you provide?
Background context is provided in `docs/tutorials/integrations/nginx.md`, reproduced in part here:

>  it is crucial to set up TLS correctly when you deploy Conjur...

> Do not leave this to chance: even a small flaw can totally compromise your
> secrets. Setting up Conjur and TLS without the appropriate expertise is like
> packing your own parachute and jumping out of a plane.


#### Where should the reviewer start?
The tutorial flow is in `docs/tutorials/integrations/nginx.md`, the supporting files are in `docs/integrations/tutorials/nginx/`

#### How should this be manually tested?
Run through the tutorial flow and check the container logs to verify that TLS is being used.
