### PR TITLE
Don't audit fetches of nonexistent resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Handling of absolute user ids in policies.
+- Attempts to fetch a secret from a nonexistent resource no longer cause 500.
 
 ## [1.0.0] - 2018-7-16
 ### Added

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -75,6 +75,9 @@ class SecretsController < RestController
   end
 
   def audit_fetch resource, version: nil
+    # don't audit the fetch if the resource doesn't exist
+    return unless resource
+
     Audit::Event::Fetch.new(
       error_info.merge(
         resource: resource,

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -45,12 +45,6 @@ class SecretsController < RestController
   end
 
   def batch
-    raise ArgumentError, 'variable_ids' if params[:variable_ids].blank?
-
-    variable_ids = params[:variable_ids].split(',').compact
-
-    raise ArgumentError, 'variable_ids' if variable_ids.blank?
-    
     variables = Resource.where(resource_id: variable_ids).eager(:secrets).all
 
     unless variable_ids.count == variables.count
@@ -120,5 +114,12 @@ class SecretsController < RestController
     authorize :update
     Secret.update_expiration(resource.id, nil)
     head :created
+  end
+
+  private
+
+  def variable_ids
+    @variable_ids ||= (params[:variable_ids] || '').split(',').compact
+      .tap { |ids| raise ArgumentError, 'variable_ids' if ids.empty? }
   end
 end

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -22,6 +22,11 @@ Feature: Adding and fetching secrets
     When I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
 
+  Scenario: Fetching a secret for a nonexistent resource
+
+    When I GET "/secrets/cucumber/variable/non-existent"
+    Then the HTTP response status code is 404
+
   Scenario: The 'conjur/mime_type' annotation is used in the value response.
 
     If the annotation `conjur/mime_type` exists on a resource, then when a

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
+ENV['CONJUR_ACCOUNT'] = 'cucumber'
+ENV['RAILS_ENV'] ||= 'test'
+
 # so that we can require relative to the project root
-$LOAD_PATH.unshift(Dir.pwd)
+$LOAD_PATH.unshift File.expand_path '../../../..', __dir__
 require 'config/environment'
 
 require 'json_spec/cucumber'
 require_relative 'utils'
-
-ENV['CONJUR_ACCOUNT'] = 'cucumber'
-ENV['RAILS_ENV'] ||= 'test'
 
 # This line is here to support running these tests outside a container,
 # per Rafal's request.  It could be deleted were it not for that.


### PR DESCRIPTION
Closes #629.

There are three commits in this PR. One is a minor style fix, one is a configuration fix, and one is the actual fix.

It's not clear to me if we want to audit attempts to fetch resources which do not exist; I'm pretty sure we didn't in v4. Also it was an easier fix not to so I picked that option. Feedback welcome.