### PR TITLE
Add export command to gather data needed to migrate to EE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Adds `conjurctl export` command to provide a migration data package to Conjur EE
+
 ## [1.0.1] - 2018-7-23
 ### Fixed
 - Handling of absolute user ids in policies.

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -272,4 +272,17 @@ command :wait do |c|
   end
 end
 
+desc "Export the Conjur data for migration to Conjur Enteprise Edition"
+command :export do |c|
+  c.desc "Output directory"
+  c.arg_name :out_dir
+  c.default_value Dir.pwd
+  c.flag [:o, :out_dir]
+
+  c.action do |global_options,options,args|
+    connect
+    exec "rake export[#{options[:out_dir]}]"
+  end
+end
+
 exit run(ARGV)

--- a/cucumber/api/features/export.feature
+++ b/cucumber/api/features/export.feature
@@ -1,0 +1,8 @@
+Feature: Export Conjur Open Source data
+
+   The database and data key from Conjur can be exported to import
+   into a Conjur EE appliance
+
+   Scenario: Export using `conjurctl`
+   When I run conjurctl export
+   Then the export file exists

--- a/cucumber/api/features/step_definitions/export_steps.rb
+++ b/cucumber/api/features/step_definitions/export_steps.rb
@@ -1,0 +1,8 @@
+When(/^I run conjurctl export$/) do
+  system("conjurctl export -o cuke_export/") || fail
+end
+
+Then(/^the export file exists$/) do
+  Dir['cuke_export/*.tar.xz.gpg'].any? || fail
+  File.exists?('cuke_export/key') || fail
+end

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -3,6 +3,7 @@
 # Generates random unique names
 #
 require 'haikunator'
+require 'fileutils'
 
 Before do
   @user_index = 0
@@ -20,6 +21,10 @@ Before do
   Account.find_or_create_accounts_resource
   admin_role = Role.create(role_id: "cucumber:user:admin")
   Credentials.new(role: admin_role).save(raise_on_save_failure: true)
+end
+
+After do
+  FileUtils.remove_dir('cuke_export') if Dir.exists?('cuke_export')
 end
 
 Before("@logged-in") do

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'time'
+require 'pathname'
+
+desc "Export the Conjur data necessary to migrate to Enterprise Edition"
+task :export, [ "out_dir" ] do |t,args|
+  out_dir = Pathname.new args[:out_dir]
+
+  puts "Exporting to '#{out_dir}'..."
+
+  # Make sure output directory exists and we can write to it
+  FileUtils.mkpath out_dir
+  FileUtils.chmod 0770, out_dir
+
+  export_key_file = out_dir.join("key")
+  if File.exist?(export_key_file)
+    puts "Using key from #{export_key_file}"
+  else
+    generate_key(export_key_file)
+  end
+
+  # Timestamp to name export file
+  timestamp = Time.now.strftime("%Y-%m-%dT%H-%M-%SZ")
+
+  dbdump = data_key_file = archive_file = nil
+  with_umask 077 do
+    # Export Conjur database
+    FileUtils.mkpath out_dir.join("backup")
+    dbdump = out_dir.join("backup/conjur.db")
+    call %(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']}) or
+      raise 'unable to get database backup'
+
+    # export CONJUR_DATA_KEY
+    FileUtils.mkpath out_dir.join("etc")
+    data_key_file = out_dir.join("etc/conjur.key")
+    File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
+
+    archive_file = out_dir.join("#{timestamp}.tar.xz")
+    call %(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
+         %(--transform="s|^|/opt/conjur/|" ) +
+         %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}") or
+      raise 'unable to make archive for backup'
+  end
+
+  call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
+    %("#{export_key_file}" --no-use-agent "#{archive_file}")
+
+  puts
+  puts "Export placed in #{archive_file}.gpg"
+  puts "It's encrypted with key in #{export_key_file}."
+  puts "If you're going to store the export, make"
+  puts "sure to store the key file separately."
+
+ensure
+  call %(rm -f "#{archive_file}" "#{dbdump}" "#{data_key_file}") or
+  warn 'unable to remove temporary files'
+end
+
+def with_umask umask, &block
+  saved_umask = File.umask umask
+  begin
+    yield
+  ensure
+    File.umask saved_umask
+  end
+end
+
+def call *args
+  system(*args).tap do |result|
+    warn "command #{Array(args).join(' ')} failed" unless result
+  end
+end
+
+def generate_key(file)
+  with_umask 077 do
+    puts "Generating key file #{file}"
+    File.write(file, SecureRandom.base64(64))
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -9,44 +9,18 @@ task :export, ['out_dir'] do |_t, args|
   out_dir = Pathname.new args[:out_dir]
 
   puts "Exporting to '#{out_dir}'..."
-
-  # Make sure output directory exists and we can write to it
-  FileUtils.mkpath out_dir
-  FileUtils.chmod 0o770, out_dir
-
-  export_key_file = out_dir.join('key')
-  if File.exist?(export_key_file)
-    puts "Using key from #{export_key_file}"
-  else
-    generate_key(export_key_file)
-  end
-
-  # Timestamp to name export file
-  timestamp = Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
+  create_export_directory(out_dir)
+  export_key_file = ensure_export_key(out_dir)  
 
   dbdump = data_key_file = archive_file = nil
-  with_umask 0o77 do
-    # Export Conjur database
-    FileUtils.mkpath out_dir.join('backup')
-    dbdump = out_dir.join('backup/conjur.db')
-    call(%(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']})) ||
-      raise('unable to get database backup')
-
-    # export CONJUR_DATA_KEY
-    FileUtils.mkpath out_dir.join('etc')
-    data_key_file = out_dir.join('etc/possum.key')
-    File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
-
-    archive_file = out_dir.join("#{timestamp}.tar.xz")
-    call(%(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
-         %(--transform="s|^|/opt/conjur/|" ) +
-         %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}")) ||
-      raise('unable to make archive for backup')
+  with_umask 077 do
+    dbdump = export_database(out_dir)
+    data_key_file = export_data_key(out_dir)
+    archive_file = create_export_archive(out_dir, dbdump, data_key_file)    
   end
 
-  call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
-       %("#{export_key_file}" --no-use-agent "#{archive_file}")
-
+  encrypt_export_archive(export_key_file, archive_file)
+  
   puts
   puts "Export placed in #{archive_file}.gpg"
   puts "It's encrypted with key in #{export_key_file}."
@@ -54,28 +28,82 @@ task :export, ['out_dir'] do |_t, args|
   puts 'sure to store the key file separately.'
 
 ensure
-  call(%(rm -f "#{archive_file}" "#{dbdump}" "#{data_key_file}")) ||
+  cleanup_export_files(archive_file, out_dir)  
+end
+
+def create_export_directory(out_dir)
+  # Make sure output directory exists and we can write to it
+  FileUtils.mkpath(out_dir)
+  FileUtils.chmod(0770, out_dir)
+end
+
+def ensure_export_key(out_dir)
+  export_key_file = out_dir.join('key')
+  if File.exist?(export_key_file)
+    puts "Using key from #{export_key_file}"
+  else
+    generate_key(export_key_file)
+  end
+  export_key_file
+end
+
+def export_database(out_dir) 
+  # Export Conjur database
+  FileUtils.mkpath out_dir.join('backup')
+  dbdump = out_dir.join('backup/conjur.db')
+  call(%(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']})) ||
+    raise('unable to get database backup')
+  dbdump
+end
+
+def export_data_key(out_dir)
+  # export CONJUR_DATA_KEY
+  FileUtils.mkpath out_dir.join('etc')
+  data_key_file = out_dir.join('etc/possum.key')
+  File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
+  data_key_file
+end
+
+def create_export_archive(out_dir, dbdump, data_key_file)
+  # Timestamp to name export file
+  timestamp = Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
+
+  archive_file = out_dir.join("#{timestamp}.tar.xz")
+  call(%(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
+       %(--transform="s|^|/opt/conjur/|" ) +
+       %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}")) ||
+    raise('unable to make archive for backup')
+  archive_file
+end
+
+def encrypt_export_archive(export_key_file, archive_file)
+  call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
+       %("#{export_key_file}" --no-use-agent "#{archive_file}")
+end
+
+def cleanup_export_files(archive_file, out_dir)
+  call(%(rm -rf "#{archive_file}" "#{out_dir.join('backup')}" "#{out_dir.join('etc')}")) ||
     warn('unable to remove temporary files')
 end
 
-def with_umask umask
-  saved_umask = File.umask umask
-  begin
-    yield
-  ensure
-    File.umask saved_umask
-  end
-end
-
-def call *args
+def call(*args)
   system(*args).tap do |result|
     warn "command #{Array(args).join(' ')} failed" unless result
   end
 end
 
 def generate_key(file)
-  with_umask 0o77 do
+  with_umask 077 do
     puts "Generating key file #{file}"
     File.write(file, SecureRandom.base64(64))
+  end
+end
+
+def with_umask(umask)
+  saved_umask = File.umask umask
+  begin
+    yield
+  ensure
+    File.umask saved_umask
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -34,7 +34,7 @@ task :export, [ "out_dir" ] do |t,args|
 
     # export CONJUR_DATA_KEY
     FileUtils.mkpath out_dir.join("etc")
-    data_key_file = out_dir.join("etc/conjur.key")
+    data_key_file = out_dir.join("etc/possum.key")
     File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
 
     archive_file = out_dir.join("#{timestamp}.tar.xz")

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -4,17 +4,17 @@ require 'fileutils'
 require 'time'
 require 'pathname'
 
-desc "Export the Conjur data necessary to migrate to Enterprise Edition"
-task :export, [ "out_dir" ] do |t,args|
+desc 'Export the Conjur data necessary to migrate to Enterprise Edition'
+task :export, ['out_dir'] do |_t, args|
   out_dir = Pathname.new args[:out_dir]
 
   puts "Exporting to '#{out_dir}'..."
 
   # Make sure output directory exists and we can write to it
   FileUtils.mkpath out_dir
-  FileUtils.chmod 0770, out_dir
+  FileUtils.chmod 0o770, out_dir
 
-  export_key_file = out_dir.join("key")
+  export_key_file = out_dir.join('key')
   if File.exist?(export_key_file)
     puts "Using key from #{export_key_file}"
   else
@@ -22,43 +22,43 @@ task :export, [ "out_dir" ] do |t,args|
   end
 
   # Timestamp to name export file
-  timestamp = Time.now.strftime("%Y-%m-%dT%H-%M-%SZ")
+  timestamp = Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
 
   dbdump = data_key_file = archive_file = nil
-  with_umask 077 do
+  with_umask 0o77 do
     # Export Conjur database
-    FileUtils.mkpath out_dir.join("backup")
-    dbdump = out_dir.join("backup/conjur.db")
-    call %(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']}) or
-      raise 'unable to get database backup'
+    FileUtils.mkpath out_dir.join('backup')
+    dbdump = out_dir.join('backup/conjur.db')
+    call(%(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']})) ||
+      raise('unable to get database backup')
 
     # export CONJUR_DATA_KEY
-    FileUtils.mkpath out_dir.join("etc")
-    data_key_file = out_dir.join("etc/possum.key")
+    FileUtils.mkpath out_dir.join('etc')
+    data_key_file = out_dir.join('etc/possum.key')
     File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
 
     archive_file = out_dir.join("#{timestamp}.tar.xz")
-    call %(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
+    call(%(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
          %(--transform="s|^|/opt/conjur/|" ) +
-         %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}") or
-      raise 'unable to make archive for backup'
+         %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}")) ||
+      raise('unable to make archive for backup')
   end
 
   call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
-    %("#{export_key_file}" --no-use-agent "#{archive_file}")
+       %("#{export_key_file}" --no-use-agent "#{archive_file}")
 
   puts
   puts "Export placed in #{archive_file}.gpg"
   puts "It's encrypted with key in #{export_key_file}."
   puts "If you're going to store the export, make"
-  puts "sure to store the key file separately."
+  puts 'sure to store the key file separately.'
 
 ensure
-  call %(rm -f "#{archive_file}" "#{dbdump}" "#{data_key_file}") or
-  warn 'unable to remove temporary files'
+  call(%(rm -f "#{archive_file}" "#{dbdump}" "#{data_key_file}")) ||
+    warn('unable to remove temporary files')
 end
 
-def with_umask umask, &block
+def with_umask umask
   saved_umask = File.umask umask
   begin
     yield
@@ -74,7 +74,7 @@ def call *args
 end
 
 def generate_key(file)
-  with_umask 077 do
+  with_umask 0o77 do
     puts "Generating key file #{file}"
     File.write(file, SecureRandom.base64(64))
   end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -9,17 +9,17 @@ task :export, ['out_dir'] do |_t, args|
   out_dir = Pathname.new args[:out_dir]
 
   puts "Exporting to '#{out_dir}'..."
-  create_export_directory(out_dir)
-  export_key_file = ensure_export_key(out_dir)  
+  ExportTask.create_export_directory(out_dir)
+  export_key_file = ExportTask.ensure_export_key(out_dir)  
 
   dbdump = data_key_file = archive_file = nil
-  with_umask 077 do
-    dbdump = export_database(out_dir)
-    data_key_file = export_data_key(out_dir)
-    archive_file = create_export_archive(out_dir, dbdump, data_key_file)    
+  ExportTask.with_umask 077 do
+    dbdump = ExportTask.export_database(out_dir)
+    data_key_file = ExportTask.export_data_key(out_dir)
+    archive_file = ExportTask.create_export_archive(out_dir, dbdump, data_key_file)    
   end
 
-  encrypt_export_archive(export_key_file, archive_file)
+  ExportTask.encrypt_export_archive(export_key_file, archive_file)
   
   puts
   puts "Export placed in #{archive_file}.gpg"
@@ -28,82 +28,86 @@ task :export, ['out_dir'] do |_t, args|
   puts 'sure to store the key file separately.'
 
 ensure
-  cleanup_export_files(archive_file, out_dir)  
+  ExportTask.cleanup_export_files(archive_file, out_dir)  
 end
 
-def create_export_directory(out_dir)
-  # Make sure output directory exists and we can write to it
-  FileUtils.mkpath(out_dir)
-  FileUtils.chmod(0770, out_dir)
-end
+module ExportTask
+  class << self
+    def create_export_directory(out_dir)
+      # Make sure output directory exists and we can write to it
+      FileUtils.mkpath(out_dir)
+      FileUtils.chmod(0770, out_dir)
+    end
 
-def ensure_export_key(out_dir)
-  export_key_file = out_dir.join('key')
-  if File.exist?(export_key_file)
-    puts "Using key from #{export_key_file}"
-  else
-    generate_key(export_key_file)
-  end
-  export_key_file
-end
+    def ensure_export_key(out_dir)
+      export_key_file = out_dir.join('key')
+      if File.exist?(export_key_file)
+        puts "Using key from #{export_key_file}"
+      else
+        generate_key(export_key_file)
+      end
+      export_key_file
+    end
 
-def export_database(out_dir) 
-  # Export Conjur database
-  FileUtils.mkpath out_dir.join('backup')
-  dbdump = out_dir.join('backup/conjur.db')
-  call(%(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']})) ||
-    raise('unable to get database backup')
-  dbdump
-end
+    def export_database(out_dir) 
+      # Export Conjur database
+      FileUtils.mkpath out_dir.join('backup')
+      dbdump = out_dir.join('backup/conjur.db')
+      call(%(pg_dump -Fc -f \"#{dbdump}\" #{ENV['DATABASE_URL']})) ||
+        raise('unable to get database backup')
+      dbdump
+    end
 
-def export_data_key(out_dir)
-  # export CONJUR_DATA_KEY
-  FileUtils.mkpath out_dir.join('etc')
-  data_key_file = out_dir.join('etc/possum.key')
-  File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
-  data_key_file
-end
+    def export_data_key(out_dir)
+      # export CONJUR_DATA_KEY
+      FileUtils.mkpath out_dir.join('etc')
+      data_key_file = out_dir.join('etc/possum.key')
+      File.write(data_key_file, "CONJUR_DATA_KEY=#{ENV['CONJUR_DATA_KEY']}\n")
+      data_key_file
+    end
 
-def create_export_archive(out_dir, dbdump, data_key_file)
-  # Timestamp to name export file
-  timestamp = Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
+    def create_export_archive(out_dir, dbdump, data_key_file)
+      # Timestamp to name export file
+      timestamp = Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
 
-  archive_file = out_dir.join("#{timestamp}.tar.xz")
-  call(%(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
-       %(--transform="s|^|/opt/conjur/|" ) +
-       %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}")) ||
-    raise('unable to make archive for backup')
-  archive_file
-end
+      archive_file = out_dir.join("#{timestamp}.tar.xz")
+      call(%(tar Jcf "#{archive_file}" -C "#{out_dir}" ) +
+          %(--transform="s|^|/opt/conjur/|" ) +
+          %("#{dbdump.relative_path_from(out_dir)}" "#{data_key_file.relative_path_from(out_dir)}")) ||
+        raise('unable to make archive for backup')
+      archive_file
+    end
 
-def encrypt_export_archive(export_key_file, archive_file)
-  call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
-       %("#{export_key_file}" --no-use-agent "#{archive_file}")
-end
+    def encrypt_export_archive(export_key_file, archive_file)
+      call %(gpg -c --cipher-algo AES256 --batch --passphrase-file ) +
+          %("#{export_key_file}" --no-use-agent "#{archive_file}")
+    end
 
-def cleanup_export_files(archive_file, out_dir)
-  call(%(rm -rf "#{archive_file}" "#{out_dir.join('backup')}" "#{out_dir.join('etc')}")) ||
-    warn('unable to remove temporary files')
-end
+    def cleanup_export_files(archive_file, out_dir)
+      call(%(rm -rf "#{archive_file}" "#{out_dir.join('backup')}" "#{out_dir.join('etc')}")) ||
+        warn('unable to remove temporary files')
+    end
 
-def call(*args)
-  system(*args).tap do |result|
-    warn "command #{Array(args).join(' ')} failed" unless result
-  end
-end
+    def call(*args)
+      system(*args).tap do |result|
+        warn "command #{Array(args).join(' ')} failed" unless result
+      end
+    end
 
-def generate_key(file)
-  with_umask 077 do
-    puts "Generating key file #{file}"
-    File.write(file, SecureRandom.base64(64))
-  end
-end
+    def generate_key(file)
+      with_umask 077 do
+        puts "Generating key file #{file}"
+        File.write(file, SecureRandom.base64(64))
+      end
+    end
 
-def with_umask(umask)
-  saved_umask = File.umask umask
-  begin
-    yield
-  ensure
-    File.umask saved_umask
+    def with_umask(umask)
+      saved_umask = File.umask umask
+      begin
+        yield
+      ensure
+        File.umask saved_umask
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #625 

#### What does this pull request do?

Adds a `conjurctl export` command to export the database backup and data key to use
when configuring a new EE master.

#### What background context can you provide?
Child of https://github.com/conjurinc/evoke/issues/151
 
#### How should this be manually tested?

See the workflow in the issue, #625 

#### Link to build in Jenkins
https://jenkins.conjur.net/job/cyberark--conjur/job/conjurctl_export/

#### Remaining
- [x] Update changelog
