### PR TITLE
adding wait method to conjurctl

### DIFF
--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -210,10 +210,23 @@ command :role do |cgrp|
 end
 
 desc "Wait for the Conjur server to be ready"
-command :wait_for_conjur do |c|
+command :wait do |c|
+  c.desc 'Port'
+  c.arg_name :port
+  c.default_value ENV['PORT'] || '80'
+  c.flag [ :p, :port ], :must_match => /\d+/
+
+  c.desc 'Number of retries'
+  c.arg_name :retries
+  c.default_value 90
+  c.flag [ :r, :retries ], :must_match => /\d+/
+
   c.action do |global_options,options,args|
     puts "Waiting for Conjur to be ready..."
-    while `curl -o /dev/null -s -w '%{http_code}' $CONJUR_APPLIANCE_URL` != "200"
+    retry_num = 0
+    while `curl -o /dev/null -s -w '%{http_code}' http://localhost:#{options[:port]}` != "200"
+      retry_num += 1
+      break unless retry_num < options[:retries].to_i
       puts "."
       sleep 1
     end

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -209,4 +209,16 @@ command :role do |cgrp|
   end
 end
 
+desc "Wait for the Conjur server to be ready"
+command :wait_for_conjur do |c|
+  c.action do |global_options,options,args|
+    puts "Waiting for Conjur to be ready..."
+    while `curl -o /dev/null -s -w '%{http_code}' $CONJUR_APPLIANCE_URL` != "200"
+      puts "."
+      sleep 1
+    end
+    puts "Done."
+  end
+end
+
 exit run(ARGV)


### PR DESCRIPTION
Closes #503 

This PR adds a `wait` command to `conjurctl` so that applications that depend on Conjur have a method to wait for it to be running before proceeding. It assumes that the `CONJUR_APPLIANCE_URL` environment variable is present on the container running the command.

To test this out, you can stand up a Conjur instance using the standard `./build.sh` and `dev/start.sh` commands, call `conjurctl wait` from within the Conjur container, open another Conjur container with `docker exec -it $(docker-compose ps -q conjur) bash;`, and run `conjurctl server`. In the waiting container you will see:
```
Waiting for Conjur to be ready...
.
.
.
```
until you run `conjurctl server` to start Conjur; once the server starts you will see "Done."

  