### PR TITLE
Authn Core moved into a gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y \
       update-notifier-common \
       tzdata
 
-RUN gem install -N -v 1.11.2 bundler
+RUN gem install -N -v 1.16.1 bundler
 
 RUN mkdir -p /opt/conjur-server
 
@@ -26,9 +26,11 @@ WORKDIR /opt/conjur-server
 ADD Gemfile      .
 ADD Gemfile.lock .
 
+RUN bundle --without test development local
+
 ADD . .
 
-RUN bundle --without test development website
+RUN bundle --without test development
 
 RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN apt-get install -y \
     jq \
     tzdata
       
-RUN gem install -N -v 1.11.2 bundler
+RUN gem install -N -v 1.16.1 bundler
 
 RUN mkdir -p /src/conjur-server
 
@@ -31,7 +31,7 @@ WORKDIR /src/conjur-server
 ADD Gemfile      .
 ADD Gemfile.lock .
 
-RUN bundle
+RUN bundle --without local
 
 RUN rm /etc/service/sshd/down
 RUN ln -sf /src/conjur-server/bin/conjurctl /usr/local/bin/

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem 'bootstrap-sass', '~> 3.2.0'
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 4.7.0'
 
+group :local do
+  gem 'authn_local', path: 'lib/gems/authn_local'
+end
+
 group :production do
   gem 'rails_12factor'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 gem 'rake'
 gem 'rails-api'
 gem 'rails', '~> 4.2'
-gem 'nokogiri', '>= 1.8.1'
+gem 'nokogiri', '>= 1.8.2'
 gem 'puma'
 
 gem 'sequel-rails'
@@ -44,7 +44,7 @@ gem 'bootstrap-sass', '~> 3.2.0'
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 4.7.0'
 
-group :core do
+group :local do
   gem 'authn_core', path: 'lib/gems/authn_core'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,12 @@ GIT
       activesupport
       rest-client
 
+PATH
+  remote: lib/gems/authn_core
+  specs:
+    authn_core (0.1.0)
+      conjur-api (~> 5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -294,6 +300,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   aruba
+  authn_core!
   autoprefixer-rails
   base32-crockford
   bcrypt-ruby (~> 3.0.0)
@@ -311,7 +318,7 @@ DEPENDENCIES
   gli
   json_spec
   listen
-  nokogiri (>= 1.8.1)
+  nokogiri (>= 1.8.2)
   parallel
   pg
   pry-byebug
@@ -341,4 +348,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_controller/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+Bundler.require(:local)
 
 module Possum
   class Application < Rails::Application

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -12,6 +12,7 @@ fi
 export CONJUR_DATA_KEY="$(cat data_key)"
 
 docker-compose up -d
+docker-compose exec conjur bundle
 docker-compose exec conjur conjurctl db migrate
 docker-compose exec conjur conjurctl account create cucumber || true
 docker-compose exec -d conjur conjurctl server

--- a/dev/stop.sh
+++ b/dev/stop.sh
@@ -3,3 +3,5 @@
 export COMPOSE_PROJECT_NAME=conjurdev
 
 docker-compose down -v
+
+rm -f data_key

--- a/lib/gems/authn_core/.gitignore
+++ b/lib/gems/authn_core/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/lib/gems/authn_core/.rspec
+++ b/lib/gems/authn_core/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/lib/gems/authn_core/.travis.yml
+++ b/lib/gems/authn_core/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.2.6
+before_install: gem install bundler -v 1.15.4

--- a/lib/gems/authn_core/Gemfile
+++ b/lib/gems/authn_core/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in authn_core.gemspec
+gemspec

--- a/lib/gems/authn_core/LICENSE.txt
+++ b/lib/gems/authn_core/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Jason Vanderhoof
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/gems/authn_core/README.md
+++ b/lib/gems/authn_core/README.md
@@ -1,39 +1,27 @@
 # AuthnCore
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/authn_core`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'authn_core'
-```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install authn_core
+This gem provides a standard set of methods to implement the core security
+requirements of a Conjur custom authenticator.
 
 ## Usage
 
-TODO: Write usage instructions here
+Using this core functionality within `cyberark/conjur` is supported by default, as the `authn-core` gem is included in the project Gemfile.
 
-## Development
+This gem assumes your custom authenticator accepts POST requests to `/[service-id]/users/[user-id]/authenticate`
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+To use `authn-core`, include the following commands in your custom authenticator to validate the authenticate request before performing any checks specific to your authenticator.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+The example code below assumes your authenticator has received a request where the `service-id` is `sample/id` and the `user-id` is `host/sample-host`. It also assumes your custom authenticator is called `authn-example`
 
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/authn_core.
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+```
+require 'authn_core'
+auth_sec = AuthenticatorSecurityRequirements.new(authn_type: "example")
+auth_sec.validate("sample/id", "host/sample-host")
+```
+an exception will be raised if:
+- `authn-example/sample/id` is not whitelisted in the `CONJUR_AUTHENTICATORS
+` environment variable on the Conjur node
+- there is no `conjur/authn-example/sample/id` webservice in Conjur policy
+- there is no role with id `host/sample-host`
+- the `host/sample-host` role is not authorized with `authenticate` privileges o
+n the `conjur/authn-example/sample/id` webservice

--- a/lib/gems/authn_core/README.md
+++ b/lib/gems/authn_core/README.md
@@ -1,0 +1,39 @@
+# AuthnCore
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/authn_core`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'authn_core'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install authn_core
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/authn_core.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/gems/authn_core/Rakefile
+++ b/lib/gems/authn_core/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/gems/authn_core/authn_core.gemspec
+++ b/lib/gems/authn_core/authn_core.gemspec
@@ -1,0 +1,38 @@
+# coding: utf-8
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "authn_core/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "authn_core"
+  spec.version       = AuthnCore::VERSION
+  spec.authors       = ["Jason Vanderhoof"]
+  spec.email         = ["jvanderhoof@gmail.com"]
+
+  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
+  spec.description   = %q{TODO: Write a longer description or delete this line.}
+  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.license       = "MIT"
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency 'conjur-api'
+
+  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/lib/gems/authn_core/authn_core.gemspec
+++ b/lib/gems/authn_core/authn_core.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Jason Vanderhoof", "Geri Jennings", "Jonah Goldstein"]
   spec.email         = ["jvanderhoof@gmail.com", "geri.jennings@cyberark.com", "jonah.goldstein@cyberark.com"]
 
-  spec.summary       = %q{Conjur custom authenticator security requirements}
+  spec.summary       = %q{Conjur custom authenticator core requirements}
+  spec.description   = "An implementation of the minimal security requirements for Conjur custom authenticators. All Conjur custom authenticators should make use of this core functionality."
   spec.homepage      = "https://github.com/cyberark/conjur/lib/gems/authn_core/README.md"
   spec.license       = "MIT"
 
@@ -29,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'conjur-api'
+  spec.add_runtime_dependency 'conjur-api', '~> 5'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/gems/authn_core/bin/console
+++ b/lib/gems/authn_core/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "authn_core"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/gems/authn_core/bin/setup
+++ b/lib/gems/authn_core/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/gems/authn_core/lib/authn_core.rb
+++ b/lib/gems/authn_core/lib/authn_core.rb
@@ -1,7 +1,6 @@
-require 'conjur-api'
+require "authn_core/version"
 
-class AuthnCore
-
+module AuthnCore
   class BadRequestError < RuntimeError
   end
 
@@ -21,7 +20,7 @@ class AuthnCore
 
       raise BadRequestError, "Invalid authn configuration" if @authn_type.empty? || @service_id.empty? || @user_id.empty?
 
-      enabled? && service_exists? && user_exists? && user_authorized?    
+      enabled? && service_exists? && user_exists? && user_authorized?
     end
 
     def enabled?

--- a/lib/gems/authn_core/lib/authn_core.rb
+++ b/lib/gems/authn_core/lib/authn_core.rb
@@ -1,3 +1,4 @@
+require 'conjur-api'
 require "authn_core/version"
 
 # Outstanding questions:

--- a/lib/gems/authn_core/lib/authn_core/version.rb
+++ b/lib/gems/authn_core/lib/authn_core/version.rb
@@ -1,0 +1,3 @@
+module AuthnCore
+  VERSION = "0.1.0"
+end

--- a/lib/gems/authn_core/spec/authn_core_spec.rb
+++ b/lib/gems/authn_core/spec/authn_core_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe AuthnCore do
+  it "has a version number" do
+    expect(AuthnCore::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/lib/gems/authn_core/spec/spec_helper.rb
+++ b/lib/gems/authn_core/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "authn_core"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
#### What does this pull request do?
Moves to `authn_core` functionality into a gem. This will make it easier to share with new authenticators.
