### PR TITLE
Prevent anonymous LDAP authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   host, rather than use the value from the CSR.
 - Update Conjur issued certificates to include a SPIFFE SVID as a subject alternative
   name (SAN).
+- Prevent anonymous (password-less) authentication with LDAP.
 
 ## [1.2.0] - 2018-09-07
 ### Added

--- a/app/domain/authentication/authn_ldap/authenticator.rb
+++ b/app/domain/authentication/authn_ldap/authenticator.rb
@@ -24,7 +24,7 @@ module Authentication
       def valid?(input)
         login, password = input.username, input.password
 
-        # Prevent authenticating with username only
+        # Prevent anonymous LDAP authentication with username only
         return false if password.blank?
 
         # Prevent LDAP injection attack

--- a/app/domain/authentication/authn_ldap/authenticator.rb
+++ b/app/domain/authentication/authn_ldap/authenticator.rb
@@ -23,6 +23,10 @@ module Authentication
 
       def valid?(input)
         login, password = input.username, input.password
+
+        # Prevent authenticating with username only
+        return false if password.blank?
+
         # Prevent LDAP injection attack
         safe_login = Net::LDAP::Filter.escape(login)
         return false if blacklisted_ldap_user?(safe_login)

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnLdap::Authenticator do
+  let(:authenticator_instance) do
+    Authentication::AuthnLdap::Authenticator.new(env: {})
+  end
+  
+  let(:input) do
+    ::Authentication::Strategy::Input.new(
+      authenticator_name: 'ldap',
+      service_id: 'test',
+      account: 'test',
+      username: username,
+      password: password,
+      origin: '127.0.0.1',
+      request: nil
+    )
+  end
+
+  before do
+    allow_any_instance_of(Net::LDAP)
+      .to receive(:bind_as)
+      .and_return(:valid_login?)
+  end
+
+  context "as user alice" do
+    let(:username) { 'alice'}
+
+    context "with valid non-empty password" do
+      let(:valid_login?) { true } 
+      let(:password) { 'secret' }
+
+      it "is accepted" do
+        expect(authenticator_instance.valid?(input)).to be(true)
+      end
+    end
+
+    context "with valid empty password" do
+      let(:valid_login?) { true } 
+      let(:password) { '' }
+
+      it "is rejected" do
+        expect(authenticator_instance.valid?(input)).to be(false)
+      end
+    end
+  end
+
+  context "with admin user" do
+    let(:valid_login?) { true }
+    let(:username) { 'admin' }
+    let(:password) { 'my_password' }
+
+    it "is rejected" do
+      expect(authenticator_instance.valid?(input)).to be(false)
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -20,16 +20,16 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
   end
 
   before do
+    # Assume all of the LDAP binds would be valid
     allow_any_instance_of(Net::LDAP)
       .to receive(:bind_as)
-      .and_return(:valid_login?)
+      .and_return(true)
   end
 
   context "as user alice" do
     let(:username) { 'alice'}
 
     context "with valid non-empty password" do
-      let(:valid_login?) { true } 
       let(:password) { 'secret' }
 
       it "is accepted" do
@@ -38,7 +38,6 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
     end
 
     context "with valid empty password" do
-      let(:valid_login?) { true } 
       let(:password) { '' }
 
       it "is rejected" do
@@ -48,7 +47,6 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
   end
 
   context "with admin user" do
-    let(:valid_login?) { true }
     let(:username) { 'admin' }
     let(:password) { 'my_password' }
 


### PR DESCRIPTION
#### What does this PR do?
This PR ports over the check from V4 LDAP authentication that specifically forbids blank passwords. This is to ensure that anonymous LDAP binding is not allowed in Conjur, even if the LDAP server enables it.

#### What ticket does this PR close?
Closes #672 

#### Where should the reviewer start?

It is a simple change in `app/domain/authentication/authn_ldap/authenticator.rb` with additional tests added to verify the behavior.

#### How should this be manually tested?

This is tested automatically in CI.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/no_blank_ldap_password/

#### Has the Version and Changelog been updated?
Yes

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
No

> Has this change been documented (Readme, docs, etc.)?
No

> Does the knowledge base need an update?
I don't think so.