### PR TITLE
Add tests to error_class and validate_pod_request

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ test.sh
 publish.sh
 push-image.sh
 website.sh
+
+# Ignore vim swapfiles
+*.sw[po]

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ api.html
 # Emacs backup files
 *~
 
+# Vim backup files
+*.sw[po]
+
 brakeman-output.*
 .idea
 TEMP_NOTES.txt

--- a/app/domain/authentication/authn_k8s/errors.rb
+++ b/app/domain/authentication/authn_k8s/errors.rb
@@ -48,6 +48,5 @@ module Authentication
     ClientCertificateExpired = ::Util::ErrorClass.new(
       "Client certificate expired"
     )
-    
   end
 end

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -96,10 +96,17 @@ module Authentication
           pod.spec.initContainers.find { |c| c.name == container_name }
       end
 
+      def default_container_name
+        'authenticator'
+      end
+
       def container_name
         name = 'kubernetes/authentication-container-name'
         annotation = host.annotations.find { |a| a.values[:name] == name }
-        annotation[:value] || 'authenticator'
+
+        return default_container_name unless annotation
+
+        annotation[:value] || default_container_name
       end
 
       def pod

--- a/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
@@ -1,0 +1,290 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
+  let(:error_template) { "An error occured" }
+
+  let(:k8s_resolver) { double("K8sResolver") }
+
+  let(:account) { "SomeAccount" }
+
+  let(:host_id) { "HostId" }
+  let(:host_role) { double("HostRole", :id => host_id) }
+
+  let(:k8s_authn_container_name) { 'kubernetes/authentication-container-name' }
+  let(:host_annotation_1) { double("Annot1", :values => { :name => "first" }) }
+  let(:host_annotation_2) { double("Annot2") }
+
+  let(:host_annotations) { [ host_annotation_1, host_annotation_2 ] }
+
+  let(:host) { double("Host", :role => host_role,
+                              :annotations => host_annotations) }
+
+  let(:k8s_host_object) { "K8sHostObject" }
+  let(:k8s_host_namespace) { "K8sHostNamespace" }
+  let(:k8s_host) { double("K8sHost", :account => account,
+                                     :conjur_host_id => host_id,
+                                     :namespace => k8s_host_namespace,
+                                     :object => k8s_host_object) }
+
+  let (:container_name) { "ContainerName" }
+
+  let(:bad_service_name) { "BadMockService" }
+  let(:good_service_name) { "MockService" }
+
+  let(:good_webservice) { double("GoodWebservice") }
+
+  let(:spiffe_name) { "SpiffeName" }
+  let(:spiffe_namespace) { "SpiffeNamespace" }
+  let(:spiffe_id) { double("SpiffeId", :name => spiffe_name,
+                                       :namespace => spiffe_namespace) }
+  let(:pod_request) { double("PodRequest", :k8s_host => k8s_host,
+                                           :spiffe_id => spiffe_id) }
+
+  let(:dependencies) { { resource_repo: double(),
+                         k8s_resolver: k8s_resolver,
+                         k8s_object_lookup: double() } }
+
+  before(:each) do
+    allow(Resource).to receive(:[])
+      .with(host_id)
+      .and_return(host)
+
+    allow(Resource).to receive(:[])
+      .with("#{account}:webservice:conjur/authn-k8s/#{good_service_name}")
+      .and_return(good_webservice)
+    allow(Resource).to receive(:[])
+      .with("#{account}:webservice:conjur/authn-k8s/#{bad_service_name}")
+      .and_return(nil)
+
+  end
+
+  context "invocation" do
+    subject(:validator) { Authentication::AuthnK8s::ValidatePodRequest
+      .new(dependencies: dependencies) }
+
+    it 'raises WebserviceNotFound error when webservice is missing' do
+      allow(pod_request).to receive(:service_id).and_return(bad_service_name)
+
+      expected_message = "Webservice '#{bad_service_name}' wasn't found"
+      expect { validator.(pod_request: pod_request) }
+        .to raise_error(Authentication::AuthnK8s::WebserviceNotFound, expected_message)
+    end
+
+    it 'raises HostNotAuthorized when host is not allowed to authenticate to service' do
+      allow(pod_request).to receive(:service_id).and_return(good_service_name)
+      allow(host_role).to receive(:allowed_to?)
+        .with("authenticate", good_webservice)
+        .and_return(false)
+
+      expected_message = "'#{host_id}' does not have 'authenticate' privilege on #{good_service_name}"
+
+      expect { validator.(pod_request: pod_request) }
+        .to raise_error(Authentication::AuthnK8s::HostNotAuthorized, expected_message)
+    end
+
+    it 'raises PodNotFound when pod is not known' do
+      allow(pod_request).to receive(:service_id).and_return(good_service_name)
+      allow(host_role).to receive(:allowed_to?)
+        .with("authenticate", good_webservice)
+        .and_return(true)
+      allow(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
+        .with(spiffe_name, spiffe_namespace)
+        .and_return(nil)
+
+      expected_message = "No Pod found for podname '#{spiffe_name}' " \
+        "in namespace '#{spiffe_namespace}'"
+
+      expect { validator.(pod_request: pod_request) }
+        .to raise_error(Authentication::AuthnK8s::PodNotFound, expected_message)
+    end
+
+    context 'when namespace scoped' do
+      let (:pod_spec) { double("PodSpec") }
+      let (:pod) { double("Pod", :spec => pod_spec) }
+
+      before(:each) do
+        allow(pod_request).to receive(:service_id).and_return(good_service_name)
+        allow(host_role).to receive(:allowed_to?)
+          .with("authenticate", good_webservice)
+          .and_return(true)
+        allow(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
+          .with(spiffe_name, spiffe_namespace)
+          .and_return(pod)
+        allow(k8s_host).to receive(:namespace_scoped?)
+          .and_return(true)
+      end
+
+      it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
+        allow(pod_spec).to receive(:initContainers)
+          .and_return({})
+        allow(pod_spec).to receive(:containers)
+          .and_return({})
+        allow(host_annotation_2).to receive(:values)
+          .and_return({ :name => k8s_authn_container_name })
+        allow(host_annotation_2).to receive(:[])
+          .with(:value)
+          .and_return(nil)
+
+        expected_message = "Container authenticator was not found for requesting pod"
+        expect { validator.(pod_request: pod_request) }
+          .to raise_error(Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
+        allow(pod_spec).to receive(:initContainers)
+          .and_return({})
+        allow(pod_spec).to receive(:containers)
+          .and_return({})
+        allow(host_annotation_2).to receive(:values)
+          .and_return({ :name => "notimportant" })
+
+        expected_message = "Container authenticator was not found for requesting pod"
+        expect { validator.(pod_request: pod_request) }
+          .to raise_error(Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'does not raise errors if all checks pass' do
+        allow(pod_spec).to receive(:initContainers)
+          .and_return({})
+        allow(pod_spec).to receive(:containers)
+          .and_return([ double("Container1", :name => "notimportant"),
+                        double("Container2", :name => container_name) ])
+        allow(host_annotation_2).to receive(:values)
+          .and_return({ :name => k8s_authn_container_name })
+        allow(host_annotation_2).to receive(:[])
+          .with(:value)
+          .and_return(container_name)
+
+        expect { validator.(pod_request: pod_request) }.to_not raise_error
+      end
+    end
+
+    context 'when not namespace scoped' do
+      let (:pod_spec) { double("PodSpec") }
+      let (:pod) { double("Pod", :spec => pod_spec) }
+      let (:k8s_host_controller) { "K8sHostController" }
+
+      before(:each) do
+        allow(pod_request).to receive(:service_id).and_return(good_service_name)
+        allow(host_role).to receive(:allowed_to?)
+          .with("authenticate", good_webservice)
+          .and_return(true)
+        allow(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
+          .with(spiffe_name, spiffe_namespace)
+          .and_return(pod)
+        allow(k8s_host).to receive(:namespace_scoped?)
+          .and_return(false)
+        allow(k8s_host).to receive(:controller)
+          .and_return(k8s_host_controller)
+      end
+
+      it 'raises ScopeNotSupported if host is not in permitted scope' do
+        allow(k8s_host).to receive(:permitted_scope?)
+          .and_return(false)
+
+        expected_message = "Resource type '#{k8s_host_controller}' identity scope is " \
+          "not supported in this version of authn-k8s"
+        expect { validator.(pod_request: pod_request) }
+          .to raise_error(Authentication::AuthnK8s::ScopeNotSupported, expected_message)
+      end
+
+      context 'in permitted scope' do
+        let (:k8s_resolver_for_controller) { double("K8sResoverForController") }
+        let (:k8s_host_controller_object) { double("K8sHostControllerObject") }
+        let (:k8s_host_instantiated_controller) { double("K8sHostInstantiatedController") }
+
+        before(:each) do
+          allow(k8s_host).to receive(:permitted_scope?)
+            .and_return(true)
+          allow(Authentication::AuthnK8s::K8sObjectLookup).to receive(:find_object_by_name)
+            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
+            .and_return(k8s_host_controller_object)
+          allow(Authentication::AuthnK8s::K8sResolver).to receive(:for_controller)
+            .with(k8s_host_controller)
+            .and_return(k8s_resolver_for_controller)
+          allow(k8s_resolver_for_controller).to receive(:new)
+            .with(k8s_host_controller_object, pod)
+            .and_return(k8s_host_instantiated_controller)
+          allow(k8s_host_instantiated_controller).to receive(:validate_pod)
+            .and_return(false)
+        end
+
+        it 'raises ControllerNotFound if controller object cannot be found' do
+          allow(Authentication::AuthnK8s::K8sObjectLookup)
+            .to receive(:find_object_by_name)
+            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
+            .and_return(nil)
+
+          expected_message = "Kubernetes K8sHostController K8sHostObject " \
+            "not found in namespace K8sHostNamespace"
+          expect { validator.(pod_request: pod_request) }
+            .to raise_error(Authentication::AuthnK8s::ControllerNotFound, expected_message)
+        end
+
+        it 'raises error if pod metadata fails validation' do
+          expected_message = "PodValidationFailed"
+
+          allow(Authentication::AuthnK8s::K8sObjectLookup)
+            .to receive(:find_object_by_name)
+            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
+            .and_raise(expected_message)
+
+          expect { validator.(pod_request: pod_request) }.to raise_error(RuntimeError,
+                                                                         expected_message)
+        end
+
+        it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
+          allow(pod_spec).to receive(:initContainers)
+            .and_return({})
+          allow(pod_spec).to receive(:containers)
+            .and_return({})
+          allow(host_annotation_2).to receive(:values)
+            .and_return({ :name => k8s_authn_container_name })
+          allow(host_annotation_2).to receive(:[])
+            .with(:value)
+            .and_return(nil)
+
+          expected_message = "Container authenticator was not found for requesting pod"
+          expect { validator.(pod_request: pod_request) }
+            .to raise_error(Authentication::AuthnK8s::ContainerNotFound, expected_message)
+        end
+
+        it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
+          allow(pod_spec).to receive(:initContainers)
+            .and_return({})
+          allow(pod_spec).to receive(:containers)
+            .and_return({})
+          allow(host_annotation_2).to receive(:values)
+            .and_return({ :name => "notimportant" })
+
+          expected_message = "Container authenticator was not found for requesting pod"
+          expect { validator.(pod_request: pod_request) }
+            .to raise_error(Authentication::AuthnK8s::ContainerNotFound, expected_message)
+        end
+
+        it 'does not raise errors if all checks pass' do
+          allow(pod_spec).to receive(:initContainers)
+            .and_return({})
+          allow(pod_spec).to receive(:containers)
+            .and_return([ double("Container1", :name => "notimportant"),
+                          double("Container2", :name => container_name) ])
+          allow(host_annotation_2).to receive(:values)
+            .and_return({ :name => k8s_authn_container_name })
+          allow(host_annotation_2).to receive(:[])
+            .with(:value)
+            .and_return(container_name)
+
+          begin
+            validator.(pod_request: pod_request)
+          rescue => err
+            puts err
+          end
+
+          expect { validator.(pod_request: pod_request) }.to_not raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/util/error_spec.rb
+++ b/spec/app/domain/util/error_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Util::ErrorClass' do
+  context 'object' do
+    let(:error_template) { "An error occured" }
+
+    subject(:error_class) { Util::ErrorClass.new(error_template) }
+
+    it 'is of type RuntimeError' do
+      expect { raise error_class.new() }.to raise_error(RuntimeError)
+    end
+
+    it 'has the expected templated error' do
+      expect { raise error_class.new() }.to raise_error(error_template)
+    end
+  end
+
+  context 'templating' do
+    let(:error_template) { "Variable is \#{0}." }
+
+    subject(:error_class) { Util::ErrorClass.new(error_template) }
+
+    it 'works for nil' do
+      expect { raise error_class.new(nil) }.to raise_error("Variable is #nil.")
+    end
+
+    it 'works for strings' do
+      expect { raise error_class.new("") }.to raise_error("Variable is #.")
+      expect { raise error_class.new("ABC") }.to raise_error("Variable is #ABC.")
+    end
+
+    it 'works for Fixnums' do
+      expect { raise error_class.new(9) }.to raise_error("Variable is #9.")
+      expect { raise error_class.new(0) }.to raise_error("Variable is #0.")
+    end
+
+    it 'works for booleans' do
+      expect { raise error_class.new(false) }.to raise_error("Variable is #false.")
+      expect { raise error_class.new(true) }.to raise_error("Variable is #true.")
+    end
+
+    it 'works for objects' do
+      expect { raise error_class.new(Class) }.to raise_error("Variable is #Class.")
+      expect { raise error_class.new(Util::ErrorClass) }.to raise_error("Variable is #Util::ErrorClass.")
+    end
+
+    it 'works for arrays' do
+      expect { raise error_class.new(["aA", "bB"]) }.to raise_error("Variable is #[\"aA\", \"bB\"].")
+    end
+
+    it 'handles overflow args' do
+      expect { raise error_class.new("AA", "BB") }.to raise_error("Variable is #AA.")
+    end
+
+    it 'handles underflow args' do
+      expect { raise error_class.new() }.to raise_error("Variable is #\{0\}.")
+    end
+
+    context 'with multiple args' do
+      let(:non_repeating_error_template) { "Variables are \#{0} \#{1} \#{2} \#{3} \#{4} \#{5}." }
+      let(:mixed_error_template) { "Variables are \#{2} \#{1} \#{2} \#{0} \#{4} \#{4}." }
+
+      subject(:non_repeating_error_class) { Util::ErrorClass.new(non_repeating_error_template) }
+      subject(:mixed_error_class) { Util::ErrorClass.new(mixed_error_template) }
+
+      it 'handles multiple args' do
+        expect { raise non_repeating_error_class.new("00", "11", "22", "33", "44", "55") }
+          .to raise_error("Variables are #00 #11 #22 #33 #44 #55.")
+      end
+
+      it 'handles repeating and mixed args' do
+        expect { raise mixed_error_class.new("00", "11", "22", "33", "44", "55") }
+          .to raise_error("Variables are #22 #11 #22 #00 #44 #44.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

Adds rspec tests to error_class and validate_pod_request

#### Any background context you want to provide?

See #761 

#### What ticket does this PR close?

Closes #763 

#### How should this be manually tested?

`rspec`

#### Link to build in Jenkins (if appropriate)

https://jenkins.conjur.net/view/cyberark/job/cyberark--conjur/job/763-add-tests-to-oc-code/

#### Has the Version and Changelog been updated?

No - no functional change