### PR TITLE
Available authenticators endpoint

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module Possum
         /^\/authn\/.*\/authenticate$/,
         /^\/host_factories\/hosts$/,
         /^\/assets\/.*/,
+        /^\/authenticators$/,
         /^\/$/
       ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ end
 Rails.application.routes.draw do
   scope format: false do
     get '/' => 'status#index'
+    get '/authenticators' => 'authenticate#index'
 
     constraints id: /[^\/\?]+/ do
       resources :accounts, only: [ :create, :index, :destroy ]

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -11,6 +11,8 @@ api: >
 authenticators: >
   --format pretty
   -r cucumber/authenticators/features/support
+  -r cucumber/api/features/support/world.rb
+  -r cucumber/api/features/step_definitions/request_steps.rb
   -r cucumber/authenticators/features/step_definitions cucumber/authenticators
 
 # NOTE: We have to require the needed files from "api" individually, because

--- a/cucumber/authenticators/features/available_authn.feature
+++ b/cucumber/authenticators/features/available_authn.feature
@@ -1,0 +1,32 @@
+Feature: The list of available authentication providers is discoverable
+  through the API.
+
+  Background:
+    Given a policy:
+    """
+    - !user alice
+    - !user bob
+
+    - !policy
+      id: conjur/authn-ldap/test
+      body:
+      - !webservice
+
+      - !group clients
+
+      - !permit
+        role: !group clients
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !grant
+      role: !group conjur/authn-ldap/test/clients
+      member: !user alice
+    """
+
+  Scenario: List authenticators
+  
+  When I retrieve the list of authenticators
+  Then the installed authenticators contains "authn-ldap"
+  And the configured authenticators contains "authn-ldap/test"
+  And the enabled authenticators contains "authn-ldap/test"

--- a/cucumber/authenticators/features/step_definitions/available_authn_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/available_authn_steps.rb
@@ -1,0 +1,7 @@
+When(/I retrieve the list of authenticators/) do
+  step "I successfully GET \"/authenticators\""
+end
+
+Then(/^the (\S+) authenticators contains "([^"]*)"$/) do |category, value|
+  step "the JSON at \"#{category}\" should include \"#{value}\""
+end

--- a/cucumber/authenticators/features/support/env.rb
+++ b/cucumber/authenticators/features/support/env.rb
@@ -2,6 +2,7 @@ require 'rest-client'
 require 'aruba'
 require 'aruba/cucumber'
 require 'conjur-api'
+require 'json_spec/cucumber'
 
 require ::File.expand_path('../../../../../config/environment', __FILE__)
 


### PR DESCRIPTION
For

#### What does this pull request do?

This PR adds an endpoint in Conjur, `/authenticators`, that returns the installed and configured authenticators.

#### Where should the reviewer start?

The route is setup between:
- `config/application.rb`
- `config/routes.rb`

Because this is going to be access by the Info service on the appliance, which has no identify, this endpoint is not authenticated. I welcome opinions on that, or ideas on how to not have it be so.

The data for the endpoint itself is assembled in:
`app/controllers/authenticate_controller.rb`

There is a test for the expected behavior in:
`cucumber/authenticators/features/available_authn.feature`

#### How should this be manually tested?

1) Start a development server, this alone should show the installed authenticator strategies and the default `authn` option at the `/authenticators` endpoint.

2) Load authenticator policies (per https://github.com/cyberark/conjur/blob/master/AUTHENTICATORS.md) and update the `CONJUR_AUTHENTICATORS` environment variable to change the information returned by the endpoint.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/available_authenticators/

#### Questions:
> Does this have automated Cucumber tests?
Yes

> Can we make a blog post, video, or animated GIF out of this?
Maybe?

> Is this explained in documentation?
No

> Does the knowledge base need an update?
I don't know
