### PR TITLE
Endpoint for expiring rotating variables early

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -85,6 +85,23 @@ class SecretsController < RestController
     ).log_to Audit.logger
   end
 
+  # NOTE: We're following REST/http semantics here by representing this as 
+  #       an "expirations" that you POST to you.  This may seem strange given
+  #       that what we're doing is simply updating an attribute on a secret.
+  #       But keep in mind this purely an implementation detail -- we could 
+  #       have implemented expirations in many ways.  We want to expose the
+  #       concept of an "expiration" to the user.  And per standard rest, 
+  #       we do that with a resource, "expirations."  Expiring a variable
+  #       is then a matter of POSTing to create a new "expiration" resource.
+  #       
+  #       It is irrelevant that the server happens to implement this request
+  #       by assigning nil to `expires_at`.
+  #
+  #       Unfortuneatly, to be consistent with our other routes, we're abusing
+  #       query strings to represent what is in fact a new resource.  Ideally,
+  #       we'd use a slash instead, but decided that consistency trumps 
+  #       correctness in this case.
+  #
   def expire
     authorize :update
     Secret.update_expiration(@resource.id, nil)

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -86,7 +86,7 @@ class SecretsController < RestController
   end
 
   def expire
-    raise 'WE MADE IT'
+    authorize :update
     Secret.update_expiration(@resource.id, nil)
     head :created
   end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -84,4 +84,10 @@ class SecretsController < RestController
       user: current_user
     ).log_to Audit.logger
   end
+
+  def expire
+    raise 'WE MADE IT'
+    Secret.update_expiration(@resource.id, nil)
+    head :created
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,10 +42,14 @@ Rails.application.routes.draw do
       get     "/resources/:account"                   => "resources#index"
       get     "/resources"                            => "resources#index"
 
+      # NOTE: the order of these routes matters: we need the expire 
+      #       route to come first.
+      constraints account: /[^\/]*/, kind: /[^\/]+/, identifier: /.+/ do
+        post    "/secrets/:account/:kind/:identifier/expirations" => "secrets#expire"
+      end
       get     "/secrets/:account/:kind/*identifier" => 'secrets#show'
       post    "/secrets/:account/:kind/*identifier" => 'secrets#create'
       get     "/secrets"                            => 'secrets#batch'
-      post    "/secrets/:account/:kind/*identifier/expirations" => "secrets#expire"
 
       put     "/policies/:account/:kind/*identifier" => 'policies#put'
       patch   "/policies/:account/:kind/*identifier" => 'policies#patch'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,8 @@ Rails.application.routes.draw do
 
       # NOTE: the order of these routes matters: we need the expire 
       #       route to come first.
-      constraints account: /[^\/]*/, kind: /[^\/]+/, identifier: /.+/ do
-        post    "/secrets/:account/:kind/:identifier/expirations" => "secrets#expire"
-      end
+      post    "/secrets/:account/:kind/*identifier" => "secrets#expire",
+        :constraints => QueryParameterActionRecognizer.new("expirations")
       get     "/secrets/:account/:kind/*identifier" => 'secrets#show'
       post    "/secrets/:account/:kind/*identifier" => 'secrets#create'
       get     "/secrets"                            => 'secrets#batch'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
       get     "/secrets/:account/:kind/*identifier" => 'secrets#show'
       post    "/secrets/:account/:kind/*identifier" => 'secrets#create'
       get     "/secrets"                            => 'secrets#batch'
+      post    "/secrets/:account/:kind/*identifier/expirations" => "secrets#expire"
 
       put     "/policies/:account/:kind/*identifier" => 'policies#put'
       patch   "/policies/:account/:kind/*identifier" => 'policies#patch'

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -13,11 +13,17 @@ authenticators: >
   -r cucumber/authenticators/features/support
   -r cucumber/authenticators/features/step_definitions cucumber/authenticators
 
+# NOTE: We have to require the needed files from "api" individually, because
+#       if you mass require the folder it includes "api"s env.rb, which screws
+#       things up because (I think) it sets ENV['CONJUR_ACCOUNT'].  Cucumber
+#       profiles need to be thought through better and refactored most likely.
+#       
 rotators: >
   --format pretty
   --tags ~@manual
   -r cucumber/api/features/support/world.rb
   -r cucumber/api/features/step_definitions/request_steps.rb
+  -r cucumber/api/features/step_definitions/user_steps.rb
   -r cucumber/policy
   -r cucumber/rotators
   cucumber/rotators

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -16,8 +16,11 @@ authenticators: >
 rotators: >
   --format pretty
   --tags ~@manual
-  -r cucumber/rotators/features/support
-  -r cucumber/rotators/features/step_definitions cucumber/rotators
+  -r cucumber/api/features/support/world.rb
+  -r cucumber/api/features/step_definitions/request_steps.rb
+  -r cucumber/policy
+  -r cucumber/rotators
+  cucumber/rotators
 
 manual-rotators: >
   --format pretty

--- a/cucumber/api/features/expiration.feature
+++ b/cucumber/api/features/expiration.feature
@@ -1,0 +1,35 @@
+@logged-in
+Feature: Manually expiring a rotating variable
+
+  This feature is an API endpoint allowing a rotating variable to be expired
+  prematurely.
+
+  Background: Configure a postgres rotator
+    Given I reset my root policy
+    And I have the root policy:
+    """
+    - !policy
+       id: db-reports
+       body:
+         - &variables
+           - !variable url
+           - !variable username
+           - !variable
+             id: password
+             annotations:
+               rotation/rotator: postgresql/password
+               rotation/ttl: P1D
+    """
+    And I add the value "testdb" to variable "db-reports/url"
+    And I add the value "test" to variable "db-reports/username"
+    And I add the value "secret" to variable "db-reports/password"
+    And I create a db user "test" with password "secret"
+
+  Scenario: Expiring causes the secret to change
+
+    Given I wait until "secret" is not longer the password
+    And I successfully GET "/secrets/cucumber/variable/db-reports/password"
+    And save the response as "initil-password"
+    And I POST "/expirations/cucumber/variable/db-reports/password"
+    Then the HTTP response status code is 201
+    And the variable "db-reports/passwords" will rotate

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -1,13 +1,15 @@
 Feature: Adding and fetching secrets
 
-  Each resource in Possum has an associated list of "secrets", each of which is an arbitrary
-  piece of encrypted data. Access to secrets is governed by privileges:
+  Each resource in Possum has an associated list of "secrets", each of which is
+  an arbitrary piece of encrypted data. Access to secrets is governed by
+  privileges:
 
   - **execute** permission to fetch the value of a secret
   - **update** permission to change the value of a secret
 
-  The list of secrets on a resource is appended when a new secret value is added. The list
-  is capped to the last 20 secret values in order to limit the size of the backend database.
+  The list of secrets on a resource is appended when a new secret value is
+  added. The list is capped to the last 20 secret values in order to limit the
+  size of the backend database.
 
   Secrets are encrypted using AES-256-GCM.
 
@@ -15,15 +17,16 @@ Feature: Adding and fetching secrets
     Given I am a user named "eve"
     Given I create a new "variable" resource called "probe"
 
-  Scenario: When a new resource has no secret values, fetching the secret results in a 404 error.
+  Scenario: Fetching a resource with no secret values returna a 404 error.
 
     When I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
 
   Scenario: The 'conjur/mime_type' annotation is used in the value response.
 
-    If the annotation `conjur/mime_type` exists on a resource, then when a secret value is fetched
-    from the resource, that mime type is used as the `Content-Type` header in the response. 
+    If the annotation `conjur/mime_type` exists on a resource, then when a
+    secret value is fetched from the resource, that mime type is used as the
+    `Content-Type` header in the response. 
 
     Given I set annotation "conjur/mime_type" to "application/json"
     And I successfully POST "/secrets/cucumber/variable/probe" with body:
@@ -50,10 +53,10 @@ Feature: Adding and fetching secrets
     When I successfully GET "/secrets/cucumber/variable/probe"
     Then the binary result is preserved
 
-  Scenario: When fetching a secret, the last secret in the secrets list is the default.
+  Scenario: The last secret is the default one returned.
 
-    Adding a new secret appends to a list of values on the resource. When retrieving secrets,
-    the last value in the list is returned by default.
+    Adding a new secret appends to a list of values on the resource. When
+    retrieving secrets, the last value in the list is returned by default.
 
     Given I successfully POST "/secrets/cucumber/variable/probe" with body:
     """
@@ -76,7 +79,8 @@ Feature: Adding and fetching secrets
 
   Scenario: When fetching a secret, a specific secret index can be specified.
 
-    The `version` parameter can be used to select a specific secret value from the list.
+    The `version` parameter can be used to select a specific secret value from
+    the list.
 
     Given I successfully POST "/secrets/cucumber/variable/probe" with body:
     """
@@ -97,7 +101,7 @@ Feature: Adding and fetching secrets
       cucumber:user:eve fetched version 1 of cucumber:variable:probe
     """
 
-  Scenario: Fetching a secret with a non-existant secret version results in a 404 error.
+  Scenario: Fetching with a non-existant secret version returns a 404 error.
 
     Given I successfully POST "/secrets/cucumber/variable/probe" with body:
     """

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -1,6 +1,6 @@
 Feature: Adding and fetching secrets
 
-  Each resource in Possum has an associated list of "secrets", each of which is
+  Each resource in Conjur has an associated list of "secrets", each of which is
   an arbitrary piece of encrypted data. Access to secrets is governed by
   privileges:
 

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -118,3 +118,8 @@ Then(/^I (?:can )*authenticate with the admin API key for the account "(.*?)"/) 
     And I can GET "/authn/#{account}/login" with username "admin" and password "#{user.api_key}"
   }
 end
+
+Then(/^I save the response as "(.+)"$/) do |name|
+  @saved_results = @saved_results || {}
+  @saved_results[name] = @result
+end

--- a/cucumber/authenticators/features/support/env.rb
+++ b/cucumber/authenticators/features/support/env.rb
@@ -3,5 +3,7 @@ require 'aruba'
 require 'aruba/cucumber'
 require 'conjur-api'
 
+require ::File.expand_path('../../../../../config/environment', __FILE__)
+
 Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://possum'
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/cucumber/rotators/features/expiration.feature
+++ b/cucumber/rotators/features/expiration.feature
@@ -37,6 +37,6 @@ Feature: Manually expiring a rotating variable
     And I login as "admin"
     And I successfully GET "/secrets/cucumber/variable/db-reports/password"
     And I save the response as "password_before_expiration"
-    And I POST "/secrets/cucumber/variable/db-reports/password/expirations"
+    And I POST "/secrets/cucumber/variable/db-reports/password?expirations"
     Then the HTTP response status code is 201
     And the password will change from "password_before_expiration"

--- a/cucumber/rotators/features/expiration.feature
+++ b/cucumber/rotators/features/expiration.feature
@@ -34,8 +34,9 @@ Feature: Manually expiring a rotating variable
     # works.
     #
     Given I wait until the initial password has rotated away
-    And I successfully GET "/resources/cucumber/variable/db-reports/password"
+    And I login as "admin"
+    And I successfully GET "/secrets/cucumber/variable/db-reports/password"
     And I save the response as "password_before_expiration"
-    And I POST "/resources/cucumber/variable/db-reports/password/expirations"
+    And I POST "/secrets/cucumber/variable/db-reports/password/expirations"
     Then the HTTP response status code is 201
     And the password will change from "password_before_expiration"

--- a/cucumber/rotators/features/expiration.feature
+++ b/cucumber/rotators/features/expiration.feature
@@ -1,4 +1,3 @@
-@logged-in
 Feature: Manually expiring a rotating variable
 
   This feature is an API endpoint allowing a rotating variable to be expired
@@ -19,6 +18,7 @@ Feature: Manually expiring a rotating variable
              annotations:
                rotation/rotator: postgresql/password
                rotation/ttl: P1D
+               rotation/postgresql/password/length: 32
     """
     And I add the value "testdb" to variable "db-reports/url"
     And I add the value "test" to variable "db-reports/username"
@@ -27,9 +27,15 @@ Feature: Manually expiring a rotating variable
 
   Scenario: Expiring causes the secret to change
 
-    Given I wait until "secret" is not longer the password
-    And I successfully GET "/secrets/cucumber/variable/db-reports/password"
-    And save the response as "initil-password"
-    And I POST "/expirations/cucumber/variable/db-reports/password"
+    # The initial password is rotated right away, and the subsequent rotation
+    # won't occur for a full day.  We wait for the initial rotation to occur
+    # before proceeding, because the 2nd password (ie, the first one generated
+    # by the rotator) will be stable, so we'll know if our early expiration
+    # works.
+    #
+    Given I wait until the initial password has rotated away
+    And I successfully GET "/resources/cucumber/variable/db-reports/password"
+    And I save the response as "password_before_expiration"
+    And I POST "/resources/cucumber/variable/db-reports/password/expirations"
     Then the HTTP response status code is 201
-    And the variable "db-reports/passwords" will rotate
+    And the password will change from "password_before_expiration"

--- a/cucumber/rotators/features/step_definitions/expiration_steps.rb
+++ b/cucumber/rotators/features/step_definitions/expiration_steps.rb
@@ -1,0 +1,24 @@
+# NOTE: I saw no reason to make this dynamically accept parameters --
+#       the step is by nature coupled to the expiration feature, so
+#       hardcoding these values should actually be preferred.
+#
+Then(/^I wait until the initial password has rotated away$/) do
+  @history_before_expiration = pg_history_after_rotation(
+    var_name: 'db-reports/password',
+    db_user: 'test',
+    orig_pw: 'secret'
+  )
+end
+
+Then(/^the password will change from "(.+)"$/) do |saved_result_key|
+  old_value = @saved_results[saved_result_key]
+
+  # We don't care about the value returned in this case.  As long as the method
+  # returns without error, we know the password changed
+  #
+  pg_history_after_rotation(
+    var_name: 'db-reports/password',
+    db_user: 'test',
+    orig_pw: old_value
+  )
+end

--- a/cucumber/rotators/features/step_definitions/rotator_steps.rb
+++ b/cucumber/rotators/features/step_definitions/rotator_steps.rb
@@ -7,9 +7,9 @@ Then(/^I create a db user "(.*?)" with password "(.*?)"$/) do |user, pw|
 end
 
 regex = /^I moniter "(.+)" and db user "(.+)" for (\d+) values in (\d+) seconds$/
-Then(regex) do |var_id, db_user, vals_needed_str, timeout_str|
+Then(regex) do |var_name, db_user, vals_needed_str, timeout_str|
   @pg_pw_history = postgres_password_history(
-    var_id: var_id,
+    var_name: var_name,
     db_user: db_user,
     values_needed: vals_needed_str.to_i,
     timeout: timeout_str.to_i

--- a/cucumber/rotators/features/support/env.rb
+++ b/cucumber/rotators/features/support/env.rb
@@ -3,6 +3,9 @@
 require_relative './world.rb'
 # require_relative '../../../policy/features/support/world.rb'
 
+ENV['RAILS_ENV'] ||= 'test'
+require ::File.expand_path('../../../../../config/environment', __FILE__)
+
 Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://possum'
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'
 

--- a/cucumber/rotators/features/support/env.rb
+++ b/cucumber/rotators/features/support/env.rb
@@ -1,7 +1,7 @@
 # Bring in the policy's World
 #
 require_relative './world.rb'
-require_relative '../../../policy/features/support/world.rb'
+# require_relative '../../../policy/features/support/world.rb'
 
 Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://possum'
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/cucumber/rotators/features/support/world.rb
+++ b/cucumber/rotators/features/support/world.rb
@@ -135,7 +135,6 @@ module RotatorWorld
       history = []
       loop do
         history = updated_history(history)
-        p history
         return history if stop?(history)
         raise error_msg if timer.has_exceeded?(@timeout)
         sleep(0.3)


### PR DESCRIPTION
Closes #568 

#### What does this pull request do?

• Fixes a bug in `Secret.scheduled_rotations` query
• Adds an API endpoint to instantly expire a rotating variable
• Adds cucumber tests to test that endpoint

#### Where should the reviewer start?

1. `cd dev && ./start --rotators`
2. Start conjur container in another tab `conjurctl server`
3. `bundle exec cucumber -p rotators`

The `expiration.feature` is the new cuke relevant to this PR.

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/job/cyberark--conjur/job/expire-api/5/

#### Questions:
> Does this have automated Cucumber tests?

Yes