### PR TITLE
fix rewriting of /api and / so they're not URL-decoded before proxying upstream

### DIFF
--- a/distrib/nginx/40_possum.conf
+++ b/distrib/nginx/40_possum.conf
@@ -1,9 +1,20 @@
+# The rewrites in this location strip off the leading /api, and ensure
+# that the URL sent to the upstream is *not* URL decoded.
+#
+# Having it remain URL-encoded is important, because Conjur ids can
+# have embedded slashes in them. Those slashes need to be passed to
+# the upstream as '%2F', not as '/'.
+#
+# See https://stackoverflow.com/a/37584637 for a discussion of the rewrite gymnastics.
 location /api/ {
   if (-f /tmp/possum-congested.flag) {
     return 503;
   }
 
-  proxy_pass http://127.0.0.1:5000/;
+  rewrite ^ $request_uri;
+  rewrite ^/api(/.*) $1; break;
+  return 400;
+  proxy_pass http://127.0.0.1:5000$uri;
 }
 
 location / {
@@ -11,5 +22,7 @@ location / {
     return 503;
   }
 
-  proxy_pass http://127.0.0.1:5000/;
+  # Do not be tempted to put a trailing slash on the URL below. If you
+  # do, the URL sent to the upstream will be URL-decoded.
+  proxy_pass http://127.0.0.1:5000;
 }


### PR DESCRIPTION
Closes conjurinc/appliance#232

#### What does this pull request do?
Fixes the nginx location rules for `/api` and `/` to avoid decoding before proxying to the upstream.

#### What background context can you provide?
This was first noticed because hosts can no longer authenticate.

#### Where should the reviewer start?

The Stack Overflow answer linked in the comments is probably worth a look.

#### How should this be manually tested?

I did an appliance build including this change. If you pull `registry2.itci.conjur.net/conjur-appliance:use-nginx-rewrite_20180626` and follow the steps in the issue, you should see that a host can now authenticate.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/use-nginx-rewrite_20180626/

#### Questions:
> Does this have automated Cucumber tests?
No, but it really should. Probably in another PR.

> Can we make a blog post, video, or animated GIF out of this?
no

> Is this explained in documentation?
no

> Does the knowledge base need an update?
no
