### PR TITLE
Added port mapping to insure port 80 is available on local port 8080

### DIFF
--- a/docs/get-started/docker-compose.quickstart.yml
+++ b/docs/get-started/docker-compose.quickstart.yml
@@ -11,7 +11,7 @@ services:
       CONJUR_DATA_KEY:
     depends_on: [ database ]
     ports:
-      - "3000:80"
+      - "8080:80"
 
   client:
     image: conjurinc/cli5

--- a/docs/get-started/docker-compose.quickstart.yml
+++ b/docs/get-started/docker-compose.quickstart.yml
@@ -10,6 +10,8 @@ services:
       DATABASE_URL: postgres://postgres@database/postgres
       CONJUR_DATA_KEY:
     depends_on: [ database ]
+    ports:
+      - "3000:80"
 
   client:
     image: conjurinc/cli5

--- a/docs/get-started/install-conjur.md
+++ b/docs/get-started/install-conjur.md
@@ -77,7 +77,7 @@ Please enter admin\'s password (it will not be echoed):
 
 {% include toc.md key='explore' %}
 
-Conjur is installed and ready for use! If you want to confirm that Conjur was installed properly, you can open a browser and go to _localhost:3000_ and view the included status UI page.
+Conjur is installed and ready for use! If you want to confirm that Conjur was installed properly, you can open a browser and go to _localhost:8080_ and view the included status UI page.
 
 Ready to do more?  Here are some suggestions:
 


### PR DESCRIPTION
Closes #474

#### What does this pull request do?
This PR adds a mapping of http://localhost:3000 to the Conjur running on port 80. This change allows a user to visually confirm that Conjur is running.

#### Where should the reviewer start?
`docker-compose.yml` is where all the action is.

#### How should this be manually tested?
Download the updated `docker-compose.yml` file and run:
```bash
$ docker-compose run --no-deps --rm conjur data-key generate > data_key
$ export CONJUR_DATA_KEY="$(< data_key)"
$ docker-compose up
```
Then confirm the Conjur status page loads when you go to: `http://localhost:3000'

#### Screenshots (if appropriate)
![screen shot 2017-11-29 at 12 15 53 pm](https://user-images.githubusercontent.com/124978/33394293-16fe2fee-d4ff-11e7-9bbe-d50fb52663db.png)

#### Link to build in Jenkins (if appropriate)
Not relevant


> Does the knowledge base need an update?

