### PR TITLE
Adding `RolesController#members` search API endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ permission on them.
 - RolesController now implements #direct_memberships to return the
   direct members of a role, without recursive expansion.
 
-- Updated Ruby version from 2.2, which is no longer supported, to version 2.5. 
+- Updated Ruby version from 2.2, which is no longer supported, to version 2.5.
+
+- RolesController now implements #members to return a searchable, pageable collection
+  of members of a Role.
 
 ### Added
 - Experimental audit querying engine mounted at /audit. It can be configured to work with

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,9 @@ gem 'gli', require: false
 # Gem::InstallError: ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
 gem 'ruby_dep', '= 1.3.1'
 
-gem 'conjur-api', '~> 5.1'
+ # Pinned to update for role member search, using ref so merging and removing the branch doesn't
+ # immediately break this link
+gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'search_role_members'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'
 gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'possum'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,15 @@ GIT
       activesupport (~> 4.2)
       safe_yaml
 
+GIT
+  remote: https://github.com/cyberark/conjur-api-ruby.git
+  revision: 099d6c8e11864f2561d0985c6325f4621edc3e27
+  branch: search_role_members
+  specs:
+    conjur-api (5.2.0)
+      activesupport
+      rest-client
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -70,9 +79,6 @@ GEM
       rspec (>= 2.14, < 4)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
-    conjur-api (5.1.0)
-      activesupport
-      rest-client
     conjur-cli (6.1.0)
       activesupport (>= 4.2, < 6)
       conjur-api (~> 5.1)
@@ -112,7 +118,7 @@ GEM
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -329,7 +335,7 @@ DEPENDENCIES
   bcrypt-ruby (~> 3.0.0)
   bootstrap-sass (~> 3.2.0)
   ci_reporter_rspec
-  conjur-api (~> 5.1)
+  conjur-api!
   conjur-cli (~> 6.1)
   conjur-debify
   conjur-policy-parser!

--- a/apidocs/src/api.md
+++ b/apidocs/src/api.md
@@ -64,6 +64,8 @@ Only the twenty most recent values in a Variable are retained; this prevents the
 
 <!-- include(show_role.md) -->
 
+<!-- include(list_role_members.md) -->
+
 <!-- include(list_resources.md) -->
 
 <!-- include(show_resource.md) -->

--- a/apidocs/src/list_resources.md
+++ b/apidocs/src/list_resources.md
@@ -4,24 +4,13 @@
 
 Lists resources within an organization account.
 
-If a `kind` query parameter is given, narrows results to only resources of that
-kind.
+<!-- include(partials/search_kind.md) -->
 
-If a `limit` is given, returns no more than that number of results. Providing an
-`offset` skips a number of resources before returning the rest. In addition,
-providing an `offset` will give `limit` a default value of 10 if none other is
-provided. These two parameters can be combined to page through results.
+<!-- include(partials/list_paging.md) -->
 
-If the parameter `count` is `true`, returns only the number of items in the
-list.
+<!-- include(partials/list_count.md) -->
 
-#### Text search
-
-If the `search` parameter is provided, narrows results to those pertaining to
-the search query. Search works across resource IDs and the values of
-annotations. It weights results so that those with matching `id` or a matching
-value of an annotation called `name` appear first, then those with another
-matching annotation value, and finally those with a matching `kind`.
+<!-- include(partials/search_text.md) -->
 
 #### Example with `curl` and `jq`
 

--- a/apidocs/src/list_role_members.md
+++ b/apidocs/src/list_role_members.md
@@ -1,0 +1,72 @@
+## List a role's members [/roles/{account}/{kind}/{identifier}?members{?search}{?limit}{?offset}{?count}]
+
+### List role members [GET]
+
+List members within a role.
+
+<!-- include(partials/search_kind.md) -->
+
+<!-- include(partials/list_paging.md) -->
+
+<!-- include(partials/list_count.md) -->
+
+<!-- include(partials/search_text.md) -->
+
+#### Example with `curl` and `jq`
+
+Suppose your organization name is "myorg" and you want to search for the first
+two members matching the word "db":
+
+```bash
+curl -H "$(conjur authn authenticate -H)" \
+     'https://eval.conjur.org/roles/myorg/group/devs?members&search=db&limit=2' \
+     | jq .
+```
+
+<!-- include(partials/role_kinds.md) -->
+
+<!-- include(partials/url_encoding.md) -->
+
+---
+
+<!-- include(partials/auth_header_table.md) -->
+
+**Response**
+
+| Code | Description                                              |
+|------|----------------------------------------------------------|
+|  200 | The response body contains the requested role members    |
+|<!-- include(partials/http_401.md) -->|
+|<!-- include(partials/http_403.md) -->|
+|  404 | The requested role does not exist |
+
+Supposing the requested members are for a group named "devs" at an organization called "myorg":
+
++ Parameters
+  + <!-- include(partials/account_param.md) -->
+  + kind: group (string) - kind of role requested
+  + identifier: devs (string) - identifier of the role
+
++ Request
+  <!-- include(partials/auth_header_code.md) -->
+  
++ Response 200 (application/json)
+
+    ```json
+    [
+      {
+            "admin_option": false,
+            "member": "myorg:user:alice",
+            "ownership": false,
+            "policy": "myorg:policy:root",
+            "role": "myorg:group:devs"
+        },
+        {
+            "admin_option": false,
+            "member": "myorg:user:bob",
+            "ownership": false,
+            "policy": "myorg:policy:root",
+            "role": "myorg:group:devs"
+        }
+    ]
+    ```

--- a/apidocs/src/partials/list_count.md
+++ b/apidocs/src/partials/list_count.md
@@ -1,0 +1,2 @@
+If the parameter `count` is `true`, returns only the number of items in the
+list.

--- a/apidocs/src/partials/list_paging.md
+++ b/apidocs/src/partials/list_paging.md
@@ -1,0 +1,4 @@
+If a `limit` is given, returns no more than that number of results. Providing an
+`offset` skips a number of resources before returning the rest. In addition,
+providing an `offset` will give `limit` a default value of 10 if none other is
+provided. These two parameters can be combined to page through results.

--- a/apidocs/src/partials/search_kind.md
+++ b/apidocs/src/partials/search_kind.md
@@ -1,0 +1,2 @@
+If a `kind` query parameter is given, narrows results to only resources of that
+kind.

--- a/apidocs/src/partials/search_text.md
+++ b/apidocs/src/partials/search_text.md
@@ -1,0 +1,7 @@
+#### Text search
+
+If the `search` parameter is provided, narrows results to those pertaining to
+the search query. Search works across resource IDs and the values of
+annotations. It weights results so that those with matching `id` or a matching
+value of an annotation called `name` appear first, then those with another
+matching annotation value, and finally those with a matching `kind`.

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,8 +1,7 @@
 class RolesController < RestController
-  before_filter :find_role, only: [ :show, :all_memberships, :direct_memberships, :members ]
 
   def show
-    render json: @role.as_json.merge(members: @role.memberships)
+    render json: role.as_json.merge(members: role.memberships)
   end
 
   # Find all role memberships, expanded recursively. If no parameters
@@ -10,20 +9,13 @@ class RolesController < RestController
   #
   # If +params[:filter]+ is given, return (as role ids), the subset of
   # memberships that matches the filter
-  
+  #
   # If +params[:count]+ is given, return the count of memberships,
   # rather than the memberships themselves
   #
   def all_memberships
-    options = membership_options
-    
-    memberships = with_filter(options) do
-      @role.all_roles
-    end
-
-    json = render_count(memberships, options) || memberships.map(&:role_id)
-    
-    render json: json
+    memberships = filtered_roles(role.all_roles, membership_filter)
+    render_dataset(memberships) { |dataset| dataset.map(&:role_id) }
   end
 
   # Find all direct memberships, i.e don't recursively expand member
@@ -36,14 +28,8 @@ class RolesController < RestController
   # +params[:filter]+ and +params[:count]+ are handled as for +#all_memberships+
   #
   def direct_memberships
-    options = membership_options
-    
-    memberships = with_filter(options) do
-      @role.memberships_as_member_dataset
-    end
-
-    json = render_count(memberships, options) || memberships
-    render json: json
+    memberships = filtered_roles(role.memberships_as_member_dataset, membership_filter)
+    render_dataset(memberships)
   end
   
   # Find all members of this role.
@@ -54,71 +40,59 @@ class RolesController < RestController
   # +params[:count] returns only the number of members
   # +params[:limit] and [:offset] control the paging
   # +params[:search] returns only the members that match the search string
+  # +params[:kind] (array) returns only the members that match the specified kinds
   def members
-    filter_options, render_options = members_options
+    # There is already a :kind parameter in the path so we need to specify
+    # that the role member params come from the query string.
+    filter_opts = filter_params
+    render_opts = render_params
 
-    render_options[:order_by] ||= :member_id
-
-    members = @role.memberships_dataset
-                   .search(filter_options)
-                   .select(:role_memberships.*)
-
-    json = render_count_or_results(members, render_options)
-    render json: json
+    members = role.members_dataset(filter_opts)
+    render_dataset(members) { |dataset| dataset.result_set(render_opts) }
   end
 
   protected
 
-  def render_count_or_results(dataset, render_options)
-    render_count(dataset, render_options) || render_results(dataset, render_options)
+  def filter_params
+    request.query_parameters.slice(:search, :kind).symbolize_keys
+  end
+
+  def render_params
+    params.slice(:limit, :offset).symbolize_keys
+  end
+
+  def membership_filter        
+    filter = params[:filter]
+    filter = Array(filter).map{ |id| Role.make_full_id id, account } if filter
+    return filter
+  end
+
+  def filtered_roles(roles, filter)
+    filter ? roles.member_of(filter) : roles
+  end
+
+  def render_dataset(dataset, &block)
+    resp = count_only?  ? count_payload(dataset) :
+           block_given? ? yield(dataset)         : dataset.all
+
+    render json: resp    
+  end
+
+  def count_only?
+    params.key?(:count)
+  end
+
+  def count_payload(dataset)
+    { count: dataset.count }
+  end
+
+  def role
+    @role ||= Role[role_id]
+    raise Exceptions::RecordNotFound, role_id unless @role
+    return @role
   end
 
   def role_id
     [ params[:account], params[:kind], params[:identifier] ].join(":")
-  end
-  
-  def find_role
-    @role = Role[role_id]
-    raise Exceptions::RecordNotFound, role_id unless @role
-  end
-
-  def membership_options
-    @membership_options ||= params.slice(:count, :filter).symbolize_keys
-  end
-
-  def members_options
-    # There is already a :kind parameter in the path so we need to specify
-    # that the role member params come from the query string.
-    params = request.query_parameters
-    [
-      params.slice(:search, :kind).symbolize_keys,
-      params.slice(:count, :limit, :offset).symbolize_keys
-    ]
-  end
-  
-  def with_filter(options, &block)
-    filter = options[:filter]
-    if filter
-      filter = Array(filter).map{|id| Role.make_full_id id, account}
-    end
-
-    roles = yield
-
-    filter ? roles.member_of(filter) : roles
-  end
-    
-  def render_count(dataset, options)
-    { count: dataset.count } if options.has_key?(:count)
-  end
-  
-  def render_results(dataset, order_by: nil, offset: nil, limit: nil)
-    if offset || limit
-      dataset = dataset.order(order_by).limit(
-        (limit || 10).to_i,
-        (offset || 0).to_i
-      )
-    end
-
-    dataset.all
   end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -87,8 +87,11 @@ class RolesController < RestController
   end
 
   def members_options
+    # There is already a :kind parameter in the path so we need to specify
+    # that the role member params come from the query string.
+    params = request.query_parameters
     [
-      params.slice(:search).symbolize_keys,
+      params.slice(:search, :kind).symbolize_keys,
       params.slice(:count, :limit, :offset).symbolize_keys
     ]
   end

--- a/app/models/membership_search.rb
+++ b/app/models/membership_search.rb
@@ -1,0 +1,28 @@
+# MembershipSearch provides the `search`` extension method
+# for Roles.membership_dataset to allow text searching
+# and paging of Role members
+module MembershipSearch
+  # @param search [String] - a search term in the resource id
+  def search(search: nil)
+    scope = self
+
+    # Filter by string search
+    scope = scope.textsearch(search) if search
+
+    scope
+  end
+
+  def textsearch(input)
+    # If I use 3 literal spaces, it gets send to PG as one space.
+    query = Sequel.function(:plainto_tsquery, "english",
+                            Sequel.function(:translate, input.to_s, "./-", "   "))
+
+    # Default weights for ts_rank_cd are {0.1, 0.2, 0.4, 1.0} for DCBA resp.
+    # Sounds just about right. A are name and id, B is rest of annotations, C is kind.
+    rank = Sequel.function(:ts_rank_cd, :textsearch, query)
+
+    left_join(:resources_textsearch, resource_id: :member_id)
+      .where("? @@ textsearch", query)
+      .order(Sequel.desc(rank))
+  end
+end

--- a/app/models/membership_search.rb
+++ b/app/models/membership_search.rb
@@ -4,17 +4,18 @@
 module MembershipSearch
   # @param search [String] - a search term in the resource id
   def search(search: nil, kind: nil)
-    scope = self
+    filter_kind(kind).textsearch(search)
+  end
 
-    scope = scope.where(Sequel.lit("kind(member_id) in ?", Array(kind))) if kind
+  def filter_kind(kind)
+    return self unless kind
 
-    # Filter by string search
-    scope = scope.textsearch(search) if search
-
-    scope
+    where(Sequel.lit("kind(member_id) in ?", Array(kind))) 
   end
 
   def textsearch(input)
+    return self unless input
+
     # If I use 3 literal spaces, it gets send to PG as one space.
     query = Sequel.function(:plainto_tsquery, "english",
                             Sequel.function(:translate, input.to_s, "./-", "   "))
@@ -24,7 +25,25 @@ module MembershipSearch
     rank = Sequel.function(:ts_rank_cd, :textsearch, query)
 
     left_join(:resources_textsearch, resource_id: :member_id)
-      .where("? @@ textsearch", query)
+      .where(Sequel.lit("? @@ textsearch", query))
       .order(Sequel.desc(rank))
+  end
+
+  # result_set renders a dataset to a result set using the
+  # provided order and paging parameters
+  def result_set(order_by: nil, offset: nil, limit: nil)
+    scope = self
+
+    order_by ||= :member_id
+    scope = scope.order(order_by)
+
+    if offset || limit
+      scope = scope.limit(
+        (limit || 10).to_i,
+        (offset || 0).to_i
+      )
+    end
+
+    scope.all
   end
 end

--- a/app/models/membership_search.rb
+++ b/app/models/membership_search.rb
@@ -3,8 +3,10 @@
 # and paging of Role members
 module MembershipSearch
   # @param search [String] - a search term in the resource id
-  def search(search: nil)
+  def search(search: nil, kind: nil)
     scope = self
+
+    scope = scope.where(Sequel.lit("kind(member_id) in ?", Array(kind))) if kind
 
     # Filter by string search
     scope = scope.textsearch(search) if search

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -93,6 +93,11 @@ class Role < Sequel::Model
     end.map(&:role)
   end
 
+  def members_dataset(search_options = {})
+    memberships_dataset.search(search_options)
+                       .select(:role_memberships.*)
+  end
+
   # Role grants are performed by the policy loader, but not exposed through the API.
   def grant_to member, options = {}
     options[:admin_option] ||= false

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,7 +3,7 @@ class Role < Sequel::Model
   
   unrestrict_primary_key
 
-  one_to_many :memberships, class: :RoleMembership
+  one_to_many :memberships, class: :RoleMembership, extend: MembershipSearch
   one_to_many :memberships_as_member, class: :RoleMembership, key: :member_id
   one_to_one  :credentials, reciprocal: :role
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
 
       get "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
       get "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
+      get "/roles/:account/:kind/*identifier" => "roles#members", :constraints => QueryParameterActionRecognizer.new("members")
+
       get "/roles/:account/:kind/*identifier" => "roles#show"
 
       get "/resources/:account/:kind/*identifier" => 'resources#check_permission', :constraints => QueryParameterActionRecognizer.new("check")

--- a/cucumber/api/features/member_list.feature
+++ b/cucumber/api/features/member_list.feature
@@ -49,6 +49,13 @@ The members of a role can be listed, searched, and paged.
         },
         {
             "admin_option": false,
+            "member": "cucumber:user:alicia",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
             "member": "cucumber:user:bob",
             "ownership": false,
             "policy": "cucumber:policy:root",
@@ -57,13 +64,6 @@ The members of a role can be listed, searched, and paged.
         {
             "admin_option": false,
             "member": "cucumber:user:charlotte",
-            "ownership": false,
-            "policy": "cucumber:policy:root",
-            "role": "cucumber:group:dev"
-        },
-        {
-            "admin_option": false,
-            "member": "cucumber:user:alicia",
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:dev"
@@ -166,18 +166,18 @@ The members of a role can be listed, searched, and paged.
     """
     [
         {
-          "admin_option": true,
-          "member": "cucumber:user:admin",
-          "ownership": true,
-          "policy": "cucumber:policy:root",
-          "role": "cucumber:group:employees"
-        },
-        {
             "admin_option": false,
             "member": "cucumber:group:dev",
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:employees"
+        },
+        {
+          "admin_option": true,
+          "member": "cucumber:user:admin",
+          "ownership": true,
+          "policy": "cucumber:policy:root",
+          "role": "cucumber:group:employees"
         },
         {
             "admin_option": false,
@@ -190,6 +190,20 @@ The members of a role can be listed, searched, and paged.
     """
 
     When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group"
+    Then the JSON should be:
+    """
+    [
+        {
+            "admin_option": false,
+            "member": "cucumber:group:dev",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:employees"
+        }
+    ]
+    """
+
+    When I successfully GET "/roles/cucumber/group/employees?members&kind=group"
     Then the JSON should be:
     """
     [

--- a/cucumber/api/features/member_list.feature
+++ b/cucumber/api/features/member_list.feature
@@ -1,0 +1,163 @@
+Feature: List and filter members of a role
+
+The members of a role can be listed, searched, and paged.
+
+  Background:
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !user alice
+    - !user bob
+    - !user charlotte
+    - !user alicia
+
+    - !group dev
+
+    - !grant
+      role: !group dev
+      member: !user alice
+
+    - !grant
+      role: !group dev
+      member: !user bob
+
+    - !grant
+      role: !group dev
+      member: !user charlotte
+
+    - !grant
+      role: !group dev
+      member: !user alicia
+    """
+
+  Scenario: List role members
+    When I successfully GET "/roles/cucumber/group/dev?members"
+    Then the JSON should be:
+        """
+        [
+        {
+            "admin_option": true,
+            "member": "cucumber:user:admin",
+            "ownership": true,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alice",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:bob",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:charlotte",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alicia",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        }
+        ]
+        """
+
+  Scenario: Search role members
+    When I successfully GET "/roles/cucumber/group/dev?members&search=alice"
+    Then the JSON should be: 
+        """
+        [
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alice",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        }
+        ]
+        """
+
+  Scenario: Search for non-existant member
+     When I successfully GET "/roles/cucumber/group/dev?members&search=non_existent_user"
+     Then the JSON should be: 
+         """
+         []
+         """      
+  
+  Scenario: Page role members
+    When I successfully GET "/roles/cucumber/group/dev?members&limit=3"
+    Then the JSON should be:
+        """
+        [
+        {
+            "admin_option": true,
+            "member": "cucumber:user:admin",
+            "ownership": true,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alice",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:bob",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        }
+        ]
+        """
+
+    When I successfully GET "/roles/cucumber/group/dev?members&limit=3&offset=3"
+    Then the JSON should be:
+        """
+        [
+        {
+            "admin_option": false,
+            "member": "cucumber:user:charlotte",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alicia",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:dev"
+        }         
+        ]
+        """
+
+  Scenario: Counting role members
+    When I successfully GET "/roles/cucumber/group/dev?members&count=true"
+    Then the JSON should be:
+    """
+    {
+        "count": 5 
+    }
+    """
+
+    When I successfully GET "/roles/cucumber/group/dev?members&count=true&limit=3"
+    Then the JSON should be:
+    """
+    {
+        "count": 5 
+    }
+    """

--- a/cucumber/api/features/member_list.feature
+++ b/cucumber/api/features/member_list.feature
@@ -6,28 +6,26 @@ The members of a role can be listed, searched, and paged.
     Given I am the super-user
     And I successfully PUT "/policies/cucumber/policy/root" with body:
     """
-    - !user alice
-    - !user bob
-    - !user charlotte
-    - !user alicia
+    - &users
+      - !user alice
+      - !user bob
+      - !user charlotte
+      - !user alicia
 
     - !group dev
+    - !group employees
 
     - !grant
       role: !group dev
-      member: !user alice
+      members: *users
 
     - !grant
-      role: !group dev
-      member: !user bob
+      role: !group employees
+      member: !group dev
 
     - !grant
-      role: !group dev
-      member: !user charlotte
-
-    - !grant
-      role: !group dev
-      member: !user alicia
+      role: !group employees
+      members: !user alice
     """
 
   Scenario: List role members
@@ -116,7 +114,7 @@ The members of a role can be listed, searched, and paged.
         },
         {
             "admin_option": false,
-            "member": "cucumber:user:bob",
+            "member": "cucumber:user:alicia",
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:dev"
@@ -130,14 +128,14 @@ The members of a role can be listed, searched, and paged.
         [
         {
             "admin_option": false,
-            "member": "cucumber:user:charlotte",
+            "member": "cucumber:user:bob",
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:dev"
         },
         {
             "admin_option": false,
-            "member": "cucumber:user:alicia",
+            "member": "cucumber:user:charlotte",
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:dev"
@@ -160,4 +158,47 @@ The members of a role can be listed, searched, and paged.
     {
         "count": 5 
     }
+    """
+
+  Scenario: Filter role members by kind
+    When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group&kind[]=user"
+    Then the JSON should be:
+    """
+    [
+        {
+          "admin_option": true,
+          "member": "cucumber:user:admin",
+          "ownership": true,
+          "policy": "cucumber:policy:root",
+          "role": "cucumber:group:employees"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:group:dev",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:employees"
+        },
+        {
+            "admin_option": false,
+            "member": "cucumber:user:alice",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:employees"
+        }
+    ]
+    """
+
+    When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group"
+    Then the JSON should be:
+    """
+    [
+        {
+            "admin_option": false,
+            "member": "cucumber:group:dev",
+            "ownership": false,
+            "policy": "cucumber:policy:root",
+            "role": "cucumber:group:employees"
+        }
+    ]
     """


### PR DESCRIPTION
For CONJ-5074

#### What does this pull request do?
This PR adds the `?members` endpoint back to the Roles API. This endpoint allows searching, filtering, and paging of the Role members.

#### What background context can you provide?

This is to support searching and paging members in the Conjur UI.

#### Where should the reviewer start?

The new cucumber tests are probably the best place to start:
<https://github.com/cyberark/conjur/pull/557/files#diff-c7d2b396124fd17f55303b265705a6c7>

#### How should this be manually tested?

The cucumber API tests will test the new and updated features.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/view/cyberark/job/cyberark--conjur/job/search_role_members/

#### Questions:
> Does this have automated Cucumber tests?
**Yes**

> Is this explained in documentation?
**Yes**

#### What's left to do:
- [x] Add `kind` filter to members
- [x] Update API documentation
- [x] Update tests
- [x] Update changelog