### PR TITLE
Honor the acting_as query parameter when listing resources

### DIFF
--- a/app/controllers/concerns/assumed_role.rb
+++ b/app/controllers/concerns/assumed_role.rb
@@ -17,17 +17,16 @@ module AssumedRole
     end
   end
 
-  def assumed_role(param_name = :role)
-    @assumed_role ||= find_assumed_role(param_name)
+  def assumed_role(role_id = params[:role].presence)
+    @assumed_role ||= find_assumed_role(role_id)
   end
 
   private
 
-  def find_assumed_role(param_name)
-    acting_as = params[param_name].presence
-    return current_user unless acting_as
+  def find_assumed_role(role_id)
+    return current_user unless role_id
 
-    role = Role[acting_as]
+    role = Role[role_id]
     raise ApplicationController::Forbidden unless role && role.ancestor_of?(current_user)
 
     role

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -11,8 +11,11 @@ class ResourcesController < RestController
       ownerid = Role.make_full_id(params[:owner], account)
       options[:owner] = Role[ownerid] or raise Exceptions::RecordNotFound, ownerid
     end
-    
-    scope = Resource.visible_to(assumed_role).search options
+
+    # The v5 API currently sends +acting_as+ when listing resources
+    # for a role other than the current user.
+    query_role = params[:role].presence || params[:acting_as].presence
+    scope = Resource.visible_to(assumed_role(query_role)).search options
 
     result =
       if params[:count] == 'true'

--- a/cucumber/api/features/resource_list_by_role.feature
+++ b/cucumber/api/features/resource_list_by_role.feature
@@ -18,7 +18,12 @@ Feature: List resources for another role
         - !variable prod-var
     """
 
-  Scenario: The resource list can be retrieved for a different role, specified by query parameter
+  Scenario: The resource list can be retrieved for a different role, specified the query parameter role
     When I successfully GET "/resources?role=cucumber:user:alice"
+    Then the resource list should contain "variable" "dev/dev-var"
+    And the resource list should not contain "variable" "prod/prod-var"
+
+  Scenario: The resource list can be retrieved for a different role, specified the query parameter acting_as
+    When I successfully GET "/resources?acting_as=cucumber:user:alice"
     Then the resource list should contain "variable" "dev/dev-var"
     And the resource list should not contain "variable" "prod/prod-var"


### PR DESCRIPTION

#### What does this pull request do?
Updates ResourcesController#index so it pays attention to the `acting_as` parameter.

#### What background context can you provide?
The v5 API currently sends `acting_as` to list resources for users other than the current user. It should be updated at some point, but in the meantime, the backend can support `acting_as` in addition to `role`.

#### Where should the reviewer start?
Read the code changes, they're pretty simple.

#### How should this be manually tested?
No need to manually test, there's a new cuke for the change.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/resource-listing_20180613/

#### Questions:
> Does this have automated Cucumber tests?
Yes.


> Can we make a blog post, video, or animated GIF out of this?
No.

> Is this explained in documentation?
No.

> Does the knowledge base need an update?
No.
