### PR TITLE
authn-k8s authenticator expects a URL-escaped client cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Change authn-k8s to expect the client cert (passed in `X-SSL-Client-Certificate`) to be
+  url-escaped.
+
 ## [1.2.0] - 2018-09-07
 ### Added
 - Added support for issuing certificates to Hosts using CAs configured as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ format and pushed to a UNIX socket for further processing.
 The first tagged version.
 
 [Unreleased]: https://github.com/cyberark/conjur/compare/v1.1.0...HEAD
+[1.2.0]: https://github.com/cyberark/conjur/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/cyberark/conjur/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/cyberark/conjur/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/cyberark/conjur/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/cyberark/conjur/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/cyberark/conjur/compare/v0.9.0...v1.0.0

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Authentication
   module AuthnK8s
     class AuthenticationError < RuntimeError; end
@@ -198,7 +200,7 @@ module Authentication
       #----------------------------------------
 
       def pod_certificate
-        client_cert = @request.env['HTTP_X_SSL_CLIENT_CERTIFICATE']
+        client_cert = CGI.unescape(@request.env['HTTP_X_SSL_CLIENT_CERTIFICATE'])
         raise AuthenticationError, "No client certificate provided" unless client_cert
 
         if !@pod_cert

--- a/ci/authn-k8s/.gitignore
+++ b/ci/authn-k8s/.gitignore
@@ -1,0 +1,4 @@
+dev/interventions/*.gke.yml
+dev/tls/nginx.*
+nginx.crt
+/output/

--- a/ci/authn-k8s/dev/tls/default.conf
+++ b/ci/authn-k8s/dev/tls/default.conf
@@ -7,7 +7,7 @@ server {
   ssl_certificate_key /etc/nginx/nginx.key;
   ssl_verify_client optional_no_ca;
 
-  proxy_set_header X-SSL-Client-Certificate $ssl_client_raw_cert;
+  proxy_set_header X-SSL-Client-Certificate $ssl_client_escaped_cert;
 
   location / {
     proxy_pass http://conjur;


### PR DESCRIPTION
#### What does this PR do?
Changes authn-k8s authenticator to expect the client cert to be URL-escaped. Changes test infrastructure to ensure the cert passed from nginx is URL-escaped.

#### Any background context you want to provide?
nginx's `http_proxy_pass` fails if `X-SSL-Client-Certificate` is set to the raw client cert. URL-escaping the cert instead allows it to succeed.

#### What ticket does this PR close?
Closes [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
Read the changes, they're pretty simple.

#### How should this be manually tested?
No need for a manual test, automated tests ensure that this change functions correctly.

#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
#### Has the Version and Changelog been updated?
Changelog has been updated.

#### Questions:
> Does this work have automated integration and unit tests?
yes

> Can we make a blog post, video, or animated GIF of this?
no

> Has this change been documented (Readme, docs, etc.)?
no

> Does the knowledge base need an update?
no