### PR TITLE
Make the `api` namespace optional on API requests

### DIFF
--- a/distrib/nginx/40_possum.conf
+++ b/distrib/nginx/40_possum.conf
@@ -5,3 +5,11 @@ location /api/ {
 
   proxy_pass http://127.0.0.1:5000/;
 }
+
+location / {
+  if (-f /tmp/possum-congested.flag) {
+    return 503;
+  }
+
+  proxy_pass http://127.0.0.1:5000/;
+}


### PR DESCRIPTION
In order to support the V4 and Open Source APIs, the appliance needs to
accept requests from:
  * /api/authn/<account>/login
  * /authn/<account>/login

Enabling both allows customers to move from V4 to V5 with minimal
changes, keeps V4 docs valid, and allows a simple transition from OS to
Appliance.

Closes [225](https://github.com/conjurinc/appliance/issues/225)

This PR means requests without a path are sent to the status page.  This issue has been addressed in: https://github.com/conjurinc/conjur-ui/pull/182

#### What does this pull request do?
Adds a default route after the `api/` Nginx request match to insure requests can be made using the `/api/...` or `/...` convention.

#### Screenshots (if appropriate)
<img width="769" alt="screen shot 2018-06-21 at 2 04 10 pm" src="https://user-images.githubusercontent.com/124978/41742703-0d19d250-755c-11e8-92e2-2233240e0d23.png">

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/support-api-no-api-prefix/