### PR TITLE
update README to recommend using webrick for debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ To use it:
    * find or create the token-signing key
    * start the web server
 
-   If you are going to be debugging Conjur using `pry.byebug`, you may choose
-   to start the web server by calling `rails server webrick` instead. This will
-   allow you to work in the debugger without the server timing out.
+   If you are going to be debugging Conjur using `pry.byebug`, you may choose to
+   start the web server by calling `rails server -b 0.0.0.0 webrick` instead of
+   `conjurctl server`. This will allow you to work in the debugger without the
+   server timing out.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ To use it:
    * find or create the token-signing key
    * start the web server
 
+   If you are going to be debugging Conjur using `pry.byebug`, you may choose
+   to start the web server by calling `rails server webrick` instead. This will
+   allow you to work in the debugger without the server timing out.
+
 ## Testing
 
 Conjur has `rspec` and `cucumber` tests.


### PR DESCRIPTION
This PR just adds a brief blurb to the README to recommend using `webrick` instead of `puma` if you are planning to debug (ie using `pry-byebug`) to prevent timeout issues.

Jenkins build is [here](https://jenkins.conjur.net/job/cyberark--conjur/job/update-readme-web-server-command-for-debug/).