### PR TITLE
Set LDAP settings only with `--authn-ldap` flag

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -16,12 +16,6 @@ services:
       CONJUR_PASSWORD_ALICE: secret
       CONJUR_DATA_KEY:
       RAILS_ENV:
-      CONJUR_AUTHENTICATORS: authn-ldap/test
-      LDAP_URI: ldap://ldap-server:389
-      LDAP_BASE: dc=conjur,dc=net
-      LDAP_FILTER: '(uid=%s)'
-      LDAP_BINDDN: cn=admin,dc=conjur,dc=net
-      LDAP_BINDPW: ldapsecret
     ports:
       - "3000:3000"
     expose:

--- a/dev/start
+++ b/dev/start
@@ -40,8 +40,15 @@ docker-compose exec conjur bundle
 docker-compose exec conjur conjurctl db migrate
 docker-compose exec conjur conjurctl account create cucumber || true
 
+env_args=
 if [[ $ENABLE_AUTHN_LDAP = true ]]; then
   services="$services ldap-server"
+  env_args="$env_args -e CONJUR_AUTHENTICATORS=authn-ldap/test"
+  env_args="$env_args -e LDAP_URI=ldap://ldap-server:389"
+  env_args="$env_args -e LDAP_BASE=dc=conjur,dc=net"
+  env_args="$env_args -e LDAP_FILTER=(uid=%s)"
+  env_args="$env_args -e LDAP_BINDDN=cn=admin,dc=conjur,dc=net"
+  env_args="$env_args -e LDAP_BINDPW=ldapsecret"
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-ldap/policy.yml
 fi
 
@@ -49,4 +56,4 @@ docker-compose up -d --no-deps $services
 
 api_key=$(docker-compose exec -T conjur conjurctl \
 	role retrieve-key cucumber:user:admin | tr -d '\r')
-docker exec -e CONJUR_AUTHN_API_KEY=$api_key -it --detach-keys 'ctrl-\' $(docker-compose ps -q conjur) bash
+docker exec -e CONJUR_AUTHN_API_KEY=$api_key $env_args -it --detach-keys 'ctrl-\' $(docker-compose ps -q conjur) bash


### PR DESCRIPTION
#### What does this pull request do?
Allows visibility into an authentication error when `CONJUR_AUTHENTICATORS` is empty. 