### PR TITLE
Change Sequel statement away from deprecated form

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -69,10 +69,8 @@ class AuthenticateController < ApplicationController
     kind = Sequel.function(:kind, :resource_id)
 
     Resource
-      .where(
-        identifier.like("#{AUTHN_RESOURCE_PREFIX}%"), 
-        kind => "webservice"
-      )
+      .where(identifier.like("#{AUTHN_RESOURCE_PREFIX}%"))
+      .where(kind => "webservice")
       .select_map(identifier)
       .map { |id| id.sub /^conjur\//, "" }
       .push(::Authentication::Strategy.default_authenticator_name)


### PR DESCRIPTION
Closes #722 

#### What does this pull request do?

This PR refactors how the `AuthenticateController` uses Sequel to move away from a deprecated 
form.

#### What background context can you provide?

Prior to this update, authentication would cause deprecation warnings to be written to the Conjur log. e.g.:
```
SEQUEL DEPRECATION WARNING: 
Passing multiple arguments as filter arguments when not using a conditions specifier 
([#<Sequel::SQL::BooleanExpression @op=>:LIKE, @args=>[#<Sequel::SQL::Function @name=>:identifier, @args=>[:resource_id], @opts=>{}>, "conjur/authn-%"]>, {#<Sequel::SQL::Function @name=>:kind, @args=>[:resource_id], @opts=>{}>=>"webservice"}]) is deprecated and will be removed in Sequel 5.  Pass the arguments to separate filter methods or use Sequel.& to combine them.
```

See the Sequel Changelog for the guidance on how to refactor the condition:
https://sequel.jeremyevans.net/rdoc/files/doc/release_notes/4_45_0_txt.html

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/sequel_deprecation_warnings/


