### PR TITLE
Adds "Security Check" section to Conjur status page

### DIFF
--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -18,8 +18,8 @@
         </dd>
         <dt>Red broken lock or no lock:</dt>
         <dd>
-          Conjur is insecure. Don't put any secrets
-          in there yet! Visit the
+          Conjur is running in insecure development mode. Don't put any
+          production secrets in there! Visit the
           <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
           to learn how to deploy Conjur securely &
           <a href="https://conjur.org/support.html">contact CyberArk</a>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -4,6 +4,26 @@
   <div class="col-md-8">
     <h1 class="page-title">Status</h1>
     <p class="font-large">Your Conjur CE server is running!</p>
+    <h2>Security Check:</h2>
+    <p>
+      Does your browser show a green lock icon on the left side of the address bar?
+      <ul>
+        <li>Green lock: good, Conjur is secured and authenticated.</li>
+        <li>
+          Yellow lock: ok, Conjur is secured but not authenticated. Send your
+          Conjur admin to the
+          <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
+          to learn how to get the green lock.
+        </li>
+        <li>
+          Red broken lock or no lock: Conjur is insecure. Don't put any secrets
+          in there yet! Visit the
+          <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
+          to learn how to deploy Conjur securely &
+          <a href="https://conjur.org/support.html">contact CyberArk</a>
+          with any questions.
+        </li>
+    </p>
   </div>
   <div class="col-md-4">
     <strong>Details:</strong>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -7,22 +7,25 @@
     <h2>Security Check:</h2>
     <p>
       Does your browser show a green lock icon on the left side of the address bar?
-      <ul>
-        <li>Green lock: good, Conjur is secured and authenticated.</li>
-        <li>
-          Yellow lock: ok, Conjur is secured but not authenticated. Send your
+      <dl>
+        <dt>Green lock:</dt><dd>good, Conjur is secured and authenticated.</dd>
+        <dt>Yellow lock:</dt>
+        <dd>
+          ok, Conjur is secured but not authenticated. Send your
           Conjur admin to the
           <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
           to learn how to get the green lock.
-        </li>
-        <li>
-          Red broken lock or no lock: Conjur is insecure. Don't put any secrets
+        </dd>
+        <dt>Red broken lock or no lock:</dt>
+        <dd>
+          Conjur is insecure. Don't put any secrets
           in there yet! Visit the
           <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
           to learn how to deploy Conjur securely &
           <a href="https://conjur.org/support.html">contact CyberArk</a>
           with any questions.
-        </li>
+        </dd>
+      </dl>
     </p>
   </div>
   <div class="col-md-4">

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -8,20 +8,21 @@
     <p>
       Does your browser show a green lock icon on the left side of the address bar?
       <dl>
-        <dt>Green lock:</dt><dd>good, Conjur is secured and authenticated.</dd>
-        <dt>Yellow lock:</dt>
+        <dt>Green lock:</dt>
+        <dd>Good, Conjur is secured and authenticated.</dd>
+        <dt>Yellow lock or green with warning sign:</dt>
         <dd>
-          ok, Conjur is secured but not authenticated. Send your
+          OK, Conjur is secured but not authenticated. Send your
           Conjur admin to the
           <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
-          to learn how to get the green lock.
+          to learn how to use your own certificate &amp; upgrade to green lock.
         </dd>
         <dt>Red broken lock or no lock:</dt>
         <dd>
           Conjur is running in insecure development mode. Don't put any
           production secrets in there! Visit the
           <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
-          to learn how to deploy Conjur securely &
+          to learn how to deploy Conjur securely &amp;
           <a href="https://conjur.org/support.html">contact CyberArk</a>
           with any questions.
         </dd>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title do %>Conjur CE Status<% end %>
+<% content_for :title do %>Conjur Status<% end %>
 
 <div class="row">
   <div class="col-md-8">
     <h1 class="page-title">Status</h1>
-    <p class="font-large">Your Conjur CE server is running!</p>
+    <p class="font-large">Your Conjur server is running!</p>
     <h2>Security Check:</h2>
     <p>
       Does your browser show a green lock icon on the left side of the address bar?

--- a/cucumber/api/features/step_definitions/status_page_steps.rb
+++ b/cucumber/api/features/step_definitions/status_page_steps.rb
@@ -5,5 +5,5 @@ end
 Then(/^the status page is reachable$/) do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to include("text/html")
-  expect(@response.body).to include("Your Conjur CE server is running!")
+  expect(@response.body).to include("is running!")
 end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -13,7 +13,7 @@ describe StatusController, :type => :controller do
 
       it 'has the standard message' do
         get :index
-        expect(response.body).to include('Your Conjur CE server is running!')
+        expect(response.body).to include('is running!')
       end
 
       it 'includes the version' do


### PR DESCRIPTION
Note: do not merge this before #488, since the status page links to documentation introduced in that PR.

#### What does this pull request do?

It adds a section to the Conjur status page assisting users in assessing the security of their Conjur deployment and linking to our documentation for improving security by using NGINX for TLS.

#### What background context can you provide?

When a new user installs Conjur using the instructions on our website, it will initially be listening on port 8080 using insecure HTTP. When the user visits the status page, we want to guide their exploration and get them interested in implementing our suggested security practices.

#### Where should the reviewer start?

`app/views/status/index.html.erb`

#### How should this be manually tested?

Build the container and run the server as per the dev instructions in the README, then visit localhost:3000. Observe that your browser shows a red broken lock or no lock in the status bar, and use the guide on the status page to interpret this.

#### Screenshots (if appropriate)
<img width="1199" alt="screen shot 2017-11-29 at 3 20 43 pm" src="https://user-images.githubusercontent.com/4389854/33399615-e94064d6-d518-11e7-8bc9-65dd0f5421c5.png">


#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/status-page%252Fshow-tls-suggestions/

#### Questions:
> Does this have automated Cucumber tests?

No

> Can we make a blog post, video, or animated GIF out of this?

Yes, that would be nice
