### PR TITLE
Configurable Export Archive Filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.1] - 2018-8-10
 ### Added
 - `conjurctl export` now includes the account list to support migration
+- `conjurctl export` allows the operator to specify the file name label using the `-l` or `--label` flag
 - Update puma to a version that understands how to handle having ipv6 disabled
 - Update puma worker timeout to allow longer requests to finish (from 1 minute to 10 minutes)
 

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -279,9 +279,14 @@ command :export do |c|
   c.default_value Dir.pwd
   c.flag [:o, :out_dir]
 
+  c.desc "Label to use for archive filename"
+  c.arg_name :label
+  c.default_value Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
+  c.flag [:l, :label]
+
   c.action do |global_options,options,args|
     connect
-    exec "rake export[#{options[:out_dir]}]"
+    exec %(rake export["#{options[:out_dir]}","#{options[:label]}"])
   end
 end
 

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -272,14 +272,14 @@ command :wait do |c|
   end
 end
 
-desc "Export the Conjur data for migration to Conjur Enteprise Edition"
+desc 'Export the Conjur data for migration to Conjur Enteprise Edition'
 command :export do |c|
-  c.desc "Output directory"
+  c.desc 'Output directory'
   c.arg_name :out_dir
   c.default_value Dir.pwd
   c.flag [:o, :out_dir]
 
-  c.desc "Label to use for archive filename"
+  c.desc 'Label to use for archive filename'
   c.arg_name :label
   c.default_value Time.now.strftime('%Y-%m-%dT%H-%M-%SZ')
   c.flag [:l, :label]

--- a/cucumber/api/features/export.feature
+++ b/cucumber/api/features/export.feature
@@ -10,3 +10,7 @@ Feature: Export Conjur Open Source data
    When I run conjurctl export
    Then the export file exists
    And the accounts file contains "export_account"
+
+   Scenario: Export with chosen label
+   When I run conjurctl export with label "my_export"
+   Then the export file exists with label "my_export"

--- a/cucumber/api/features/step_definitions/export_steps.rb
+++ b/cucumber/api/features/step_definitions/export_steps.rb
@@ -1,9 +1,12 @@
-When(/^I run conjurctl export$/) do
-  system("conjurctl export -o cuke_export/") || fail('Could not execute `conjurctl export`')
+When(/^I run conjurctl export(?: with label "([^"]*)")?$/) do |label|
+  command = "conjurctl export -o cuke_export/"
+  command << " -l #{label}" unless label.nil?
+  system(command) || fail('Could not execute `conjurctl export`')
 end
 
-Then(/^the export file exists$/) do
-  Dir['cuke_export/*.tar.xz.gpg'].any? || fail('No export archive file exists')
+Then(/^the export file exists(?: with label "([^"]*)")?$/) do |label|
+  archive_name = label.nil? ? '*' : label
+  Dir["cuke_export/#{archive_name}.tar.xz.gpg"].any? || fail('No export archive file exists')
   File.exists?('cuke_export/key') || fail('No export archive key file exists')
 end
 

--- a/cucumber/api/features/step_definitions/export_steps.rb
+++ b/cucumber/api/features/step_definitions/export_steps.rb
@@ -1,5 +1,5 @@
 When(/^I run conjurctl export(?: with label "([^"]*)")?$/) do |label|
-  command = "conjurctl export -o cuke_export/"
+  command = 'conjurctl export -o cuke_export/'
   command << " -l #{label}" unless label.nil?
   system(command) || fail('Could not execute `conjurctl export`')
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,7 +5,7 @@ require 'time'
 require 'pathname'
 
 desc 'Export the Conjur data necessary to migrate to Enterprise Edition'
-task :export, ['out_dir', 'label'] => :environment do |_t, args|
+task :export, %w[out_dir label] => :environment do |_t, args|
   out_dir = Pathname.new args[:out_dir]
   label = args[:label]
 


### PR DESCRIPTION
Closes #653 
Depends on #652 

#### What does this pull request do?
This PR makes it possible to choose the label used to create the export archive filename (defaults to the current timestamp).

#### What background context can you provide?
This is intended to make it easier to automate migration.

#### Where should the reviewer start?
* `bin/conjur-cli.rb` is where the new CLI flag is added
* `cucumber/api/features/step_definitions/export_steps.rb` is where the tests are updated to use the new flag

#### How should this be manually tested?
1) `cd dev && ./start` to start a development container
2) `conjurctl export --help` should show the new flag
    ```sh-session
    $ conjurctl export --help
    NAME
        export - Export the Conjur data for migration to Conjur Enteprise Edition

    SYNOPSIS
        conjurctl [global options] export [command options]

    COMMAND OPTIONS
        -l, --label=label     - Label to use for archive filename (default: 2018-08-02T20-09-52Z)
        -o, --out_dir=out_dir - Output directory (default: /src/conjur-server).
    ```
3) Running the export command with the label flag should cause the filename to use it
```sh-session
$ conjurctl export -o /opt/export -l my_export
Exporting to '/opt/export'...
Generating key file /opt/export/key

Export placed in /opt/export/my_export.tar.xz.gpg
It's encrypted with key in /opt/export/key.
If you're going to store the export, make
sure to store the key file separately.

$ ls -la /opt/export
total 24
drwxrwx--- 2 root root  4096 Aug  2 20:11 .
drwxr-xr-x 1 root root  4096 Aug  2 20:11 ..
-rw------- 1 root root    88 Aug  2 20:11 key
-rw-r--r-- 1 root root 12099 Aug  2 20:11 my_export.tar.xz.gpg
```

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/export_filename/

#### Questions:
> Does this have automated Cucumber tests?
Yes

> Does the documentation need an update?
Yes

#### Remaining
- [x] Update changelog
- [ ] Let Perry know about migration documentation updates
