### PR TITLE
Make authentication more obvious in the API documentation

### DIFF
--- a/apidocs/src/authenticate.md
+++ b/apidocs/src/authenticate.md
@@ -7,6 +7,8 @@ Gets a [short-lived access token](/reference/cryptography.html#authentication-to
 The login must be [URL encoded][percent-encoding]. For example, `alice@devops`
 must be encoded as `alice%40devops`.
 
+For host authentication, the login is the host ID with the prefix `host/`. For example, the host `webserver` would login as `host/webserver`, and would be encoded as `host%2Fwebserver`.
+
 [percent-encoding]: https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding
 
 For API usage, the access token is ordinarily passed as an HTTP Authorization "Token" header.


### PR DESCRIPTION
Closes #691 

#### What does this pull request do?
This PR updates the Conjur API documentation to make it more clear how to authenticate as a host rather than a user. 

#### What background context can you provide?
This information was available in the parameter notes before, but this makes the host authentication
more prominent and a little harder to get wrong on accident.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/api_host_auth/