### PR TITLE
Switch literal SQL strings to use Sequel.lit()

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -72,8 +72,8 @@ class Resource < Sequel::Model
       scope = self
       
       # Filter by kind and account.
-      scope = scope.where("account(resource_id) = ?", account) if account
-      scope = scope.where("kind(resource_id) = ?", kind) if kind
+      scope = scope.where(Sequel.lit("account(resource_id) = ?", account)) if account
+      scope = scope.where(Sequel.lit("kind(resource_id) = ?", kind)) if kind
       
       # Filter by owner
       if owner


### PR DESCRIPTION


Closes [relevant GitHub issues, eg #76]

#### What does this pull request do?
This resolves deprecation warnings in the conjur logs for Sequel.

```sh-session
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: SEQUEL DEPRECATION WARNING: Calling a dataset filtering method with multiple arguments or an array where the first argument/element is a string is deprecated and will be removed in Sequel 5.  Use Sequel.lit("account(resource_id) = ?", "cucumber") to create an SQL fragment expression and pass that to the dataset filtering method, or use the auto_literal_strings extension.
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: /opt/conjur/possum/vendor/bundle/ruby/2.5.0/gems/sequel-4.46.0/lib/sequel/dataset/query.rb:1293:in `filter_expr'
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: /opt/conjur/possum/vendor/bundle/ruby/2.5.0/gems/sequel-4.46.0/lib/sequel/dataset/query.rb:1249:in `add_filter'
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: /opt/conjur/possum/vendor/bundle/ruby/2.5.0/gems/sequel-4.46.0/lib/sequel/dataset/query.rb:1034:in `where'
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: /opt/conjur/possum/app/models/resource.rb:75:in `search'
conjur_1  | Jun  8 15:01:07 430b36ccf0b7 conjur-possum: /opt/conjur/possum/app/controllers/resources_controller.rb:14:in `index'
```

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/sequel_deprecation_fix/

