### PR TITLE
Authenticate audit events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 2.2
+
+Style/AndOr:
+  EnforcedStyle: conditionals

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,5 @@
 SimpleCov.start 'rails' do
-  coverage_dir File.join(ENV['REPORT_ROOT'], 'coverage')
+  coverage_dir File.join(ENV['REPORT_ROOT'] || __dir__, 'coverage')
   # any custom configs like groups and filters can be here at a central place
 end
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -15,9 +15,10 @@ class AuthenticateController < ApplicationController
 
     authentication_token = ::Authentication::Strategy.new(
       authenticators: ::Authentication::InstalledAuthenticators.new(ENV),
+      audit_log: ::Authentication::AuditLog,
       security: nil,
       env: ENV,
-      role_class: ::Authentication::MemoizedRole,
+      role_cls: ::Role,
       token_factory: TokenFactory.new
     ).conjur_token(
       ::Authentication::Strategy::Input.new(

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -5,7 +5,7 @@
 #       It's purpose it to load all the pluggable authenticator files into 
 #       memory, so we can determine which authenticators are available
 #
-Dir[File.join("./app/domain/authentication/**/", "*.rb")].each do |f|
+Dir[File.expand_path("../domain/authentication/**/*.rb", __dir__)].each do |f|
   require f
 end
 

--- a/app/domain/authentication/audit_log.rb
+++ b/app/domain/authentication/audit_log.rb
@@ -1,0 +1,18 @@
+module Authentication
+  class AuditLog
+    def self.record_authn_event(role:, webservice_id:, authenticator_name:,
+                                success:, message: nil)
+      return unless role
+      event = ::Audit::Event::Authn.new(
+        role: role,
+        authenticator_name: authenticator_name,
+        service: Resource[webservice_id]
+      )
+      if success
+        event.emit_success
+      else
+        event.emit_failure message
+      end
+    end
+  end
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -8,6 +8,14 @@ module Audit
       logger.info LogMessage.new msg, msgid, data, Syslog::LOG_NOTICE
     end
 
+    def info msg, msgid, data
+      logger.info LogMessage.new msg, msgid, data, Syslog::LOG_INFO
+    end
+
+    def warn msg, msgid, data
+      logger.warn LogMessage.new msg, msgid, data, Syslog::LOG_WARNING
+    end
+
     def logger
       @logger ||= Rails.logger
     end
@@ -21,7 +29,7 @@ module Audit
     # cf. https://pen.iana.org
     CONJUR_PEN = 43868
     def self.conjur_sdid label
-      [label, CONJUR_PEN].join('@').freeze
+      [label, CONJUR_PEN].join('@').intern
     end
 
     POLICY = conjur_sdid 'policy'

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -37,6 +37,9 @@ module Audit
     ACTION = conjur_sdid 'action'
   end
 
+  # This inherits from String in order to preserve compatibility with Ruby's
+  # built-in formatters, which check the class of the parameter (probably as
+  # an optimization).
   class LogMessage < String
     def initialize msg, msgid, structured_data = nil, severity = nil, facility = nil
       super msg
@@ -90,7 +93,8 @@ module Audit
       facility = msg.try(:facility) || 4
 
       fields = [timestamp, hostname, progname, pid, msgid, sd, msg]
-      ["<#{severity + (facility << 3)}>1", *fields.map {|x| x || '-'}].join(" ") + "\n"
+      # per RFC5424 priority = severity + facility * 8
+      ["<#{severity + facility * 8}>1", *fields.map {|x| x || '-'}].join(" ") + "\n"
     end
 
   private

--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 class Audit::Event::Authn < OpenStruct
-  def initialize role:, service: nil, authenticator_name:
+  def initialize role:, service:, authenticator_name:
     super
   end
 
@@ -31,14 +31,6 @@ class Audit::Event::Authn < OpenStruct
     " service #{service_id}" if service_id
   end
 
-  def role_id
-    role.id
-  end
-
-  def service_id
-    service.try :id
-  end
-
   def success?
     !!success
   end
@@ -57,6 +49,14 @@ class Audit::Event::Authn < OpenStruct
   end
 
   private
+
+  def role_id
+    role.id
+  end
+
+  def service_id
+    service && service.id
+  end
 
   def auth_sd
     { authenticator: authenticator_name }.tap do |result|

--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -7,13 +7,13 @@ class Audit::Event::Authn < OpenStruct
 
   def emit_success
     self.success = true
-    Audit.info message, 'authn', structured_data
+    Audit.info message, 'authn', facility: 10, **structured_data
   end
 
   def emit_failure error_message
     self.error_message = error_message
     self.success = false
-    Audit.warn message, 'authn', structured_data
+    Audit.warn message, 'authn', facility: 10, **structured_data
   end
 
   def message

--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -1,0 +1,66 @@
+require 'ostruct'
+
+class Audit::Event::Authn < OpenStruct
+  def initialize role:, service: nil, authenticator_name:
+    super
+  end
+
+  def emit_success
+    self.success = true
+    Audit.info message, 'authn', structured_data
+  end
+
+  def emit_failure error_message
+    self.error_message = error_message
+    self.success = false
+    Audit.warn message, 'authn', structured_data
+  end
+
+  def message
+    if success?
+      format SUCCESS_TEMPLATE, role_id, authenticator_name, service_message_part
+    else
+      format FAILURE_TEMPLATE, role_id, authenticator_name, service_message_part, error_message
+    end
+  end
+
+  SUCCESS_TEMPLATE = "%s successfully authenticated with authenticator %s%s".freeze
+  FAILURE_TEMPLATE = "%s failed to authenticate with authenticator %s%s: %s".freeze
+
+  def service_message_part
+    " service #{service_id}" if service_id
+  end
+
+  def role_id
+    role.id
+  end
+
+  def service_id
+    service.try :id
+  end
+
+  def success?
+    !!success
+  end
+
+  SDID = ::Audit::SDID
+
+  def structured_data
+    {
+      SDID::SUBJECT => { role: role_id },
+      SDID::AUTH => auth_sd,
+      SDID::ACTION => {
+        operation: 'authenticate',
+        result: success?? 'success' : 'failure'
+      }
+    }
+  end
+
+  private
+
+  def auth_sd
+    { authenticator: authenticator_name }.tap do |result|
+      result[:service] = service_id if service_id
+    end
+  end
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -52,6 +52,12 @@ class Resource < Sequel::Model
       res = find *a
       res if res.try :visible_to?, role
     end
+
+    # Specialization to allow lookup by composite ids,
+    # eg. Resource[account, kind, id]
+    def [] *args
+      args.length == 3 ? super(args.join ':') : super
+    end
   end
 
   def extended_associations

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -58,6 +58,10 @@ class Role < Sequel::Model
       filter_memberships = Set.new(role_ids.map{|id| Role[id]}.compact.map(&:role_id))
       where(role_id: filter_memberships.to_a)
     end
+
+    def by_login login, account:
+      self[role_id: Role.roleid_from_username(account, login)]
+    end
   end
   
   def password= password

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # TODO: figure out how to make it work in a spring environment
+  config.audit_socket = Test::AuditSink.instance.address
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,8 +1,6 @@
 if ENV['RAILS_ENV'] == 'test'
   require 'simplecov'
-  SimpleCov.start do
-    coverage_dir File.join(ENV['REPORT_ROOT'], 'coverage')
-  end
+  load File.expand_path '../.simplecov', __dir__
 end
 
 Spring.after_fork do

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -11,10 +11,26 @@ Feature: Exchange a role's API key for a signed authentication token
 
   Scenario: A role's API can be used to authenticate
     Then I can POST "/authn/cucumber/alice/authenticate" with plain text body ":alice_api_key"
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
 
   Scenario: Attempting to use an invalid API key to authenticate result in 401 error
     When I POST "/authn/cucumber/alice/authenticate" with plain text body "wrong-api-key"
     Then the HTTP response status code is 401
+    And there is an audit record matching:
+    """
+      <84>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="failure"]
+      cucumber:user:alice failed to authenticate with authenticator authn
+    """
 
   Scenario: User cannot login as a same-named user in a different account
 

--- a/cucumber/api/features/step_definitions/audit_steps.rb
+++ b/cucumber/api/features/step_definitions/audit_steps.rb
@@ -1,0 +1,48 @@
+Then(/^there is an audit record matching:$/) do |given|
+  if Utils.local_conjur_server
+    expect(audit_messages).to include(matching(audit_template(given)))
+  else
+    puts "Note: audit tests currently rely on in-process server, skipping"
+  end
+end
+
+module CucumberAuditHelper
+  def audit_messages
+    Test::AuditSink.messages.map(&method(:normalize_message))
+  end
+
+  def last_message
+    normalize_message Test::AuditSink.messages.last
+  end
+
+  def audit_template template
+    normalize_message(template).map(&method(:matcher))
+  end
+  
+  private
+
+  # I suppose it's acceptable to :reek:UtilityFunction
+  # for this test-related method
+  def normalize_message message
+    raise ArgumentError, "no audit message received" unless message
+    *fields, tail = message
+      .gsub(/\s+/m, ' ')
+      .gsub(/\] \[/, '][')
+      .split(' ', 7)
+    *sdata, msg = tail.split(/(?<=\])/).map(&:strip)
+    sdata, msg = msg.split ' ', 2 if sdata.empty?
+    [*fields, sdata, msg]
+  end
+  
+  def matcher val
+    case val
+    when '*' then be
+    when Array then match_array val
+    else match val
+    end
+  end
+end
+
+Before { Test::AuditSink.messages.clear }
+
+World CucumberAuditHelper

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -1,7 +1,11 @@
+require_relative 'utils'
+
 ENV['CONJUR_ACCOUNT'] = 'cucumber'
-ENV['CONJUR_APPLIANCE_URL'] ||= 'http://localhost:3000'
+ENV['RAILS_ENV'] ||= 'test'
 
 require ::File.expand_path('../../../../../config/environment', __FILE__)
+
+ENV['CONJUR_APPLIANCE_URL'] ||= Utils.start_local_server
 
 require 'json_spec/cucumber'
 

--- a/cucumber/api/features/support/utils.rb
+++ b/cucumber/api/features/support/utils.rb
@@ -1,0 +1,26 @@
+# Miscellaneous utility functions for cucumber tests
+module Utils
+  class << self
+    # Runs a webrick for the app in a thread on an ephemeral port.
+    # Returns the URI to it.
+    # Note the server will automatically shutdown when the test run is finished.
+    # Also note that since this is a ruby thread it will sleep when GIL is taken.
+    # This means it might be inconvenient to use eg. when interactively debugging.
+    def start_local_server addr = 'localhost'
+      port = find_ephemeral_port addr
+      Thread.new do
+        Rack::Server.start \
+          config: File.expand_path('../../../../config.ru', __dir__),
+          server: :webrick,
+          Port: port
+      end
+      @local_conjur_server = "http://#{addr}:#{port}"
+    end
+
+    attr_reader :local_conjur_server
+
+    def find_ephemeral_port addr = 'localhost'
+      TCPServer.open(addr, 0) { |server| server.addr[1] }
+    end
+  end
+end

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -37,6 +37,7 @@ For messages generated in response to web request, this is a web request GUID. F
 ### Message ID
 
 This field is the type of event. Allowed values:
+- `authn` for authentication events,
 - `policy` for policy changes.
 
 ### Structured data
@@ -67,15 +68,32 @@ All identifiers are fully-qualified.
 
 This SD-ID specifies the action performed and/or its result. 
 
-- `operation`: optional, one of: `add`, `remove`, `change`.
+- `operation`: optional, one of: `add`, `authenticate`, `remove`, `change`,
+- `result`: on authentication or permission check, one of: `success`, `failure`.
 
 #### auth@43868
 
-This SD-ID is used on every event log caused by an authenticated user.
+This SD-ID is used on every event log caused by an authenticated user or on
+attempted authentication.
 
-- `user`: fully-qualified id of the authenticated user.
+- `user`: fully-qualified id of the authenticated user. Note this parameter is
+  only present when the user had been successfully authenticated. Events
+  related to authentication attempts (whether failed or successful) will instead
+  have a `role` parameter on `subject` SD-ID.
+- `authenticator`: when authenticating, the name of the authenticator being used.
+- `service`: when authenticating, the fully qualified id of the service requested.
 
 ### Message
 
 The body of the message should provide English-language summary of the event.
 
+## Message types
+
+### `authn` messages
+
+These messages always have subject@43868/role parameter set to the role on which
+authentication is attempted. The facility number is 10.
+
+### Examples
+
+        <46>1 - - conjur - authn [subject@43868 role="example:user:alice"][auth@43868 authenticator="authn-ldap" service="example:webservice:bacon"][action@43868 operation="authenticate" result="success"] example:user:alice successfully authenticated with authenticator authn-ldap service example:webservice:bacon

--- a/engines/conjur_audit/app/models/conjur_audit/message.rb
+++ b/engines/conjur_audit/app/models/conjur_audit/message.rb
@@ -28,7 +28,8 @@ module ConjurAudit
           # all the places where a resource id can be
           [
             { 'subject@43868': { resource: id } },
-            { 'policy@43868': { policy: id } }
+            { 'policy@43868': { policy: id } },
+            { 'auth@43868': { service: id } }
           ].map(&method(:sdata)).inject:|
         end
 

--- a/lib/test/audit_sink.rb
+++ b/lib/test/audit_sink.rb
@@ -1,0 +1,34 @@
+module Test
+  class AuditSink
+    def initialize
+      @socket = UNIXServer.new ''
+      @messages = []
+      listen
+    end
+
+    def listen backlog = 1
+      socket.listen backlog
+      Thread.new { loop { handle socket.accept } }
+        .abort_on_exception = true # to ease debugging
+    end
+
+    def handle sock
+      sock.each_line(&messages.method(:push))
+    end
+
+    def address
+      socket.addr[1]
+    end
+
+    attr_reader :socket, :messages
+
+    class << self
+      def instance
+        @instance ||= new
+      end
+      
+      extend Forwardable
+      def_delegators :instance, :messages
+    end
+  end
+end

--- a/spec/app/domain/authentication/strategy_spec.rb
+++ b/spec/app/domain/authentication/strategy_spec.rb
@@ -170,7 +170,9 @@ RSpec.describe 'Authentication::Strategy' do
         authenticators: authenticators,
         security: passing_security,
         env: two_authenticator_env,
-        token_factory: token_factory
+        token_factory: token_factory,
+        audit_log: nil,
+        role_cls: nil
       )
     end
 
@@ -190,7 +192,9 @@ RSpec.describe 'Authentication::Strategy' do
           authenticators: authenticators,
           security: passing_security,
           env: two_authenticator_env,
-          token_factory: token_factory
+          token_factory: token_factory,
+          audit_log: nil,
+          role_cls: nil
         )
       end
 
@@ -220,7 +224,9 @@ RSpec.describe 'Authentication::Strategy' do
           authenticators: authenticators,
           security: failing_security,
           env: two_authenticator_env,
-          token_factory: token_factory
+          token_factory: token_factory,
+          audit_log: nil,
+          role_cls: nil
         )
       end
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Audit::Event::Authn do
+  it 'sends an info message on success' do
+    expect(Audit).to receive(:info).with \
+      matching(/successfully authenticated/),
+      'authn',
+      'subject@43868': { role: "rspec:user:alice" },
+      'auth@43868': {
+        authenticator: 'authn-test',
+        service: 'rspec:webservice:test'
+      },
+      'action@43868': {
+        operation: 'authenticate',
+        result: 'success',
+      }
+    event.emit_success
+  end
+
+  it 'sends a warning message on failure' do
+      expect(Audit).to receive(:warn).with \
+        matching(/failed to authenticate.*: test error/),
+        'authn',
+        'subject@43868': { role: "rspec:user:alice" },
+        'auth@43868': {
+          authenticator: 'authn-test',
+          service: 'rspec:webservice:test'
+        },
+        'action@43868': {
+          operation: 'authenticate',
+          result: 'failure',
+        }
+      event.emit_failure 'test error'
+  end
+
+  subject(:event) do
+    Audit::Event::Authn.new \
+      role: the_user,
+      authenticator_name: 'authn-test',
+      service: service
+  end
+
+  let(:service) { double(Resource, id: 'rspec:webservice:test') }
+
+  context "with no webservice parameter" do
+    let(:service) { nil }
+
+    it 'does not include service in metadata nor message' do
+      expect(Audit).to receive(:info) do |msg, _, metadata|
+        expect(msg).not_to include 'service'
+        expect(metadata[:'auth@43868']).not_to have_key :service
+      end
+      event.emit_success
+    end
+  end
+
+  include_context("create user") { let(:login) { 'alice' } }
+end
+
+describe Audit do
+  describe '.info' do
+    it 'sends a message with appropriate severity' do
+      expect(logger).to receive(:info).with an_object_having_attributes \
+        msgid: 'test-msg', structured_data: { test: 'data' }, severity: 6, to_s: 'test message'
+      Audit.info 'test message', 'test-msg', test: 'data'
+    end
+  end
+
+  describe '.warn' do
+    it 'sends a message with appropriate severity' do
+      expect(logger).to receive(:warn).with an_object_having_attributes \
+        msgid: 'test-msg', structured_data: { test: 'data' }, severity: 4, to_s: 'test message'
+      Audit.warn 'test message', 'test-msg', test: 'data'
+    end
+  end
+
+  let(:logger) { double Logger }
+  before { allow(Audit).to receive_messages logger: logger }
+end

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -5,6 +5,7 @@ describe Audit::Event::Authn do
     expect(Audit).to receive(:info).with \
       matching(/successfully authenticated/),
       'authn',
+      facility: 10,
       'subject@43868': { role: "rspec:user:alice" },
       'auth@43868': {
         authenticator: 'authn-test',
@@ -21,6 +22,7 @@ describe Audit::Event::Authn do
       expect(Audit).to receive(:warn).with \
         matching(/failed to authenticate.*: test error/),
         'authn',
+        facility: 10,
         'subject@43868': { role: "rspec:user:alice" },
         'auth@43868': {
           authenticator: 'authn-test',
@@ -76,4 +78,13 @@ describe Audit do
 
   let(:logger) { double Logger }
   before { allow(Audit).to receive_messages logger: logger }
+end
+
+describe Audit::RFC5424Formatter do
+  it "can be given facility by object attribute" do
+    msg = double "message", facility: 5
+    expect(formatter.call(3, Time.now, nil, msg)).to start_with '<43>'
+  end
+
+  subject(:formatter) { Audit::RFC5424Formatter.new }
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -5,8 +5,16 @@ describe Resource, :type => :model do
   
   let(:login) { "u-#{random_hex}" }
   let(:kind) { "the-kind" }
-  let(:resource_id) { "rspec:#{kind}:r-#{random_hex}"}
+  let(:resource_id_id) { "r-#{random_hex}" }
+  let(:resource_id) { "rspec:#{kind}:#{resource_id_id}"}
   let(:the_resource) { Resource.create(resource_id: resource_id, owner: the_user) }
+
+  describe '.[]' do
+    it "allows looking up by composite ids" do
+      the_resource or raise # vivify
+      expect(Resource['rspec', kind, resource_id_id]).to eq the_resource
+    end
+  end
 
   # Hideous hack to make tests pass temporarily with rotator change
   #

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -31,4 +31,8 @@ describe Role, :type => :model do
     let(:as_json) { base_hash }
     it_should_behave_like "provides expected JSON"
   end
+
+  it "can find by login" do
+    expect(Role.by_login(login, account: 'rspec')).to eq the_user
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
   config.order = "random"
   config.filter_run_excluding performance: true
   config.infer_spec_type_from_file_location!
+  config.filter_run_when_matching :focus
 end
 
 Slosilo["authn:rspec"] ||= Slosilo::Key.new


### PR DESCRIPTION
This adds 'authenticate' audit events to the audit stream. 

Note the volume of these messages is substantial so we should consider whether they should be enabled by default, or somehow filtered. (These messages weren't present in v4.)

Comments welcome especially on the message schema (see docs/audit.md).