### PR TITLE
Adds a `conjur-dev` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,47 @@ To use it:
     ```
     Running `stop` removes the running Docker Compose containers and the data key.
 
+### `conjur-dev` CLI
+
+As a developer, there are a number of common scenarios when actively working on Conjur.
+The `./conjur-dev` script, located in the `dev` folder is intended to streamline these tasks.
+
+```sh-session
+$ ./conjur-dev --help
+
+NAME
+    conjur - Developement tool to simplify working with a Conjur container.
+
+SYNOPSIS
+    conjur [global options] command [command options] [arguments...]
+
+GLOBAL OPTIONS
+    --help                                    - Show this message
+
+COMMANDS
+
+    exec                                      - Steps into the running Conjur container, into a bash shell.
+
+    policy load <account> <policy/path.yml>   - Loads a conjur policy into the provided account.
+```
+
+#### Step into the running Conjur container
+
+```sh-session
+$ ./conjur-dev exec
+
+root@88d43f7b3dfa:/src/conjur-server#
+```
+
+
+#### Load a policy
+
+```sh-session
+$ ./conjur-dev policy load <account> <policy/path/from/project/root.yml>
+```
+
+For most development work, the account will be `cucumber`, which is created when the developement environment starts. The policy path must be inside the `cyberark/conjur` project folder, and referenced from the project root.
+
 ## Testing
 
 Conjur has `rspec` and `cucumber` tests.

--- a/dev/conjur-dev
+++ b/dev/conjur-dev
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+function print_help() {
+  cat << EOF
+NAME
+    conjur - Developement tool to simplify working with a Conjur container.
+
+SYNOPSIS
+    conjur [global options] command [command options] [arguments...]
+
+GLOBAL OPTIONS
+    --help                                    - Show this message
+
+COMMANDS
+
+    exec                                      - Steps into the running Conjur container, into a bash shell.
+
+    policy load <account> <policy/path.yml>   - Loads a conjur policy into the provided account.
+EOF
+exit
+}
+
+while true ; do
+  case "$1" in
+    -h | --help ) print_help ; shift ;;
+    exec ) docker exec -it --detach-keys 'ctrl-\' $(docker-compose ps -q conjur) bash ; shift ;;
+    policy )
+      case "$2" in
+        load )
+          account="$3"
+          policy_file=$4
+          docker-compose exec conjur conjurctl policy load "$account" "/src/conjur-server/$policy_file"
+          shift 4 ;;
+        * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
+      esac ;;
+     * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
+  esac
+done


### PR DESCRIPTION
#### What does this pull request do?
This PR provides a new CLI tool `conjur-dev` in the `dev` folder.  This tool simplifies:
* Stepping into the running Conjur container
* Loading policies into Conjur

#### What background context can you provide?
This is part of ongoing work to improve the development experience, and make it easier to develop and test Conjur.

#### Where should the reviewer start?
`README.md` has most of the details, `dev/conjur-dev` has the fun stuff.

#### How should this be manually tested?
Pull this branch down and start a development environment.  In a new shell, you should be able to run the following:
* `./conjur-dev --help`
* `./conjur-dev exec`
* `./conjur-dev policy load cucumber dev/files/authn-ldap/policy.yml` # assuming there is a policy file in that location.
