### PR TITLE
Export account list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `conjurctl export` now includes the account list to support migration
 
 ## [1.1.0] - 2018-7-30
 ### Added

--- a/cucumber/api/features/export.feature
+++ b/cucumber/api/features/export.feature
@@ -3,6 +3,10 @@ Feature: Export Conjur Open Source data
    The database and data key from Conjur can be exported to import
    into a Conjur EE appliance
 
+   Background:
+   Given I create a new user "admin" in account "export_account"
+
    Scenario: Export using `conjurctl`
    When I run conjurctl export
    Then the export file exists
+   And the accounts file contains "export_account"

--- a/cucumber/api/features/step_definitions/export_steps.rb
+++ b/cucumber/api/features/step_definitions/export_steps.rb
@@ -1,8 +1,30 @@
 When(/^I run conjurctl export$/) do
-  system("conjurctl export -o cuke_export/") || fail
+  system("conjurctl export -o cuke_export/") || fail('Could not execute `conjurctl export`')
 end
 
 Then(/^the export file exists$/) do
-  Dir['cuke_export/*.tar.xz.gpg'].any? || fail
-  File.exists?('cuke_export/key') || fail
+  Dir['cuke_export/*.tar.xz.gpg'].any? || fail('No export archive file exists')
+  File.exists?('cuke_export/key') || fail('No export archive key file exists')
+end
+
+Then (/^the accounts file contains "([^"]*)"$/) do |contents|
+  key_file = 'cuke_export/key'.freeze
+  temp_dir = "#{Dir.tmpdir()}/#{SecureRandom.hex(5)}".freeze
+  plain_backup_file = temp_dir + '/backup.tar.xz'
+  backup_file = Dir['cuke_export/*.tar.xz.gpg'].sort().first
+
+  # Decrypt export archive
+  FileUtils.mkpath(temp_dir)
+  system %(gpg --quiet --batch --no-use-agent --passphrase-file #{key_file} -o #{plain_backup_file} #{backup_file})
+  
+  Dir.chdir temp_dir do
+    # Extract archive contents
+    system %(tar -v -x -f #{plain_backup_file})
+
+    # Check accounts contents
+    accounts = File.read("#{temp_dir}/opt/conjur/backup/accounts")
+    fail('Exported accounts does not contain expected content') unless accounts.include?(contents)
+  end 
+ensure
+  FileUtils.rm_rf(temp_dir)
 end

--- a/cucumber/api/features/step_definitions/export_steps.rb
+++ b/cucumber/api/features/step_definitions/export_steps.rb
@@ -9,22 +9,21 @@ end
 
 Then (/^the accounts file contains "([^"]*)"$/) do |contents|
   key_file = 'cuke_export/key'.freeze
-  temp_dir = "#{Dir.tmpdir()}/#{SecureRandom.hex(5)}".freeze
-  plain_backup_file = temp_dir + '/backup.tar.xz'
   backup_file = Dir['cuke_export/*.tar.xz.gpg'].sort().first
 
-  # Decrypt export archive
-  FileUtils.mkpath(temp_dir)
-  system %(gpg --quiet --batch --no-use-agent --passphrase-file #{key_file} -o #{plain_backup_file} #{backup_file})
-  
-  Dir.chdir temp_dir do
-    # Extract archive contents
-    system %(tar -v -x -f #{plain_backup_file})
+  Dir.mktmpdir do |temp_dir|
+    plain_backup_file = temp_dir + '/backup.tar.xz'
 
-    # Check accounts contents
-    accounts = File.read("#{temp_dir}/opt/conjur/backup/accounts")
-    fail('Exported accounts does not contain expected content') unless accounts.include?(contents)
-  end 
-ensure
-  FileUtils.rm_rf(temp_dir)
+    # Decrypt export archive
+    system %(gpg --quiet --batch --no-use-agent --passphrase-file #{key_file} -o #{plain_backup_file} #{backup_file})
+
+    Dir.chdir temp_dir do
+      # Extract archive contents
+      system %(tar -v -x -f #{plain_backup_file})
+  
+      # Check accounts contents
+      accounts = File.read("#{temp_dir}/opt/conjur/backup/accounts")
+      fail('Exported accounts does not contain expected content') unless accounts.include?(contents)
+    end 
+  end
 end

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -9,6 +9,8 @@ require 'config/environment'
 
 require 'json_spec/cucumber'
 require_relative 'utils'
+require 'tmpdir'
+require 'securerandom'
 
 # This line is here to support running these tests outside a container,
 # per Rafal's request.  It could be deleted were it not for that.


### PR DESCRIPTION
Closes #652 

#### What does this pull request do?

This PR adds the list of accounts to the export archive.

#### What background context can you provide?

This is to make it simpler for `evoke configure` to select the right account to configure
the right account for the migrated Conjur master.

#### Where should the reviewer start?
`lib/tasks/export.rake`

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/export_account_list/

#### Questions:
> Does this have automated Cucumber tests?
Yes