### PR TITLE
Return 409 on concurrent policy loads instead of 500

### DIFF
--- a/.rubocop_settings.yml
+++ b/.rubocop_settings.yml
@@ -75,3 +75,11 @@ Layout/SpaceAroundOperators:
   AllowForAlignment: false
 Layout/SpaceBeforeFirstArg:
   AllowForAlignment: false
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 25
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,9 +43,6 @@ pipeline {
         stage('Kubernetes 1.7 in GKE') {
           steps { sh 'cd ci/authn-k8s && summon ./test.sh gke' }
         }
-        stage('OpenShift 3.3 in AWS') {
-          steps { sh 'cd ci/authn-k8s && summon -e openshift33 ./test.sh openshift33' }
-        }
         /*
         stage('OpenShift 3.7 in AWS') {
           steps { sh 'cd ci/authn-k8s && summon -e openshift37 ./test.sh openshift37' }

--- a/apidocs/src/append_policy.md
+++ b/apidocs/src/append_policy.md
@@ -51,6 +51,7 @@ The request body should be a policy file. For example:
 | <!-- include(partials/http_401.md) -->                                                               |
 | <!-- include(partials/http_403.md) -->                                                               |
 |  404 | The policy referred to a role or resource that does not exist in the specified account        |
+| <!-- include(partials/http_409.md) --> |
 |  422 | The request body was empty or the policy was not valid YAML or the policy includes a deletion |
 
 + Parameters

--- a/apidocs/src/partials/http_409.md
+++ b/apidocs/src/partials/http_409.md
@@ -1,0 +1,1 @@
+409 | Policy load already in progress, retry after a delay

--- a/apidocs/src/replace_policy.md
+++ b/apidocs/src/replace_policy.md
@@ -51,6 +51,7 @@ The request body is a policy file. For example:
 | <!-- include(partials/http_401.md) -->                                                        |
 | <!-- include(partials/http_403.md) -->                                                        |
 |  404 | The policy referred to a role or resource that does not exist in the specified account |
+| <!-- include(partials/http_409.md) --> |
 |  422 | The request body was empty or the policy was not valid YAML                            |
 
 + Parameters

--- a/apidocs/src/update_policy.md
+++ b/apidocs/src/update_policy.md
@@ -48,6 +48,7 @@ The request body should be a policy file. For example:
 | <!-- include(partials/http_401.md) -->                                                        |
 | <!-- include(partials/http_403.md) -->                                                        |
 |  404 | The policy referred to a role or resource that does not exist in the specified account |
+| <!-- include(partials/http_409.md) --> |
 |  422 | The request body was empty or the policy was not valid YAML                            |
 
 + Parameters

--- a/spec/controllers/authenticate_controller_spec.rb
+++ b/spec/controllers/authenticate_controller_spec.rb
@@ -73,4 +73,6 @@ describe AuthenticateController, :type => :controller do
     #   end
     # end
   end
+
+  before(:all) { Slosilo["authn:rspec"] ||= Slosilo::Key.new }
 end

--- a/spec/controllers/credentials_controller_spec.rb
+++ b/spec/controllers/credentials_controller_spec.rb
@@ -152,4 +152,6 @@ describe CredentialsController, :type => :controller do
       end
     end
   end
+
+  before(:all) { Slosilo["authn:rspec"] ||= Slosilo::Key.new }
 end

--- a/spec/controllers/policies_controller_spec.rb
+++ b/spec/controllers/policies_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'parallel'
+DatabaseCleaner.strategy = :truncation
+
+describe PoliciesController, type: :controller do
+  describe '#post' do
+    before { put '[!variable preexisting]' }
+
+    it "adds to an existing policy" do
+      post '[!variable added]'
+      expect(variable('preexisting')).to exist
+      expect(variable('added')).to exist
+    end
+
+    it "does not return 500 when performed in parallel" do
+      policies = Array.new(2) { |i| "[!variable test#{i}]" }
+      Sequel::Model.db.disconnect # the children have to reconnect
+      Parallel.each policies, in_processes: 2 do |policy|
+        post policy
+        expect(response.code).to_not be >= 500
+      end
+    end
+
+    it "allows making nonconflicting changes in parallel" do
+      # I've thought about this long and hard and I'm not sure if we really
+      # want this with the current interface. Because we return sequential
+      # version to the client, even when there is no conflict the subsequent
+      # transactions need to wait for the first one to commit. This wait,
+      # however it is implemented, will necessarily hold resources (ie. the
+      # HTTP and a database connection).
+      # Perhaps it's smarter to let the client retry instead.
+      #
+      # Even if we do want to block transactions waiting, with the current
+      # design the lock would have to be obtained for the full duration of
+      # policy loading -- policy version (and the sequential number) is created
+      # on the entry point to the update method. Fixing that would require
+      # a significant refactoring of the policy loading code.
+      # -- divide
+      pending
+      vars = Array.new(2) { |i| "test#{i}" }
+      policies = vars.map { |var| "[!variable #{var}]" }
+      Sequel::Model.db.disconnect # the children have to reconnect
+      Parallel.each policies, in_processes: 2 do |policy|
+        post policy
+      end
+      vars.each { |var| expect(variable(var)).to exist }
+    end
+  end
+
+  before do
+    allow_any_instance_of(described_class)
+      .to receive_messages current_user: current_user
+  end
+
+  %i(put post patch).each do |meth|
+    define_method meth do |text|
+      super meth, text, account: 'rspec', identifier: 'root', kind: 'policy'
+    end
+  end
+
+  # :reek:UtilityFunction is okay for this test util
+  def variable name
+    Resource["rspec:variable:#{name}"]
+  end
+
+  let(:current_user) { Role.find_or_create role_id: 'rspec:user:admin' }
+
+  before(:all) do
+    # there doesn't seem to be a sane way to get this
+    @original_database_cleaner_strategy =
+      DatabaseCleaner.connections.first.strategy
+        .class.name.downcase[/[^:]+$/].intern
+    # we need truncation here because the tests span many transactions
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  after(:all) { DatabaseCleaner.strategy = @original_database_cleaner_strategy }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,4 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
 end
 
-Slosilo["authn:rspec"] ||= Slosilo::Key.new
-
 require 'simplecov'


### PR DESCRIPTION
Closes #656.

#### What does this pull request do?

Currently when loading a policy concurrently 500 error might be returned. This pull request makes it return 409 instead, with a `Retry-After` header indicating to the client it should retry after 1..8 seconds (chosen at random).

#### What background context can you provide?

The 500 error has been due to duplicate key on _policy_versions_ which happens when there's more than one concurrent update on a policy -- a policy version includes a sequential version number, and it's determined by taking max + 1. I've done some experiments in how we can support concurrent updates and realized that we can't do that keeping the API that guarantees returning a sequential version number; at least not without blocking, but then the updates won't be concurrent anymore and we might as well ask the client to retry instead of holding server resources. To see this imagine I do some concurrent updates and the first one fails -- the version numbers returned from the subsequent ones will have been different. This means we can't respond to other transactions until the first one is committed.

Note we might want revisit the sequential versioning requirement; it's not that strict anyway, as applying a policy which includes the body of a subpolicy won't create a policy version of the subpolicy.

> Does the knowledge base need an update?

We might want to add a mention that the client can expect a 409 and should retry in this case.