### PR TITLE
Removed backtick to insure help text displayed as desired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changes
 - Optimize audit database and responses, for a significant improvement of performance.
 
+### Fixed
+- `start` no longer fails to show Help information.
+
+
 ## [0.8.1] - 2018-06-29
 ### Added
 - Audit events for failed variable fetches and updates.

--- a/dev/start
+++ b/dev/start
@@ -5,18 +5,19 @@ function print_help() {
 Starts Conjur for development. Once setup is complete, the user is dropped into the Conjur container.
 To start the application server, run:
     # conjurctl server
+
 Usage: start [options]
     --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable authentication via:
                     'curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate'
     --rotators      Starts a cucumber and test postgres container.
                     Drops you into the cucumber container.
-                    You then manually start `conjurctl server` in another tab.
+                    You then manually start 'conjurctl server' in another tab.
 
     --authn-iam     Starts with authn-iam/prod as authenticator
 
     -h, --help      Shows this help message.
 EOF
-exit
+  exit
 }
 
 unset COMPOSE_PROJECT_NAME


### PR DESCRIPTION
Closes #612

#### What does this pull request do?
Fixes a bug where the `dev/start` script fails to display help information.

#### Where should the reviewer start?
`dev/start`

#### How should this be manually tested?
Verify help information is displayed with either the `./start -h` or `./start --help` flags.

