### PR TITLE
API Endpoints for Granting and Revoking Role Members

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -436,7 +436,7 @@ Lint/DuplicateMethods:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleAlignWith, AutoCorrect.
 # SupportedStylesAlignWith: keyword, variable, start_of_line
-Lint/EndAlignment:
+Layout/EndAlignment:
   Exclude:
     - 'app/controllers/resources_controller.rb'
     - 'app/controllers/secrets_controller.rb'
@@ -529,7 +529,6 @@ Lint/UnusedBlockArgument:
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
 Lint/UnusedMethodArgument:
   Exclude:
-    - 'app/controllers/roles_controller.rb'
     - 'app/models/loader/orchestrate.rb'
     - 'cucumber/policy/features/support/world.rb'
 
@@ -608,14 +607,6 @@ Naming/FileName:
 Naming/VariableNumber:
   Exclude:
     - 'spec/models/secret_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/HashEachMethods:
-  Exclude:
-    - 'app/models/account.rb'
-    - 'cucumber/api/features/support/hooks.rb'
 
 # Offense count: 6
 # Cop supports --auto-correct.
@@ -820,7 +811,6 @@ Style/HashSyntax:
 # Cop supports --auto-correct.
 Style/IfUnlessModifier:
   Exclude:
-    - 'app/controllers/roles_controller.rb'
     - 'app/controllers/secrets_controller.rb'
     - 'app/models/account.rb'
     - 'app/models/loader/orchestrate.rb'
@@ -948,7 +938,6 @@ Style/PerlBackrefs:
 # SupportedStyles: short, verbose
 Style/PreferredHashMethods:
   Exclude:
-    - 'app/controllers/roles_controller.rb'
     - 'config/routes.rb'
 
 # Offense count: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ permission on them.
 - Experimental audit querying engine mounted at /audit. It can be configured to work with
 an external audit database by using config.audit_database configuration entry.
 
+- API endpoints for granting and revoking role membership
+
 ## [0.4.0] - 2018-04-10
 ### Added
 - Policy changes now generate audit log messages. These can optionally be generated in RFC5424

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'ruby_dep', '= 1.3.1'
 
  # Pinned to update for role member search, using ref so merging and removing the branch doesn't
  # immediately break this link
-gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'search_role_members'
+gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'
 gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'possum'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/conjur-api-ruby.git
-  revision: 099d6c8e11864f2561d0985c6325f4621edc3e27
-  branch: search_role_members
+  revision: 4cbe5c4e64f96c3a669b844a51edc588134d63f6
+  branch: master
   specs:
-    conjur-api (5.2.0)
+    conjur-api (5.1.0)
       activesupport
       rest-client
 

--- a/app/controllers/concerns/authorize_resource.rb
+++ b/app/controllers/concerns/authorize_resource.rb
@@ -5,11 +5,12 @@ module AuthorizeResource
     include CurrentUser
   end
   
-  def authorize privilege
-    auth(current_user, privilege, @resource)
+  def authorize(privilege, resource=nil)
+    resource ||= @resource 
+    auth(current_user, privilege, resource)
   end
 
-  def authorize_many resources, privilege
+  def authorize_many(resources, privilege)
     resources.each do |resource|
       auth(current_user, privilege, resource)
     end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -45,30 +45,24 @@ class RolesController < RestController
   # +params[:search] returns only the members that match the search string
   # +params[:kind] (array) returns only the members that match the specified kinds
   def members
-    # There is already a :kind parameter in the path so we need to specify
-    # that the role member params come from the query string.
-    filter_opts = filter_params
-    render_opts = render_params
-
-    members = role.members_dataset(filter_opts)
-    render_dataset(members) { |dataset| dataset.result_set(render_opts) }
+    members = role.members_dataset(filter_params)
+    render_dataset(members) { |dataset| dataset.result_set(render_params) }
   end
 
   # update_member will add or modify an existing role membership
   #
   # This API endpoint exists to manage group entitlements through
   # the UI or other integrations outside of loading a policy.
-  def update_member
-    resource = Resource[role_id]
-    authorize(:create, resource.policy)
+  def add_member
+    authorize(:create, policy)
 
     member_id = params[:member]
     member = Role[member_id]
     raise Exceptions::RecordNotFound, member_id unless member
 
-    @role.grant_to member
+    role.grant_to member
 
-    #TODO: Record audit event
+    # TODO: Record audit event
     
     head :no_content
   end
@@ -78,41 +72,43 @@ class RolesController < RestController
   # This API endpoint exists to manage group entitlements through
   # the UI or other integrations outside of loading a policy.
   def delete_member
-    resource = Resource[role_id]
-    authorize(:update, resource.policy)
+    authorize(:update, policy)
 
     member_id = params[:member]
-    membership = @role.memberships_dataset.where(member_id: member_id).first
+    membership = role.memberships_dataset.where(member_id: member_id).first
     raise Exceptions::RecordNotFound, member_id unless membership
 
     membership.destroy
 
-    #TODO: Record audit event
+    # TODO: Record audit event
 
     head :no_content
   end
 
   protected
 
-  def filter_params
-    request.query_parameters.slice(:search, :kind).symbolize_keys
+  def policy
+    resource.policy
   end
-  
-  def membership_grant_permitted
-    # If admin
-    
-    # Has create privilige on owning policy
+
+  def resource
+    Resource[role_id]
+  end
+
+  def role
+    @role ||= Role[role_id]
+    raise Exceptions::RecordNotFound, role_id unless @role
+    return @role
   end
 
   def role_id
     [ params[:account], params[:kind], params[:identifier] ].join(":")
   end
-  
-  def find_role
-    @role = Role[role_id]
-    raise Exceptions::RecordNotFound, role_id unless @role
-  end
 
+  def filter_params
+    request.query_parameters.slice(:search, :kind).symbolize_keys
+  end
+  
   def render_params
     params.slice(:limit, :offset).symbolize_keys
   end
@@ -142,13 +138,5 @@ class RolesController < RestController
     { count: dataset.count }
   end
 
-  def role
-    @role ||= Role[role_id]
-    raise Exceptions::RecordNotFound, role_id unless @role
-    return @role
-  end
 
-  def role_id
-    [ params[:account], params[:kind], params[:identifier] ].join(":")
-  end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -51,6 +51,30 @@ class RolesController < RestController
     render_dataset(members) { |dataset| dataset.result_set(render_opts) }
   end
 
+  # update_member will add or modify an existing role membership
+  #
+  # This API endpoint exists to manage group entitlements through
+  # the UI or other integrations outside of loading a policy.
+  def update_member
+    member_id = params[:member]
+
+    member = Role[member_id]
+
+    @role.grant_to member
+  end
+
+  # delete_member will delete a role membership
+  #
+  # This API endpoint exists to manage group entitlements through
+  # the UI or other integrations outside of loading a policy.
+  def delete_member
+    member_id = params[:member]
+
+    membership = @role.memberships_dataset.where(member_id: member_id).first
+
+    membership.destroy
+  end
+
   protected
 
   def filter_params

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -9,6 +9,7 @@ class Resource < Sequel::Model
   one_to_many :policy_versions, reciprocal: :resource, order: :version
   one_to_many :host_factory_tokens, reciprocal: :resource
   many_to_one :owner, class: :Role
+  many_to_one :policy, class: :Resource
   
   alias id resource_id
   

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -104,6 +104,8 @@ class Role < Sequel::Model
     options[:member] = member
 
     add_membership options
+  rescue Sequel::UniqueConstraintViolation
+    # Membership grant already exists
   end
   
   def allowed_to? privilege, resource

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,10 +29,10 @@ Rails.application.routes.draw do
       get     "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
       get     "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
       get     "/roles/:account/:kind/*identifier" => "roles#members", :constraints => QueryParameterActionRecognizer.new("members")
-
-      put     "/roles/:account/:kind/*identifier" => "roles#update_member", :constraints => QueryParameterActionRecognizer.new("members")
+      post    "/roles/:account/:kind/*identifier" => "roles#add_member", :constraints => QueryParameterActionRecognizer.new("members")
       delete  "/roles/:account/:kind/*identifier" => "roles#delete_member", :constraints => QueryParameterActionRecognizer.new("members")
       get     "/roles/:account/:kind/*identifier" => "roles#show"
+     
 
       get     "/resources/:account/:kind/*identifier" => 'resources#check_permission', :constraints => QueryParameterActionRecognizer.new("check")
       get     "/resources/:account/:kind/*identifier" => 'resources#permitted_roles', :constraints => QueryParameterActionRecognizer.new("permitted_roles")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,28 +26,30 @@ Rails.application.routes.draw do
           'authenticate#authenticate'
       end
 
-      get "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
-      get "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
-      get "/roles/:account/:kind/*identifier" => "roles#members", :constraints => QueryParameterActionRecognizer.new("members")
+      get     "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
+      get     "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
+      get     "/roles/:account/:kind/*identifier" => "roles#members", :constraints => QueryParameterActionRecognizer.new("members")
 
-      get "/roles/:account/:kind/*identifier" => "roles#show"
+      put     "/roles/:account/:kind/*identifier" => "roles#update_member", :constraints => QueryParameterActionRecognizer.new("members")
+      delete  "/roles/:account/:kind/*identifier" => "roles#delete_member", :constraints => QueryParameterActionRecognizer.new("members")
+      get     "/roles/:account/:kind/*identifier" => "roles#show"
 
-      get "/resources/:account/:kind/*identifier" => 'resources#check_permission', :constraints => QueryParameterActionRecognizer.new("check")
-      get "/resources/:account/:kind/*identifier" => 'resources#permitted_roles', :constraints => QueryParameterActionRecognizer.new("permitted_roles")
-      get "/resources/:account/:kind/*identifier" => "resources#show"
-      get "/resources/:account/:kind" => "resources#index"
-      get "/resources/:account" => "resources#index"
-      get "/resources" => "resources#index"
+      get     "/resources/:account/:kind/*identifier" => 'resources#check_permission', :constraints => QueryParameterActionRecognizer.new("check")
+      get     "/resources/:account/:kind/*identifier" => 'resources#permitted_roles', :constraints => QueryParameterActionRecognizer.new("permitted_roles")
+      get     "/resources/:account/:kind/*identifier" => "resources#show"
+      get     "/resources/:account/:kind"             => "resources#index"
+      get     "/resources/:account"                   => "resources#index"
+      get     "/resources"                            => "resources#index"
 
-      get "/secrets/:account/:kind/*identifier" => 'secrets#show'
-      post "/secrets/:account/:kind/*identifier" => 'secrets#create'
-      get "/secrets" => 'secrets#batch'
+      get     "/secrets/:account/:kind/*identifier" => 'secrets#show'
+      post    "/secrets/:account/:kind/*identifier" => 'secrets#create'
+      get     "/secrets"                            => 'secrets#batch'
 
-      put "/policies/:account/:kind/*identifier" => 'policies#put'
-      patch "/policies/:account/:kind/*identifier" => 'policies#patch'
-      post "/policies/:account/:kind/*identifier" => 'policies#post'
+      put     "/policies/:account/:kind/*identifier" => 'policies#put'
+      patch   "/policies/:account/:kind/*identifier" => 'policies#patch'
+      post    "/policies/:account/:kind/*identifier" => 'policies#post'
 
-      get "/public_keys/:account/:kind/*identifier" => 'public_keys#show'
+      get     "/public_keys/:account/:kind/*identifier" => 'public_keys#show'
     end
 
     post "/host_factories/hosts" => 'host_factories#create_host'

--- a/cucumber/api/features/membership_entitlements.feature
+++ b/cucumber/api/features/membership_entitlements.feature
@@ -1,0 +1,65 @@
+Feature: Manage the role entitlements through the API
+
+  As an affordance for users to manage the entitlements for group membership,
+  there are two API endpoints for granting and revoking role membership.
+
+  Background:
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !user alice
+    - !user bob
+    
+    - !group developers
+
+    - !grant
+      role: !group developers
+      member: !user alice
+    """
+
+  Scenario: Add a group membership through the API
+
+    When I successfully PUT "/roles/cucumber/group/developers?members&member=cucumber:user:bob"
+    And I successfully GET "/roles/cucumber/group/developers"
+    Then the JSON at "members" should be:
+    """
+    [
+      {
+        "admin_option": true,
+        "member": "cucumber:user:admin",
+        "ownership": true,
+        "policy": "cucumber:policy:root",
+        "role": "cucumber:group:developers"
+      },
+      {
+        "admin_option": false,
+        "member": "cucumber:user:alice",
+        "ownership": false,
+        "policy": "cucumber:policy:root",
+        "role": "cucumber:group:developers"
+      },
+      {
+        "admin_option": false,
+        "member": "cucumber:user:bob",
+        "ownership": false,
+        "role": "cucumber:group:developers"
+      }
+    ]
+    """
+
+    Scenario: Revoke a group membership through the API
+
+    When I successfully DELETE "/roles/cucumber/group/developers?members&member=cucumber:user:alice"
+    And I successfully GET "/roles/cucumber/group/developers"
+    Then the JSON at "members" should be:
+    """
+    [
+      {
+        "admin_option": true,
+        "member": "cucumber:user:admin",
+        "ownership": true,
+        "policy": "cucumber:policy:root",
+        "role": "cucumber:group:developers"
+      }
+    ]
+    """

--- a/cucumber/api/features/support/world.rb
+++ b/cucumber/api/features/support/world.rb
@@ -41,6 +41,7 @@ module PossumWorld
   
   def set_result result
     @response_api_key = nil
+    @status = result.code
     if result.headers[:content_type] =~ /^application\/json/
       @result = JSON.parse(result)
       @response_api_key = @result['api_key'] if @result.is_a?(Hash)
@@ -174,6 +175,7 @@ module PossumWorld
     begin
       yield
     rescue RestClient::Exception
+      puts $!
       @exception = $!
       @status = $!.http_code
       if can


### PR DESCRIPTION
For CONJ-5088

#### What does this pull request do?

This PR adds the API endpoints to Roles to add and remove members

#### What background context can you provide?

To support the UI operations to add and delete group members, we considered two
different approaches:

1) Generate and load a policy document to `!grant` or `!revoke` the role membership
    We decided against this approach because this would cause the state of the loaded policy
    to change without a corresponding change to the source document. This means that
    future attempts to load the policy with `--replace` would remove these changes, without
    an obvious indication as to why.

2) Reinstate API methods to add or revoke Role memberships outside of a policy
    We decided on this approach because it solves the issue of allowing membership changes
    in the user interface in the simplest way imagined.

#### Where should the reviewer start?

The new tests best describe the endpoints and behavior: 
`cucumber/api/features/membership_entitlements.feature`

The implementation changes are primarily in `app/controllers/roles_controller.rb`

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/membership_grant_revoke/

#### Questions:
> Does this have automated Cucumber tests?
Yes


#### Remaining Work:
- [x] Add authorization check
