### PR TITLE
Use git_tag in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -ex
 
-TAG="$(< VERSION)-$(git rev-parse --short HEAD)"
+. git_tag.sh
+
+TAG="$(git_tag)"
 
 function finish {
 	docker rm -f $pg_cid


### PR DESCRIPTION
This pull request updates test.sh to use unified git_tag function. That makes it use the same image tagging convention as the other scripts.