### PR TITLE
Secure LDAP Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.3.2] - 2018-11-14
+## [Unreleased]
+### Added
+ - Added support for secure LDAP connections in the LDAP authenticator.
+ - Added support to configure the LDAP authenticator with policy instead
+   of environment variables.
 
+## [1.3.2] - 2018-11-14
 ### Fixed
 - Fixed request parameter parsing when creating or deleting a host factory token.
 - Updated ffi and loofah dependencies to latest versions of each.

--- a/app/domain/authentication/authn_ldap/configuration.rb
+++ b/app/domain/authentication/authn_ldap/configuration.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module Authentication
+  module AuthnLdap
+    # Provides the LDAP connections settings for a given
+    # authenticator config
+    class Configuration
+
+      def initialize(input, env, log: nil)
+        @input = input
+        @env = env
+        @log = log
+      end
+
+      def settings
+        {
+          connect_type: connect_type,
+          host: host,
+          port: port,
+          base: base_dn,
+          auth: auth,
+          encryption: encryption,
+          instrumentation_service: log
+        }.reject { |_, value| value == :not_configured }
+      end
+
+      def filter_template
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "filter_template"),
+          EnvironmentLoader.new(@env, "LDAP_FILTER"),
+          default: "(&(objectClass=posixAccount)(uid=%s))"
+        )
+      end
+
+      private 
+
+      def log
+        @log || :not_configured
+      end
+
+      def auth
+        return :not_configured unless bind_dn
+
+        {
+          method: :simple,
+          username: bind_dn,
+          password: bind_pw
+        }
+      end
+
+      def encryption
+        return :not_configured unless connect_type_secure?
+
+        {
+          method: connect_type_ssl? ? :simple_tls : :start_tls,
+          tls_options: tls_options
+        }
+      end
+
+      def tls_options
+        {
+          verify_mode: OpenSSL::SSL::VERIFY_PEER,
+          cert_store: LdapCaStore.new(tls_ca_cert).store
+        }
+      end
+
+      def host
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "host"),
+          default: uri.host
+        )
+      end
+
+      def port
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "port"),
+          default: uri.port || default_port
+        )
+      end
+
+      def default_port
+        connect_type_ssl? ? 636 : 389
+      end
+
+      # One of 'plain', 'tls', or 'ssl'
+      def connect_type
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "connect_type"),
+          default: uri_connect_type,
+          &:to_sym
+        )
+      end
+
+      def connect_type_secure?
+        %i(ssl tls).include?(connect_type)
+      end
+
+      def uri_connect_type
+        uri.scheme == 'ldaps' ? :ssl : :plain
+      end
+
+      def connect_type_ssl?
+        connect_type == :ssl
+      end
+
+      def uri
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "uri"),
+          EnvironmentLoader.new(@env, "LDAP_URI"),
+          default: ''
+        ) { |uri_str| URI(uri_str)}
+      end
+
+      def base_dn
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "base_dn"),
+          EnvironmentLoader.new(@env, "LDAP_BASE"),
+          default: :not_configured
+        ) 
+      end
+
+      def bind_dn
+        ConfigurationLoader.load(
+          AnnotationLoader.new(@input, "bind_dn"),
+          EnvironmentLoader.new(@env, "LDAP_BINDDN")
+        )
+      end
+
+      def bind_pw
+        ConfigurationLoader.load(
+          VariableLoader.new(@input, "bind-password"),
+          EnvironmentLoader.new(@env, "LDAP_BINDPW")
+        )
+      end
+
+      def tls_ca_cert
+        # "tls-ca-cert" is the correct annotation, "tls-cert" is allowed
+        # for compatibility with LDAP sync legacy annotations
+        ConfigurationLoader.load(
+          VariableLoader.new(@input, "tls-ca-cert"),
+          VariableLoader.new(@input, "tls-cert")
+        )
+      end     
+    end
+
+    # Specialized CA store for LDAP configuration
+    class LdapCaStore
+      class << self
+        def create_cert_file(ca_cert)
+          Tempfile.new('ca-cert').tap do |ca_cert_file|
+            ca_cert_file.write(ca_cert)
+            ca_cert_file.close
+          end
+        end
+      end
+
+      def initialize(ca_cert)
+        @ca_cert = ca_cert
+      end
+      
+      def store
+        @store ||= build_store
+      end
+
+      private
+
+      def build_store
+        OpenSSL::X509::Store.new.tap do |cert_store|
+          cert_store.set_default_paths
+          cert_store.add_file(self.class.create_cert_file(@ca_cert).path) if @ca_cert
+        end
+      rescue OpenSSL::X509::StoreError => ex
+        raise ArgumentError, "Invalid CA certificate in LDAP configuration: #{ex.message}"
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_ldap/configuration_loader.rb
+++ b/app/domain/authentication/authn_ldap/configuration_loader.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Authentication
+  module AuthnLdap
+
+    # Interface to load LDAP configuration variables from various
+    # config value locations.
+    #
+    # Will attempt to load the first valid value and will fallback
+    # to a default if provided.
+    #
+    # If a block is given, the value will be transformed by the block
+    # before returning.
+    class ConfigurationLoader
+      class << self
+        def load(*loaders, default: nil)
+          value = loaders.map(&:value).find(&:present?) || default
+          block_given? ? yield(value) : value
+        end
+      end
+    end
+
+    # Base class for loading configuration values from
+    # a Conjur Webservice object
+    class WebServiceLoader
+      def initialize(input)
+        @input = input
+      end
+
+      def webservice
+        @webservice ||= ::Authentication::Webservice.new(
+          account:            @input.account,
+          authenticator_name: @input.authenticator_name,
+          service_id:         @input.service_id
+        )
+      end
+    end
+
+    # Configuration loader for webservice annotations
+    class AnnotationLoader < WebServiceLoader
+      ANNOTATION_PREFIX = "ldap-authn/"
+
+      def initialize(input, name)
+        super(input)
+        @name = name
+      end
+
+      def value
+        webservice.annotation(ANNOTATION_PREFIX + @name)
+      end
+    end
+
+    # Configuration loader for webservice variables
+    class VariableLoader < WebServiceLoader
+      def initialize(input, name)
+        super(input)
+        @name = name
+      end
+
+      def value
+        webservice.variable(@name)&.secret&.value
+      end
+    end
+
+    # Configuration loader for environment variables
+    class EnvironmentLoader
+      def initialize(env, name)
+        @env = env
+        @name = name
+      end
+
+      def value
+        @env[@name]
+      end
+    end
+
+  end
+end

--- a/app/domain/authentication/authn_ldap/server.rb
+++ b/app/domain/authentication/authn_ldap/server.rb
@@ -8,28 +8,9 @@ module Authentication
   module AuthnLdap
 
     class Server
-
-      def self.new(uri:, base:, bind_dn:, bind_pw:, log: nil)
-        Net::LDAP.new(options(log)).tap do |ldap|
-          if uri
-            uri_obj = URI.parse(uri)
-            ldap.host = uri_obj.host
-            ldap.port = uri_obj.port
-            ldap.encryption(:simple_tls) if uri_obj.scheme == 'ldaps'
-          end
-
-          ldap.auth(bind_dn, bind_pw) if bind_dn
-          ldap.base = base
-        end
+      def self.new(config)
+        Net::LDAP.new(config.settings)
       end
-
-      private
-
-      def self.options(log)
-        log ? {instrumentation_service: log} : {}
-      end
-
     end
-
   end
 end

--- a/app/domain/authentication/webservice.rb
+++ b/app/domain/authentication/webservice.rb
@@ -13,9 +13,12 @@ require 'types'
 
 module Authentication
   class Webservice < ::Dry::Struct
+    constructor_type :schema
+
     attribute :account,            ::Types::NonEmptyString
     attribute :authenticator_name, ::Types::NonEmptyString
     attribute :service_id,         ::Types::NonEmptyString.optional
+    attribute :resource_class,     (::Types::Any.default { ::Resource })
 
     def self.from_string(account, str)
       type, id = *str.split('/', 2)
@@ -28,6 +31,26 @@ module Authentication
 
     def resource_id
       "#{account}:webservice:conjur/#{name}"
+    end
+
+    def resource
+      @resource ||= resource_class[resource_id]
+    end
+
+    def annotation(name)
+      resource&.annotation(name)
+    end
+
+    # Retrieves a Conjur variable relative to the webservice.
+    # This is used to read configuration values stored as
+    # Conjur secrets.
+    def variable(variable_name)
+      resource_class[variable_id(variable_name)]
+    end
+
+    def variable_id(variable_name)
+      identifier = "conjur/#{name}/#{variable_name}"
+      [account, "variable", identifier].join(":")
     end
   end
 end

--- a/ci/authn-ldap/conjur.env
+++ b/ci/authn-ldap/conjur.env
@@ -1,4 +1,4 @@
-CONJUR_AUTHENTICATORS="authn-ldap/test"
+CONJUR_AUTHENTICATORS="authn-ldap/test,authn-ldap/secure"
 LDAP_URI="ldap://ldap-server:389"
 LDAP_BASE="dc=conjur,dc=net"
 LDAP_FILTER="'(uid=%s)'"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       CONJUR_ACCOUNT: cucumber
       CONJUR_DATA_KEY:
       RAILS_ENV:
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-oidc/keycloak
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'
@@ -24,6 +24,7 @@ services:
     volumes:
       - authn-local:/run/authn-local
       - ./authn-oidc/keycloak:/authn-oidc/keycloak/scripts
+      - ldap-certs:/ldap-certs
     expose:
       - "80"
     links:
@@ -45,6 +46,7 @@ services:
       - ..:/src/conjur-server
       - authn-local:/run/authn-local
       - ./authn-oidc/phantomjs:/authn-oidc/phantomjs/scripts
+      - ldap-certs:/ldap-certs
     links:
       - conjur
       - pg
@@ -54,12 +56,15 @@ services:
   ldap-server:
     image: osixia/openldap
     command: --copy-service --loglevel debug
+    hostname: ldap-server
     environment:
       LDAP_ORGANISATION: CyberArk
       LDAP_DOMAIN: conjur.net
       LDAP_ADMIN_PASSWORD: ldapsecret
+      LDAP_TLS_VERIFY_CLIENT: allow
     volumes:
       - ./authn-ldap/ldap-data:/container/service/slapd/assets/config/bootstrap/ldif/custom
+      - ldap-certs:/ldap-certs
 
   oidc-keycloak:
     image: jboss/keycloak:4.3.0.Final
@@ -78,3 +83,4 @@ services:
 
 volumes:
   authn-local:
+  ldap-certs:

--- a/ci/test
+++ b/ci/test
@@ -66,6 +66,18 @@ function run_cucumber_tests() {
   docker-compose down --rmi 'local' --volumes
 }
 
+function prepare_env_auth_ldap() {
+  docker-compose up --no-deps -d ldap-server
+
+  docker-compose exec -T ldap-server bash -c "
+    while [[ ! -f /container/run/service/slapd/assets/certs/ca.crt ]]
+    do
+      sleep 2
+    done
+    cp /container/run/service/slapd/assets/certs/*.crt /ldap-certs/
+  "
+}
+
 function prepare_env_auth_oidc() {
   docker-compose up --no-deps -d pg conjur oidc-keycloak
 
@@ -154,6 +166,7 @@ fi
 if [[ $RUN_AUTHENTICATORS = true || $RUN_ALL = true ]]; then
   services="$services oidc-keycloak ldap-server"
   prepare_env_auth_oidc
+  prepare_env_auth_ldap
   run_cucumber_tests 'authenticators'
 fi
 

--- a/cucumber/authenticators/features/step_definitions/authn_ldap_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/authn_ldap_steps.rb
@@ -3,17 +3,19 @@
 # Uses cucumber's multiline string feature: https://bit.ly/2vpzqJx
 #
 
-When(/I login via LDAP as (?:\S)+ Conjur user "(\S+)"/) do |username|
-  login_with_ldap(service_id: 'test', account: 'cucumber', 
+When(/I login via( secure)? LDAP as (?:\S)+ Conjur user "(\S+)"/) do |secure, username|
+  service_id = secure ? 'secure' : 'test'
+  login_with_ldap(service_id: service_id, account: 'cucumber', 
                   username: username, password: username)
 end
 
 # First non-captured group allows for adjectives to clarify the
 # purpose of the test.  They aren't actually used.
 #
-When(/I authenticate via LDAP as (?:\S)+ Conjur user "(\S+)"( using key)?/) do |username, using_key|
+When(/I authenticate via( secure)? LDAP as (?:\S)+ Conjur user "(\S+)"( using key)?/) do |secure, username, using_key|
   password = using_key ? ldap_auth_key : username
-  authenticate_with_ldap(service_id: 'test', account: 'cucumber', 
+  service_id = secure ? 'secure' : 'test'
+  authenticate_with_ldap(service_id: service_id, account: 'cucumber', 
                          username: username, api_key: password)
 end
 
@@ -35,4 +37,12 @@ end
 
 Then(/it is forbidden/) do
   expect(forbidden?).to be true
+end
+
+Given(/^I store the LDAP bind password in "([^"]*)"$/) do |variable_name|
+  save_variable_value('cucumber', variable_name, 'ldapsecret')
+end
+
+Given(/^I store the LDAP CA certificate in "([^"]*)"$/) do |variable_name|
+  save_variable_value('cucumber', variable_name, ldap_ca_certificate_value)
 end

--- a/cucumber/authenticators/features/support/authenticator_helpers.rb
+++ b/cucumber/authenticators/features/support/authenticator_helpers.rb
@@ -33,6 +33,15 @@ module AuthenticatorHelpers
     post(path, api_key)
   end
 
+  def save_variable_value(account, variable_name, value)
+    resource_id = [account, "variable", variable_name].join(":")
+    conjur_api.resource(resource_id).add_value(value)
+  end
+
+  def ldap_ca_certificate_value
+    @ldap_ca_certificate_value ||= File.read('/ldap-certs/ca.crt')
+  end
+
   def login_with_oidc(service_id:, account:)
     path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/login"
     payload = { code: oidc_auth_code, redirect_uri: oidc_redirect_uri }

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     - ..:/src/conjur-server
     - ../../conjur-policy-parser:/src/conjur-policy-parser
     - authn-local:/run/authn-local
+    - ldap-certs:/ldap-certs
     links:
     - pg:pg
     - ldap-server
@@ -49,6 +50,7 @@ services:
     volumes:
       - ..:/src/conjur-server
       - authn-local:/run/authn-local
+      - ldap-certs:/ldap-certs
     links:
       - conjur
       - pg
@@ -70,13 +72,16 @@ services:
   ldap-server:
     image: osixia/openldap
     command: --copy-service --loglevel debug
+    hostname: ldap-server
     environment:
       LDAP_ORGANISATION: CyberArk
       LDAP_DOMAIN: conjur.net
       LDAP_ADMIN_PASSWORD: ldapsecret
+      LDAP_TLS_VERIFY_CLIENT: allow
 
     volumes:
       - ./files/authn-ldap/ldap:/container/service/slapd/assets/config/bootstrap/ldif/custom
+      - ldap-certs:/ldap-certs
 
   oidc-keycloak:
     image: jboss/keycloak
@@ -118,3 +123,4 @@ services:
 
 volumes:
   authn-local:
+  ldap-certs:

--- a/dev/start
+++ b/dev/start
@@ -66,7 +66,7 @@ if [[ $ENABLE_AUTHN_LDAP = true ]]; then
   env_args="$env_args -e LDAP_BINDDN=cn=admin,dc=conjur,dc=net"
   env_args="$env_args -e LDAP_BINDPW=ldapsecret"
 
-  enabled_authenticators="$enabled_authenticators,authn-ldap/test"
+  enabled_authenticators="$enabled_authenticators,authn-ldap/test,authn-ldap/secure"
 
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-ldap/policy.yml
 fi
@@ -142,6 +142,12 @@ docker-compose up -d --no-deps $services
 
 api_key=$(docker-compose exec -T conjur conjurctl \
 	role retrieve-key cucumber:user:admin | tr -d '\r')
+
+if [[ $ENABLE_AUTHN_LDAP = true ]]; then
+  docker-compose exec ldap-server bash -c "
+    cp /container/run/service/slapd/assets/certs/*.crt /ldap-certs/
+  "
+fi
 
 docker exec -e CONJUR_AUTHN_API_KEY=$api_key $env_args \
   -it --detach-keys 'ctrl-\' "$(docker-compose ps -q conjur)" bash


### PR DESCRIPTION
#### What does this PR do?
This PR:
* Adds support for LDAP authentication over TLS or SSL to the LDAP server
* Moves LDAP authenticator configuration to policy annotation and variables, rather than environment variables

#### Any background context you want to provide?

This is motivated by https://github.com/conjurinc/ldap-sync/issues/103, fixing support for syncing users over a secure LDAP connection. After syncing, those users will need to be able to authenticate over a similarly secure LDAP connection. 

Additionally, LDAP sync is configured using policy, which allows for greater flexibility and privacy of values such as the bind password or TLS certificate. The move to policy instead of environment variables for configuration makes LDAP authentication more similar to LDAP sync to configure.

#### What ticket does this PR close?
Connected to #777

#### How should this be manually tested?
This may be manually tested using the demo environment in https://github.com/conjurdemos/conjur-intro/tree/master/demos/ldap-integration on the `secure-ldap-authentication` branch.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/secure-ldap-sync/

#### Has the Version and Changelog been updated?

CHANGELOG has been updated

#### Questions:
> Does this work have automated integration and unit tests?

Yes

> Has this change been documented (Readme, docs, etc.)?

- [ ] TODO: Create ticket for docs update
