### PR TITLE
update expired CTA w/ new content

### DIFF
--- a/docs/_data/cta.yml
+++ b/docs/_data/cta.yml
@@ -52,16 +52,16 @@ hosted:
       path: /get-started/try-conjur.html
 
 cta1:
-  type: Webinar
-  title: Best Practices for Securing Containerised Applications
+  type: Article
+  title: Painful lessons breaches teach us about DevOps and security
   text: ""
-  text-secondary: November 30
+  text-secondary: Cloud and DevOps are critical technology engines helping to power transformational advances across many businesses...
   link:
     button:
-      button-text: Register
+      button-text: Read Now
       class: tertiary
       target: _blank
-      url: https://www.isc2.org/News-and-Events/Webinars/EMEA-Webinars/Focused-Webinars?commid=287129&cyberark
+      url: https://www.cyberark.com/blog/painful-lessons-breaches-teach-us-devops-security/
 
 cta2:
   type: Survey
@@ -73,4 +73,4 @@ cta2:
       button-text: Download
       class: tertiary
       target: _blank
-      url: https://www.cyberark.com/THREAT-LANDSCAPE-SURVEY-2018-FOCUS-ON-DEVOPS/ 
+      url: https://www.cyberark.com/THREAT-LANDSCAPE-SURVEY-2018-FOCUS-ON-DEVOPS/


### PR DESCRIPTION
Closes [CONJ-4528](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-4528)

#### What does this pull request do?
Updated CTAs on conjur.org. Removes expired webinar, and adds article on cyberark.com
#### What background context can you provide?
Part of regular scheduled maintenance
#### Where should the reviewer start?
Homepage.
#### How should this be manually tested?
Confirm that new CTA content has been added. Should link to [this article](https://www.cyberark.com/blog/painful-lessons-breaches-teach-us-devops-security/)
#### Screenshots (if appropriate)
Homepage: 
![screenshot 2017-12-06 15 12 29](https://user-images.githubusercontent.com/123787/33683186-0fb0127c-da98-11e7-93d1-f42c70efe28e.png)

Subpage:
![screenshot 2017-12-06 15 12 40](https://user-images.githubusercontent.com/123787/33683191-1684d7d6-da98-11e7-9463-508ca03b5fef.png)


#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/cta-updates-120617/
#### Questions:
> Does this have automated Cucumber tests?
No

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
No

> Does the knowledge base need an update?
No
