### PR TITLE
CONJ-5040 List or count a role's direct memberships.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Resources are now only visible if the user is a member of a role that owns them or has some
 permission on them.
 
+- RolesController now implements #direct_memberships to return the
+  direct members of a role, without recursive expansion.
+
 ## [0.4.0] - 2018-04-10
 ### Added
 - Policy changes now generate audit log messages. These can optionally be generated in RFC5424

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :production do
 end
 
 group :development, :test do
+  gem 'pry-rails'
   gem 'pry-byebug'
   gem 'conjur-debify', require: false
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     puma (3.8.2)
     rack (1.6.8)
     rack-rewrite (1.5.1)
@@ -343,6 +345,7 @@ DEPENDENCIES
   parallel
   pg
   pry-byebug
+  pry-rails
   puma
   rack-rewrite
   rails (~> 4.2)

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -6,12 +6,18 @@ class RolesController < RestController
   end
   
   def memberships
-    filter = params[:filter]
+    options = params.slice(:all, :count, :filter, :memberships).symbolize_keys
+    
+    filter = options[:filter]
     if filter
       filter = Array(filter).map{|id| Role.make_full_id id, account}
     end
+
+    roles = roles_as_dataset(options)
+
+    roles = roles.member_of(filter) if options[:filter]
     
-    render json: @role.all_roles(filter).map(&:role_id)
+    render json: roles_as_json(roles, options)
   end
 
   protected
@@ -24,4 +30,27 @@ class RolesController < RestController
     @role = Role[role_id]
     raise Exceptions::RecordNotFound, role_id unless @role
   end
+
+  def roles_as_dataset(options)
+    case
+    when options.has_key?(:all)
+      @role.all_roles
+    when options.has_key?(:memberships)
+      @role.memberships_as_member_dataset
+    else
+      raise "Routing misconfigured, expected params[:all] or params[:membership] to be present"
+    end
+  end
+  
+  def roles_as_json(roles, options)
+    case
+    when options.has_key?(:count)
+      { count: roles.count }
+    when options.has_key?(:memberships)
+      roles
+    else
+      roles.map(&:role_id)
+    end
+  end
+  
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,25 +1,51 @@
 class RolesController < RestController
-  before_filter :find_role, only: [ :show, :memberships ]
+  before_filter :find_role, only: [ :show, :all_memberships, :direct_memberships ]
 
   def show
     render json: @role.as_json.merge(members: @role.memberships)
   end
+
+  # Find all role memberships, expanded recursively. If no parameters
+  # are given, the role id of each membership is returned.
+  #
+  # If +params[:filter]+ is given, return (as role ids), the subset of
+  # memberships that matches the filter
   
-  def memberships
-    options = params.slice(:all, :count, :filter, :memberships).symbolize_keys
+  # If +params[:count]+ is given, return the count of memberships,
+  # rather than the memberships themselves
+  #
+  def all_memberships
+    options = membership_options
     
-    filter = options[:filter]
-    if filter
-      filter = Array(filter).map{|id| Role.make_full_id id, account}
+    memberships = with_filter(options) do
+      @role.all_roles
     end
 
-    roles = roles_as_dataset(options)
-
-    roles = roles.member_of(filter) if options[:filter]
+    json = render_count(memberships, options) || memberships.map(&:role_id)
     
-    render json: roles_as_json(roles, options)
+    render json: json
   end
 
+  # Find all direct memberships, i.e don't recursively expand member
+  # roles.
+  #
+  # For each membership, return the full details of the grant as a
+  # JSON object.
+  # 
+  #
+  # +params[:filter]+ and +params[:count]+ are handled as for +#all_memberships+
+  #
+  def direct_memberships
+    options = membership_options
+    
+    memberships = with_filter(options) do
+      @role.memberships_as_member_dataset
+    end
+
+    json = render_count(memberships, options) || memberships
+    render json: json
+  end
+  
   protected
 
   def role_id
@@ -31,26 +57,23 @@ class RolesController < RestController
     raise Exceptions::RecordNotFound, role_id unless @role
   end
 
-  def roles_as_dataset(options)
-    case
-    when options.has_key?(:all)
-      @role.all_roles
-    when options.has_key?(:memberships)
-      @role.memberships_as_member_dataset
-    else
-      raise "Routing misconfigured, expected params[:all] or params[:membership] to be present"
-    end
+  def membership_options
+    @membership_options ||= params.slice(:count, :filter).symbolize_keys
   end
   
-  def roles_as_json(roles, options)
-    case
-    when options.has_key?(:count)
-      { count: roles.count }
-    when options.has_key?(:memberships)
-      roles
-    else
-      roles.map(&:role_id)
+  def with_filter(options, &block)
+    filter = options[:filter]
+    if filter
+      filter = Array(filter).map{|id| Role.make_full_id id, account}
     end
+
+    roles = yield
+
+    filter ? roles.member_of(filter) : roles
+  end
+    
+  def render_count(roles, options)
+    { count: roles.count } if options.has_key?(:count)
   end
   
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -52,6 +52,13 @@ class Role < Sequel::Model
       end
     end
   end
+
+  dataset_module do
+    def member_of role_ids
+      filter_memberships = Set.new(role_ids.map{|id| Role[id]}.compact.map(&:role_id))
+      where(role_id: filter_memberships.to_a)
+    end
+  end
   
   def password= password
     self.credentials ||= Credentials.new(role: self)
@@ -98,12 +105,7 @@ class Role < Sequel::Model
     Role.from(Sequel.function(:is_role_allowed_to, id, privilege.to_s, resource.id)).first[:is_role_allowed_to]
   end
   
-  def all_roles filter = nil
-    if filter.nil?
-      Role.from(Sequel.function(:all_roles, id))
-    else
-      filter_roles = Set.new(filter.map{|id| Role[id]}.compact.map(&:role_id))
-      Role.from(Sequel.function(:all_roles, id)).where(role_id: filter_roles.to_a)
-    end
+  def all_roles
+    Role.from(Sequel.function(:all_roles, id))
   end
 end

--- a/app/models/role_membership.rb
+++ b/app/models/role_membership.rb
@@ -11,4 +11,11 @@ class RoleMembership < Sequel::Model
       end
     end
   end
+
+  dataset_module do
+    def member_of role_ids
+      subset_roles = Set.new(role_ids.map{|id| Role[id]}.compact.map(&:role_id))
+      where(member_id: subset_roles.to_a)
+    end
+  end
 end

--- a/ci/test
+++ b/ci/test
@@ -27,9 +27,9 @@ EOF
 exit
 }
 
-# Cleanup started containers
+# Cleanup started containers, ok they're already gone.
 function finish {
-  docker-compose down --rmi 'local' --volumes
+  docker-compose down --rmi 'local' --volumes || true
 }
 trap finish EXIT
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,16 @@ class QueryParameterActionRecognizer
   end
 end
 
+class QueryParameterActionsRecognizer
+  def initialize(*actions)
+    @actions = actions
+  end
+
+  def matches?(request)
+    !request.params.slice(*@actions).empty?
+  end
+end
+
 Rails.application.routes.draw do
   scope format: false do
     get '/' => 'status#index'
@@ -26,7 +36,7 @@ Rails.application.routes.draw do
           'authenticate#authenticate'
       end
 
-      get "/roles/:account/:kind/*identifier" => "roles#memberships", :constraints => QueryParameterActionRecognizer.new("all")
+      get "/roles/:account/:kind/*identifier" => "roles#memberships", :constraints => QueryParameterActionsRecognizer.new("all", "memberships")
 
       get "/roles/:account/:kind/*identifier" => "roles#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,16 +8,6 @@ class QueryParameterActionRecognizer
   end
 end
 
-class QueryParameterActionsRecognizer
-  def initialize(*actions)
-    @actions = actions
-  end
-
-  def matches?(request)
-    !request.params.slice(*@actions).empty?
-  end
-end
-
 Rails.application.routes.draw do
   scope format: false do
     get '/' => 'status#index'
@@ -36,7 +26,8 @@ Rails.application.routes.draw do
           'authenticate#authenticate'
       end
 
-      get "/roles/:account/:kind/*identifier" => "roles#memberships", :constraints => QueryParameterActionsRecognizer.new("all", "memberships")
+      get "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
+      get "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
 
       get "/roles/:account/:kind/*identifier" => "roles#show"
 

--- a/spec/routing/roles_routing_spec.rb
+++ b/spec/routing/roles_routing_spec.rb
@@ -21,13 +21,23 @@ describe "routing from roles" do
       identifier: 'admin')
   end
   
-  it "routes GET /roles/:account/:role?all to roles#all_roles" do
+  it "routes GET /roles/:account/:role?all to roles#all_memberships" do
     expect(get: '/roles/the-account/user/admin?all').to route_to(
       account: 'the-account',
       controller: 'roles',
-      action: 'memberships',
+      action: 'all_memberships',
       kind: 'user',
       identifier: 'admin',
       all: nil)
+  end
+
+  it "routes GET /roles/:account/:role?memberships to roles#direct_memberships" do
+    expect(get: '/roles/the-account/user/admin?memberships').to route_to(
+      account: 'the-account',
+      controller: 'roles',
+      action: 'direct_memberships',
+      kind: 'user',
+      identifier: 'admin',
+      memberships: nil)
   end
 end


### PR DESCRIPTION
Closes https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-5040

#### What does this pull request do?
Enhances the `/roles/:account/:kind/*identifier` route to allow listing or counting only direct memberships 
#### What background context can you provide?
This API entry point now matches the v4 functionality

#### Where should the reviewer start?
https://github.com/cyberark/conjur/compare/direct-memberships_20180508?expand=1#diff-70d472b9d955da65928bdd31d9487fa6

#### How should this be manually tested?
New cukes were added. As longs as the build's green, doesn't need manual testing.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/direct-memberships_20180508/6/

#### Questions:
> Does this have automated Cucumber tests?
Yes.

> Can we make a blog post, video, or animated GIF out of this?
No.

> Is this explained in documentation?
No, API docs need to be updated.

> Does the knowledge base need an update?
No.