### PR TITLE
Adds hint to URL encode identifiers, with examples table

### DIFF
--- a/apidocs/src/add_secret.md
+++ b/apidocs/src/add_secret.md
@@ -6,6 +6,8 @@ Creates a secret value within the specified Variable.
 
 Note: Conjur will allow you to add a secret to any resource, but the best practice is to store and retrieve secret data only using Variable resources.
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example with `curl`
 
 ```

--- a/apidocs/src/append_policy.md
+++ b/apidocs/src/append_policy.md
@@ -9,6 +9,8 @@ the policy file will result in an error.
 
 <!-- include(partials/policy_size_restriction.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 **Permissions required**
 
 `create` privilege on the policy.

--- a/apidocs/src/authenticate.md
+++ b/apidocs/src/authenticate.md
@@ -4,6 +4,11 @@
 
 Gets a [short-lived access token](/reference/cryptography.html#authentication-tokens), which can be used to authenticate requests to (most of) the rest of the Conjur API. A client can obtain an access token by presenting a valid login name and API key.
 
+The login must be [URL encoded][percent-encoding]. For example, `alice@devops`
+must be encoded as `alice%40devops`.
+
+[percent-encoding]: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
+
 For API usage, the access token is ordinarily passed as an HTTP Authorization "Token" header.
 
 ```

--- a/apidocs/src/batch_retrieval.md
+++ b/apidocs/src/batch_retrieval.md
@@ -4,6 +4,8 @@
 
 Fetches multiple secret values in one invocation. It's faster to fetch secrets in batches than to fetch them one at a time.
 
+<!-- include(partials/url_encoding.md) -->
+
 **Response**
 
 | Code | Description                                                      |

--- a/apidocs/src/check_permission.md
+++ b/apidocs/src/check_permission.md
@@ -7,6 +7,8 @@ authorized to `execute` (fetch the value of) this Secret?
 
 <!-- include(partials/resource_kinds.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example with `curl`
 
 Suppose your account name is "myorg" and you want to check whether Host

--- a/apidocs/src/partials/url_encoding.md
+++ b/apidocs/src/partials/url_encoding.md
@@ -1,0 +1,15 @@
+#### Note: entity IDs must be url-encoded
+
+Any identifier included in the URL must be [percent encoded][percent-encoding]
+to be recognized by the Conjur API.
+
+Examples:
+| Identifier             | Encoded                    |
+|------------------------|----------------------------|
+| `myapp-01`             | `myapp-01` _(no change)_   |
+| `alice@devops`         | `alice%40devops`           |
+| `prod/aws/db-password` | `prod%2Faws%2Fdb-password` |
+| `research+development` | `research%2Bdevelopment`   |
+| `sales&marketing`      | `sales%26marketing`        |
+
+[percent-encoding]: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding

--- a/apidocs/src/partials/url_encoding.md
+++ b/apidocs/src/partials/url_encoding.md
@@ -1,10 +1,10 @@
-#### Note: entity IDs must be url-encoded
+#### Note: entity IDs must be URL-encoded
 
-Any identifier included in the URL must be [percent encoded][percent-encoding]
-to be recognized by the Conjur API.
+Any identifier included in the URL must be [URL-encoded][percent-encoding] to be
+recognized by the Conjur API.
 
 Examples:
-| Identifier             | Encoded                    |
+| Identifier             | URL-Encoded                |
 |------------------------|----------------------------|
 | `myapp-01`             | `myapp-01` _(no change)_   |
 | `alice@devops`         | `alice%40devops`           |

--- a/apidocs/src/replace_policy.md
+++ b/apidocs/src/replace_policy.md
@@ -9,6 +9,8 @@ Any policy data which already exists on the server but is **not** explicitly spe
 
 <!-- include(partials/policy_size_restriction.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 **Permissions required**
 
 `update` privilege on the policy.

--- a/apidocs/src/retrieve_secret.md
+++ b/apidocs/src/retrieve_secret.md
@@ -8,6 +8,8 @@ The secret data is returned in the response body.
 
 Note: Conjur will allow you to add a secret to any resource, but the best practice is to store and retrieve secret data only using Variable resources.
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example with `curl`
 
 ```

--- a/apidocs/src/rotate_api_key.md
+++ b/apidocs/src/rotate_api_key.md
@@ -60,6 +60,8 @@ Rotates the API key of another role you can update.
 
 Note that the body of the request must be the empty string.
 
+<!-- include(partials/url_encoding.md) -->
+
 <!-- include(partials/role_kinds.md) -->
 
 **Permissions required**

--- a/apidocs/src/show_permitted_roles.md
+++ b/apidocs/src/show_permitted_roles.md
@@ -1,10 +1,12 @@
-## Show permitted roles [/resources/{account}/{kind}/{id}?permitted_roles=true&privilege={privilege}]
+## Show permitted roles [/resources/{account}/{kind}/{identifier}?permitted_roles=true&privilege={privilege}]
 
 ### Show permitted roles [GET]
 
 Lists the roles which have the named permission on a resource.
 
 <!-- include(partials/resource_kinds.md) -->
+
+<!-- include(partials/url_encoding.md) -->
 
 #### Example with `curl` and `jq`
 
@@ -37,7 +39,7 @@ curl -H "$(conjur authn authenticate -H)" \
 + Parameters
   + <!-- include(partials/account_param.md) -->
   + kind: variable (string) - kind of resource requested
-  + id: db-password (string) - the identifier of the resource
+  + identifier: db-password (string) - the identifier of the resource
   + privilege: execute (string) - roles permitted to exercise this privilege are
     shown
 

--- a/apidocs/src/show_public_keys.md
+++ b/apidocs/src/show_public_keys.md
@@ -8,6 +8,8 @@ Returns an empty string if the resource does not exist, to prevent attackers fro
 
 <!-- include(partials/resource_kinds.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example using `curl`
 
 ```

--- a/apidocs/src/show_resource.md
+++ b/apidocs/src/show_resource.md
@@ -10,6 +10,8 @@ The response to this method is a JSON document describing a single resource.
 
 <!-- include(partials/resource_kinds.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example using `curl` and `jq`
 
 ```

--- a/apidocs/src/show_role.md
+++ b/apidocs/src/show_role.md
@@ -10,6 +10,8 @@ portion of the returned JSON.
 
 <!-- include(partials/role_kinds.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 #### Example using `curl` and `jq`
 
 Suppose your account is "myorg" and you want to get information about the user "alice":

--- a/apidocs/src/update_policy.md
+++ b/apidocs/src/update_policy.md
@@ -7,6 +7,8 @@ Data may be explicitly deleted using the `!delete`, `!revoke`, and `!deny` state
 
 <!-- include(partials/policy_size_restriction.md) -->
 
+<!-- include(partials/url_encoding.md) -->
+
 **Permissions required**
 
 `update` privilege on the policy.


### PR DESCRIPTION
Closes #508 

#### What does this pull request do?

It adds additional hints to the API docs so that people know to URL-encode identifiers when they are part of an API URL. Additionally, it provides a table of examples to clarify common use cases.

#### What background context can you provide?

People making requests to the Conjur API have been stumped by unexpected responses, only to eventually discover that the problem was a result of failure to URL encode their identifiers. This pull request is intended, then, to help make the Conjur API more approachable.

#### Where should the reviewer start?

Read the new partial: `apidocs/src/partials/url_encoding.md`

Notice that it's been included in the body of any API route that includes a partial.

#### How should this be manually tested?

Generate the API docs as per https://github.com/cyberark/conjur/tree/master/apidocs#working-on-the-api-docs and visit localhost:3000

#### Screenshots (if appropriate)

<img width="1148" alt="screen shot 2018-02-09 at 4 19 17 pm" src="https://user-images.githubusercontent.com/4389854/36052865-0a06aef8-0db5-11e8-8b03-729a0aff8f19.png">

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/apidocs-url-encoding-hint/

#### Questions:
> Does this have automated Cucumber tests?

No

> Can we make a blog post, video, or animated GIF out of this?

Nope