### PR TITLE
Updates image and link for Anchore image status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Conjur on DockerHub](https://img.shields.io/docker/pulls/cyberark/conjur.svg)](https://hub.docker.com/r/cyberark/conjur/)
 [![Conjur on Quay.io](https://img.shields.io/badge/quay%20build-automated-0db7ed.svg)](https://quay.io/repository/cyberark/conjur)
-[![Anchore Image Overview](https://anchore.io/service/badges/image/9845720073cdb8472274be47a98d4b7381f44f31e944fdb712f67946b644adc8)](https://anchore.io/image/dockerhub/9845720073cdb8472274be47a98d4b7381f44f31e944fdb712f67946b644adc8?repo=cyberark%2Fconjur&tag=latest)
+[![Anchore Image Overview](https://img.shields.io/badge/image%20overview-cyberark%2Fconjur-blue.svg)](https://anchore.io/image/dockerhub/cyberark%2Fconjur%3Alatest)
 
 [![Join Conjur Slack](https://img.shields.io/badge/slack-open-e01563.svg)][slack]
 [![Follow Conjur on Twitter](https://img.shields.io/twitter/follow/conjurinc.svg?style=social&label=Follow%20%40ConjurInc)][twitter]


### PR DESCRIPTION
#### What does this pull request do?

* updates the Anchore badge image to use shields.io instead of Anchore's own image server (for better privacy)
* links badge to latest version of the Conjur image instead of a pinned, now-outdated version

#### What background context can you provide?

When the badge was originally set up, it was pinned to a specific image ID rather than to the "latest" tag itself. With this change, users will be brought to the most up-to-date image.

#### How should this be manually tested?

1. Visit the readme here: https://github.com/cyberark/conjur/tree/update-anchore-badge
2. Click on the "image overview | cyberark/conjur" badge
3. Verify that it says "updated 7 days ago" or similar, not September 2017 like it had been