### PR TITLE
Add support for encrypted private keys in a Conjur CA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added support for issuing certificates to Hosts using CAs configured as
   Conjur services. More details are available [here](docs/CERTIFICATE_SIGNING.md).
+- Added support for Conjur CAs to use encrypted private keys
 
 ## [1.1.2] - 2018-
 ### Security

--- a/app/domain/ca/certificate_authority.rb
+++ b/app/domain/ca/certificate_authority.rb
@@ -63,7 +63,14 @@ module CA
     protected
 
     def private_key
-      @private_key ||= OpenSSL::PKey::RSA.new secret(private_key_var)
+      @private_key ||= private_key_password? ?
+        OpenSSL::PKey::RSA.new(secret(private_key_var), private_key_password)
+        :
+        OpenSSL::PKey::RSA.new(secret(private_key_var))
+    end
+
+    def private_key_password?
+      !private_key_password.to_s.empty?
     end
 
     def private_key_password
@@ -95,7 +102,7 @@ module CA
     end
 
     def secret(name)
-      Resource[secret_id(name)].secret.value
+      Resource[secret_id(name)]&.secret&.value
     end
 
     def secret_id(name)

--- a/app/domain/ca/certificate_authority.rb
+++ b/app/domain/ca/certificate_authority.rb
@@ -63,14 +63,19 @@ module CA
     protected
 
     def private_key
-      @private_key ||= private_key_password? ?
+      @private_key ||= load_private_key
+    end
+
+    def load_private_key
+      if private_key_password?
         OpenSSL::PKey::RSA.new(secret(private_key_var), private_key_password)
-        :
+      else
         OpenSSL::PKey::RSA.new(secret(private_key_var))
+      end
     end
 
     def private_key_password?
-      !private_key_password.to_s.empty?
+      private_key_password.present?
     end
 
     def private_key_password

--- a/cucumber/api/features/certificate_authority.feature
+++ b/cucumber/api/features/certificate_authority.feature
@@ -30,10 +30,34 @@ Feature: Conjur signs certificates using a configured CA
     - !grant
       role: !group conjur/kitchen/ca/clients
       member: !host bacon
+
+    - !policy
+      id: conjur/dining-room/ca
+      body:
+        - !variable private-key
+        - !variable private-key-password
+        - !variable cert-chain
+
+        - !webservice
+          annotations:
+            ca/private-key: conjur/dining-room/ca/private-key
+            ca/private-key-password: conjur/dining-room/ca/private-key-password
+            ca/certificate-chain: conjur/dining-room/ca/cert-chain
+            ca/max_ttl: P1Y
+
+    - !host table
+    - !permit
+      role: !host table
+      privilege: [ sign ]
+      resource: !webservice conjur/dining-room/ca
     """
-    And I have an intermediate CA
-    And I add the intermediate CA private key to the resource "cucumber:variable:conjur/kitchen/ca/private-key"
-    And I add the intermediate CA cert chain to the resource "cucumber:variable:conjur/kitchen/ca/cert-chain"
+    And I have an intermediate CA "kitchen"
+    And I add the "kitchen" intermediate CA private key to the resource "cucumber:variable:conjur/kitchen/ca/private-key"
+    And I add the "kitchen" intermediate CA cert chain to the resource "cucumber:variable:conjur/kitchen/ca/cert-chain"
+    And I have an intermediate CA "dining-room" with password "secret"
+    And I add the "dining-room" intermediate CA private key to the resource "cucumber:variable:conjur/dining-room/ca/private-key"
+    And I add the "dining-room" intermediate CA cert chain to the resource "cucumber:variable:conjur/dining-room/ca/cert-chain"
+    And I add the secret value "secret" to the resource "cucumber:variable:conjur/dining-room/ca/private-key-password"
 
   Scenario: A non-existent ca returns a 404
     When I POST "/ca/cucumber/living-room/sign"
@@ -58,7 +82,7 @@ Feature: Conjur signs certificates using a configured CA
     When I send a CSR for "bacon" to the "kitchen" CA with a ttl of "P6M" and CN of "bacon"
     Then the HTTP response status code is 201
     And the HTTP response content type is "application/json"
-    And the resulting json certificate is valid according to the intermediate CA
+    And the resulting json certificate is valid according to the "kitchen" intermediate CA
 
   Scenario: I can receive the result directly as a PEM formatted certificate
     Given I login as "cucumber:host:bacon"
@@ -66,5 +90,10 @@ Feature: Conjur signs certificates using a configured CA
     When I send a CSR for "bacon" to the "kitchen" CA with a ttl of "P6M" and CN of "bacon"
     Then the HTTP response status code is 201
     And the HTTP response content type is "application/x-pem-file"
-    And the resulting pem certificate is valid according to the intermediate CA
+    And the resulting pem certificate is valid according to the "kitchen" intermediate CA
 
+  Scenario: I can sign a CSR using an encrypted CA private key
+    Given I login as "cucumber:host:table"
+    When I send a CSR for "table" to the "dining-room" CA with a ttl of "P6M" and CN of "table"
+    Then the HTTP response status code is 201
+    And the resulting json certificate is valid according to the "dining-room" intermediate CA


### PR DESCRIPTION
Closes #706 

#### What does this pull request do?
This PR adds support for encrypted PEM encoded private keys with a Conjur CA.

#### What background context can you provide?

Most OpenSSL guides instruct you to generate your CA private key and export it in an encrypted PEM format. Before this PR, you had to upload the unencrypted PEM format for a Conjur CA to work. With this update, either encrypted or unencrypted is accepted. If encrypted, an additional annotation on the CA service points to a Conjur variable containing the decryption password.

#### Where should the reviewer start?

The change in `app/domain/ca/certificate_authority.rb` is relatively small. See also the updated tests to verify the behavior. 

#### How should this be manually tested?

Running the CA tests in the API cucumber suite will verify the behavior. This can also be tested in the context of the mutual TLS demo by generating an encrypted Intermediate CA private key, rather than a unencrypted key file.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/ca_encrypted_key/

#### Questions:
> Does this have automated Cucumber tests?
Yes

> Can we make a blog post, video, or animated GIF out of this?
No

> Is this explained in documentation?
Not yet

> Does the knowledge base need an update?
No, the developer Readme already references this planned feature.