### PR TITLE
Verify docker image before delete

### DIFF
--- a/ci/authn-k8s/dev/utils.sh
+++ b/ci/authn-k8s/dev/utils.sh
@@ -32,6 +32,6 @@ delete_image() {
     local tag="${array[1]}"
     
     if gcloud container images list-tags $image | grep $tag; then
-        gcloud container images delete --force-delete-tags -q $image
+        gcloud container images delete --force-delete-tags -q $image_and_tag
     fi
 }

--- a/ci/authn-k8s/dev/utils.sh
+++ b/ci/authn-k8s/dev/utils.sh
@@ -23,3 +23,15 @@ wait_for_it() {
         done
     fi
 }
+
+delete_image() {
+    local image_and_tag=$1
+
+    IFS=':' read -r -a array <<< $image_and_tag
+    local image="${array[0]}"
+    local tag="${array[1]}"
+    
+    if gcloud container images list-tags $image | grep $tag; then
+        gcloud container images delete --force-delete-tags -q $image
+    fi
+}

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -35,8 +35,11 @@ function finish {
   echo 'Removing namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE'
   echo '-----'
   kubectl --ignore-not-found=true delete namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE
-  gcloud container images delete -q \
-    $CONJUR_AUTHN_K8S_TAG $CONJUR_TEST_AUTHN_K8S_TAG $INVENTORY_TAG $NGINX_TAG
+
+  delete_image $CONJUR_TEST_AUTHN_K8S_TAG
+  delete_image $CONJUR_AUTHN_K8S_TAG
+  delete_image $INVENTORY_TAG
+  delete_image $NGINX_TAG
 }
 trap finish EXIT
 
@@ -66,7 +69,7 @@ function main() {
 
 function sourceFunctions() {
   source dev/utils.sh
-  source dev/templatecmd.sh
+  source dev/tesmplatecmd.sh
   source dev/conjurcmd.sh
 }
 

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -69,7 +69,7 @@ function main() {
 
 function sourceFunctions() {
   source dev/utils.sh
-  source dev/tesmplatecmd.sh
+  source dev/templatecmd.sh
   source dev/conjurcmd.sh
 }
 


### PR DESCRIPTION
Check that a Docker image exists in the k8s registry before deleting it to try and prevent a fairly frequent build error that I believe is happening when the build script tries to delete a non-existent tag.