### PR TITLE
Implement role membership search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for issuing certificates to Hosts using CAs configured as
   Conjur services. More details are available [here](docs/CERTIFICATE_SIGNING.md).
 - Added support for Conjur CAs to use encrypted private keys
+- Implemented keyword search for Role memberships
 
 ## [1.1.2] - 2018-
 ### Security

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -33,7 +33,7 @@ class RolesController < RestController
   # +params[:filter]+ and +params[:count]+ are handled as for +#all_memberships+
   #
   def direct_memberships
-    memberships = filtered_roles(role.memberships_as_member_dataset, membership_filter)
+    memberships = filtered_roles(role.direct_memberships_dataset(filter_params), membership_filter)
     render_dataset(memberships)
   end
   

--- a/app/models/membership_search.rb
+++ b/app/models/membership_search.rb
@@ -3,68 +3,59 @@
 # MembershipSearch provides the `search`` extension method
 # for Role membership datasets to allow text searching
 # and paging of Role members
-class MembershipSearch < Module
+module MembershipSearch 
 
-  def initialize(id_column)
-    super() do 
-      define_search
-      define_filter_kind(id_column)
-      define_textsearch(id_column)
-      define_result_set(id_column)
-    end
+  # @param search [String] - a search term in the resource id
+  def search(search: nil, kind: nil)
+    filter_kind(kind).textsearch(search)
   end
 
-  def define_search
-    # @param search [String] - a search term in the resource id
-    define_method :search do |search: nil, kind: nil|
-      filter_kind(kind).textsearch(search)
-    end
+  def filter_kind(kind)
+    return self unless kind
+
+    kind_function = Sequel.function(:kind, search_key)
+    where(kind_function => Array(kind))
   end
 
-  def define_filter_kind(id_column)
-    define_method :filter_kind do |kind|
-      return self unless kind
+  def textsearch(input)
+    return self unless input
 
-      kind_function = Sequel.function(:kind, id_column)
-      where(kind_function => Array(kind))
-    end
+    # If I use 3 literal spaces, it gets send to PG as one space.
+    query = Sequel.function(:plainto_tsquery, "english",
+      Sequel.function(:translate, input.to_s, "./-", "   "))
+
+    # Default weights for ts_rank_cd are {0.1, 0.2, 0.4, 1.0} for DCBA resp.
+    # Sounds just about right. A are name and id, B is rest of annotations, C is kind.
+    rank = Sequel.function(:ts_rank_cd, :textsearch, query)
+
+    left_join(:resources_textsearch, resource_id: search_key)
+      .where(Sequel.lit("? @@ textsearch", query))
+      .order(Sequel.desc(rank))
   end
 
-  def define_textsearch(id_column)
-    define_method :textsearch do |input|
-      return self unless input
-  
-      # If I use 3 literal spaces, it gets send to PG as one space.
-      query = Sequel.function(:plainto_tsquery, "english",
-        Sequel.function(:translate, input.to_s, "./-", "   "))
-  
-      # Default weights for ts_rank_cd are {0.1, 0.2, 0.4, 1.0} for DCBA resp.
-      # Sounds just about right. A are name and id, B is rest of annotations, C is kind.
-      rank = Sequel.function(:ts_rank_cd, :textsearch, query)
-  
-      left_join(:resources_textsearch, resource_id: id_column)
-        .where(Sequel.lit("? @@ textsearch", query))
-        .order(Sequel.desc(rank))
+  # result_set renders a dataset to a result set using the
+  # provided order and paging parameters
+  def result_set(order_by: nil, offset: nil, limit: nil)
+    scope = self
+
+    order_by ||= search_key
+    scope = scope.order(order_by)
+
+    if offset || limit
+      scope = scope.limit(
+        (limit || 10).to_i,
+        (offset || 0).to_i
+      )
     end
+
+    scope.all
   end
 
-  def define_result_set(id_column)
-    # result_set renders a dataset to a result set using the
-    # provided order and paging parameters
-    define_method :result_set do |order_by: nil, offset: nil, limit: nil|
-      scope = self
+  private
 
-      order_by ||= id_column
-      scope = scope.order(order_by)
-
-      if offset || limit
-        scope = scope.limit(
-          (limit || 10).to_i,
-          (offset || 0).to_i
-        )
-      end
-
-      scope.all
-    end
+  # Column to use when join free text search results
+  # for resource Id
+  def search_key
+    association_reflection[:search_key]
   end
 end

--- a/app/models/membership_search.rb
+++ b/app/models/membership_search.rb
@@ -1,51 +1,70 @@
 # frozen_string_literal: true
 
 # MembershipSearch provides the `search`` extension method
-# for Roles.membership_dataset to allow text searching
+# for Role membership datasets to allow text searching
 # and paging of Role members
-module MembershipSearch
-  # @param search [String] - a search term in the resource id
-  def search(search: nil, kind: nil)
-    filter_kind(kind).textsearch(search)
-  end
+class MembershipSearch < Module
 
-  def filter_kind(kind)
-    return self unless kind
-
-    where(Sequel.lit("kind(member_id) in ?", Array(kind))) 
-  end
-
-  def textsearch(input)
-    return self unless input
-
-    # If I use 3 literal spaces, it gets send to PG as one space.
-    query = Sequel.function(:plainto_tsquery, "english",
-                            Sequel.function(:translate, input.to_s, "./-", "   "))
-
-    # Default weights for ts_rank_cd are {0.1, 0.2, 0.4, 1.0} for DCBA resp.
-    # Sounds just about right. A are name and id, B is rest of annotations, C is kind.
-    rank = Sequel.function(:ts_rank_cd, :textsearch, query)
-
-    left_join(:resources_textsearch, resource_id: :member_id)
-      .where(Sequel.lit("? @@ textsearch", query))
-      .order(Sequel.desc(rank))
-  end
-
-  # result_set renders a dataset to a result set using the
-  # provided order and paging parameters
-  def result_set(order_by: nil, offset: nil, limit: nil)
-    scope = self
-
-    order_by ||= :member_id
-    scope = scope.order(order_by)
-
-    if offset || limit
-      scope = scope.limit(
-        (limit || 10).to_i,
-        (offset || 0).to_i
-      )
+  def initialize(id_column)
+    super() do 
+      define_search
+      define_filter_kind(id_column)
+      define_textsearch(id_column)
+      define_result_set(id_column)
     end
+  end
 
-    scope.all
+  def define_search
+    # @param search [String] - a search term in the resource id
+    define_method :search do |search: nil, kind: nil|
+      filter_kind(kind).textsearch(search)
+    end
+  end
+
+  def define_filter_kind(id_column)
+    define_method :filter_kind do |kind|
+      return self unless kind
+
+      kind_function = Sequel.function(:kind, id_column)
+      where(kind_function => Array(kind))
+    end
+  end
+
+  def define_textsearch(id_column)
+    define_method :textsearch do |input|
+      return self unless input
+  
+      # If I use 3 literal spaces, it gets send to PG as one space.
+      query = Sequel.function(:plainto_tsquery, "english",
+        Sequel.function(:translate, input.to_s, "./-", "   "))
+  
+      # Default weights for ts_rank_cd are {0.1, 0.2, 0.4, 1.0} for DCBA resp.
+      # Sounds just about right. A are name and id, B is rest of annotations, C is kind.
+      rank = Sequel.function(:ts_rank_cd, :textsearch, query)
+  
+      left_join(:resources_textsearch, resource_id: id_column)
+        .where(Sequel.lit("? @@ textsearch", query))
+        .order(Sequel.desc(rank))
+    end
+  end
+
+  def define_result_set(id_column)
+    # result_set renders a dataset to a result set using the
+    # provided order and paging parameters
+    define_method :result_set do |order_by: nil, offset: nil, limit: nil|
+      scope = self
+
+      order_by ||= id_column
+      scope = scope.order(order_by)
+
+      if offset || limit
+        scope = scope.limit(
+          (limit || 10).to_i,
+          (offset || 0).to_i
+        )
+      end
+
+      scope.all
+    end
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -6,8 +6,8 @@ class Role < Sequel::Model
   
   unrestrict_primary_key
 
-  one_to_many :memberships, class: :RoleMembership, extend: MembershipSearch.new(:member_id)
-  one_to_many :memberships_as_member, class: :RoleMembership, key: :member_id, extend: MembershipSearch.new(:role_id)
+  one_to_many :memberships, class: :RoleMembership, extend: MembershipSearch, search_key: :member_id
+  one_to_many :memberships_as_member, class: :RoleMembership, key: :member_id, extend: MembershipSearch, search_key: :role_id
   one_to_one  :credentials, reciprocal: :role
   
   alias id role_id

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -6,8 +6,8 @@ class Role < Sequel::Model
   
   unrestrict_primary_key
 
-  one_to_many :memberships, class: :RoleMembership, extend: MembershipSearch
-  one_to_many :memberships_as_member, class: :RoleMembership, key: :member_id
+  one_to_many :memberships, class: :RoleMembership, extend: MembershipSearch.new(:member_id)
+  one_to_many :memberships_as_member, class: :RoleMembership, key: :member_id, extend: MembershipSearch.new(:role_id)
   one_to_one  :credentials, reciprocal: :role
   
   alias id role_id
@@ -116,6 +116,11 @@ class Role < Sequel::Model
     memberships_as_member.select do |membership|
       membership.role.kind == "layer"
     end.map(&:role)
+  end
+
+  def direct_memberships_dataset(search_options = {})
+    memberships_as_member_dataset.search(search_options)
+                                 .select(:role_memberships.*)
   end
 
   def members_dataset(search_options = {})

--- a/cucumber/api/features/memberships.feature
+++ b/cucumber/api/features/memberships.feature
@@ -82,6 +82,24 @@ Feature: Obtain the memberships of a role
     }
     """
 
+  Scenario: Direct memberships can be searched
+    Given I create a new user "bob"
+    And I create a new user "carol"
+    And I grant user "alice" to user "bob"
+    And I grant user "carol" to user "bob"
+    When I successfully GET "/roles/cucumber/user/bob?memberships&search=alice"
+    Then the JSON should be:
+    """
+    [
+      {
+        "admin_option": false,
+        "member": "cucumber:user:bob",
+        "ownership": false,
+        "role": "cucumber:user:alice"
+      }
+    ]
+    """
+
   Scenario: The role memberships list can be filtered.
 
     The `filter` parameter can be used to select just a subset of the


### PR DESCRIPTION
#### What does this PR do?
This PR implements the keyword search of role memberships in the Conjur API. 

#### Any background context you want to provide?
The Conjur UI supports searching the membership for a given role by keyword. This was not currently implemented in the open source / V5 API.

#### What ticket does this PR close?
Closes https://github.com/conjurinc/conjur-ui/issues/200

#### Where should the reviewer start?
The implementation is added in `app/controllers/roles_controller.rb`. The updates to the `Role` Sequel model are in `app/models/role.rb` with a refactor of the `MembershipSearch` module to support reuse between `membership` and `member` search.

#### How should this be manually tested?
The most simple way to test this is through the new cucumber test in the API profile for searching memberships.

```
bundle exec cucumber --profile api cucumber/api/features/memberships.feature:85
```

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/membership_search/

#### Has the Version and Changelog been updated?
Yes

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
No

> Has this change been documented (Readme, docs, etc.)?
N/A

> Does the knowledge base need an update?
No
