### PR TITLE
Disable interpreting request bodies as request parameters by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Don't try to interpret request bodies as request parameters by default.
+  This fixes a problem body data would end up being written to logs under
+  some circumstances.
+
 ## [1.3.1] - 2018-10-19
 ### Fixed
 - Fixed host factory `500` server response when a `Role` for a given host ID already

--- a/apidocs/src/append_policy.md
+++ b/apidocs/src/append_policy.md
@@ -7,8 +7,6 @@ Deletions are not allowed. Any policy objects that exist on the server but
 are omitted from the policy file will not be deleted and any explicit deletions in
 the policy file will result in an error.
 
-<!-- include(partials/policy_size_restriction.md) -->
-
 <!-- include(partials/url_encoding.md) -->
 
 **Permissions required**

--- a/apidocs/src/partials/policy_size_restriction.md
+++ b/apidocs/src/partials/policy_size_restriction.md
@@ -1,4 +1,0 @@
-**Size restriction**
-
-The body of this request (the policy to be appended) will be rejected by the
-server if it is larger than 10MiB.

--- a/apidocs/src/replace_policy.md
+++ b/apidocs/src/replace_policy.md
@@ -7,8 +7,6 @@ document.
 
 Any policy data which already exists on the server but is **not** explicitly specified in the new policy file **will be deleted**. 
 
-<!-- include(partials/policy_size_restriction.md) -->
-
 <!-- include(partials/url_encoding.md) -->
 
 **Permissions required**

--- a/apidocs/src/update_policy.md
+++ b/apidocs/src/update_policy.md
@@ -5,8 +5,6 @@
 Modifies an existing [Conjur policy](/reference/policy.html).
 Data may be explicitly deleted using the `!delete`, `!revoke`, and `!deny` statements. Unlike "replace" mode, no data is ever implicitly deleted.
 
-<!-- include(partials/policy_size_restriction.md) -->
-
 <!-- include(partials/url_encoding.md) -->
 
 **Permissions required**

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -2,6 +2,7 @@
 
 class AccountsController < ApplicationController
   include AuthorizeResource
+  include BodyParser
 
   def index
     authorize :read

--- a/app/controllers/certificate_authority_controller.rb
+++ b/app/controllers/certificate_authority_controller.rb
@@ -4,6 +4,7 @@
 # certificate authority (CA) service
 class CertificateAuthorityController < RestController
   include ActionController::MimeResponds
+  include BodyParser
 
   before_action :verify_ca
   before_action :verify_host, only: :sign

--- a/app/controllers/concerns/body_parser.rb
+++ b/app/controllers/concerns/body_parser.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Mixin for controllers to parse body parameters.
+#
+# We disable parsing body parameters globally due to security concerns.
+# Use this mixin instead if a controller specifically needs it.
+module BodyParser
+  # :reek:NilCheck should be acceptable here
+  def body_params
+    @body_params ||= ActionController::Parameters.new \
+      case request.media_type
+      when nil, 'application/x-www-form-urlencoded'
+        decode_form_body
+      when 'application/json'
+        JSON.parse request.body.read
+      else
+        {}
+      end
+  end
+
+  def params
+    super.merge body_params
+  end
+
+  private
+
+  # note it does not parse rails magic [] params syntax, but we don't need it
+  def decode_form_body
+    Hash[*URI.decode_www_form(request.body.read).flatten(1)]
+  end
+end

--- a/app/controllers/host_factories_controller.rb
+++ b/app/controllers/host_factories_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HostFactoriesController < ApplicationController
+  include BodyParser
+
   before_filter :verify_token,  only: :create_host
 
   # Ask the host factory to create a host.

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,5 +63,10 @@ module Possum
         /^\/authenticators$/,
         /^\/$/
       ]
+
+    # NOTE: removing this middleware is important for security.
+    # ParamsParser can cause data from the body to end up in params and then
+    # in logs. It's better to explicitly parse the body where needed.
+    config.middleware.delete ActionDispatch::ParamsParser
   end
 end

--- a/config/initializers/limits.rb
+++ b/config/initializers/limits.rb
@@ -4,11 +4,3 @@
 def secrets_version_limit
   ( ENV['SECRETS_VERSION_LIMIT'] || 20 ).to_i
 end
-
-# Max size of policies that can be loaded (or data sent to POST endpoints in
-# general.)
-# This sets the default size of a Rack::Utils::KeySpaceConstrainedParam, which
-# is the type of the body of a policy load API request.
-# http://www.rubydoc.info/gems/rack/1.6.2/Rack/Utils/KeySpaceConstrainedParams
-
-Rack::Utils.key_space_limit = 1048576 * 10 # 10 MiB

--- a/config/initializers/rack_request.rb
+++ b/config/initializers/rack_request.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# NOTE: These two lines are important for security.
+#
+# They prevent Rack from interpreting request bodies as form parameters
+# and stuffing them in the params hash, which ends up in logs.
+# It's better to explicitly parse form data where required.
+
+Rack::Request::FORM_DATA_MEDIA_TYPES.clear
+Rack::Request::PARSEABLE_DATA_MEDIA_TYPES.clear

--- a/cucumber/api/features/host_factory_create_host.feature
+++ b/cucumber/api/features/host_factory_create_host.feature
@@ -21,6 +21,24 @@ Feature: Create a host using the host factory.
     }
     """
 
+  Scenario: Creating a host with parameters in POST body
+    Given I authorize the request with the host factory token
+    When I successfully POST "/host_factories/hosts" with body:
+    """
+    id=host-01
+    """
+    Then the JSON should be:
+    """
+    {
+      "annotations" : [],
+      "id": "cucumber:host:host-01",
+      "owner": "cucumber:host_factory:the-layer-factory",
+      "api_key": "@response_api_key@",
+      "permissions": [],
+      "restricted_to": []
+    }
+    """
+
   @logged-in-admin
   Scenario: Invalid tokens are rejected.
 

--- a/spec/controllers/concerns/body_parser_spec.rb
+++ b/spec/controllers/concerns/body_parser_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BodyParser do
+  describe "#body_params" do
+    context "with an unrecognized content type" do
+      let(:media_type) { 'application/octet-stream' }
+      it "returns an empty hash" do
+        expect(controller.body_params).to eq({})
+      end
+    end
+
+    shared_context "urlencoded form data" do
+      let(:body_data) { "id=foo&test=bar%20baz&plus=one+two" }
+      it "parses the body parameters" do
+        expect(controller.body_params).to eq \
+          'id' => 'foo',
+          'test' => 'bar baz',
+          'plus' => 'one two'
+      end
+    end
+
+    context "with no explicit content type" do
+      let(:media_type) { nil }
+      include_context "urlencoded form data"
+    end
+
+    context "with form data content type" do
+      let(:media_type) { 'application/x-www-form-urlencoded' }
+      include_context "urlencoded form data"
+    end
+
+    context "with json media type" do
+      let(:media_type) { 'application/json' }
+      let(:body_data) { '{"foo": "bar" }' }
+      it "attempts to parse as JSON" do
+        expect(controller.body_params).to eq "foo" => "bar"
+      end
+    end
+
+    it "returns a hash with indifferent access" do
+      expect(controller.body_params[:id]).to eq 'foo'
+    end
+  end
+
+  describe '#params' do
+    it "merges the body params with others" do
+      expect(controller.params).to include get: 'params', id: 'foo'
+    end
+  end
+
+  subject(:controller) do
+    base = Class.new do
+      # :reek:UtilityFunction
+      def params
+        ActionController::Parameters.new 'get' => 'params'
+      end
+    end
+    Class.new(base) { include BodyParser }.new
+  end
+
+  before { allow(request).to receive(:body) { StringIO.new body_data } }
+  before { allow(controller).to receive(:request) { request } }
+  let(:media_type) { 'application/x-www-form-urlencoded' }
+  let(:body_data) { "id=foo&test=bar%20baz&plus=one+two" }
+  let(:request) { instance_double Rack::Request, media_type: media_type }
+end

--- a/spec/request/generic_post_spec.rb
+++ b/spec/request/generic_post_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# It should not really matter which paths we test since the problematic
+# parsing of the body happens before the controller is even created and we
+# want to make sure it's disabled globally.
+
+describe 'POST handler', type: :request do
+  it 'does not interpret an urlencoded body' do
+    post '/the/path/does/not/really/matter', 'secret-api-key'
+    expect(request.params.to_s).to_not include 'secret-api-key'
+  end
+
+  it 'does not interpret a JSON body' do
+    post '/some/path', '{ "secretkey": "here" }',
+      'Content-Type': 'application/json'
+    expect(request.params.to_s).to_not include 'secretkey'
+  end
+
+  it 'does not interpret a body with multipart/mixed type' do
+    post '/some/path', '{ "secretkey": "here" }',
+      'Content-Type': 'multipart/mixed'
+    expect(request.params.to_s).to_not include 'secretkey'
+  end
+end


### PR DESCRIPTION
This fixes a problem where body data would end up being written to logs under some circumstances. Controllers that are actually expected to use body parameters have been changed to explicitly parse them.

Closes conjurinc/appliance#377