### PR TITLE
Correct guard for LDAP vs IAM authentication in dev start script

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -66,7 +66,7 @@ if [[ $ENABLE_ROTATORS = true ]]; then
   services="$services testdb cucumber"
 fi
 
-if [[ $ENABLE_AUTHN_LDAP = true ]]; then
+if [[ $ENABLE_AUTHN_IAM = true ]]; then
   env_args="$env_args -e CONJUR_AUTHENTICATORS=authn-iam/prod"
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-iam/policy.yml
 fi


### PR DESCRIPTION
This PR corrects a typo in the dev environment start script that causes the authenticators to be incorrectly configured for LDAP.

Jenkins build:
https://jenkins.conjur.net/job/cyberark--conjur/job/start_script_fix/