### PR TITLE
WIP Restoring role graph for V5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ an external audit database by using config.audit_database configuration entry.
 
 - API endpoints for granting and revoking role membership
 
+- API endpoint for the role graph
+
 ## [0.4.0] - 2018-04-10
 ### Added
 - Policy changes now generate audit log messages. These can optionally be generated in RFC5424

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -49,6 +49,11 @@ class RolesController < RestController
     render_dataset(members) { |dataset| dataset.result_set(render_params) }
   end
 
+  # Returns a graph of the roles anchored on the current Role
+  def graph
+    render json: role.graph
+  end
+
   # update_member will add or modify an existing role membership
   #
   # This API endpoint exists to manage group entitlements through

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -119,4 +119,8 @@ class Role < Sequel::Model
   def ancestor_of? role
     Role.from(Sequel.function(:is_role_ancestor_of, id, role.id)).first[:is_role_ancestor_of]
   end
+
+  def graph
+    Role.from(Sequel.function(:role_graph, id)).order(:parent, :child)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
           'authenticate#authenticate'
       end
 
+      get     "/roles/:account/:kind/*identifier" => "roles#graph", :constraints => QueryParameterActionRecognizer.new("graph")
       get     "/roles/:account/:kind/*identifier" => "roles#all_memberships", :constraints => QueryParameterActionRecognizer.new("all")
       get     "/roles/:account/:kind/*identifier" => "roles#direct_memberships", :constraints => QueryParameterActionRecognizer.new("memberships")
       get     "/roles/:account/:kind/*identifier" => "roles#members", :constraints => QueryParameterActionRecognizer.new("members")

--- a/cucumber/api/features/role_graph.feature
+++ b/cucumber/api/features/role_graph.feature
@@ -1,0 +1,63 @@
+Feature: Retrieve the role graph for a given role
+
+  The full graph of ancestor and descendent roles for a given
+  role can be retrieved throug the api
+
+  Background:
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+
+    - !group internal
+    - !layer applications
+    - !group shipping
+    - !user alice
+
+    - !grant
+      role: !group internal
+      member: !layer applications
+
+    - !grant
+      role: !layer applications
+      member: !group shipping
+
+    - !grant
+      role: !group shipping
+      member: !user alice
+    """
+
+  Scenario: Retrieve role graph
+    When I successfully GET "/roles/cucumber/group/internal?graph"
+    Then the JSON should be:
+        """
+        [
+          {
+            "parent": "cucumber:group:internal",
+            "child": "cucumber:layer:applications"
+          },
+          {
+            "parent": "cucumber:group:internal",
+            "child": "cucumber:user:admin"
+          },
+          {
+            "parent": "cucumber:group:shipping",
+            "child": "cucumber:user:admin"
+          },
+          {
+            "parent": "cucumber:group:shipping",
+            "child": "cucumber:user:alice"
+          },
+          {
+            "parent": "cucumber:layer:applications",
+            "child": "cucumber:group:shipping"
+          },
+          {
+            "parent": "cucumber:layer:applications",
+            "child": "cucumber:user:admin"
+          },
+          {
+            "parent": "cucumber:user:alice",
+            "child": "cucumber:user:admin"
+          }
+        ]
+        """

--- a/db/migrate/20180618161021_role_graph.rb
+++ b/db/migrate/20180618161021_role_graph.rb
@@ -1,0 +1,70 @@
+Sequel.migration do
+  up do
+    execute %Q{
+      CREATE TYPE role_graph_edge AS (
+        parent text,
+        child text
+      );
+
+      CREATE OR REPLACE FUNCTION role_graph(start_role text)
+      RETURNS SETOF role_graph_edge
+      LANGUAGE SQL STABLE
+      CALLED ON NULL INPUT
+      AS $$
+
+        WITH RECURSIVE 
+        -- Ancestor tree
+        up AS (
+          (SELECT role_id, member_id FROM role_memberships LIMIT 0)
+          UNION ALL
+            SELECT start_role, NULL
+
+          UNION
+
+          SELECT rm.role_id, rm.member_id FROM role_memberships rm, up
+          WHERE up.role_id = rm.member_id
+        ),
+
+        -- Descendent tree
+        down AS (
+            (SELECT role_id, member_id FROM role_memberships LIMIT 0)
+          UNION ALL
+            SELECT NULL, start_role
+
+          UNION
+
+          SELECT rm.role_id, rm.member_id FROM role_memberships rm, down
+          WHERE down.member_id = rm.role_id
+        ),
+
+        total AS (
+          SELECT * FROM up
+          UNION
+
+          -- add immediate children of the ancestors
+          -- (they can be fetched anyway through role_members method)
+          SELECT rm.role_id, rm.member_id FROM role_memberships rm, up WHERE rm.role_id = up.role_id
+
+          UNION
+          SELECT * FROM down
+        )
+
+        SELECT * FROM total WHERE role_id IS NOT NULL AND member_id IS NOT NULL
+        UNION
+        SELECT role_id, member_id FROM role_memberships WHERE start_role IS NULL
+
+      $$;
+
+      COMMENT ON FUNCTION role_graph(text) IS
+      'if role is not null, returns role_memberships culled to include only the two trees rooted at given role, plus the skin of the up tree; otherwise returns all of role_memberships';
+
+    }
+  end
+
+  down do
+    execute %Q{
+      DROP FUNCTION role_graph(start_role text);
+      DROP TYPE role_graph_edge;
+    }
+  end
+end


### PR DESCRIPTION
#### What does this pull request do?
This PR restores the Role graph endpoint to show the relationship between roles and their members.

#### What background context can you provide?

This PR is required for https://github.com/conjurinc/conjur-ui/pull/175 to restore the role graph
in the Conjur V5 UI.

#### Where should the reviewer start?

The best place to start would be the new cucumber test for the functionality:
<https://github.com/cyberark/conjur/pull/573/files#diff-6f5a51b69c097aae1b142da2be5fe0b1>

#### How should this be manually tested?

I would suggest running the cucumber test to verify the behavior.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/v5_role_graph/

#### Questions:
> Does this have automated Cucumber tests?
Yes

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
No

> Does the knowledge base need an update?
I'm not sure
