### PR TITLE
729  refactor kubectl exec class

### DIFF
--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -145,6 +145,9 @@ module Authentication
         
         response = exec.copy "/etc/conjur/ssl/client.pem", cert.to_pem, "0644"
 
+        puts "##### Response: #{response}"
+        puts "##### Response: #{response[:error]}"
+        
         if response[:error].present?
           raise AuthenticationError, response[:error].join
         end

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -135,7 +135,14 @@ module Authentication
       #----------------------------------------
       
       def install_signed_cert cert
-        exec = KubectlExec.new @pod, container: k8s_container_name
+        exec = KubectlExec.new(
+          pod_name: @pod.metadata.name.inspect,
+          pod_namespace: @pod.metadata.namespace.inspect,
+          logger: Rails.logger,
+          kubeclient: K8sObjectLookup.kubectl_client,
+          container: k8s_container_name
+        )
+        
         response = exec.copy "/etc/conjur/ssl/client.pem", cert.to_pem, "0644"
 
         if response[:error].present?

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -136,8 +136,8 @@ module Authentication
       
       def install_signed_cert cert
         exec = KubectlExec.new(
-          pod_name: @pod.metadata.name.inspect,
-          pod_namespace: @pod.metadata.namespace.inspect,
+          pod_name: @pod.metadata.name,
+          pod_namespace: @pod.metadata.namespace,
           logger: Rails.logger,
           kubeclient: K8sObjectLookup.kubectl_client,
           container: k8s_container_name

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -145,9 +145,6 @@ module Authentication
         
         response = exec.copy "/etc/conjur/ssl/client.pem", cert.to_pem, "0644"
 
-        Rails.logger.debug("##### Response: #{response}")
-        Rails.logger.debug("##### Response: #{response[:error]}")
-        
         if response[:error].present?
           raise AuthenticationError, response[:error].join
         end

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -145,8 +145,8 @@ module Authentication
         
         response = exec.copy "/etc/conjur/ssl/client.pem", cert.to_pem, "0644"
 
-        puts "##### Response: #{response}"
-        puts "##### Response: #{response[:error]}"
+        Rails.logger.debug("##### Response: #{response}")
+        Rails.logger.debug("##### Response: #{response[:error]}")
         
         if response[:error].present?
           raise AuthenticationError, response[:error].join

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -265,7 +265,7 @@ module Authentication
 
       def server_url(cmds, stdin)
         api_uri = @kubeclient.api_endpoint
-        base_url = "ws://#{api_uri.host}:#{api_uri.port}"
+        base_url = "wss://#{api_uri.host}:#{api_uri.port}"
         path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
         query = query_string(cmds, stdin)
         "#{base_url}#{path}?#{query}"

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -116,10 +116,10 @@ module Authentication
       def add_websocket_event_handlers(ws, body, stdin)
         this_obj = self
         
-        ws.on(:open, ->() { this_obj.on_open(ws, body, stdin) })
-        ws.on(:message, ->() { this_obj.on_message })
-        ws.on(:close, ->() { this_obj.on_close })
-        ws.on(:error, ->() { this_obj.on_error })
+        ws.on(:open,    &->() { this_obj.on_open(ws, body, stdin) })
+        ws.on(:message, &->() { this_obj.on_message })
+        ws.on(:close,   &->() { this_obj.on_close })
+        ws.on(:error,   &->() { this_obj.on_error })
       end
       
       def on_open(ws, body, stdin)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -117,7 +117,7 @@ module Authentication
         else
           @logger.debug("Pod #{@pod_name} : channel open")
 
-          if @stdin
+          if stdin
             data = WebSocketMessage.channel_byte('stdin') + body
             ws.send(data)
             ws.send(nil, type: :close)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -39,12 +39,15 @@ module Authentication
         @messages = Hash.new { |hash,key| hash[key] = [] }
       end
 
-      # This is taking either a string or message DATA
-      def save_message(msg, stream: nil)
+      def save_message(msg)
         puts "* SAVING MESSAGE: #{msg}"
         strm ||= stream_name(msg)
         raise "Unexpected channel: #{channel(msg)}" unless strm
         @messages[strm.to_sym] << msg
+      end
+
+      def save_string(str, stream: nil)
+        @messages[stream] << str
       end
 
       def stream_name(msg)
@@ -183,10 +186,8 @@ module Authentication
           if msg.type == :binary
             puts "* BINARY"
 
-            
             #messages.save_message(messages.msg_data(msg))
             messages.save_message(msg)
-
             
             logger.debug("Pod #{pod_name}, stream #{messages.stream_name(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == :close
@@ -232,7 +233,7 @@ module Authentication
           stream_state.close
           logger.debug("Pod #{pod_name} error: #{e.inspect}")
           
-          messages.save_message(e.inspect, stream: "error")
+          messages.save_string(e.inspect, stream: :error)
         end
       end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -125,13 +125,13 @@ module Authentication
         end
       end
 
-      def on_message(msg)
+      def on_message(msg, ws)
         if msg.type == :binary
           @logger.debug("Pod #{@pod_name}, channel #{WebSocketMessage.channel_name(msg)}: #{WebSocketMessage.msg_data(msg)}")
           @message_log.save_message(msg)
         elsif msg.type == :close
           @logger.debug("Pod: #{@pod_name}, message: close, data: #{WebSocketMessage.msg_data(msg)}")
-          @close
+          ws.close
         end
       end
       
@@ -153,7 +153,7 @@ module Authentication
         kubectl = self
         
         ws.on(:open) { kubectl.on_open(ws, body, stdin) }
-        ws.on(:message) { |msg| kubectl.on_message(msg) }
+        ws.on(:message) { |msg| kubectl.on_message(msg, ws) }
         ws.on(:close) { kubectl.on_close }
         ws.on(:error) { |err| kubectl.on_error(err) }
       end

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -66,7 +66,7 @@ module Authentication
       private
 
       def channel_from_message(msg)
-        if !msg.response_to?(:data)
+        if !msg.respond_to?(:data)
           puts "&&&&&&&&&&&&&&"
           puts msg.class
           puts msg

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -5,12 +5,6 @@ require 'rubygems/package'
 require 'active_support/time'
 require 'websocket-client-simple'
 
-#require 'util/error_class'
-#require 'util/web_socket/stream_state'
-#require 'util/web_socket/with_attributes'
-#require 'util/web_socket/with_message_saving'
-#require 'util/web_socket/stream_state'
-
 module WebSocket
   module Client
     module Simple

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -113,7 +113,7 @@ module Authentication
       def execute(cmds, body: "", stdin: false)
         url = server_url(cmds, stdin)
         headers = @kubeclient.headers.clone
-        WebSocket::Client::Simple.connect(url, headers: headers)
+        ws = WebSocket::Client::Simple.connect(url, headers: headers)
 
         add_websocket_event_handlers(ws, body, stdin)
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -21,6 +21,10 @@ module Authentication
           channel_names[channel_number_from_message(msg)]
         end
 
+        def channel_byte(channel_name)
+          channel_number(channel_name).chr
+        end
+        
         private
 
         def channel_number_from_message(msg)
@@ -30,10 +34,6 @@ module Authentication
         
         def channel_number(channel_name)
           channel_names.index(channel_name)
-        end
-
-        def channel_byte(channel_name)
-          channel_number(channel_name).chr
         end
 
         def channel_names

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -177,7 +177,7 @@ module Authentication
         ws.on(:message) do |msg|
           if msg.type == :binary
             puts "* BINARY!"
-            messages.save_message(ws.msg_data(msg))
+            messages.save_message(messages.msg_data(msg))
             logger.debug("Pod #{@pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == :close
             puts "* CLOSED!"

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -194,7 +194,7 @@ module Authentication
           hs = ws.handshake
 
           if hs.error
-            emit(:error, ws.messages)
+            emit(:error, @messages.messages)
           else
             puts "*** IT WORKED!"
             logger.debug("Pod #{@pod_name} : channel open")

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -116,10 +116,10 @@ module Authentication
       def add_websocket_event_handlers(ws, body, stdin)
         this_obj = self
         
-        ws.on(:open) { this_obj.on_open(ws, body, stdin) })
-        ws.on(:message) { |msg| this_obj.on_message(msg) })
-        ws.on(:close) { this_obj.on_close })
-        ws.on(:error) { |err| { this_obj.on_error(err) }
+        ws.on(:open) { this_obj.on_open(ws, body, stdin) }
+        ws.on(:message) { |msg| this_obj.on_message(msg) }
+        ws.on(:close) { this_obj.on_close }
+        ws.on(:error) { |err| this_obj.on_error(err) }
       end
       
       def on_open(ws, body, stdin)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -1,133 +1,227 @@
+# Collect messages and return them
+# Log certain things to a logger
+#
+#
+#
+require 'uri'
 require 'websocket'
 require 'rubygems/package'
 
+require 'active_support/time'
+require 'websocket-client-simple'
+require 'pry'
+
+#require 'util/error_class'
+#require 'util/web_socket/stream_state'
+#require 'util/web_socket/with_attributes'
+#require 'util/web_socket/with_message_saving'
+#require 'util/web_socket/stream_state'
+
+module WebSocket
+  module Client
+    module Simple
+      class Client
+        alias_method :send_msg, :send
+      end
+    end
+  end
+end
+
 module Authentication
   module AuthnK8s
+    CommandTimedOut = ::Util::ErrorClass.new(
+      "Command timed out in container '{0}' of pod '{1}'"
+    )
+    
     class KubectlExec
-      STDIN_CHANNEL = 0
-      STDOUT_CHANNEL = 1
-      STDERR_CHANNEL = 2
-      ERROR_CHANNEL = 3
-      RESIZE_CHANNEL = 4
-
-      attr_reader :pod, :container, :timeout, :ws
-
-      def initialize pod, container: "authentication", timeout: 5.seconds
-        @pod = pod
+      # logger: an object responding to `debug`
+      # kubeclient: Kubeclient::Client from "kubeclient" gem
+      #
+      def initialize(
+        pod_name:,
+        pod_namespace:,
+        logger:,
+        kubeclient:,
+        container: 'authentication',
+        timeout: 1.seconds
+      )
+        @pod_name = pod_name
+        @pod_namespace = pod_namespace
         @container = container
         @timeout = timeout
+        @logger = logger
+        @kubeclient = kubeclient
       end
 
-      def exec command, body: "", stdin: false
-        kubectl = K8sObjectLookup.kubectl_client
+      def execute(cmds, body: "", stdin: false)
+        ws = websocket_client(cmds, stdin)
 
-        base_url = "wss://#{kubectl.api_endpoint.host}:#{kubectl.api_endpoint.port}"
-        path = "/api/v1/namespaces/#{pod.metadata.namespace}/pods/#{pod.metadata.name}/exec"
+        add_websocket_event_handlers(ws, stdin)
+        #add_simple_event_handlers(ws, stdin)
 
-        query = [
-          "container=#{CGI.escape container}",
-          "stderr=true",
-          "stdout=true",
-        ]
-        query << "stdin=true" if stdin
+        url = server_url(cmds, stdin)
+        ws.connect(url, headers: headers)
 
-        for arg in Array(command)
-          query << "command=#{CGI.escape arg}"
-        end
-        query = query.join("&")
+        # JT: I *think* the connection is not being established until this
+        # method exists, which means the open callback never gets hit and
+        # the CommandTimeOut error is raised before a connection is established.
+        
 
-        url = "#{base_url}#{path}?#{query}"
-        headers = kubectl.headers.clone
-
-        ws = @ws = WebSocket::Client::Simple.connect url, headers: headers
-        ws.instance_variable_set "@messages", Hash.new {|hash,key| hash[key] = []}
-        ws.instance_variable_set "@pod", pod
-        ws.instance_variable_set "@closed", false
-
-        class << ws
-          def message_binary msg
-            channel = msg.data[0..0].bytes.first
-            stream = case channel
-                     when STDOUT_CHANNEL
-                       "stdout"
-                     when STDERR_CHANNEL
-                       "stderr"
-                     when ERROR_CHANNEL
-                       "error"
-                     when RESIZE_CHANNEL
-                       "resize"
-                     else
-                       raise "Unexpected channel number : #{channel}"
-                     end
-            @messages[stream.to_sym] << msg.data[1..-1]
-            Rails.logger.debug "Pod #{@pod.metadata.name.inspect} message :#{stream} : #{msg.data[1..-1]}"
-          end
-
-          def message_close msg
-            Rails.logger.debug "Pod #{@pod.metadata.name.inspect} message :#{close} : #{msg.data[1..-1]}"
-            close
-          end
-        end
-
-        ws.on :message do |msg|
-          __send__ "message_#{msg.type}", msg
-        end
-
-        ws.on :open do
-          hs = ws.handshake
-          if hs.error
-            emit :error, hs.instance_variable_get("@data")
-          else
-            Rails.logger.debug "Pod #{@pod.metadata.name.inspect} : channel open"
-
-            if stdin
-              ws.send(STDIN_CHANNEL.chr + body)
-              ws.send nil, :type => :close
-            end
-          end
-        end
-
-        ws.on :close do |e|
-          @closed = true
-          Rails.logger.debug "Pod #{@pod.metadata.name.inspect} : channel closed"
-        end
-
-        ws.on :error do |e|
-          @closed = true
-          Rails.logger.debug "Pod #{@pod.metadata.name.inspect} error : #{e.inspect}"
-          @messages[:error] << e.inspect
-        end
-
-        ws.send "\n"
-
-        (@timeout / 0.1).to_i.times do
-          break if ws.instance_variable_get("@closed")
-          sleep 0.1
-        end
-
-        if ws.instance_variable_get("@closed")
-          ws.instance_variable_get "@messages"
-        else
-          raise "Command timed out in container #{container.inspect} of Pod #{@pod.metadata.name.inspect}"
-        end
+        ws.send_msg("\n") #TODO: remove or add comment why this is needed
+        wait_for_close_message(ws)
+        
+        puts "*** puts newline"
+        
+        raise CommandTimedOut, @container, @pod_name unless closed?(ws)
+        
+        # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
+        ws.messages
       end
-
-      def copy path, content, mode
-        exec [ 'tar', 'xvf', '-', '-C', '/' ], stdin: true, body: generate_file_tar_string(path, content, mode)
+      
+      def copy(path, content, mode)
+        exec(
+          [ 'tar', 'xvf', '-', '-C', '/' ],
+          stdin: true,
+          body: generate_file_tar_string(path, content, mode)
+        )
       end
 
       private
 
-      def generate_file_tar_string path, content, mode
+      def closed?(ws)
+        ws.stream_state.closed?
+      end
+
+      def add_simple_event_handlers(ws, stdin)
+        ws.on :open do
+          puts "*** OPEN!"
+          ws.send_msg("hello world")
+        end
+        
+        ws.on :message do |msg|
+          puts "*** MESSAGE!"
+          puts msg.to_s
+        end
+
+        ws.on :error do |e|
+          puts "*** ERROR!"
+          puts e
+        end
+      end
+
+      def add_websocket_event_handlers(ws, stdin)
+        # NOTE: `logger` here calls the method `logger` created by
+        # `WithAttributes`, and returns @logger (the one from KubectlExec)  In
+        # this way we avoid the "self" problems inherent in the callback blocks
+        #
+        
+        ws.on(:message) do |msg|
+          puts "*** MESSAGE!"
+          p msg
+          # if msg.type == 'binary'
+          if msg.type == 'text'
+            ws.save_message(ws.msg_data(msg))
+            #TODO fix pod_name
+            ws.logger.debug("Pod #{@pod_name}, stream #{ws.stream(msg)}: #{ws.msg_data(msg)}")
+          elsif msg.type == 'close'
+            ws.stream_state.close
+            ws.logger.debug("Pod: #{@pod_name}, message: close, data: #{ws.msg_data(msg)}")
+          end
+        end
+
+        ws.on :open do
+          puts "*** OPEN!"
+          hs = ws.handshake
+
+          if hs.error
+            emit(:error, ws.messages)
+          else
+            puts "WORKED"
+            ws.logger.debug("Pod #{@pod_name} : channel open")
+
+            if stdin
+              data = ws.channel('stdin').chr + body
+              ws.send_msg(data)
+              ws.send_msg(nil, type: :close)
+            end
+          end
+        end
+
+        ws.on(:close) do |e|
+          puts "*** CLOSE!"
+          ws.stream_state.close
+          ws.logger.debug("Pod #{@pod_name} : channel closed")
+        end
+
+        ws.on(:error) do |e|
+          puts "*** ERROR!"
+          puts e.inspect
+          ws.stream_state.close
+          ws.logger.debug("Pod #{@pod_name} error: #{e.inspect}")
+          ws.save_message(e.inspect, stream: "error")
+        end
+      end
+
+      def wait_for_close_message(ws)
+        (@timeout / 0.1).to_i.times do
+          puts "*** wait for close..."
+          break if closed?(ws)
+          sleep 0.1
+        end
+      end
+
+      # Decorates the websocket gem's default client with the ability to save
+      # messages, and to hold objects that can be used within the callback
+      # blocks, to allow features like logging
+      #
+      def websocket_client(cmds, stdin)
+        url = server_url(cmds, stdin)
+        #ws = WebSocket::Client::Simple.connect(url, headers: headers)
+        ws = WebSocket::Client::Simple::Client.new
+        ws = Util::WebSocket::WithMessageSaving.new(ws)
+        Util::WebSocket::WithAttributes.new(ws, websocket_client_attrs)
+      end
+
+      def websocket_client_attrs
+        stream_state = Util::WebSocket::StreamState.new
+        {logger: @logger, pod_name: @pod_name, stream_state: stream_state}
+      end
+
+      def query_string(cmds, stdin)
+        stdin_part = stdin ? ['stdin=true'] : []
+        cmds_part = cmds.map { |c| "command=#{CGI.escape(c)}" }
+        (base_query_string_parts + stdin_part + cmds_part).join("&")
+      end
+
+      def base_query_string_parts
+        [ "container=#{CGI.escape(@container)}", "stderr=true", "stdout=true" ]
+      end
+
+      def server_url(cmds, stdin)
+        api_uri = @kubeclient.api_endpoint
+        base_url = "ws://#{api_uri.host}:#{api_uri.port}"
+        path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
+        query = query_string(cmds, stdin)
+        "#{base_url}#{path}?#{query}"
+        #TODO: remove
+        base_url
+      end
+
+      def headers
+        @kubeclient.headers.clone
+      end
+
+      def generate_file_tar_string(path, content, mode)
         tarfile = StringIO.new("")
         Gem::Package::TarWriter.new(tarfile) do |tar|
-          tar.add_file path, mode do |tf|
-            tf.write content
+          tar.add_file(path, mode) do |tf|
+            tf.write(content)
           end
         end
 
         tarfile.string
       end
+
     end
   end
 end

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -131,7 +131,7 @@ module Authentication
         
         puts "*** puts newline"
         
-        raise CommandTimedOut, @container, @pod_name unless @stream_state.closed?
+        raise CommandTimedOut.new(@container, @pod_name) unless @stream_state.closed?
         
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 #        ws.messages

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -43,7 +43,7 @@ module Authentication
         puts "* SAVING MESSAGE: #{msg}"
         strm ||= stream_name(msg)
         raise "Unexpected channel: #{channel(msg)}" unless strm
-        @messages[strm.to_sym] << msg
+        @messages[strm.to_sym] << msg_data(msg)
       end
 
       def save_string(str, stream: nil)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -212,11 +212,13 @@ module Authentication
           @logger.debug("Pod #{@pod_name} : channel closed")
         end
 
+        strm_state = @stream_state
+        
         ws.on(:error) do |e|
           puts "*** ERROR!"
           puts e.inspect
           
-          @stream_state.close
+          strm_state.close
           @logger.debug("Pod #{@pod_name} error: #{e.inspect}")
           
           @messages.save_message(e.inspect, stream: "error")

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -69,6 +69,7 @@ module Authentication
         if !msg.respond_to?(:data)
           puts "&&&&&&&&&&&&&&"
           puts msg.class
+          puts msg.type
           puts msg
         end
         

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -270,8 +270,6 @@ module Authentication
         path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
         query = query_string(cmds, stdin)
         "#{base_url}#{path}?#{query}"
-        #TODO: remove
-        base_url
       end
 
       def headers

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -116,7 +116,7 @@ module Authentication
       def execute(cmds, body: "", stdin: false)
         ws = websocket_client(cmds, stdin)
 
-        add_websocket_event_handlers(ws, stdin)
+        add_websocket_event_handlers(ws, body, stdin)
         #add_simple_event_handlers(ws, stdin)
 
         #url = server_url(cmds, stdin)
@@ -166,7 +166,7 @@ module Authentication
         end
       end
 =end
-      def add_websocket_event_handlers(ws, stdin)
+      def add_websocket_event_handlers(ws, body, stdin)
         # These callbacks have access to local variables, but we can't use the
         # instance variables because 'self' is not KubectlExec. Make some local
         # vars to pass the instance variables in.

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -17,6 +17,16 @@ module Authentication
         def channel_byte(channel_name)
           channel_number_from_name(channel_name).chr
         end
+
+        private
+        
+        def channel_number_from_name(channel_name)
+          channel_names.index(channel_name)
+        end
+
+        def channel_names
+          %w(stdin stdout stderr error resize)
+        end
       end
       
       def initialize(msg)
@@ -32,7 +42,7 @@ module Authentication
       end
 
       def channel_name
-        channel_names[channel_number]
+        self.class.channel_names[channel_number]
       end
       
       def channel_number
@@ -41,16 +51,6 @@ module Authentication
         end
         
         @msg.data[0..0].bytes.first
-      end
-
-      public
-      
-      def channel_number_from_name(channel_name)
-        channel_names.index(channel_name)
-      end
-
-      def channel_names
-        %w(stdin stdout stderr error resize)
       end
     end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -9,7 +9,6 @@ require 'rubygems/package'
 
 require 'active_support/time'
 require 'websocket-client-simple'
-require 'pry'
 
 #require 'util/error_class'
 #require 'util/web_socket/stream_state'
@@ -32,6 +31,50 @@ module Authentication
     CommandTimedOut = ::Util::ErrorClass.new(
       "Command timed out in container '{0}' of pod '{1}'"
     )
+
+    class Messages
+      attr_reader :messages
+      
+      def initialize
+        @messages = Hash.new { |hash,key| hash[key] = [] }
+      end
+
+      def save_message(msg, stream: nil)
+        strm ||= stream(msg)
+        raise "Unexpected channel: #{channel(msg)}" unless strm
+        @messages[strm.to_sym] << msg
+      end
+
+      def stream(msg)
+        stream_name(channel_from_message(msg))
+      end
+
+      def msg_data(msg)
+        msg.data[1..-1]
+      end
+
+      # NOTE: yes, a hash would be more efficient, but it doesn't matter
+      #
+      def channel(stream_name)
+        stream_names.index(stream_name)
+      end
+
+      def stream_name(channel)
+        stream_names[channel]
+      end
+
+      private
+
+      def channel_from_message(msg)
+        # THIS LINE WAS THE FIX
+        return channel('error') unless msg.respond_to?(:data)
+        msg.data[0..0].bytes.first
+      end
+
+      def stream_names
+        %[stdin stdout stderr error resize]
+      end
+    end
     
     class KubectlExec
       # logger: an object responding to `debug`
@@ -51,6 +94,9 @@ module Authentication
         @timeout = timeout
         @logger = logger
         @kubeclient = kubeclient
+
+        @messages = Messages.new
+        @stream_state = Util::WebSocket::StreamState.new
       end
 
       def execute(cmds, body: "", stdin: false)
@@ -59,23 +105,24 @@ module Authentication
         add_websocket_event_handlers(ws, stdin)
         #add_simple_event_handlers(ws, stdin)
 
-        url = server_url(cmds, stdin)
-        ws.connect(url, headers: headers)
+        #url = server_url(cmds, stdin)
+        #ws.connect(url, headers: headers)
 
         # JT: I *think* the connection is not being established until this
         # method exists, which means the open callback never gets hit and
         # the CommandTimeOut error is raised before a connection is established.
-        
 
         ws.send_msg("\n") #TODO: remove or add comment why this is needed
         wait_for_close_message(ws)
         
         puts "*** puts newline"
         
-        raise CommandTimedOut, @container, @pod_name unless closed?(ws)
+        raise CommandTimedOut, @container, @pod_name unless @stream_state.closed?
         
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
-        ws.messages
+#        ws.messages
+
+        @messages
       end
       
       def copy(path, content, mode)
@@ -87,11 +134,7 @@ module Authentication
       end
 
       private
-
-      def closed?(ws)
-        ws.stream_state.closed?
-      end
-
+=begin
       def add_simple_event_handlers(ws, stdin)
         ws.on :open do
           puts "*** OPEN!"
@@ -108,7 +151,7 @@ module Authentication
           puts e
         end
       end
-
+=end
       def add_websocket_event_handlers(ws, stdin)
         # NOTE: `logger` here calls the method `logger` created by
         # `WithAttributes`, and returns @logger (the one from KubectlExec)  In
@@ -117,30 +160,31 @@ module Authentication
         
         ws.on(:message) do |msg|
           puts "*** MESSAGE!"
-          p msg
+          puts msg
+          
           # if msg.type == 'binary'
           if msg.type == 'text'
-            ws.save_message(ws.msg_data(msg))
-            #TODO fix pod_name
-            ws.logger.debug("Pod #{@pod_name}, stream #{ws.stream(msg)}: #{ws.msg_data(msg)}")
+            @messages.save_message(ws.msg_data(msg))
+            @logger.debug("Pod #{@pod_name}, stream #{@messages.stream(msg)}: #{@messages.msg_data(msg)}")
           elsif msg.type == 'close'
-            ws.stream_state.close
-            ws.logger.debug("Pod: #{@pod_name}, message: close, data: #{ws.msg_data(msg)}")
+            @stream_state.close
+            @logger.debug("Pod: #{@pod_name}, message: close, data: #{ws.msg_data(msg)}")
           end
         end
 
         ws.on :open do
           puts "*** OPEN!"
+          
           hs = ws.handshake
 
           if hs.error
             emit(:error, ws.messages)
           else
             puts "WORKED"
-            ws.logger.debug("Pod #{@pod_name} : channel open")
+            @logger.debug("Pod #{@pod_name} : channel open")
 
             if stdin
-              data = ws.channel('stdin').chr + body
+              data = @messages.channel('stdin').chr + body
               ws.send_msg(data)
               ws.send_msg(nil, type: :close)
             end
@@ -149,23 +193,26 @@ module Authentication
 
         ws.on(:close) do |e|
           puts "*** CLOSE!"
-          ws.stream_state.close
-          ws.logger.debug("Pod #{@pod_name} : channel closed")
+          
+          @stream_state.close
+          @logger.debug("Pod #{@pod_name} : channel closed")
         end
 
         ws.on(:error) do |e|
           puts "*** ERROR!"
           puts e.inspect
-          ws.stream_state.close
-          ws.logger.debug("Pod #{@pod_name} error: #{e.inspect}")
-          ws.save_message(e.inspect, stream: "error")
+          
+          @stream_state.close
+          @logger.debug("Pod #{@pod_name} error: #{e.inspect}")
+          
+          @messages.save_message(e.inspect, stream: "error")
         end
       end
 
       def wait_for_close_message(ws)
         (@timeout / 0.1).to_i.times do
           puts "*** wait for close..."
-          break if closed?(ws)
+          break if @stream_state.closed?
           sleep 0.1
         end
       end
@@ -176,16 +223,16 @@ module Authentication
       #
       def websocket_client(cmds, stdin)
         url = server_url(cmds, stdin)
-        #ws = WebSocket::Client::Simple.connect(url, headers: headers)
-        ws = WebSocket::Client::Simple::Client.new
-        ws = Util::WebSocket::WithMessageSaving.new(ws)
-        Util::WebSocket::WithAttributes.new(ws, websocket_client_attrs)
+        WebSocket::Client::Simple.connect(url, headers: headers)
+        #ws = WebSocket::Client::Simple::Client.new
+#        ws = Util::WebSocket::WithMessageSaving.new(ws)
+        #        Util::WebSocket::WithAttributes.new(ws, websocket_client_attrs)
       end
 
-      def websocket_client_attrs
-        stream_state = Util::WebSocket::StreamState.new
-        {logger: @logger, pod_name: @pod_name, stream_state: stream_state}
-      end
+#      def websocket_client_attrs
+#        stream_state = Util::WebSocket::StreamState.new
+#        {logger: @logger, pod_name: @pod_name, stream_state: stream_state}
+#      end
 
       def query_string(cmds, stdin)
         stdin_part = stdin ? ['stdin=true'] : []

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -66,6 +66,12 @@ module Authentication
       private
 
       def channel_from_message(msg)
+        if !msg.response_to?(:data)
+          puts "&&&&&&&&&&&&&&"
+          puts msg.class
+          puts msg
+        end
+        
         # THIS LINE WAS THE FIX
         return channel('error') unless msg.respond_to?(:data)
         msg.data[0..0].bytes.first

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -110,17 +110,6 @@ module Authentication
           body: tar_file_as_string(path, content, mode)
         )
       end
-
-      private
-
-      def add_websocket_event_handlers(ws, body, stdin)
-        this_obj = self
-        
-        ws.on(:open) { this_obj.on_open(ws, body, stdin) }
-        ws.on(:message) { |msg| this_obj.on_message(msg) }
-        ws.on(:close) { this_obj.on_close }
-        ws.on(:error) { |err| this_obj.on_error(err) }
-      end
       
       def on_open(ws, body, stdin)
         if ws.handshake.error
@@ -155,6 +144,17 @@ module Authentication
         @channel_closed = true
         @logger.debug("Pod #{@pod_name} error : #{err.inspect}")
         @message_log.save_error_string(err.inspect)
+      end
+
+      private
+
+      def add_websocket_event_handlers(ws, body, stdin)
+        this_obj = self
+        
+        ws.on(:open) { this_obj.on_open(ws, body, stdin) }
+        ws.on(:message) { |msg| this_obj.on_message(msg) }
+        ws.on(:close) { this_obj.on_close }
+        ws.on(:error) { |err| this_obj.on_error(err) }
       end
 
       def wait_for_close_message

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -140,7 +140,7 @@ module Authentication
       end
       
       def copy(path, content, mode)
-        exec(
+        execute(
           [ 'tar', 'xvf', '-', '-C', '/' ],
           stdin: true,
           body: generate_file_tar_string(path, content, mode)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -32,7 +32,7 @@ module Authentication
       end
 
       def channel_name
-        channel_names[channel_number_from_message]
+        channel_names[channel_number]
       end
       
       def channel_number

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -116,10 +116,10 @@ module Authentication
       def add_websocket_event_handlers(ws, body, stdin)
         this_obj = self
         
-        ws.on(:open,    &->() { this_obj.on_open(ws, body, stdin) })
-        ws.on(:message, &->() { this_obj.on_message })
-        ws.on(:close,   &->() { this_obj.on_close })
-        ws.on(:error,   &->() { this_obj.on_error })
+        ws.on(:open) { this_obj.on_open(ws, body, stdin) })
+        ws.on(:message) { |msg| this_obj.on_message(msg) })
+        ws.on(:close) { this_obj.on_close })
+        ws.on(:error) { |err| { this_obj.on_error(err) }
       end
       
       def on_open(ws, body, stdin)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -194,7 +194,7 @@ module Authentication
           hs = ws.handshake
 
           if hs.error
-            emit(:error, @messages.messages)
+            emit(:error, messages.messages)
           else
             puts "*** IT WORKED!"
             logger.debug("Pod #{@pod_name} : channel open")

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -175,15 +175,11 @@ module Authentication
         stream_state = @stream_state
         
         ws.on(:message) do |msg|
-          puts "*** MESSAGE!"
-          puts "type: #{msg.type}"
-          puts msg
-          
-          if msg.type == 'binary'
+          if msg.type == :binary
             puts "* BINARY!"
             messages.save_message(ws.msg_data(msg))
             logger.debug("Pod #{@pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
-          elsif msg.type == 'close'
+          elsif msg.type == :close
             puts "* CLOSED!"
             stream_state.close
             logger.debug("Pod: #{@pod_name}, message: close, data: #{messages.msg_data(msg)}")

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -72,7 +72,7 @@ module Authentication
       end
 
       def stream_names
-        %[stdin stdout stderr error resize]
+        %w[stdin stdout stderr error resize]
       end
     end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -194,6 +194,7 @@ module Authentication
           hs = ws.handshake
 
           if hs.error
+            puts "handshake err: #{hs.error}"
             emit(:error, messages.messages)
           else
             puts "*** IT WORKED!"

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -126,11 +126,11 @@ module Authentication
         # method exists, which means the open callback never gets hit and
         # the CommandTimeOut error is raised before a connection is established.
 
-        ws.send_msg("\n") #TODO: remove or add comment why this is needed
-        wait_for_close_message(ws)
-        
         puts "*** puts newline"
         
+        ws.send_msg("\n") #TODO: remove or add comment why this is needed
+        wait_for_close_message(ws)
+
         raise CommandTimedOut.new(@container, @pod_name) unless @stream_state.closed?
         
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
@@ -176,13 +176,14 @@ module Authentication
         
         ws.on(:message) do |msg|
           puts "*** MESSAGE!"
+          puts "type: #{msg.type}"
           puts msg
           
-          # if msg.type == 'binary'
-          if msg.type == 'text'
+          if msg.type == 'binary'
             messages.save_message(ws.msg_data(msg))
             logger.debug("Pod #{@pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == 'close'
+            puts "* CLOSED!"
             stream_state.close
             logger.debug("Pod: #{@pod_name}, message: close, data: #{messages.msg_data(msg)}")
           end

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -100,7 +100,7 @@ module Authentication
         logger:,
         kubeclient:,
         container: 'authentication',
-        timeout: 1.seconds
+        timeout: 5.seconds
       )
         @pod_name = pod_name
         @pod_namespace = pod_namespace

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -136,7 +136,7 @@ module Authentication
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 #        ws.messages
 
-        @messages
+        @messages.messages
       end
       
       def copy(path, content, mode)
@@ -239,6 +239,9 @@ module Authentication
       #
       def websocket_client(cmds, stdin)
         url = server_url(cmds, stdin)
+
+        puts "*** connecting to: #{url}"
+        
         WebSocket::Client::Simple.connect(url, headers: headers)
         #ws = WebSocket::Client::Simple::Client.new
 #        ws = Util::WebSocket::WithMessageSaving.new(ws)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -117,9 +117,9 @@ module Authentication
         this_obj = self
         
         ws.on(:open, ->() { this_obj.on_open(ws, body, stdin) })
-        ws.on(:message, { this_obj.on_message })
-        ws.on(:close, { this_obj.on_close })
-        ws.on(:error, { this_obj.on_error })
+        ws.on(:message, ->() { this_obj.on_message })
+        ws.on(:close, ->() { this_obj.on_close })
+        ws.on(:error, ->() { this_obj.on_error })
       end
       
       def on_open(ws, body, stdin)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -39,7 +39,7 @@ module Authentication
         def channel_names
           %w[stdin stdout stderr error resize]
         end
-      end      
+      end
     end
 
     class MessageLog
@@ -141,6 +141,7 @@ module Authentication
       end
 
       def on_error(err)
+        puts("*** error: #{err.inspect}")
         @channel_closed = true
         @logger.debug("Pod #{@pod_name} error : #{err.inspect}")
         @message_log.save_error_string(err.inspect)
@@ -149,12 +150,12 @@ module Authentication
       private
 
       def add_websocket_event_handlers(ws, body, stdin)
-        this_obj = self
+        kubectl = self
         
-        ws.on(:open) { this_obj.on_open(ws, body, stdin) }
-        ws.on(:message) { |msg| this_obj.on_message(msg) }
-        ws.on(:close) { this_obj.on_close }
-        ws.on(:error) { |err| this_obj.on_error(err) }
+        ws.on(:open) { kubectl.on_open(ws, body, stdin) }
+        ws.on(:message) { |msg| kubectl.on_message(msg) }
+        ws.on(:close) { kubectl.on_close }
+        ws.on(:error) { |err| kubectl.on_error(err) }
       end
 
       def wait_for_close_message

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -39,15 +39,16 @@ module Authentication
         @messages = Hash.new { |hash,key| hash[key] = [] }
       end
 
+      # This is taking either a string or message DATA
       def save_message(msg, stream: nil)
         puts "* SAVING MESSAGE: #{msg}"
-        strm ||= stream(msg)
+        strm ||= stream_name(msg)
         raise "Unexpected channel: #{channel(msg)}" unless strm
         @messages[strm.to_sym] << msg
       end
 
-      def stream(msg)
-        stream_name(channel_from_message(msg))
+      def stream_name(msg)
+        stream_names[channel_from_message(msg)]
       end
 
       def msg_data(msg)
@@ -58,10 +59,6 @@ module Authentication
       #
       def channel(stream_name)
         stream_names.index(stream_name)
-      end
-
-      def stream_name(channel)
-        stream_names[channel]
       end
 
       private
@@ -185,8 +182,13 @@ module Authentication
           
           if msg.type == :binary
             puts "* BINARY"
-            messages.save_message(messages.msg_data(msg))
-            logger.debug("Pod #{pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
+
+            
+            #messages.save_message(messages.msg_data(msg))
+            messages.save_message(msg)
+
+            
+            logger.debug("Pod #{pod_name}, stream #{messages.stream_name(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == :close
             puts "* CLOSE"
             logger.debug("Pod: #{pod_name}, message: close, data: #{messages.msg_data(msg)}")

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -180,6 +180,7 @@ module Authentication
           puts msg
           
           if msg.type == 'binary'
+            puts "* BINARY!"
             messages.save_message(ws.msg_data(msg))
             logger.debug("Pod #{@pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == 'close'

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -133,9 +133,9 @@ module Authentication
         # method exists, which means the open callback never gets hit and
         # the CommandTimeOut error is raised before a connection is established.
 
-        puts "*** puts newline"
+#        puts "*** puts newline"
         
-        ws.send_msg("\n") #TODO: remove or add comment why this is needed
+#        ws.send_msg("\n") #TODO: remove or add comment why this is needed
         wait_for_close_message(ws)
 
         raise CommandTimedOut.new(@container, @pod_name) unless @stream_state.closed?

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -75,6 +75,20 @@ module Authentication
         %[stdin stdout stderr error resize]
       end
     end
+
+    class StreamState
+      def initialize
+        @closed = false
+      end
+
+      def close
+        @closed = true
+      end
+
+      def closed?
+        @closed
+      end
+    end
     
     class KubectlExec
       # logger: an object responding to `debug`
@@ -96,7 +110,7 @@ module Authentication
         @kubeclient = kubeclient
 
         @messages = Messages.new
-        @stream_state = Util::WebSocket::StreamState.new
+        @stream_state = StreamState.new
       end
 
       def execute(cmds, body: "", stdin: false)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -124,7 +124,7 @@ module Authentication
         if ws.handshake.error
           ws.emit(:error, @message_log.messages)
         else
-          @logger.debug("Pod #{pod_name} : channel open")
+          @logger.debug("Pod #{@pod_name} : channel open")
 
           if @stdin
             data = WebSocketMessage.channel_byte('stdin') + body

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -114,7 +114,7 @@ module Authentication
       private
 
       def add_websocket_event_handlers(ws, body, stdin)
-        ws.on(:open, &method(:on_open).curry.(ws, body, stdin))
+        ws.on(:open, &method(:on_open).curry.(ws, body, stdin, x))
         ws.on(:message, &method(:on_message))
         ws.on(:close, &method(:on_close))
         ws.on(:error, &method(:on_error))

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -189,8 +189,8 @@ module Authentication
             logger.debug("Pod #{pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == :close
             puts "* CLOSE"
-            stream_state.close
             logger.debug("Pod: #{pod_name}, message: close, data: #{messages.msg_data(msg)}")
+            close
           end
         end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -1,8 +1,3 @@
-# Collect messages and return them
-# Log certain things to a logger
-#
-#
-#
 require 'uri'
 require 'websocket'
 require 'rubygems/package'

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -114,10 +114,12 @@ module Authentication
       private
 
       def add_websocket_event_handlers(ws, body, stdin)
-        ws.on(:open, &method(:on_open).curry.(ws, body, stdin, x))
-        ws.on(:message, &method(:on_message))
-        ws.on(:close, &method(:on_close))
-        ws.on(:error, &method(:on_error))
+        this_obj = self
+        
+        ws.on(:open, ->() { this_obj.on_open(ws, body, stdin) })
+        ws.on(:message, { this_obj.on_message })
+        ws.on(:close, { this_obj.on_close })
+        ws.on(:error, { this_obj.on_error })
       end
       
       def on_open(ws, body, stdin)

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -15,7 +15,7 @@ module Authentication
     class WebSocketMessage
       class << self
         def channel_byte(channel_name)
-          channel_number(channel_name).chr
+          channel_number_from_name(channel_name).chr
         end
       end
       
@@ -36,13 +36,16 @@ module Authentication
       end
       
       def channel_number
-        return channel_number('error') unless @msg.respond_to?(:data)
+        unless @msg.respond_to?(:data)
+          return self.class.channel_number_from_name('error') 
+        end
+        
         @msg.data[0..0].bytes.first
       end
 
       public
       
-      def channel_number(channel_name)
+      def channel_number_from_name(channel_name)
         channel_names.index(channel_name)
       end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -18,8 +18,6 @@ module Authentication
           channel_number_from_name(channel_name).chr
         end
 
-        private
-        
         def channel_number_from_name(channel_name)
           channel_names.index(channel_name)
         end

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -170,6 +170,7 @@ module Authentication
         # These callbacks have access to local variables, but we can't use the
         # instance variables because 'self' is not KubectlExec. Make some local
         # vars to pass the instance variables in.
+        pod_name = @pod_name
         logger = @logger
         messages = @messages
         stream_state = @stream_state
@@ -178,11 +179,11 @@ module Authentication
           if msg.type == :binary
             puts "* BINARY!"
             messages.save_message(messages.msg_data(msg))
-            logger.debug("Pod #{@pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
+            logger.debug("Pod #{pod_name}, stream #{messages.stream(msg)}: #{messages.msg_data(msg)}")
           elsif msg.type == :close
             puts "* CLOSED!"
             stream_state.close
-            logger.debug("Pod: #{@pod_name}, message: close, data: #{messages.msg_data(msg)}")
+            logger.debug("Pod: #{pod_name}, message: close, data: #{messages.msg_data(msg)}")
           end
         end
 
@@ -196,7 +197,7 @@ module Authentication
             emit(:error, messages.messages)
           else
             puts "*** IT WORKED!"
-            logger.debug("Pod #{@pod_name} : channel open")
+            logger.debug("Pod #{pod_name} : channel open")
 
             if stdin
               data = messages.channel('stdin').chr + body
@@ -210,7 +211,7 @@ module Authentication
           puts "*** CLOSE!"
           
           stream_state.close
-          logger.debug("Pod #{@pod_name} : channel closed")
+          logger.debug("Pod #{pod_name} : channel closed")
         end
 
         ws.on(:error) do |e|
@@ -218,7 +219,7 @@ module Authentication
           puts e.inspect
           
           stream_state.close
-          logger.debug("Pod #{@pod_name} error: #{e.inspect}")
+          logger.debug("Pod #{pod_name} error: #{e.inspect}")
           
           messages.save_message(e.inspect, stream: "error")
         end

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -41,7 +41,7 @@ function finish {
   delete_image $INVENTORY_TAG
   delete_image $NGINX_TAG
 }
-trap finish EXIT
+#trap finish EXIT
 
 export TEMPLATE_TAG=gke.
 export API_VERSION=rbac.authorization.k8s.io/v1beta1

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -41,7 +41,7 @@ function finish {
   delete_image $INVENTORY_TAG
   delete_image $NGINX_TAG
 }
-#trap finish EXIT
+trap finish EXIT
 
 export TEMPLATE_TAG=gke.
 export API_VERSION=rbac.authorization.k8s.io/v1beta1

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -14,7 +14,7 @@ Before do
     next if pod.metadata.name =~ /conjur\-authn\-k8s/
 
     pod.spec.containers.each do |container|
-      exec = KubectlExec.new(
+      exec = Authentication::AuthnK8s::KubectlExec.new(
         pod_name: pod.metadata.name.inspect,
         pod_namespace: pod.metadata.namespace.inspect,
         logger: Rails.logger,

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -22,7 +22,7 @@ Before do
         container: container.name
       )
       
-      response = exec.exec %w(ls /etc/conjur/ssl)
+      response = exec.execute %w(ls /etc/conjur/ssl)
       if response[:error] && response[:error].join =~ /command terminated with non-zero exit code/
       else
         # $stderr.puts "Cleaning /etc/conjur/ssl on container #{container.name} of Pod #{pod.metadata.name}"

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -18,7 +18,7 @@ Before do
         pod_name: pod.metadata.name.inspect,
         pod_namespace: pod.metadata.namespace.inspect,
         logger: Rails.logger,
-        kubeclient: K8sObjectLookup.kubectl_client,
+        kubeclient: Authentication::AuthnK8s::K8sObjectLookup.kubectl_client,
         container: container.name
       )
       

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -26,7 +26,7 @@ Before do
       if response[:error] && response[:error].join =~ /command terminated with non-zero exit code/
       else
         # $stderr.puts "Cleaning /etc/conjur/ssl on container #{container.name} of Pod #{pod.metadata.name}"
-        exec.exec %w(rm -rf /etc/conjur/ssl)
+        exec.execute %w(rm -rf /etc/conjur/ssl)
       end
     end
   end

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -15,8 +15,8 @@ Before do
 
     pod.spec.containers.each do |container|
       exec = Authentication::AuthnK8s::KubectlExec.new(
-        pod_name: pod.metadata.name.inspect,
-        pod_namespace: pod.metadata.namespace.inspect,
+        pod_name: pod.metadata.name,
+        pod_namespace: pod.metadata.namespace,
         logger: Rails.logger,
         kubeclient: Authentication::AuthnK8s::K8sObjectLookup.kubectl_client,
         container: container.name

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -14,7 +14,14 @@ Before do
     next if pod.metadata.name =~ /conjur\-authn\-k8s/
 
     pod.spec.containers.each do |container|
-      exec = Authentication::AuthnK8s::KubectlExec.new pod, container: container.name
+      exec = KubectlExec.new(
+        pod_name: pod.metadata.name.inspect,
+        pod_namespace: pod.metadata.namespace.inspect,
+        logger: Rails.logger,
+        kubeclient: K8sObjectLookup.kubectl_client,
+        container: container.name
+      )
+      
       response = exec.exec %w(ls /etc/conjur/ssl)
       if response[:error] && response[:error].join =~ /command terminated with non-zero exit code/
       else

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -40,7 +40,7 @@ module AuthnK8sWorld
     count = 0
 
     while response.nil? || (!response[:error].empty? && count < retries)
-      response = exec.exec [ "cat", "/etc/conjur/ssl/client.pem" ]
+      response = exec.execute [ "cat", "/etc/conjur/ssl/client.pem" ]
       sleep 2
       count += 1
     end

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -30,7 +30,7 @@ module AuthnK8sWorld
       pod_name: @pod.metadata.name.inspect,
       pod_namespace: @pod.metadata.namespace.inspect,
       logger: Rails.logger,
-      kubeclient: K8sObjectLookup.kubectl_client,
+      kubeclient: kubectl_client,
       container: 'authenticator'
     )
 

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -26,7 +26,7 @@ module AuthnK8sWorld
 
   # get pod cert
   def pod_certificate
-    exec = KubectlExec.new(
+    exec = Authentication::AuthnK8s::KubectlExec.new(
       pod_name: @pod.metadata.name.inspect,
       pod_namespace: @pod.metadata.namespace.inspect,
       logger: Rails.logger,

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -27,8 +27,8 @@ module AuthnK8sWorld
   # get pod cert
   def pod_certificate
     exec = Authentication::AuthnK8s::KubectlExec.new(
-      pod_name: @pod.metadata.name.inspect,
-      pod_namespace: @pod.metadata.namespace.inspect,
+      pod_name: @pod.metadata.name,
+      pod_namespace: @pod.metadata.namespace,
       logger: Rails.logger,
       kubeclient: kubectl_client,
       container: 'authenticator'

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -26,7 +26,14 @@ module AuthnK8sWorld
 
   # get pod cert
   def pod_certificate
-    exec = Authentication::AuthnK8s::KubectlExec.new @pod, container: "authenticator"
+    exec = KubectlExec.new(
+      pod_name: @pod.metadata.name.inspect,
+      pod_namespace: @pod.metadata.namespace.inspect,
+      logger: Rails.logger,
+      kubeclient: K8sObjectLookup.kubectl_client,
+      container: 'authenticator'
+    )
+
     response = nil
 
     retries = 3


### PR DESCRIPTION
#### What does this PR do?

Refactors the kubectl_exec class in isolation before the full refactor merge.

#### What ticket does this PR close?

Closes #729 

#### How should this be manually tested?

Cukes should suffice

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/activity?branch=729--refactor-kubectl-exec-class

#### Has the Version and Changelog been updated?

Not yet.