### PR TITLE
Updates Conjur TLS proxy tutorial links to use current URL

### DIFF
--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -14,14 +14,20 @@
         <dd>
           OK, Conjur is secured but not authenticated. Send your
           Conjur admin to the
-          <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
+            <a href="https://www.conjur.org/tutorials/nginx.html"
+               title="Tutorial - NGINX Proxy">
+              Conjur+TLS guide
+            </a>
           to learn how to use your own certificate &amp; upgrade to green lock.
         </dd>
         <dt>Red broken lock or no lock:</dt>
         <dd>
           Conjur is running in insecure development mode. Don't put any
           production secrets in there! Visit the
-          <a href="https://conjur.org/tutorials/integrations/nginx.html">Conjur+TLS guide</a>
+            <a href="https://www.conjur.org/tutorials/nginx.html"
+               title="Tutorial - NGINX Proxy">
+                Conjur+TLS guide
+            </a>
           to learn how to deploy Conjur securely &amp;
           <a href="https://conjur.org/support.html">contact CyberArk</a>
           with any questions.


### PR DESCRIPTION
#### What does this pull request do?

It updates the Conjur status page to use the correct URL for the TLS termination tutorial.

#### What background context can you provide?

I changed the URL of the NGINX tutorial but forgot to change it here, leaving a couple broken links.

#### Where should the reviewer start?

`conjur/app/views/status/index.html.erb` has the updated links.

#### How should this be manually tested?

Build the container, start it, visit the status page in your browser, and follow each link to the NGINX tutorial.

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/fix-tls-termination-link/