### PR TITLE
Handle host builder scenario when host role already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   specifically and raises a policy load error with a description of the problem.
 - Added support for authenticators to implement `/login` in addition to `/authenticate`
 - Implemented `/login` for `authn-ldap`.
+- Fixed host factory `500` server response when a `Role` for a given host ID already
+  exists but there is no corresponding `Resource` record.
 
 ## [1.2.0] - 2018-09-18
 ### Added

--- a/app/models/host_builder.rb
+++ b/app/models/host_builder.rb
@@ -20,7 +20,7 @@ HostBuilder = Struct.new(:account, :id, :owner, :layers, :options) do
     host = Role[host_id]
     return nil unless host
 
-    raise Exceptions::Forbidden unless host.resource.owner == owner
+    raise Exceptions::Forbidden unless host.resource? && host.resource.owner == owner
     
     # Find-or-create Credentials
     host.api_key

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -107,6 +107,10 @@ class Role < Sequel::Model
     self.class.username_from_roleid(role_id)
   end
 
+  def resource?
+    Resource[id].present?
+  end
+
   def resource
     Resource[id] or raise "Resource not found for #{id}"
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -151,7 +151,10 @@ class Role < Sequel::Model
   end
 
   def graph
-    Role.from(Sequel.function(:role_graph, id)).order(:parent, :child)
+    Role.from(Sequel.function(:role_graph, id))
+        .order(:parent, :child)
+        .all
+        .map(&:values)
   end
 
   private

--- a/cucumber/api/features/host_factory_create_host.feature
+++ b/cucumber/api/features/host_factory_create_host.feature
@@ -1,8 +1,8 @@
 Feature: Create a host using the host factory.
 
   Background:
-    Given a host factory for layer "the-layer"
-    And a host factory token
+    Given I create a host factory for layer "the-layer"
+    And I create a host factory token
     
   Scenario: The host factory token authenticates and authorizes a request
     to create a new host.

--- a/cucumber/api/features/host_factory_create_token.feature
+++ b/cucumber/api/features/host_factory_create_token.feature
@@ -3,7 +3,7 @@ Feature: Create a host factory token.
 
   Background:
     Given I create a new user "alice"
-    And a host factory for layer "the-layer"
+    And I create a host factory for layer "the-layer"
 
 
   Scenario: A host factory is invisible without some permission on it

--- a/cucumber/api/features/host_factory_delete_token.feature
+++ b/cucumber/api/features/host_factory_delete_token.feature
@@ -3,8 +3,8 @@ Feature: Delete (revoke) a host factory token.
 
 Background:
   Given I create a new user "alice"
-  And a host factory for layer "the-layer"
-  And a host factory token
+  And I create a host factory for layer "the-layer"
+  And I create a host factory token
 
   Scenario: Unauthorized users cannot delete host factory tokens.
     When I DELETE "/host_factory_tokens/@host_factory_token_token@"

--- a/cucumber/api/features/host_factory_rotate_host.feature
+++ b/cucumber/api/features/host_factory_rotate_host.feature
@@ -1,0 +1,75 @@
+Feature: Rotate a host api key using the host factory.
+
+  Background:
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !policy
+      id: database
+      body:
+        - !layer users
+        - !host-factory
+          id: users
+          layers: [ !layer users ]
+    """
+    And a host factory token for "database/users"
+    And I authorize the request with the host factory token
+    And I successfully POST "/host_factories/hosts?id=brand-new-host"
+    And I log out
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    []
+    """
+
+  Scenario: The host factory can rotate the host api key
+
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !policy
+      id: database
+      body:
+        - !layer users
+        - !host-factory
+          id: users
+          layers: [ !layer users ]
+    """
+    And a host factory token for "database/users"
+    And I authorize the request with the host factory token
+    And I POST "/host_factories/hosts?id=brand-new-host"
+    Then the HTTP response status code is 403
+
+  Scenario: The host factory can rotate the host api key
+
+    Given I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !policy
+      id: database
+      body:
+        - !layer users
+        - !host-factory
+          id: users
+          layers: [ !layer users ]
+
+    - !host 
+      id: brand-new-host
+      owner: !host-factory database/users
+    """
+    And a host factory token for "database/users"
+    And I authorize the request with the host factory token
+    And I successfully POST "/host_factories/hosts?id=brand-new-host"
+    Then the HTTP response status code is 201
+    And the JSON should be:
+    """
+    {
+      "annotations" : [],
+      "id": "cucumber:host:brand-new-host",
+      "owner": "cucumber:host_factory:database/users",
+      "policy": "cucumber:policy:root",
+      "api_key": "@response_api_key@",
+      "permissions": [],
+      "restricted_to": []
+    }
+    """

--- a/cucumber/api/features/host_factory_rotate_host.feature
+++ b/cucumber/api/features/host_factory_rotate_host.feature
@@ -12,7 +12,7 @@ Feature: Rotate a host api key using the host factory.
           id: users
           layers: [ !layer users ]
     """
-    And a host factory token for "database/users"
+    And I create a host factory token for "database/users"
     And I authorize the request with the host factory token
     And I successfully POST "/host_factories/hosts?id=brand-new-host"
     And I log out
@@ -35,7 +35,7 @@ Feature: Rotate a host api key using the host factory.
           id: users
           layers: [ !layer users ]
     """
-    And a host factory token for "database/users"
+    And I create a host factory token for "database/users"
     And I authorize the request with the host factory token
     And I POST "/host_factories/hosts?id=brand-new-host"
     Then the HTTP response status code is 403
@@ -57,7 +57,7 @@ Feature: Rotate a host api key using the host factory.
       id: brand-new-host
       owner: !host-factory database/users
     """
-    And a host factory token for "database/users"
+    And I create a host factory token for "database/users"
     And I authorize the request with the host factory token
     And I successfully POST "/host_factories/hosts?id=brand-new-host"
     Then the HTTP response status code is 201

--- a/cucumber/api/features/host_factory_show.feature
+++ b/cucumber/api/features/host_factory_show.feature
@@ -3,14 +3,14 @@ Feature: Display information about a host factory.
 
   Background:
     Given I create a new user "alice"
-    And a host factory for layer "the-layer"
+    And I create a host factory for layer "the-layer"
     And I permit user "alice" to "read" it
     And I login as "alice"
 
   Scenario: The host factory displays the normal resource fields, plus
     the list of layers and tokens. 
     
-    Given a host factory token
+    Given I create a host factory token
     When I successfully GET "/resources/cucumber/host_factory/the-layer-factory"
     Then the JSON should be:
     """

--- a/cucumber/api/features/resource_show.feature
+++ b/cucumber/api/features/resource_show.feature
@@ -24,7 +24,7 @@ Feature: Fetch resource details.
           "value": "Front end server"
         }
       ],
-      "id": "cucumber:variable:app-01.mycorp.com",
+      "id": "cucumber:variable:@namespace@/app-01.mycorp.com",
       "owner": "cucumber:user:alice",
       "permissions": [
       {

--- a/cucumber/api/features/step_definitions/host_factory_steps.rb
+++ b/cucumber/api/features/step_definitions/host_factory_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given(/^a host factory for layer "([^"]*)"$/) do |layer_id|
+Given(/^I create a host factory for layer "([^"]*)"$/) do |layer_id|
   layer_p = Conjur::PolicyParser::Types::Layer.new(layer_id)
   layer_p.owner = Conjur::PolicyParser::Types::Role.new(admin_user.id)
   layer_p.account = "cucumber"
@@ -17,7 +17,7 @@ Given(/^a host factory for layer "([^"]*)"$/) do |layer_id|
   @current_resource = @host_factory = Resource[hf_p.resourceid]
 end
 
-Given(/^a host factory token(?: for "([^"]*)")?$/) do |host_factory_id|
+Given(/^I create a host factory token(?: for "([^"]*)")?$/) do |host_factory_id|
   @host_factory = Resource["cucumber:host_factory:#{host_factory_id}"] if host_factory_id.present?
   expect(@host_factory).to be
   @host_factory_token = HostFactoryToken.create(resource: @host_factory, expiration: Time.now + 10.minutes)

--- a/cucumber/api/features/step_definitions/host_factory_steps.rb
+++ b/cucumber/api/features/step_definitions/host_factory_steps.rb
@@ -17,7 +17,8 @@ Given(/^a host factory for layer "([^"]*)"$/) do |layer_id|
   @current_resource = @host_factory = Resource[hf_p.resourceid]
 end
 
-Given(/^a host factory token$/) do
+Given(/^a host factory token(?: for "([^"]*)")?$/) do |host_factory_id|
+  @host_factory = Resource["cucumber:host_factory:#{host_factory_id}"] if host_factory_id.present?
   expect(@host_factory).to be
   @host_factory_token = HostFactoryToken.create(resource: @host_factory, expiration: Time.now + 10.minutes)
 end

--- a/cucumber/api/features/step_definitions/user_steps.rb
+++ b/cucumber/api/features/step_definitions/user_steps.rb
@@ -38,6 +38,7 @@ end
 
 Given(/^I log out$/) do
   @current_user =  nil
+  headers.delete(:authorization) if headers.key?(:authorization)
 end
   
 When(/^I have a password$/) do

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -17,3 +17,5 @@ require 'securerandom'
 ENV['CONJUR_APPLIANCE_URL'] ||= Utils.start_local_server
 
 Slosilo["authn:cucumber"] ||= Slosilo::Key.new
+
+JsonSpec.excluded_keys = %w(created_at updated_at)

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - testdb
 
   client:
-    image: conjurinc/cli5
+    image: cyberark/conjur-cli:5
     entrypoint: sleep
     command: infinity
     environment:


### PR DESCRIPTION
#### What does this PR do?

This PR updates the host builder for host factories to check for the existence of a Host role and its resource with the requested ID prior to checking permissions and attempting to rotate the api key.

If a host role already exists, but there is no corresponding resource to check, the host builder will now return `403 forbidden` because we cannot verify ownership.

#### Any background context you want to provide?
If a host was previously created and then removed by either a host factory or policy, a `Role` record would exist for the host, but there would not exist a `Resource` record. A bug in the host builder assumed that if a `Role` was present, then the `Resource` would also be present. This caused the permission check to return a `500` server error for the missing record. 

#### What ticket does this PR close?
Closes #744 

#### Where should the reviewer start?

The PR consists of 2 supporting commits to update the test infrastructure, and 1 last commit that adds automated tests for this scenario and updates the host builder to include the resource existence check.

#### How should this be manually tested?

This is tested with the automated CI tests, but can be run manually with
```
bundle exec cucumber -p api cucumber/api/features/host_factory_rotate_host.feature
```

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/host-factory-744/

#### Has the Version and Changelog been updated?

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
I don't think so

> Has this change been documented (Readme, docs, etc.)?
No

> Does the knowledge base need an update?
No