### PR TITLE
Add optional security req check to authn-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New `AuthenticatorSecurity` class that implements the minimum requirements for a custom authenticator
+
+### Changed
+- `authn-local` is updated to use the `AuthenticatorSecurity` class to validate request if `authn_type` and `service_id` are sent
+
 ## [0.3.0] - 2018-01-11
 ### Added
 - `conjurctl wait` command is added that can be used to check if the Conjur server is ready

--- a/app/classes/authenticator_security.rb
+++ b/app/classes/authenticator_security.rb
@@ -1,0 +1,110 @@
+class AuthenticatorNotEnabled < RuntimeError
+  def initialize(authenticator_name)
+    super("'#{authenticator_name}' not whitelisted in CONJUR_AUTHENTICATORS")
+  end
+end
+
+class ServiceNotDefined < RuntimeError
+  def initialize(service_name)
+    super("Webservice '#{service_name}' is not defined in the Conjur policy")
+  end
+end
+
+class NotAuthorizedInConjur < RuntimeError
+  def initialize(user_id)
+    super("User '#{user_id}' is not authorized in the Conjur policy")
+  end
+end
+
+class AuthenticatorSecurity
+  def initialize(authn_type:,
+                 account:,
+                 whitelisted_authenticators: ENV['CONJUR_AUTHENTICATORS'])
+    @authn_type = authn_type
+    @account = account
+    @authenticators = authenticators_array(whitelisted_authenticators)
+
+    validate_constructor_arguments
+  end
+
+  def validate(service_id, user_id)
+    validate_nonempty('service_id', service_id)
+    validate_nonempty('user_id', user_id)
+
+    service_name = webservice_name(service_id)
+
+    validate_service_whitelisted(service_name)
+    validate_user_requirements(service_name, user_id)
+  end
+
+  private
+
+  def validate_constructor_arguments
+    validate_nonempty('authn_type', @authn_type)
+    validate_nonempty('account', @account)
+  end
+
+  def authenticators_array(comma_delimited_authenticators)
+    (comma_delimited_authenticators || '').split(',').map(&:strip)
+  end
+
+  def webservice_name(service_id)
+    "authn-#{@authn_type}/#{service_id}"
+  end
+
+  def validate_service_whitelisted(service_name)
+    is_whitelisted = @authenticators.include?(service_name)
+    raise AuthenticatorNotEnabled, service_name unless is_whitelisted
+  end
+
+  def validate_user_requirements(service_name, user_id)
+    UserSecurityRequirements.new(
+       user_id: user_id, 
+       webservice_name: service_name,
+       account: @account
+    ).validate
+  end
+
+  def validate_nonempty(name, value)
+    raise ArgumentError, "'#{name}' must not be empty" if value.to_s.empty?
+  end
+
+  class UserSecurityRequirements
+    def initialize(user_id:,
+                   webservice_name:,
+                   account:)
+
+      @user_id         = user_id
+      @webservice_name = webservice_name
+      @account  = account
+    end
+
+    def validate
+      raise ServiceNotDefined, @webservice_name unless webservice
+      raise NotAuthorizedInConjur, @user_id unless user_role
+      raise NotAuthorizedInConjur, @user_id unless user_can_authenticate_to_webservice
+    end
+
+    private
+
+    def user_role_id
+      @user_role_id ||= Role.roleid_from_username(@account, @user_id)
+    end
+
+    def user_role
+      @user_role ||= Role[user_role_id]
+    end
+
+    def webservice_id
+      "#{@account}:webservice:conjur/#{@webservice_name}"
+    end
+
+    def webservice
+      @webservice ||= Resource[webservice_id]
+    end
+
+    def user_can_authenticate_to_webservice
+      user_role.allowed_to?("authenticate", webservice)
+    end
+  end
+end

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -68,7 +68,6 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
     service_id = claims['service_id']
     raise "'sub' is required" unless claims['sub']
 
-    puts "Checking sec req: #{service_id}, #{@account}, #{@authn_type}, #{claims['sub']}"
     validate_security_requirements service_id, claims['sub'] if service_id && @authn_type
 
     key = Slosilo["authn:#{@account}"]

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -62,14 +62,32 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
 
   def issue_token claims
     claims = JSON.parse(claims)
-    claims = claims.slice("account", "sub", "exp", "cidr")
-    account = claims.delete("account") or raise "'account' is required"
+    claims = claims.slice("account", "sub", "exp", "cidr", "service_id", "authn_type")
+    @account = claims.delete("account") or raise "'account' is required"
+    @authn_type = claims['authn_type']
+    service_id = claims['service_id']
     raise "'sub' is required" unless claims['sub']
-    key = Slosilo["authn:#{account}"]
+
+    puts "Checking sec req: #{service_id}, #{@account}, #{@authn_type}, #{claims['sub']}"
+    validate_security_requirements service_id, claims['sub'] if service_id && @authn_type
+
+    key = Slosilo["authn:#{@account}"]
     if key 
       key.issue_jwt(claims).to_json
     else
-      raise "No signing key found for account #{account.inspect}"
+      raise "No signing key found for account #{@account.inspect}"
     end
+  end
+
+  def validate_security_requirements service_id, user_id
+    security_requirements.validate(service_id, user_id)
+  end
+
+  def security_requirements
+    AuthenticatorSecurity.new(
+      authn_type: @authn_type,
+      account: @account,
+      whitelisted_authenticators: ENV['CONJUR_AUTHENTICATORS']
+    )
   end
 end


### PR DESCRIPTION
## Description of changes
This PR updates `authn-local` to accept optional parameters `service_id` and `authn_type`, and if they are both set runs a set of security checks on the auth request. These include:

- Is the string `authn-[authn-type]/[service_id]` included in the comma-delimited string in the `CONJUR_AUTHENTICATORS` environment variable?
- Does the webservice `conjur/authn-[authn_type]/[service_id]` exist in Conjur policy?
- Does the user requesting authentication exist in Conjur policy?
- Does the user requesting authentication have `authenticate` privileges on the `authn-[authn-type]/[service_id]` webservice in Conjur policy?

Adding these checks is the first step in standardizing the way that custom authenticators operate in v5 Conjur.

### Work that remains to do
At current, the AuthenticatorSecurity class does not have unit tests, but there is a Jira story to add them this sprint. These updates are to provide a POC of how a standard for custom authenticators may be implemented, so the first step was getting the functionality working and then tests will be added. Documentation will also be added in a future story.

## Validating these updates
The important thing is that these updates don't break any existing tests, since nothing is using this new functionality yet. See the Jenkins build link at the bottom to verify.

If you want to test these updates, these updates can be validated by working in the `authn-ldap` branch (which includes these updates, and a custom authenticator that uses them). To stand up and configure the required containers, you can run:
```
$ ./build.sh
$ cd dev/
$ ./start.sh
# conjurctl server
```
and in a separate window run
```
cd dev/
./ldap-setup.sh
```

To run the tests, you may do the following curl requests from your local machine:
```
curl -i -X POST -d "admin" http://localhost:3000/authn-ldap/test/cucumber/admin/authenticate
[401 bc ldap creds are invalid]

curl -X POST -d "alice" http://localhost:3000/authn-ldap/tester/cucumber/alice/authenticate
[401 bc 'authn-ldap/tester' not whitelisted in CONJUR_AUTHENTICATORS]

[stop server, set CONJUR_AUTHENTICATORS=authn-ldap/tester in Conjur container, start server]
curl -X POST -d "alice" http://localhost:3000/authn-ldap/tester/cucumber/alice/authenticate
[401 bc Webservice 'authn-ldap/tester' is not defined in the Conjur policy]

[reset, update policy to not define user alice]
curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate
[401 bc User 'alice' is not authorized in the Conjur policy]

[reset policy, but don't include entitlement]
curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate
[401 bc User 'alice' is not authorized in the Conjur policy]
```

[Jenkins build](https://jenkins.conjur.net/job/cyberark--conjur/job/authenticator-security/)