### PR TITLE
Small changes for nginx config for the appliance

### DIFF
--- a/config/initializers/rewrite.rb
+++ b/config/initializers/rewrite.rb
@@ -1,1 +1,0 @@
-Possum::Application.config.middleware.insert_before Rails::Rack::Logger, Conjur::Rack::PathPrefix, '/api/v6'

--- a/distrib/nginx/40_possum.conf
+++ b/distrib/nginx/40_possum.conf
@@ -3,5 +3,5 @@ location / {
     return 503;
   }
 
-  proxy_pass http://localhost:5000;
+  proxy_pass http://127.0.0.1:5000;
 }

--- a/distrib/nginx/40_possum.conf
+++ b/distrib/nginx/40_possum.conf
@@ -1,4 +1,4 @@
-location /api/v6 {
+location / {
   if (-f /tmp/possum-congested.flag) {
     return 503;
   }


### PR DESCRIPTION
This mounts Conjur at / instead of /api/v6, and makes sure nginx doesn't use IPv6 to forward to the service (since it only listens on IPv4).