### PR TITLE
Add CIDR hostfactory test

### DIFF
--- a/app/controllers/host_factory_tokens_controller.rb
+++ b/app/controllers/host_factory_tokens_controller.rb
@@ -13,7 +13,7 @@ class HostFactoryTokensController < RestController
     expiration = params.delete(:expiration) or raise ArgumentError, "expiration"
     count = (params.delete(:count) || 1).to_i
     cidr = params.delete(:cidr)
-    
+
     options = {
       resource: host_factory,
       expiration: DateTime.iso8601(expiration)
@@ -24,29 +24,29 @@ class HostFactoryTokensController < RestController
     count.times do
       tokens << HostFactoryToken.create(options)
     end
-    
+
     render json: tokens
   end
-  
+
   def destroy
     authorize :update
-    
+
     @token.destroy
-    
+
     head 204
   end
-  
+
   protected
-  
+
   def host_factory; @resource; end
-  
+
   def find_token
     id = params[:id]
     @token = HostFactoryToken.from_token(id) or raise RecordNotFound, "*:host_factory_token:#{id}"
     @resource = @token.host_factory
     @resource_id = @resource.id
   end
-  
+
   def resource_id
     @resource_id ||= \
       params[:host_factory] or raise ArgumentError, "host_factory"

--- a/app/models/host_factory_token.rb
+++ b/app/models/host_factory_token.rb
@@ -6,12 +6,12 @@ class HostFactoryToken < Sequel::Model
   plugin :validation_helpers
 
   unrestrict_primary_key
-  
+
   attr_encrypted :token
   many_to_one :resource, reciprocal: :host_factory_tokens
 
   alias host_factory resource
-  
+
   class << self
     # Generates a random token.
     #
@@ -39,7 +39,7 @@ class HostFactoryToken < Sequel::Model
       response[:token] = token
     end
   end
-  
+
   def valid? origin: nil
     return false if expired?
     return true unless origin
@@ -60,7 +60,7 @@ class HostFactoryToken < Sequel::Model
   def expired?
     Time.now >= self.expiration
   end
-  
+
   def validate
     super
 
@@ -69,10 +69,10 @@ class HostFactoryToken < Sequel::Model
 
   def before_create
     super
-    
+
     generate_token
   end
-   
+
   private
 
   def generate_token

--- a/cucumber/api/features/host_factory_create_token.feature
+++ b/cucumber/api/features/host_factory_create_token.feature
@@ -32,3 +32,21 @@ Feature: Create a host factory token.
       }
     ]
     """
+
+  Scenario: A host factory token can be created by specifying an expiration time and CIDR.
+    Given I permit user "alice" to "execute" it
+    And I login as "alice"
+    When I successfully POST "/host_factory_tokens?host_factory=cucumber:host_factory:the-layer-factory&expiration=2050-12-31&cidr[]=123.234.0.0/16&cidr[]=222.222.222.0/24"
+    Then the JSON should be:
+    """
+    [
+      {
+        "cidr": [
+          "123.234.0.0/16",
+          "222.222.222.0/24"
+        ],
+        "expiration": "2050-12-31T00:00:00Z",
+        "token": "@host_factory_token_token@"
+      }
+    ]
+    """


### PR DESCRIPTION
#### What does this PR do?
- Adds a test for host_factory_token creation CIDR setting
- Cleans up whitespace in host_factory controller and model

#### Any background context you want to provide?
CIDR is not being honored from the CLI and this ensures that the API is not the culprit. It also adds a test for setting CIDR which we really needed anyways.

#### What ticket does this PR close?
Doesn't close any tickets but it ensures that the API works for https://github.com/conjurinc/appliance/issues/521

#### Where should the reviewer start?
Test coverage + the diff

#### How should this be manually tested?
Run cucumber tests on host_factory_tokens feature

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/view/conjurinc/job/cyberark--conjur/job/add-cidr-hostfactory-test/