### PR TITLE
Rollback login implementation for authn-ldap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed /login implementation for authn-ldap
 
 ## [1.3.1] - 2018-10-19
 ### Fixed

--- a/cucumber/authenticators/features/authn_ldap.feature
+++ b/cucumber/authenticators/features/authn_ldap.feature
@@ -23,11 +23,6 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
       member: !user alice
     """
 
-  Scenario: An LDAP user authorized in Conjur can login with a good password
-    When I login via LDAP as authorized Conjur user "alice"
-    And I authenticate via LDAP as authorized Conjur user "alice" using key
-    Then "alice" is authorized
-
   Scenario: An LDAP user authorized in Conjur can authenticate with a good password
     When I authenticate via LDAP as authorized Conjur user "alice"
     Then "alice" is authorized
@@ -37,12 +32,12 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     Then it is denied
 
   Scenario: 'admin' cannot use LDAP authentication
-    When I login via LDAP as authorized Conjur user "admin"
+    When I authenticate via LDAP as authorized Conjur user "admin"
     Then it is denied
 
   Scenario: An valid LDAP user who's not in Conjur can't login
-    When I login via LDAP as non-existent Conjur user "bob"
-    Then it is forbidden
+    When I authenticate via LDAP as non-existent Conjur user "bob"
+    Then it is denied
 
   Scenario: An empty password may never be used to authenticate
     When my LDAP password for authorized Conjur user "alice" is empty
@@ -66,5 +61,5 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
         privilege: [ read, authenticate ]
         resource: !webservice
     """
-    When I login via LDAP as authorized Conjur user "alice"
-    Then it is forbidden
+    When I authenticate via LDAP as authorized Conjur user "alice"
+    Then it is denied

--- a/cucumber/authenticators/features/step_definitions/authn_ldap_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/authn_ldap_steps.rb
@@ -1,32 +1,24 @@
 # frozen_string_literal: true
 
-# Uses cucumber's multiline string feature: https://bit.ly/2vpzqJx
-#
-
-When(/I login via LDAP as (?:\S)+ Conjur user "(\S+)"/) do |username|
-  login_with_ldap(service_id: 'test', account: 'cucumber', 
-                  username: username, password: username)
-end
-
 # First non-captured group allows for adjectives to clarify the
 # purpose of the test.  They aren't actually used.
 #
-When(/I authenticate via LDAP as (?:\S)+ Conjur user "(\S+)"( using key)?/) do |username, using_key|
-  password = using_key ? ldap_auth_key : username
+When(/I authenticate via LDAP as (?:\S)+ Conjur user "(\S+)"/) do |username|
+  password = username
   authenticate_with_ldap(service_id: 'test', account: 'cucumber', 
-                         username: username, api_key: password)
+                         username: username, password: password)
 end
 
 When(/my LDAP password for (?:\S)+ Conjur user "(\S+)" is empty/) do |username|
-  login_with_ldap(service_id: 'test', account: 'cucumber', 
-                  username: username, password: '')
+  password = ""
+  authenticate_with_ldap(service_id: 'test', account: 'cucumber', 
+    username: username, password: password)
 end
 
-
-
 When(/my LDAP password is wrong for authorized user "(\S+)"/) do |username|
-  login_with_ldap(service_id: 'test', account: 'cucumber', 
-                  username: username, password: 'BAD_PASSWORD')
+  password = "bad_password"
+  authenticate_with_ldap(service_id: 'test', account: 'cucumber', 
+    username: username, password: password)
 end
 
 Then(/it is denied/) do

--- a/cucumber/authenticators/features/support/authenticator_helpers.rb
+++ b/cucumber/authenticators/features/support/authenticator_helpers.rb
@@ -21,16 +21,9 @@ module AuthenticatorHelpers
   #
   attr_reader :response_body, :http_status, :rest_client_error, :ldap_auth_key
 
-  def login_with_ldap(service_id:, account:, username:, password:)
-    path = "#{conjur_hostname}/authn-ldap/#{service_id}/#{account}/login"
-    get(path, user: username, password: password)
-    @ldap_auth_key = response_body
-  end
-
-  def authenticate_with_ldap(service_id:, account:, username:, api_key:)
-    # TODO fix this the right way
+  def authenticate_with_ldap(service_id:, account:, username:, password:)
     path = "#{conjur_hostname}/authn-ldap/#{service_id}/#{account}/#{username}/authenticate"
-    post(path, api_key)
+    post(path, password)
   end
 
   def authenticate_with_oidc(service_id:, account:)

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -38,11 +38,6 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
       let(:password) { 'secret' }
 
       it "is accepted" do
-        expect(authenticator_instance.login(input)).to be_truthy
-      end
-
-      # Legacy behavior backward compatibly regression check
-      it "is accepted by authenticate" do
         expect(authenticator_instance.valid?(input)).to be(true)
       end
     end
@@ -51,7 +46,7 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
       let(:password) { '' }
 
       it "is rejected" do
-        expect(authenticator_instance.login(input)).to be_falsy
+        expect(authenticator_instance.valid?(input)).to be(false)
       end
     end
   end
@@ -61,7 +56,7 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
     let(:password) { 'my_password' }
 
     it "is rejected" do
-      expect(authenticator_instance.login(input)).to be_falsy
+      expect(authenticator_instance.valid?(input)).to be(false)
     end
   end
 end


### PR DESCRIPTION
This PR removes the '/login' endpoint support for authn-ldap to exchange for a conjur role token. Instead the authn-ldap only supports `/authenticate` directly with the ldap credentials.

This change:
- Updates the authn-ldap module to remove the login handler.
- Updates the rspec tests to test LDAP binds using authenticate rather than login.
- Updates the cuke tests to test LDAP auth with authenticate rather than login.