### PR TITLE
update the way we specify a minimum TLS version to be compatible with ruby 2.5

### DIFF
--- a/config/initializers/openssl.rb
+++ b/config/initializers/openssl.rb
@@ -1,2 +1,7 @@
-# require TLS due to POODLE
-OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = :TLSv1
+# Require at least TLSv1 due to POODLE. The way to specify a minimum
+# version changed in ruby 2.5.
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+  OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = :TLSv1
+else
+  OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:min_version] = OpenSSL::SSL::TLS1_VERSION
+end


### PR DESCRIPTION
#### What does this pull request do?
Sets the minimum protocol version for TLS connections in a way that works for ruby 2.5.

#### What background context can you provide?
Prior to ruby 2.5, setting `OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version]` was the way to set the minimum protocol version. Setting `ssl_version` in 2.5 is deprecated, however, and seems to clamp the version to exactly the one specified. (Or, it could be broken, I'm not really sure.)

#### Where should the reviewer start?
Take a look at the `openssl.rb`.

#### How should this be manually tested?
Running in ruby 2.5, this code shows the problem:

```
require 'openssl'
  OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = :TLSv1
  # OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:min_version] = OpenSSL::SSL::TLS1_VERSION
require 'net/http'

http = Net::HTTP.new('sts.amazonaws.com', 443)
http.use_ssl = true
http.set_debug_output($stderr)
get = Net::HTTP::Get.new('/?Action=GetCallerIdentity&Version=2011-06-15')
http.request(get)
```

The final GET will produce an error that looks like:
```
opening connection to sts.amazonaws.com:443...
opened
starting SSL for sts.amazonaws.com:443...
Conn close because of connect error SSL_connect returned=1 errno=0 state=error: bad signature
```
Changing the code to set `min_version` instead of `ssl_version` will allow the SSL connection to be established correctly, and the GET will return a 403.

The doc says that setting `min_version` will prevent a downgrade to a lesser protocol version. I haven't been able to find a way to verify that.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/tls-min-version_20180613/
#### Questions:
> Does this have automated Cucumber tests?
no

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
