### PR TITLE
Bring back /api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 #ruby-gemset=conjur
 
 gem 'rake'
+gem 'sprockets', '~> 3.7.0', '>= 3.7.2'
 gem 'rails-api'
 gem 'rails', '~> 4.2'
 gem 'nokogiri', '>= 1.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)
     libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-darwin-16)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -201,7 +202,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     puma (3.8.2)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -300,7 +301,7 @@ GEM
       spring (>= 0.9.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -325,6 +326,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-16
 
 DEPENDENCIES
   activesupport
@@ -377,9 +379,10 @@ DEPENDENCIES
   spring
   spring-commands-cucumber
   spring-commands-rspec
+  sprockets (~> 3.7.0, >= 3.7.2)
   table_print
   therubyracer
   uglifier
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/distrib/nginx/40_possum.conf
+++ b/distrib/nginx/40_possum.conf
@@ -1,7 +1,7 @@
-location / {
+location /api/ {
   if (-f /tmp/possum-congested.flag) {
     return 503;
   }
 
-  proxy_pass http://127.0.0.1:5000;
+  proxy_pass http://127.0.0.1:5000/;
 }


### PR DESCRIPTION
#### What does this pull request do?
Updates deb package to use the location `/api` in the nginx config.

Also, fixes  a build failure caused by a CVE for the `sprockets` gem.

#### What background context can you provide?
All our doc uses `/api` as the path for the appliance URL. This change brings the v5 appliance into agreement with the doc.

#### Where should the reviewer start?
Pretty simple change, just take a look.

#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/slash-api_20180619/

#### Questions:
> Does this have automated Cucumber tests?
It gets tested by HA acceptance

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
Yes.

> Does the knowledge base need an update?
Dunno.
