### PR TITLE
Removed keycloak port in ci

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -70,8 +70,6 @@ services:
       - REDIRECT_URI=http://locallhost.com/
       - CLIENT_SECRET=d7047915-9029-45b8-9bd6-7ec5c2f75e5b
       - SCOPE=openid,profile
-    ports:
-      - "7777:8080"
     volumes:
       - ./authn-oidc/keycloak:/scripts
 


### PR DESCRIPTION
#### What does this PR do?
As we don't communicate with the keycloak container in Jenkins we don't need to export ports