### PR TITLE
Fix docker image tagging and pushing

### DIFF
--- a/version_utils.sh
+++ b/version_utils.sh
@@ -5,3 +5,14 @@
 version_tag() {
   echo "$(< VERSION)-$(git rev-parse --short HEAD)"
 }
+
+# generate less specific versions, eg. given 1.2.3 will print 1.2 and 1
+# (note: the argument itself is not printed, append it explicitly if needed)
+gen_versions()
+{
+  local version=$1
+  while [[ $version = *.* ]]; do
+    version=${version%.*}
+    echo $version
+  done
+}


### PR DESCRIPTION
Following tags are created and pushed:
- Always: registry.tld/{cyberark/}conjur:x.y.z-sha.
- If on master, additionally conjur:{latest,x.y-stable,x-stable}.
- If VERSION matches git tag, also conjur:{x.y.z,x.y,x}.
  These go to dockerhub and quay, too, plus conjur:latest.

Closes #279, closes #278