### PR TITLE
Update debian package to use Ruby 2.5 instead of 2.2

### DIFF
--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -1,0 +1,25 @@
+# Build from the same version of ubuntu as phusion/baseimage
+FROM @@image@@
+
+RUN apt-get update -y && \
+    apt-get purge -y ruby2.2 ruby2.2-dev && \
+    apt-get install -y ruby2.5 ruby2.5-dev
+
+ENV BUNDLER_VERSION 1.16.1
+RUN gem install --no-rdoc --no-ri bundler:$BUNDLER_VERSION fpm
+
+RUN mkdir -p /src/opt/conjur/project
+
+WORKDIR /src/opt/conjur/project
+
+COPY Gemfile ./
+COPY Gemfile.lock ./
+
+RUN bundle --deployment
+RUN mkdir -p .bundle
+RUN cp /usr/local/bundle/config .bundle/config
+
+COPY . .
+ADD debify.sh /
+
+WORKDIR /src

--- a/package.sh
+++ b/package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
-
 debify package \
+  --dockerfile=Dockerfile.fpm \
   possum \
   -- \
   --depends tzdata


### PR DESCRIPTION
For CONJ-5071 and required for Appliance PR `#193`

#### What does this pull request do?
This PR uses an updated debify FPM image to build the conjur debian package using Ruby 2.5 rather than Ruby 2.2, so that the vendored gems are correctly versioned for the appliance.

#### What background context can you provide?

Conjur Open Source now uses Ruby 2.5 instead of Ruby 2.2. Once new Ruby language features are used in the code, the current appliance runtime will no longer run Conjur correctly. To resolved this, the appliance needs to be updated to use the Ruby 2.5 runtime rather than Ruby 2.2.

#### Where should the reviewer start?

Additional context for this and the other Ruby 2.5 PRs is available in the Appliance PR `#193`.

#### How should this be manually tested?

This update may be tested by running `./package.sh` in the repository root.

#### Link to build in Jenkins
<https://jenkins.conjur.net/job/cyberark--conjur/job/ruby_2.5_deb/>
