### PR TITLE
Updating API gem to master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'ruby_dep', '= 1.3.1'
 
  # Pinned to update for role member search, using ref so merging and removing the branch doesn't
  # immediately break this link
-gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'search_role_members'
+gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'
 gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'possum'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/conjur-api-ruby.git
-  revision: 099d6c8e11864f2561d0985c6325f4621edc3e27
-  branch: search_role_members
+  revision: 4cbe5c4e64f96c3a669b844a51edc588134d63f6
+  branch: master
   specs:
-    conjur-api (5.2.0)
+    conjur-api (5.1.0)
       activesupport
       rest-client
 


### PR DESCRIPTION
#### What does this pull request do?

This PR moves the Conjur API gem off of the development branch and back to the master.

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/updating_api_gem/
