### PR TITLE
Update deprecated Sequel query literal form

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -124,7 +124,7 @@ class Resource < Sequel::Model
       rank = Sequel.function(:ts_rank_cd, :textsearch, query)
 
       natural_join(:resources_textsearch).
-        where("? @@ textsearch", query).
+        where(Sequel.lit("? @@ textsearch", query)).
         order(Sequel.desc(rank))
     end
 


### PR DESCRIPTION
#### What does this PR do?

This PR updates another instance of a Sequel query that uses a string literal in way that is now deprecated. The update wraps the literal in `Sequal.lit(...)`.

#### Any background context you want to provide?

With the deprecated form, every time this query is executed (each resource search) a warning message and full stack trace are written to the Conjur log.

#### What ticket does this PR close?
Closes #748 

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/sequel-deprecation-fix/
