### PR TITLE
tagging docker images with minor releases

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,8 @@
 # shellcheck disable=SC1091
 . version_utils.sh
 
-TAG="$(version_tag)"
+TAGS="$(version_tags)"
+IFS=',' read -ra TAGS_ARR <<< "$TAGS"
 RUN_DEV=true
 
 while [[ $# -gt 0 ]]
@@ -19,11 +20,15 @@ esac
 shift # past argument or value
 done
 
-echo "Building image conjur:$TAG"
-docker build -t "conjur:$TAG" .
+for tag in "${TAGS_ARR[@]}"; do
+  echo "Building image conjur:$tag"
+  docker build -t "conjur:$tag" .
+done
 
-echo "Building image conjur-test:$TAG container"
-docker build --build-arg "VERSION=$TAG" -t "conjur-test:$TAG" -f Dockerfile.test .
+# we test only the full-build tag (major.minor.build)
+FULL_TAG=${TAGS_ARR[${#TAGS_ARR[@]}-1]}
+echo "Building image conjur-test:$FULL_TAG container"
+docker build --build-arg "VERSION=$FULL_TAG" -t "conjur-test:$FULL_TAG" -f Dockerfile.test .
 
 if [[ $RUN_DEV = true ]]; then
   echo "Building image conjur-dev"

--- a/ci/test
+++ b/ci/test
@@ -92,7 +92,11 @@ cd ..
 ./build.sh -j
 # Grab the build tag so we launch the correct version of Conjur
 . version_utils.sh
-export TAG="$(version_tag)"
+TAGS="$(version_tags)"
+IFS=',' read -ra TAGS_ARR <<< "$TAGS"
+
+# we test only the full-build tag (major.minor.build)
+export TAG="${TAGS_ARR[${#TAGS_ARR[@]}-1]}"
 cd ci
 
 # Run tests based on what flags were passed

--- a/push-image.sh
+++ b/push-image.sh
@@ -8,47 +8,49 @@
 # shellcheck disable=SC1091
 . version_utils.sh
 
-TAG="${1:-$(version_tag)}"
+TAGS="${1:-$(version_tags)}"
+IFS=',' read -ra TAGS_ARR <<< "$TAGS"
 
-SOURCE_IMAGE="conjur:$TAG"
 INTERNAL_IMAGE='registry.tld/conjur'
 INTERNAL_IMAGE_NEW='registry.tld/cyberark/conjur'  # We'll transition to this
 DOCKERHUB_IMAGE='cyberark/conjur'
 QUAY_IMAGE='quay.io/cyberark/conjur'
 
 function main() {
-  echo "TAG = $TAG"
+  for tag in "${TAGS_ARR[@]}"; do
+    echo "TAG = $tag"
 
-  tag_and_push $INTERNAL_IMAGE $TAG
-  tag_and_push $INTERNAL_IMAGE_NEW $TAG
+    tag_and_push $INTERNAL_IMAGE $tag
+    tag_and_push $INTERNAL_IMAGE_NEW $tag
 
-  if [ "$BRANCH_NAME" = "master" ]; then
-    local latest_tag='latest'
-    local stable_tag="$(< VERSION)-stable"
+    if [ "$BRANCH_NAME" = "master" ]; then
+      local latest_tag='latest'
+      local stable_tag="$(< VERSION)-stable"
 
-    echo "TAG = $stable_tag, stable image"
+      echo "tag = $stable_tag, stable image"
 
-    tag_and_push $INTERNAL_IMAGE $latest_tag
-    tag_and_push $INTERNAL_IMAGE $stable_tag
+      tag_and_push $INTERNAL_IMAGE $latest_tag
+      tag_and_push $INTERNAL_IMAGE $stable_tag
 
-    tag_and_push $INTERNAL_IMAGE_NEW $latest_tag
-    tag_and_push $INTERNAL_IMAGE_NEW $stable_tag
+      tag_and_push $INTERNAL_IMAGE_NEW $latest_tag
+      tag_and_push $INTERNAL_IMAGE_NEW $stable_tag
 
-    tag_and_push $DOCKERHUB_IMAGE $TAG
-    tag_and_push $DOCKERHUB_IMAGE $latest_tag
-    tag_and_push $DOCKERHUB_IMAGE $stable_tag
+      tag_and_push $DOCKERHUB_IMAGE $tag
+      tag_and_push $DOCKERHUB_IMAGE $latest_tag
+      tag_and_push $DOCKERHUB_IMAGE $stable_tag
 
-    tag_and_push $QUAY_IMAGE $TAG
-    tag_and_push $QUAY_IMAGE $latest_tag
-    tag_and_push $QUAY_IMAGE $stable_tag
-  fi
+      tag_and_push $QUAY_IMAGE $tag
+      tag_and_push $QUAY_IMAGE $latest_tag
+      tag_and_push $QUAY_IMAGE $stable_tag
+    fi
+  done
 }
 
 function tag_and_push() {
   local image="$1"
   local tag="$2"
 
-  docker tag "$SOURCE_IMAGE" "$image:$tag"
+  docker tag "conjur:$tag" "$image:$tag"
   docker push "$image:$tag"
 }
 

--- a/version_utils.sh
+++ b/version_utils.sh
@@ -2,6 +2,26 @@
 
 # Functions to generate version numbers for this project
 
-version_tag() {
-  echo "$(< VERSION)-$(git rev-parse --short HEAD)"
+version_tags() {
+  # read version to an array
+  IFS='.' read -ra VERSION_ARR <<< "$(< VERSION)"
+
+  # set suffix for tags
+  HEAD_REF=$(git rev-parse --short HEAD)
+
+  TAGS=()
+  for ((i=0; i<${#VERSION_ARR[@]}; i++)); do
+    TAG=${VERSION_ARR[0]}
+
+    for ((j=1; j<=$i; j++)); do
+      TAG="$TAG.${VERSION_ARR[$j]}"
+    done
+
+    TAG="$TAG-$HEAD_REF"
+
+    TAGS+=($TAG)
+  done
+
+  # join with comma separator
+  IFS=","; shift; echo "${TAGS[*]}";
 }


### PR DESCRIPTION
Closes #279 

#### What does this pull request do?
instead of having only one docker image per version (i.e 1.1.1-refid) we have one for each minor release (i.e 1-refid, 1.1-refid, 1.1.1-refid)

#### Where should the reviewer start?
version-utils.sh -> build.sh -> ci/test -> push-image.sh

#### How should this be manually tested?
run build.sh & test.sh

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/279-minor-releases-tags/
