### PR TITLE
WIP Credential factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ demo/run/load
 /run
 coverage
 .DS_Store
+.history
 demo/run/*.yml
 
 apidocs/node_modules

--- a/CredentialFactory.md
+++ b/CredentialFactory.md
@@ -1,8 +1,8 @@
 # Credential Factory
 
-Generates credentials dynamically from a backend which supports it, such as AWS Security Token Service.
+A credential factory is a Conjur service which creates a new set of credentials each time it is called. A credential factory is a secure and scalable way to expose a credential-issuing backend, such as AWS Security Token Service, to Conjur clients.
 
-# Policy configuration
+# Example : AWS STS credential factory
 
 Load a policy file, such as [aws_credential_factory.yml](./run/aws_credential_factory.yml). In one policy, such as `aws-dev`, define variables for AWS access key id, secret, and region. For example:
 
@@ -17,13 +17,13 @@ Create a `secrets-users` group with access to these credentials.
 
 Load valid credentials into the variables and set the `region`.
 
-In another policy, such as `myapp`, define a `!credential-factory` object and add an entitlement which grants it the `secrets-users` group (for example, `aws-dev/secrets-users`. The Credential Factory will access these credentials in order to call the AWS Security Token Service [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html) function. You must provide an annotation `credential-factory/policy`, which is the IAM policy which will be applied to the generated credentials.
+In another policy, such as `myapp`, define a `!webservice` object and add an entitlement which grants it the `secrets-users` group (for example, `aws-dev/secrets-users`. This web service will access these credentials in order to call the AWS Security Token Service [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html) function. You must provide an annotation `credential-factory/policy`, which is the IAM policy which will be applied to the generated credentials.
 
 You can also define optional annotations `credential-factory/duration-seconds` and `credential-factory/user-name`. 
 
-Then, for any role which you want to use the Credential Factory, give it the `execute` privilege on the `!credential-factory`. The client role **does not** need any privileges on the long-lived AWS credentials.
+Then, for any role which you want to use the Credential Factory, give it the `execute` privilege on the `!webservice`. The client role **does not** need any privileges on the long-lived AWS credentials.
 
-The client role can now fetch a secret using the Conjur API using the object id `<acct>:credential_factory:<the-factory-id>`, just like fetching a secret from a variable using `<acct>:variable:<the-variable-id>`. 
+The client role can now fetch a secret using the Conjur API using the object id `<acct>:webservice:<the-factory-id>`, just like fetching a secret from a variable using `<acct>:variable:<the-variable-id>`. 
 
 The data will be returned in JSON format with the following fields:
 
@@ -36,7 +36,7 @@ The data will be returned in JSON format with the following fields:
 
 The MIME type is `application/json`.
 
-# Example
+# Example : Obtaining credentials in `rails console`
 
 1. Start up `./dev/start.sh`
 2. In the `conjur` container, run the server using the AWS credential factory example policy:
@@ -59,10 +59,10 @@ Loaded policy in 0.577820945 seconds
 > Secret.create resource: r, value: "us-east-1"
 ```
 
-5. Now you can use CredentialFactory to generate credentials:
+5. Now you can use credential factory to generate credentials:
 
 ```
-> puts JSON.pretty_generate CredentialFactory.values Resource["cucumber:credential_factory:myapp"]
+> puts JSON.pretty_generate CredentialFactory.values Resource["cucumber:webservice:myapp/aws-credentials"]
 {
   "access_key_id": "ASIAI6...F7KPBKA",
   "secret_access_key": "EhyQYceI...arRtkZfYugB9dDM6",

--- a/CredentialFactory.md
+++ b/CredentialFactory.md
@@ -1,0 +1,79 @@
+# Credential Factory
+
+Generates credentials dynamically from a backend which supports it, such as AWS Security Token Service.
+
+# Policy configuration
+
+Load a policy file, such as [aws_credential_factory.yml](./run/aws_credential_factory.yml). In one policy, such as `aws-dev`, define variables for AWS access key id, secret, and region. For example:
+
+```
+- &variables
+  - !variable access_key_id
+  - !variable secret_access_key
+  - !variable region
+```
+
+Create a `secrets-users` group with access to these credentials.
+
+Load valid credentials into the variables and set the `region`.
+
+In another policy, such as `myapp`, define a `!credential-factory` object and add an entitlement which grants it the `secrets-users` group (for example, `aws-dev/secrets-users`. The Credential Factory will access these credentials in order to call the AWS Security Token Service [GetFederationToken](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html) function. You must provide an annotation `credential-factory/policy`, which is the IAM policy which will be applied to the generated credentials.
+
+You can also define optional annotations `credential-factory/duration-seconds` and `credential-factory/user-name`. 
+
+Then, for any role which you want to use the Credential Factory, give it the `execute` privilege on the `!credential-factory`. The client role **does not** need any privileges on the long-lived AWS credentials.
+
+The client role can now fetch a secret using the Conjur API using the object id `<acct>:credential_factory:<the-factory-id>`, just like fetching a secret from a variable using `<acct>:variable:<the-variable-id>`. 
+
+The data will be returned in JSON format with the following fields:
+
+* access_key_id
+* secret_access_key
+* session_token
+* expiration
+* federated_user_id
+* federated_user_arn
+
+The MIME type is `application/json`.
+
+# Example
+
+1. Start up `./dev/start.sh`
+2. In the `conjur` container, run the server using the AWS credential factory example policy:
+
+```
+$ conjurctl server -a cucumber -f ./run/aws_credential_factory.yml
+...
+Loaded policy in 0.577820945 seconds
+```
+
+3. Open `rails console` of the `conjur` container in a separate terminal.
+4. Populate the secrets:
+
+```
+> r = Resource["cucumber:variable:aws/dev-account/access_key_id"]
+> Secret.create resource: r, value: "<your-access-key-id>"
+> r = Resource["cucumber:variable:aws/dev-account/secret_access_key"]
+> Secret.create resource: r, value: "<your-secret>"
+> r = Resource["cucumber:variable:aws/dev-account/region"]
+> Secret.create resource: r, value: "us-east-1"
+```
+
+5. Now you can use CredentialFactory to generate credentials:
+
+```
+> puts JSON.pretty_generate CredentialFactory.values Resource["cucumber:credential_factory:myapp"]
+{
+  "access_key_id": "ASIAI6...F7KPBKA",
+  "secret_access_key": "EhyQYceI...arRtkZfYugB9dDM6",
+  "session_token": "FQoDYXdzEH4aD...7bz7Nw+NL0mKNr8ztYF",
+  "expiration": "2018-04-15 22:04:26 UTC",
+  "federated_user_id": "<acct-id>:myapp",
+  "federated_user_arn": "arn:aws:sts::<acct-id>:federated-user/myapp"
+}
+```
+
+# TODO
+
+* Should the `expiration` result be set as a header instead?
+

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'sequel-rails'
 gem 'pg'
 gem 'sequel-postgres-schemata', require: false
 
+gem 'aws-sdk-core'
+
 gem 'base32-crockford'
 gem 'activesupport'
 gem 'bcrypt-ruby', '~> 3.0.0'
@@ -31,7 +33,7 @@ gem 'ruby_dep', '= 1.3.1'
 gem 'conjur-api', github: 'cyberark/api-ruby'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'
-gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'possum'
+gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'feature/credential-factory'
 gem 'rack-rewrite'
 
 gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/conjurinc/conjur-policy-parser.git
-  revision: b92854c1a0db5afb6a2294b77d96fcd9831cc59e
-  branch: possum
+  revision: ed62bd0d1c60edfb5162be0ee4e3b7eb5f0c0c68
+  branch: feature/credential-factory
   specs:
     conjur-policy-parser (3.0.0)
       activesupport (~> 4.2)
@@ -62,6 +62,12 @@ GEM
       thor (~> 0.19)
     autoprefixer-rails (7.1.2.3)
       execjs
+    aws-partitions (1.80.0)
+    aws-sdk-core (3.19.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sigv4 (1.0.2)
     base32-crockford (0.1.0)
     bcrypt-ruby (3.0.1)
     bootstrap-sass (3.2.0.2)
@@ -132,6 +138,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.6)
+    jmespath (1.4.0)
     json (2.1.0)
     json_spec (1.1.5)
       multi_json (~> 1.0)
@@ -295,6 +302,7 @@ DEPENDENCIES
   activesupport
   aruba
   autoprefixer-rails
+  aws-sdk-core
   base32-crockford
   bcrypt-ruby (~> 3.0.0)
   bootstrap-sass (~> 3.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,7 @@ class ApplicationController < ActionController::API
 
   def forbidden e
     logger.debug "#{e}\n#{e.backtrace.join "\n"}"
-    if e.message
+    if e.message != "ApplicationController::Forbidden"
       render json: {
         error: {
           code: "forbidden",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -157,7 +157,16 @@ class ApplicationController < ActionController::API
 
   def forbidden e
     logger.debug "#{e}\n#{e.backtrace.join "\n"}"
-    head :forbidden
+    if e.message
+      render json: {
+        error: {
+          code: "forbidden",
+          message: e.message
+        }
+      }, status: :forbidden
+    else
+      head :forbidden
+    end
   end
 
   def unauthorized e

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -24,8 +24,8 @@ class SecretsController < RestController
     case @resource.kind
     when "variable"
       secret_from_variable
-    when "credential-factory"
-      secret_from_factory
+    when "webservice"
+      secret_from_webservice
     else
       raise Exceptions::RecordNotFound
     end
@@ -81,10 +81,10 @@ class SecretsController < RestController
     send_data value, type: mime_type
   end
 
-  def secret_from_factory
+  def secret_from_webservice
     raise ArgumentError, "version" if params[:version]
 
     values = CredentialFactory.values @resource
-    render json: values, mime_type: "application/json"
+    render json: values
   end
 end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -21,13 +21,10 @@ class SecretsController < RestController
   def show
     authorize :execute
 
-    case @resource.kind
-    when "variable"
-      secret_from_variable
-    when "webservice"
-      secret_from_webservice
+    if @resource.credential_factory_provider
+      create_secret
     else
-      raise Exceptions::RecordNotFound
+      lookup_secret
     end
   end
 
@@ -62,7 +59,7 @@ class SecretsController < RestController
 
   protected
 
-  def secret_from_variable
+  def lookup_secret
     version = params[:version]
     secret = if version.is_a?(String) && version.to_i.to_s == version
       @resource.secrets.find{|s| s.version == version.to_i}
@@ -81,7 +78,7 @@ class SecretsController < RestController
     send_data value, type: mime_type
   end
 
-  def secret_from_webservice
+  def create_secret
     raise ArgumentError, "version" if params[:version]
 
     values = CredentialFactory.values @resource

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -34,7 +34,7 @@ Account = Struct.new(:id) do
           Resource.create resource_id: role_id, owner_id: owner_id
         end
         
-        admin_api_key
+        admin_user.api_key
       end
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -34,7 +34,7 @@ Account = Struct.new(:id) do
           Resource.create resource_id: role_id, owner_id: owner_id
         end
         
-        admin_user.api_key
+        admin_api_key
       end
     end
 
@@ -54,6 +54,14 @@ Account = Struct.new(:id) do
 
   def token_key
     Slosilo["authn:#{id}"]
+  end
+
+  def admin_role_id
+    "#{id}:user:admin"
+  end
+
+  def admin_role_api_key
+    Role[admin_role_id].api_key
   end
 
   def delete

--- a/app/models/credential_factory.rb
+++ b/app/models/credential_factory.rb
@@ -31,8 +31,9 @@ module CredentialFactory
       dependent_secrets = dependent_variables.inject({}) do |memo, variable|
         # Don't reveal that a variable exists if the credential factory doesn't have permission to execute it.
         unless factory_resource.role.allowed_to?('execute', variable)
-          Rails.logger.info "#{factory_resource.resource_id.inspect} does not have 'execute' privilege on #{variable.resource_id.inspect}"
-          raise Exceptions::Forbidden
+          msg = "#{factory_resource.resource_id.inspect} does not have 'execute' privilege on #{variable.resource_id.inspect}"
+          Rails.logger.info msg
+          raise Exceptions::Forbidden, "#{factory_resource.resource_id.inspect} does not have 'execute' privilege on #{variable.resource_id.inspect}"
         end
         secret = variable.secrets.last
         unless secret

--- a/app/models/credential_factory.rb
+++ b/app/models/credential_factory.rb
@@ -1,0 +1,48 @@
+module CredentialFactory
+  class << self
+    def values factory_resource
+      provider_annotation = factory_resource.annotations_dataset.where(name: 'credential-factory/provider').first
+      raise ArgumentError, %Q(Annotation "credential-factory/provider" not found on #{factory_resource.id.inspect}) unless provider_annotation
+      require "credential_factory/#{provider_annotation.value.underscore}"
+      factory_class = self.const_get(provider_annotation.value.downcase.camelize)
+
+      annotations = factory_resource.annotations.select do |annotation|
+        annotation.name =~ /^credential-factory\// && annotation.name != "credential-factory/provider"
+      end.inject({}) do |memo, annotation|
+        memo[annotation.name] = annotation.value
+        memo
+      end
+
+      dependent_variable_ids = factory_class.dependent_variable_ids(annotations)
+
+      dependent_variables = dependent_variable_ids.map do |id|
+        tokens = id.split(":")
+        if tokens.length == 1
+          id = [ factory_resource.account, "variable", id ].join(":")
+        end
+
+        Resource[id].tap do |variable|
+          unless variable
+            Rails.logger.info "Variable #{id.inspect} required by #{factory_resource.resource_id.inspect} does not exist"
+            raise Exceptions::RecordNotFound, id
+          end
+        end
+      end
+      dependent_secrets = dependent_variables.inject({}) do |memo, variable|
+        # Don't reveal that a variable exists if the credential factory doesn't have permission to execute it.
+        unless factory_resource.role.allowed_to?('execute', variable)
+          Rails.logger.info "#{factory_resource.resource_id.inspect} does not have 'execute' privilege on #{variable.resource_id.inspect}"
+          raise Exceptions::Forbidden
+        end
+        secret = variable.secrets.last
+        unless secret
+          raise Exceptions::RecordNotFound.new(variable.resource_id, message: "#{variable.resource_id.inspect} does not contain a secret value")
+        end
+        memo[variable.identifier.split('/').last.to_sym] = secret.value
+        memo
+      end
+
+      factory_class.new(factory_resource, dependent_secrets).values
+    end
+  end
+end

--- a/app/models/credential_factory.rb
+++ b/app/models/credential_factory.rb
@@ -1,7 +1,7 @@
 module CredentialFactory
   class << self
     def values factory_resource
-      provider_annotation = factory_resource.annotations_dataset.where(name: 'credential-factory/provider').first
+      provider_annotation = factory_resource.credential_factory_provider
       raise ArgumentError, %Q(Annotation "credential-factory/provider" not found on #{factory_resource.id.inspect}) unless provider_annotation
       require "credential_factory/#{provider_annotation.value.underscore}"
       factory_class = self.const_get(provider_annotation.value.downcase.camelize)

--- a/app/models/credential_factory/aws.rb
+++ b/app/models/credential_factory/aws.rb
@@ -1,0 +1,62 @@
+module CredentialFactory
+  Aws = Struct.new(:resource, :dependent_secrets) do
+    include Base
+
+    class << self
+      # access_key_id, secret_access_key, and region are required configuration variables.
+      def dependent_variable_ids annotations
+        secret_access_key = require_annotation(annotations, 'credential-factory/secret_access_key')
+        build_variable_ids secret_access_key, %w(access_key_id secret_access_key region)
+      end
+    end
+
+    def access_key_id
+      dependent_secrets[:access_key_id]
+    end
+
+    def secret_access_key
+      dependent_secrets[:secret_access_key]
+    end
+
+    def region
+      dependent_secrets[:region]
+    end
+
+    def policy
+      require_annotation('credential-factory/policy')
+    end
+
+    def duration_seconds
+      ( annotations['credential-factory/duration-seconds'] ||
+        1.hour ).to_i
+    end
+
+    def federated_user_name
+      ( annotations['credential-factory/user-name'] || resource.identifier ).underscore.gsub('/', '-')
+    end
+
+    # Example response:
+    #
+    # {
+    #   "access_key_id": "ASIAI6...F7KPBKA",
+    #   "secret_access_key": "EhyQYceI...arRtkZfYugB9dDM6",
+    #   "session_token": "FQoDYXdzEH4aD...7bz7Nw+NL0mKNr8ztYF",
+    #   "expiration": "2018-04-15 22:04:26 UTC",
+    #   "federated_user_id": "<acct-id>:myapp",
+    #   "federated_user_arn": "arn:aws:sts::<acct-id>:federated-user/myapp"
+    # }
+    def values
+      require 'aws-sdk-sts'
+      resp = ::Aws::STS::Client.new(access_key_id: access_key_id, 
+        secret_access_key: secret_access_key,
+        region: region).get_federation_token duration_seconds: duration_seconds,
+        name: federated_user_name, 
+        policy: policy
+
+      resp.to_h[:credentials].merge({
+        federated_user_id: resp.federated_user.federated_user_id,
+        federated_user_arn: resp.federated_user.arn
+      })
+    end
+  end
+end

--- a/app/models/credential_factory/base.rb
+++ b/app/models/credential_factory/base.rb
@@ -18,7 +18,7 @@ module CredentialFactory
     module ClassMethods
       # Require annotation +name+ to be in the hash +annotations+, or a configuration error is raised.
       def require_annotation annotations, name
-        annotations[name] or raise Exceptions::ConfigurationError, "Annotation #{name.inspect} is required"
+        annotations[name] or raise ArgumentError, "Annotation #{name.inspect} is required"
       end
 
       # From an example annotation name, build a set of annotation names which are related by 

--- a/app/models/credential_factory/base.rb
+++ b/app/models/credential_factory/base.rb
@@ -1,0 +1,36 @@
+module CredentialFactory
+  module Base
+    def self.included cls
+      cls.extend ClassMethods
+    end
+
+    def annotations
+      resource.annotations.inject({}) do |memo, entry|
+        memo[entry.name] = entry.value
+        memo
+      end
+    end
+
+    def require_annotation name
+      self.class.require_annotation annotations, name
+    end
+
+    module ClassMethods
+      # Require annotation +name+ to be in the hash +annotations+, or a configuration error is raised.
+      def require_annotation annotations, name
+        annotations[name] or raise Exceptions::ConfigurationError, "Annotation #{name.inspect} is required"
+      end
+
+      # From an example annotation name, build a set of annotation names which are related by 
+      # the prefix on the example. If the example is 'aws/ci/secret_access_key' and the +names+ are
+      # 'foo' and 'bar', this method returns 'aws/ci/foo' and 'aws/ci/bar'. 
+      def build_variable_ids example, names
+        tokens = example.split('/')
+        tokens.pop
+        names.map do |name|
+          (tokens + [ name ]).join('/')
+        end
+      end
+    end
+  end
+end

--- a/app/models/credential_factory/echo.rb
+++ b/app/models/credential_factory/echo.rb
@@ -1,0 +1,19 @@
+module CredentialFactory
+  # Echos the value of a dependent variable.
+  #
+  # This is useful for testing.
+  Echo = Struct.new(:resource, :dependent_secrets) do
+    include Base
+
+    class << self
+      # Requires a variable indicated by the annotation 'credential-factory/variable'.
+      def dependent_variable_ids annotations
+        [ require_annotation(annotations, 'credential-factory/variable') ]
+      end
+    end
+
+    def values
+      [ dependent_secrets[:password] ]
+    end
+  end
+end

--- a/app/models/credential_factory/uuid.rb
+++ b/app/models/credential_factory/uuid.rb
@@ -1,0 +1,17 @@
+module CredentialFactory
+  # Provides a single securely random UUID.
+  Uuid = Struct.new(:resource, :dependent_secrets) do
+    include Base
+
+    class << self
+      # No dependent variables are required.
+      def dependent_variable_ids annotations
+        []
+      end
+    end
+
+    def values
+      [ SecureRandom.uuid ]
+    end
+  end
+end

--- a/app/models/exceptions/record_not_found.rb
+++ b/app/models/exceptions/record_not_found.rb
@@ -3,7 +3,7 @@ module Exceptions
     attr_reader :id, :account, :kind, :identifier
 
     def initialize id, message: nil
-      super message || self.class.build_message(id)
+      super(message || self.class.build_message(id))
 
       @id = id
       @account, @kind, @identifier = self.class.parse_id(id)

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -120,9 +120,6 @@ module Loader
     class Layer < Record
     end
 
-    class CredentialFactory < Record
-    end
-
     class Host < Record
     end
 
@@ -186,8 +183,6 @@ module Loader
     end
     
     class Variable < Record
-      include CreateResource
-
       def_delegators :@policy_object, :kind, :mime_type
       
       def create!
@@ -200,7 +195,6 @@ module Loader
     end
     
     class Webservice < Record
-      include CreateResource
     end
     
     class Grant < Types::Base

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -120,6 +120,9 @@ module Loader
     class Layer < Record
     end
 
+    class CredentialFactory < Record
+    end
+
     class Host < Record
     end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -132,4 +132,8 @@ class Resource < Sequel::Model
       "secrets"."version" = "delete_secrets"."version"
     SQL
   end
+
+  def credential_factory_provider
+    @credential_factory_provider ||= annotations_dataset.where(name: 'credential-factory/provider').first
+  end
 end

--- a/app/models/secret.rb
+++ b/app/models/secret.rb
@@ -20,8 +20,6 @@ class Secret < Sequel::Model
           all.
           map(&:value)
     end
-
-    
   end
 
   def as_json options = {}

--- a/app/models/secret.rb
+++ b/app/models/secret.rb
@@ -20,6 +20,8 @@ class Secret < Sequel::Model
           all.
           map(&:value)
     end
+
+    
   end
 
   def as_json options = {}

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -70,7 +70,6 @@ command :server do |c|
       system "rake policy:load[#{account},#{file_name}]" or exit $?.exitstatus
     end
 
-
     Process.fork do
       exec "rails server -p #{options[:port]} -b #{options[:'bind-address']}"
     end

--- a/cucumber/api/features/credential_factory.feature
+++ b/cucumber/api/features/credential_factory.feature
@@ -1,0 +1,178 @@
+Feature: Dynamically generated secrets.
+
+  A Conjur "webservice" can be configured with annotation "credential-factory/provider". 
+  This provider identifies an algorithm which will generate a value (normally, a credential),
+  which can be accessed through the route "GET /secrets/:account/webservice/:id".
+
+  In effect, this is a dynamically generated value which is obtained through the same URL route
+  as a statically stored secret. As with statically stored secret in a variable, "execute" privilege on the 
+  webservice is required to obtain the generated value.
+
+  The "credential-factory/provider" algorithm may use other secrets in order to perform its function.
+  For example, a credential factory which issues temporary cloud access credentials requires 
+  static cloud credentials in order to call the cloud API. This relationship between the credential factory
+  webservice and its dependent variables is managed using annotations.
+
+  To prevent unauthorized use of statically stored credentials, the credential
+  factory webservice must have "execute" permission on any variables which it tries to use.
+
+  Background:
+    Given I am the super-user
+
+  Scenario: An authorized role can obtain a value.
+  
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !webservice
+      id: uuid
+      annotations:
+        credential-factory/provider: uuid
+    """
+    When I successfully GET "/secrets/cucumber/webservice/uuid"
+    Then I receive 1 response
+    And the first text response looks like a UUID
+
+  Scenario: An unauthorized role cannot obtain a value.
+
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !user alice
+
+    - !webservice
+      id: uuid
+      annotations:
+        credential-factory/provider: uuid
+    """
+    And I login as "alice"
+    When I GET "/secrets/cucumber/webservice/uuid"
+    Then the HTTP response status code is 403
+
+  Scenario: Properly configured annotations enable a credential factory to depend on other variables.
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !variable password
+
+    - !webservice
+      id: echo
+      annotations:
+        credential-factory/provider: echo
+        credential-factory/variable: password
+
+    - !permit
+      role: !webservice echo
+      privileges: execute
+      resource: !variable password
+    """
+    And I successfully POST "/secrets/cucumber/variable/password" with body:
+    """
+    the-password
+    """
+    When I successfully GET "/secrets/cucumber/webservice/echo"
+    Then the JSON should be:
+    """
+    [ "the-password" ]
+    """
+
+  Scenario: A missing required annotation is reported as an error.
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !webservice
+      id: echo
+      annotations:
+        credential-factory/provider: echo
+    """
+    When I GET "/secrets/cucumber/webservice/echo"
+    Then the HTTP response status code is 422
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "argument_error",
+        "message": "Annotation \"credential-factory/variable\" is required"
+      }
+    } 
+    """
+
+  Scenario: A reference to a non-existent dependency variable is reported as an error.
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !webservice
+      id: echo
+      annotations:
+        credential-factory/provider: echo
+        credential-factory/variable: password
+    """
+    When I GET "/secrets/cucumber/webservice/echo"
+    Then the HTTP response status code is 404
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "not_found",
+        "message": "Variable 'password' not found in account 'cucumber'",
+        "target": "variable",
+        "details": {
+          "code": "not_found",
+          "target": "id",
+          "message": "cucumber:variable:password"
+        }
+      }
+    }    
+    """
+
+  Scenario: Insufficient authorization to a dependency variable is reported as an error.
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !variable password
+
+    - !webservice
+      id: echo
+      annotations:
+        credential-factory/provider: echo
+        credential-factory/variable: password
+    """
+    When I GET "/secrets/cucumber/webservice/echo"
+    Then the HTTP response status code is 403
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "forbidden",
+        "message": "\"cucumber:webservice:echo\" does not have 'execute' privilege on \"cucumber:variable:password\""
+      }
+    }
+    """
+
+  Scenario: Missing value in a dependency variable is reported as an error.
+    Given I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !variable password
+
+    - !webservice
+      id: echo
+      annotations:
+        credential-factory/provider: echo
+        credential-factory/variable: password
+
+    - !permit
+      role: !webservice echo
+      privileges: execute
+      resource: !variable password
+    """
+    When I GET "/secrets/cucumber/webservice/echo"
+    Then the HTTP response status code is 404
+    And the JSON should be:
+    """
+    {
+      "error": {
+        "code": "not_found",
+        "message": "\"cucumber:variable:password\" does not contain a secret value",
+        "target": "variable",
+        "details": {
+          "code": "not_found",
+          "target": "id",
+          "message": "cucumber:variable:password"
+        }
+      }
+    }
+    """

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -18,7 +18,7 @@ Then(/^the resource list should only include the searched resources$/) do
   @result.map{|r| r['id']}.should =~ @searchable_resources.map{|r| r.id}
 end
 
-Then(/^I receive (\d+) resources$/) do |count|
+Then(/^I receive (\d+) (?:resources?|responses?)$/) do |count|
   expect(@result.count).to eq(count.to_i)
 end
 
@@ -54,4 +54,8 @@ Then(/^the binary result is preserved$/) do
   expect(@result).to be
   expect(@result.headers[:content_type]).to eq("application/octet-stream")
   expect(@result).to eq(@value)
+end
+
+Then(/^the first text response looks like a UUID$/) do
+  expect(@result[0]).to match(/^[a-f0-9\-]+$/)
 end

--- a/lib/tasks/account.rake
+++ b/lib/tasks/account.rake
@@ -3,25 +3,28 @@ namespace :"account" do
     [ "authn", account ].join(":")
   end
 
-  desc "Test whether the token-signing key already exists"
+  desc "Test whether an account already exists"
   task :exists, [ "account" ] => [ "environment" ] do |t,args|
     puts !!Slosilo[signing_key_key args[:account]]
   end
 
   desc "Create an account"
-  task :create, [ "account" ] => [ "environment" ] do |t,args|
+  task :create, [ "account", "must_create" ] => [ "environment" ] do |t,args|
     Account.find_or_create_accounts_resource
+    account_id = args[:account]
     begin
-      api_key = Account.create args[:account]
-      account = Account.new args[:account]
-      $stderr.puts "Created new account account '#{account.id}'"
-      puts "Token-Signing Public Key: #{account.token_key.to_s}"
-      puts "API key for admin: #{api_key}"
+      Account.create args[:account]
+      $stderr.puts "Created new account #{account_id.inspect}"
     rescue Exceptions::RecordExists
-      $stderr.puts "Account '#{args[:account]}' already exists"
-      exit 1
+      $stderr.puts "Account #{account_id.inspect} already exists"
+      if args[:must_create] == "true"
+        exit 1
+      end
     end
-  end
+    account = Account.new account_id
+    puts "Token-Signing Public Key: #{account.token_key.to_s}"
+    puts "API key for admin: #{account.admin_role_api_key}"
+end
 
   desc "Delete an account"
   task :delete, [ "account" ] => [ "environment" ] do |t,args|

--- a/run/aws_credential_factory.yml
+++ b/run/aws_credential_factory.yml
@@ -1,0 +1,55 @@
+- !policy
+  id: aws
+  body:
+  - !policy
+      id: dev-account
+      body:
+      - &variables
+        - !variable access_key_id
+        - !variable secret_access_key
+        - !variable region
+
+      - !group secrets-users
+
+      - !permit
+        role: !group secrets-users
+        privileges: [ read, execute ]
+        resources: *variables
+
+- !policy
+  id: myapp
+  body:
+  - !credential-factory
+    annotations:
+      credential-factory/provider: AWS
+      credential-factory/secret_access_key: aws/dev-account/secret_access_key
+      credential-factory/policy: |
+        {    
+          "Version" : "2012-10-17",   
+          "Statement" : [
+            {
+              "Action" : [           
+                "sts:GetCallerIdentity"
+              ],           
+              "Effect" : "Allow",           
+              "Resource" : "*"       
+            }
+          ]
+        }
+
+  - !layer
+
+  - !permit
+    role: !layer
+    privileges: [ read, execute ]
+    resources: !credential-factory
+
+- !grant
+  role: !group aws/dev-account/secrets-users
+  members: !credential-factory myapp
+
+- !host myapp-01.internal
+
+- !grant
+  role: !layer myapp
+  member: !host myapp-01.internal

--- a/run/aws_credential_factory.yml
+++ b/run/aws_credential_factory.yml
@@ -19,7 +19,7 @@
 - !policy
   id: myapp
   body:
-  - !credential-factory
+  - !webservice aws-credentials
     annotations:
       credential-factory/provider: AWS
       credential-factory/secret_access_key: aws/dev-account/secret_access_key
@@ -35,21 +35,21 @@
               "Resource" : "*"       
             }
           ]
-        }
 
   - !layer
 
   - !permit
-    role: !layer
+    resources: !webservice aws-credentials
     privileges: [ read, execute ]
-    resources: !credential-factory
+    role: !layer
 
 - !grant
   role: !group aws/dev-account/secrets-users
-  members: !credential-factory myapp
+  members: !host myapp/aws-credentials
 
 - !host myapp-01.internal
 
 - !grant
   role: !layer myapp
   member: !host myapp-01.internal
+  


### PR DESCRIPTION
Closes [relevant GitHub issues, eg #76]

#### What does this pull request do?

A Credential Factory is a Conjur service which creates a new set of credentials each time it is called. A credential factory is a secure and scalable way to expose a credential-issuing backend, such as AWS Security Token Service, to Conjur clients.

See dependency PR - https://github.com/conjurinc/conjur-policy-parser/pull/9

#### What background context can you provide?

AWS Security Token Service (STS) is an AWS service which issues temporary credentials with a client-specified IAM policy. 

Conjur Credential Factory is a way to expose the capabilities of STS-like services without over-privileging clients or requiring clients to directly handle permanent AWS credentials. A client can use the familiar "Conjur secrets fetch" interface to obtain a temporary set of AWS credentials with a set of privileges that are pre-defined by the security administrator. Many different credential factories can be defined on a single set of permanent AWS credentials. Access to credential factories is managed exactly the same way as access to variables, providing a familiar workflow and granular control.

#### Where should the reviewer start?

Read and understand the new cucumber tests and the CredentialFactory.md.

#### How should this be manually tested?

CredentialFactory.md shows how to try this from the Rails console. You can also invoke `GET /secrets/cucumber/webservice/myapp/aws-credentials` via cURL (with a valid access token, of course).

#### Screenshots (if appropriate)

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/feature%252Fcredential-factory/

#### Questions:

> Does this have automated Cucumber tests?

Yes

> Can we make a blog post, video, or animated GIF out of this?

Yes

> Is this explained in documentation?

Not completely.

> Does the knowledge base need an update?

Yes
