### PR TITLE
Add BodyParser to HostFactoryTokensController

### DIFF
--- a/app/controllers/host_factory_tokens_controller.rb
+++ b/app/controllers/host_factory_tokens_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HostFactoryTokensController < RestController
+  include BodyParser
   include FindResource
   include AuthorizeResource
 


### PR DESCRIPTION
Fixes request params not being parsed from the body of `x-www-form-urlencoded` requests when making requests to create or delete a host factory token
