### PR TITLE
Add authn-local service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.0] - 2017-12-07
+
+- Add `authn-local` service which issues access tokens over a Unix domain socket.
+
 ## [0.1.1] - 2017-12-04
 ### Changed
 - Build scripts now look at git tags to determine version and tags to use.

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -42,16 +42,20 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
     puts "authn-local is listening at #{socket}"
 
     while conn = server.accept
-      Timeout.timeout timeout do
-        claims = conn.gets.strip
-        begin
-          conn.puts issue_token(claims)
-        rescue
-          $stderr.puts "Error in authn-local: #{$!.to_s}"
-          conn.puts
-        ensure
-          conn.close
+      begin
+        Timeout.timeout timeout do
+          claims = conn.gets.strip
+          begin
+            conn.puts issue_token(claims)
+          rescue
+            $stderr.puts "Error in authn-local: #{$!.to_s}"
+            conn.puts
+          ensure
+            conn.close
+          end
         end
+      rescue Timeout::Error
+        $stderr.puts "Timeout::Error in authn-local"
       end
     end
   end

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -65,6 +65,11 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
     claims = claims.slice("account", "sub", "exp", "cidr")
     account = claims.delete("account") or raise "'account' is required"
     raise "'sub' is required" unless claims['sub']
-    Slosilo["authn:#{account}"].issue_jwt(claims).to_json
+    key = Slosilo["authn:#{account}"]
+    if key 
+      key.issue_jwt(claims).to_json
+    else
+      raise "No signing key found for account #{account.inspect}"
+    end
   end
 end

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -27,8 +27,6 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
   def run
     FileUtils.rm_rf socket
 
-    p self
-
     server = UNIXServer.new socket
 
     trap(0) do
@@ -49,7 +47,7 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
         begin
           conn.puts issue_token(claims)
         rescue
-          $stderr.puts $!.to_s
+          $stderr.puts "Error in authn-local: #{$!.to_s}"
           conn.puts
         ensure
           conn.close

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -1,0 +1,68 @@
+require 'timeout'
+require 'fileutils'
+require 'socket'
+
+AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
+  class << self
+    def run socket:, queue_length:, timeout:
+      socket ||= '/run/authn-local/.socket'
+      socket_dir = File.dirname(socket)
+
+      unless File.directory?(socket_dir)
+        $stderr.puts "authn-local requires directory #{socket_dir.inspect} to exist and be a directory"
+        $stderr.puts "authn-local will not be enabled"
+        return
+      end
+
+      queue_length ||= 5
+      queue_length = queue_length.to_i
+
+      timeout ||= 1
+      timeout = timeout.to_i
+
+      AuthnLocal.new(socket, queue_length, timeout).run
+    end
+  end
+
+  def run
+    FileUtils.rm_rf socket
+
+    p self
+
+    server = UNIXServer.new socket
+
+    trap(0) do
+      # remove the socket on exit
+      # alternatively it can be removed on startup
+      # (or both)
+      $stderr.puts "Removing socket #{socket}"
+      File.unlink socket
+    end
+
+    server.listen queue_length
+
+    puts "authn-local is listening at #{socket}"
+
+    while conn = server.accept
+      Timeout.timeout timeout do
+        claims = conn.gets.strip
+        begin
+          conn.puts issue_token(claims)
+        rescue
+          $stderr.puts $!.to_s
+          conn.puts
+        ensure
+          conn.close
+        end
+      end
+    end
+  end
+
+  def issue_token claims
+    claims = JSON.parse(claims)
+    claims = claims.slice("account", "sub", "exp", "cidr")
+    account = claims.delete("account") or raise "'account' is required"
+    raise "'sub' is required" unless claims['sub']
+    Slosilo["authn:#{account}"].issue_jwt(claims).to_json
+  end
+end

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -69,15 +69,14 @@ command :server do |c|
     end
 
 
-    webserver_pid = Process.fork do
+    Process.fork do
       exec "rails server -p #{options[:port]} -b #{options[:'bind-address']}"
     end
-    authn_local_pid = Process.fork do
+    Process.fork do
       exec "rake authn_local:run"
     end
 
-    Process.wait webserver_pid
-    Process.wait authn_local_pid
+    Process.waitall
   end
 end
 

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -68,7 +68,16 @@ command :server do |c|
       system "rake policy:load[#{account},#{file_name}]" or exit $?.exitstatus
     end
 
-    exec "rails server -p #{options[:port]} -b #{options[:'bind-address']}"
+
+    webserver_pid = Process.fork do
+      exec "rails server -p #{options[:port]} -b #{options[:'bind-address']}"
+    end
+    authn_local_pid = Process.fork do
+      exec "rake authn_local:run"
+    end
+
+    Process.wait webserver_pid
+    Process.wait authn_local_pid
   end
 end
 

--- a/cucumber/api/features/authn_local.feature
+++ b/cucumber/api/features/authn_local.feature
@@ -1,0 +1,29 @@
+Feature: Custom Authenticators can obtain access tokens for any role
+
+  Scenario: Obtain an access token for a user
+    When I request from authn-local:
+    """
+    { "account" : "cucumber", "sub" : "alice" }
+    """
+    Then I obtain an access token for "alice" in account "cucumber"
+
+  Scenario: Obtain an access token for a host
+    When I request from authn-local:
+    """
+    { "account" : "cucumber", "sub" : "host/myapp-01" }
+    """
+    Then I obtain an access token for "host/myapp-01" in account "cucumber"
+
+  Scenario: Custom expiration time can be specified.
+    When I request from authn-local:
+    """
+    { "account" : "cucumber", "sub" : "alice", "exp" : 1512664254 }
+    """
+    Then the access token expires at 1512664254
+
+  Scenario: Sending invalid input results in an empty response
+    When I request from authn-local:
+    """
+    foobar
+    """
+    Then the response is empty

--- a/cucumber/api/features/step_definitions/authn_local_steps.rb
+++ b/cucumber/api/features/step_definitions/authn_local_steps.rb
@@ -1,0 +1,19 @@
+require 'socket'
+
+Given(/^I request from authn\-local:$/) do |claims|
+  set_token_result authn_local_request(claims)
+end
+
+Then(/^I obtain an access token for "([^"]*)" in account "([^"]*)"$/) do |user_id, account|
+  expect(token_payload['sub']).to eq(user_id)
+
+  expect(token_protected['kid']).to eq(Slosilo["authn:#{account}"].fingerprint)
+end
+
+Then(/^the access token expires at (\d+)$/) do |exp|
+  expect(token_payload['exp']).to eq(exp.to_i)
+end
+
+Then(/^the response is empty$/) do
+  expect(@result).to be_blank
+end

--- a/cucumber/api/features/support/world.rb
+++ b/cucumber/api/features/support/world.rb
@@ -51,6 +51,39 @@ module PossumWorld
       @result = result
     end
   end
+
+  def set_token_result result
+    unless result.blank?
+      @result = JSON.parse(result)
+    else
+      @result = result
+    end
+  end
+
+  def token_payload
+    unless (payload = @result['payload'])
+      raise "No 'payload' for token #{@result.inspect}"
+    end
+    JSON.parse Base64.decode64(payload)
+  end
+
+  def token_protected
+    unless (prot = @result['protected'])
+      raise "No 'protected' for token #{@result.inspect}"
+    end
+    JSON.parse Base64.decode64(prot)
+  end
+
+  # Write a command to the authn-local Unix socket.
+  def authn_local_request command
+    require 'socket'
+    socket_file = "/run/authn-local/.socket"
+    raise "Socket #{socket_file} does not exist" unless File.exists?(socket_file)
+    UNIXSocket.open socket_file do |s|
+      s.puts command
+      s.read
+    end
+  end
   
   def authn_params
     raise "No selected user" unless @selected_user

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,50 +1,55 @@
-pg:
-  image: postgres:9.3
+version: "3"
+services:
+  pg:
+    image: postgres:9.3
 
-conjur:
-  image: conjur-dev
-  environment:
-    CONJUR_APPLIANCE_URL: http://localhost:3000
-    DATABASE_URL: postgres://postgres@pg/postgres
-    CONJUR_ADMIN_PASSWORD: admin
-    CONJUR_PASSWORD_ALICE: secret
-    CONJUR_DATA_KEY:
-    RAILS_ENV:
-  ports:
-    - "3000:3000"
-  expose:
-    - "3000"
-  volumes:
-  - ..:/src/conjur-server
-  - ../../conjur-policy-parser:/src/conjur-policy-parser
-  - ./run/authn-local:/run/authn-local
-  links:
-  - pg:pg
+  conjur:
+    image: conjur-dev
+    environment:
+      CONJUR_APPLIANCE_URL: http://localhost:3000
+      DATABASE_URL: postgres://postgres@pg/postgres
+      CONJUR_ADMIN_PASSWORD: admin
+      CONJUR_PASSWORD_ALICE: secret
+      CONJUR_DATA_KEY:
+      RAILS_ENV:
+    ports:
+      - "3000:3000"
+    expose:
+      - "3000"
+    volumes:
+    - ..:/src/conjur-server
+    - ../../conjur-policy-parser:/src/conjur-policy-parser
+    - authn-local:/run/authn-local
+    links:
+    - pg:pg
 
-cucumber:
-  image: conjur-dev
-  entrypoint: bash
-  environment:
-    CONJUR_APPLIANCE_URL: http://conjur:3000
-    DATABASE_URL: postgres://postgres@pg/postgres
-    CONJUR_ADMIN_PASSWORD: admin
-    CONJUR_DATA_KEY:
-    RAILS_ENV:
-  volumes:
-  - ..:/src/conjur-server
-  - ./run/authn-local:/run/authn-local
-  links:
-  - conjur:conjur
-  - pg:pg
+  cucumber:
+    image: conjur-dev
+    entrypoint: bash
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur:3000
+      DATABASE_URL: postgres://postgres@pg/postgres
+      CONJUR_ADMIN_PASSWORD: admin
+      CONJUR_DATA_KEY:
+      RAILS_ENV:
+    volumes:
+    - ..:/src/conjur-server
+    - authn-local:/run/authn-local
+    links:
+    - conjur:conjur
+    - pg:pg
 
-client:
-  image: conjurinc/cli5
-  entrypoint: sleep
-  command: infinity
-  environment:
-    CONJUR_APPLIANCE_URL: http://conjur:3000
-    DATABASE_URL: postgres://postgres@pg/postgres
-  links:
-  - conjur:conjur
-  volumes:
-  - ..:/src/conjur-server
+  client:
+    image: conjurinc/cli5
+    entrypoint: sleep
+    command: infinity
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur:3000
+      DATABASE_URL: postgres://postgres@pg/postgres
+    links:
+    - conjur:conjur
+    volumes:
+    - ..:/src/conjur-server
+
+volumes:
+  authn-local:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -17,6 +17,7 @@ conjur:
   volumes:
   - ..:/src/conjur-server
   - ../../conjur-policy-parser:/src/conjur-policy-parser
+  - ./run/authn-local:/run/authn-local
   links:
   - pg:pg
 
@@ -31,6 +32,7 @@ cucumber:
     RAILS_ENV:
   volumes:
   - ..:/src/conjur-server
+  - ./run/authn-local:/run/authn-local
   links:
   - conjur:conjur
   - pg:pg

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -11,7 +11,7 @@ For a full reference to authentication routes and methods, see the [Authenticati
 
 ## CLI Commands
 
-## Login
+### Login
 
 Users can obtain their API key by logging in with their `username` and `password`.
 
@@ -23,7 +23,7 @@ Logged in
 
 Once the API key is obtained, it may be used to rapidly obtain authentication tokens, which are required to use most other Conjur services.
 
-## Authenticate
+### Authenticate
 
 Once you are logged in, you can use the CLI to get an authentication token which is pre-formatted
 for use as an HTTP authorization header:
@@ -38,7 +38,7 @@ $ curl -H "$token" http://conjur/resources/myaccount
 
 If you omit the `-H` option, you get the token as JSON.
 
-## Whoami
+### Whoami
 
 Once you are logged in, you can print your current logged-in identity
 with the command `conjur authn whoami`.
@@ -47,3 +47,32 @@ with the command `conjur authn whoami`.
 $ conjur authn whoami
 {"account":"myorg","username":"joe-tester"}
 {% endhighlight %}
+
+## `authn-local`
+
+If you provide your Conjur server with a directory `/run/authn-local`, Conjur will run a service called `authn-local` which listens on a Unix socket in this directory.
+
+You can send JSON requests to this socket. Each request must be formatted on a single line (no "pretty-printed" JSON). The JSON is a map which contains:
+
+* **account** The account for which the token should be issued (required).
+* **sub** The token subject (required).
+* **exp** The expiration time of the token (optional).
+* **cidr** A CIDR restriction on token validity (optional).
+
+The response will be a Conjur access token. For more details about access tokens, see [Cryptography / Authentication tokens](/reference/cryptography.html#authentication-tokens).
+
+`authn-local` is designed to be used by web services which provides custom authentication. Authenticators are responsible for implementing custom authentication logic, such as:
+
+* Verifying a password with an external LDAP.
+* Verifying a token with GitHub.
+
+Once an Authenticator has verified the credentials provided to it, it can use `authn-local` to get an access token which can be returned to the client.
+
+### Security Considerations
+
+`authn-local` should be disabled if you are not using it. You can do this by simply not creating the directory `/run/authn-local`.
+
+If you do use `authn-local`, be careful about which processes have access to the Unix domain socket, because anyone with access to this socket can issue themselves a token for any role. 
+
+
+

--- a/lib/tasks/authn_local.rake
+++ b/lib/tasks/authn_local.rake
@@ -1,0 +1,10 @@
+namespace :authn_local do
+  desc "Run the authn-local service"
+  task :run, [ "socket", "queue_length", "timeout" ] => :environment do |t,args|
+    socket = args["socket"] || ENV['CONJUR_AUTHN_LOCAL_SOCKET']
+    queue_length = args["queue_length"] || ENV['CONJUR_AUTHN_LOCAL_QUEUE_LENGTH']
+    timeout = args["timeout"] || ENV['CONJUR_AUTHN_LOCAL_TIMEOUT']
+
+    AuthnLocal.run socket: socket, queue_length: queue_length, timeout: timeout
+  end
+end

--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,7 @@ mkdir -p cucumber/policy/features/reports
 
 server_cid=$(docker run -d \
 	--link $pg_cid:pg \
+	-v $PWD/run/authn-local:/run/authn-local \
 	-e DATABASE_URL=postgres://postgres@pg/postgres \
 	-e RAILS_ENV=test \
 	conjur:$TAG server)
@@ -30,6 +31,7 @@ cat << "TEST" | docker run \
 	--link $pg_cid:pg \
 	--link $server_cid:conjur \
 	-v $PWD:/src/conjur \
+	-v $PWD/run/authn-local:/run/authn-local \
 	-e DATABASE_URL=postgres://postgres@pg/postgres \
 	-e RAILS_ENV=test \
 	-e CONJUR_APPLIANCE_URL=http://conjur \


### PR DESCRIPTION
Closes [relevant GitHub issues, eg #76]

#### What does this pull request do?

Adds `authn-local` to cyberark/conjur

#### What background context can you provide?

`authn-local` is used in Conjur v4 for custom authenticators to issue access tokens. This PR brings this feature to v5 as well, to facilitate custom authenticators. It's anticipated that custom authenticators will run alongside Conjur in a docker enginer, with a shared volume to the Unix socket file `/run/authn-local/.socket`.

#### Where should the reviewer start?

By reviewing the diff.

#### How should this be manually tested?

In the "./dev" environment, you can start the server with `./bin/conjurctl server`. You'll see a message printed that authn-local is running, along with the socket name. 

If you write proper JSON to this socket (see cukes for examples) then the service will respond with an access token.

#### Screenshots (if appropriate)

https://asciinema.org/a/CX18MgLm578MPNOZSgZk2xv2q

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/authn-local/

#### Questions:

> Does this have automated Cucumber tests?

Yes

> Can we make a blog post, video, or animated GIF out of this?

Yes

> Is this explained in documentation?

Briefly

> Does the knowledge base need an update?

A tutorial about custom authenticators would be an excellent next step.