### PR TITLE
Increase Puma Worker Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Update puma to a version that understands how to handle having ipv6 disabled
+- Update puma worker timeout to allow longer requests to finish (from 1 minute to 10 minutes)
 
 ## [1.1.0] - 2018-7-30
 ### Added

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,6 +3,7 @@
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
+worker_timeout 600
 
 preload_app!
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,6 +3,12 @@
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
+
+# [Added Aug 8, 2018]
+# With large policy files, the request can exceed the 1
+# minute default worker timeout. We've increased it to
+# 10 minutes as a stopgap until we determine the root
+# cause and implement a permanent solution.
 worker_timeout 600
 
 preload_app!


### PR DESCRIPTION
Closes https://github.com/conjurinc/appliance/issues/263

#### What does this pull request do?
This PR increases the puma worker timeout from 1 minute to 10 minutes

#### What background context can you provide?
When loading large policy documents (> 1MB) the total request time can take several minutes (> 4). This causes the server to kill the working and terminate the connection. 

There is likely another root cause for the long request, but this current behavior is blocking other development that requires large policy files (e.g. ~18,000 variables).

#### Where should the reviewer start?

This PR modifies `config/puma.rb` and it fits in with the changes in the PR here: https://github.com/conjurinc/appliance/issues/263

#### How should this be manually tested?

This can be tested using the appliance build in https://github.com/conjurinc/appliance/issues/263

#### Link to build in Jenkins (if appropriate)

Conjur Build:
https://jenkins.conjur.net/job/cyberark--conjur/job/nginx_content_size/

Appliance build:
https://jenkins.conjur.net/job/conjurinc--appliance/job/nginx_content_size/

#### Questions:
> Does this have automated Cucumber tests?
Yes, in the appliance build

#### Before Merge:
- [x] Remove failing openshift temporary fix