### PR TITLE
Allow listing of resources for a role other than the currently authenticated user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+- RolesController#index now accepts `role` as a query parameter. If
+  present, resources visible to that role are listed.
+
 - Resources are now only visible if the user is a member of a role that owns them or has some
 permission on them.
 

--- a/app/controllers/concerns/assumed_role.rb
+++ b/app/controllers/concerns/assumed_role.rb
@@ -1,0 +1,37 @@
+# AssumedRole adds support allowing the requestor to assume another
+# role. A query parameter (:role by default) is used to specify the
+# role. If the query parameter is not present, assumed_role will be
+# current_user.
+
+# The authenticated user must hold the role being assumed, or
+# ApplicationController::Forbidden will be raised.
+
+module AssumedRole
+  extend ActiveSupport::Concern
+
+  def assumed_role?
+    begin
+      assumed_role
+    rescue Forbidden
+      nil
+    end
+  end
+
+  def assumed_role(param_name = :role)
+    @assumed_role ||= find_assumed_role(param_name)
+  end
+
+  private
+
+  def find_assumed_role(param_name)
+    acting_as = params[param_name].presence
+    return current_user unless acting_as
+
+    role = Role[acting_as]
+    raise ApplicationController::Forbidden unless role && role.ancestor_of?(current_user)
+
+    role
+  end
+end
+
+    

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -108,4 +108,8 @@ class Role < Sequel::Model
   def all_roles
     Role.from(Sequel.function(:all_roles, id))
   end
+
+  def ancestor_of? role
+    Role.from(Sequel.function(:is_role_ancestor_of, id, role.id)).first[:is_role_ancestor_of]
+  end
 end

--- a/cucumber/api/features/memberships.feature
+++ b/cucumber/api/features/memberships.feature
@@ -16,10 +16,10 @@ Feature: Obtain the memberships of a role
 
 
   Background:
-    Given I am a user named "alice"
+    Given I am the super-user
+    And I create a new user "alice"
 
   Scenario: The initial memberships of a role is just the role itself.
-    Given I create a new user "bob"
     When I successfully GET "/roles/cucumber/user/alice?all"
     Then the JSON should be:
     """

--- a/cucumber/api/features/resource_list.feature
+++ b/cucumber/api/features/resource_list.feature
@@ -64,3 +64,21 @@ Feature: List resources with various types of filtering
   Scenario: The resource list is counted.
     When I successfully GET "/resources/cucumber/test-resource?count=true"
     Then I receive a count of 3
+
+  Scenario: The resource list can be retrieved for a different role.
+
+    In this scenario, bob retrieves alice's resource list. Because he
+    has no privilege on it, if he retrieved it as himself, he wouldn't
+    see the new resource.
+
+    Given I create a new resource
+    And I create a new user "alice"
+    And I permit user "alice" to "fry" it
+    And I create a new user "bob"
+
+    When I login as "bob"
+    And I successfully GET "/resources?role=cucumber:user:alice"
+    Then the resource list should include the newest resource
+
+
+    

--- a/cucumber/api/features/resource_list.feature
+++ b/cucumber/api/features/resource_list.feature
@@ -64,21 +64,3 @@ Feature: List resources with various types of filtering
   Scenario: The resource list is counted.
     When I successfully GET "/resources/cucumber/test-resource?count=true"
     Then I receive a count of 3
-
-  Scenario: The resource list can be retrieved for a different role.
-
-    In this scenario, bob retrieves alice's resource list. Because he
-    has no privilege on it, if he retrieved it as himself, he wouldn't
-    see the new resource.
-
-    Given I create a new resource
-    And I create a new user "alice"
-    And I permit user "alice" to "fry" it
-    And I create a new user "bob"
-
-    When I login as "bob"
-    And I successfully GET "/resources?role=cucumber:user:alice"
-    Then the resource list should include the newest resource
-
-
-    

--- a/cucumber/api/features/resource_list_by_role.feature
+++ b/cucumber/api/features/resource_list_by_role.feature
@@ -1,0 +1,24 @@
+@logged-in
+Feature: List resources for another role
+  Background:
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !user alice
+    - !user bob
+    - !policy
+      id: dev
+      owner: !user alice
+      body:
+        - !variable dev-var
+    - !policy
+      id: prod
+      owner: !user bob
+      body:
+        - !variable prod-var
+    """
+
+  Scenario: The resource list can be retrieved for a different role, specified by query parameter
+    When I successfully GET "/resources?role=cucumber:user:alice"
+    Then the resource list should contain "variable" "dev/dev-var"
+    And the resource list should not contain "variable" "prod/prod-var"

--- a/cucumber/api/features/rotate_api_key.feature
+++ b/cucumber/api/features/rotate_api_key.feature
@@ -15,7 +15,7 @@ Feature: Rotate the API key of a role
 
   @logged-in
   Scenario: The API key cannot be rotated by foreign role without 'update' privilege
-    Given I create a new user "bob"
+    Given I create a new admin-owned user "bob"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 

--- a/cucumber/api/features/step_definitions/user_steps.rb
+++ b/cucumber/api/features/step_definitions/user_steps.rb
@@ -3,11 +3,15 @@ When(/^I am the super\-user$/) do
 end
 
 When(/^I am a user named "([^"]*)"$/) do |login|
-  @selected_user = @current_user = create_user(login)
+  @selected_user = @current_user = create_user(login, admin_user)
 end
 
 Given(/^I create a new user "([^"]*)"$/) do |login|
-  create_user login
+  create_user login, @current_user || admin_user
+end
+
+Given(/^I create a new admin-owned user "(.*?)"$/) do |login|
+  create_user login, admin_user
 end
 
 Given(/^I create a new user "([^"]*)" in account "([^"]*)"$/) do |login, account|

--- a/cucumber/api/features/support/world.rb
+++ b/cucumber/api/features/support/world.rb
@@ -125,7 +125,7 @@ module PossumWorld
   end
   
   # Create a regular user, owned by the admin user
-  def create_user login = nil
+  def create_user login, owner
     unless login
       login = USER_NAMES[@user_index]
       @user_index += 1
@@ -136,7 +136,7 @@ module PossumWorld
     roleid = "cucumber:user:#{login}"
     Role.create(role_id: roleid).tap do |user|
       Credentials[role: user] or Credentials.new(role: user).save(raise_on_save_failure: true)
-      Resource.create(resource_id: roleid, owner: admin_user)
+      Resource.create(resource_id: roleid, owner: owner)
       users[login] = user
     end
   end

--- a/db/migrate/20180530162704_is_role_ancestor_of.rb
+++ b/db/migrate/20180530162704_is_role_ancestor_of.rb
@@ -1,0 +1,24 @@
+Sequel.migration do
+  up do
+    execute %Q{
+      CREATE FUNCTION is_role_ancestor_of(role_id text, other_id text)
+         RETURNS boolean
+         LANGUAGE sql
+         STABLE STRICT
+      AS $$
+        SELECT COUNT(*) > 0 FROM (
+          WITH RECURSIVE m(id) AS (
+            SELECT $2
+            UNION ALL
+            SELECT role_id FROM role_memberships rm, m WHERE member_id = id
+          )
+          SELECT true FROM m WHERE id = $1 LIMIT 1
+        )_
+      $$;
+    }
+  end
+
+  down do
+    execute %Q{DROP FUNCTION is_role_ancestor_of(text, text)}
+  end
+end


### PR DESCRIPTION
Closes https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-5065

#### What does this pull request do?
Adds support for a `role` parameter to the `/resources` route. Allows the call to list resources for a different role, provided that role is held by the caller.

#### What background context can you provide?
The UI uses this when rendering the "Privileges Held" sections of the details pages for various resources.

#### Where should the reviewer start?
The new cucumber scenario is a good place to start: https://github.com/cyberark/conjur/pull/555/files#diff-fb6cd84532d315ce061240eac6e7791c

#### How should this be manually tested?
No need for manual testing.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/resources-for-role_20180525/

#### Questions:
> Does this have automated Cucumber tests?
Yes.

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
API doc needs updating.

> Does the knowledge base need an update?
No
