### PR TITLE
Add audit option to the Conjur dev environment

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   pg:
     image: postgres:9.4
 
+  audit:
+    image: postgres:9.4
+
   testdb:
     image: postgres:9.3
     environment:
@@ -21,6 +24,7 @@ services:
       CONJUR_PASSWORD_ALICE: secret
       CONJUR_DATA_KEY:
       RAILS_ENV:
+      AUDIT_DATABASE_URL:
     ports:
       - "3000:3000"
     expose:

--- a/dev/start
+++ b/dev/start
@@ -17,6 +17,8 @@ Usage: start [options]
 
     --authn-oidc    Starts with authn-oidc/okta as authenticator
 
+    --audit         Starts with the audit engine and database enabled
+
     -h, --help      Shows this help message.
 EOF
   exit
@@ -29,12 +31,14 @@ ENABLE_AUTHN_LDAP=false
 ENABLE_AUTHN_IAM=false
 ENABLE_AUTHN_OIDC=false
 ENABLE_ROTATORS=false
+ENABLE_AUDIT=false
 while true ; do
   case "$1" in
     --authn-iam ) ENABLE_AUTHN_IAM=true ; shift ;;
     --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
     --authn-oidc ) ENABLE_AUTHN_OIDC=true ; shift ;;
     --rotators ) ENABLE_ROTATORS=true ; shift ;;
+    --audit ) ENABLE_AUDIT=true ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac
@@ -135,6 +139,11 @@ if [[ $ENABLE_AUTHN_IAM = true ]]; then
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-iam/policy.yml
 fi
 
+if [[ $ENABLE_AUDIT = true ]]; then
+  services="$services audit"
+  export AUDIT_DATABASE_URL=postgres://postgres@audit
+fi
+
 echo "Setting CONJUR_AUTHENTICATORS to: $enabled_authenticators"
 env_args="$env_args -e CONJUR_AUTHENTICATORS=$enabled_authenticators"
 
@@ -142,6 +151,15 @@ docker-compose up -d --no-deps $services
 
 api_key=$(docker-compose exec -T conjur conjurctl \
 	role retrieve-key cucumber:user:admin | tr -d '\r')
+
+if [[ $ENABLE_AUDIT = true ]]; then
+  # Run database migration to create audit database schema
+  docker-compose exec -T conjur bash -c '
+  BUNDLE_GEMFILE=/src/conjur-server/Gemfile \
+    bundle exec sequel $AUDIT_DATABASE_URL \
+    -E -m /src/conjur-server/engines/conjur_audit/db/migrate/
+  '
+fi
 
 docker exec -e CONJUR_AUTHN_API_KEY=$api_key $env_args \
   -it --detach-keys 'ctrl-\' "$(docker-compose ps -q conjur)" bash

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,10 +1,12 @@
-# Conjur v5 RFC5424 event specification
+# Conjur v5 Audit
 
-## Entry structure
+## RFC5424 event specification
+
+### Entry structure
 
 Compare for section 6 of RFC 5424 for full explanation of the different fields.
 
-### Priority
+#### Priority
 
 Priority header field is a decimal specification of facility and severity of the message.
 Conjur messages use facility 4 (traditionally called 'auth'); messages related to user authentication use facility 10 ('authpriv').
@@ -14,27 +16,27 @@ Severity depends on the kind of event:
 - model and value changes -- severity 5 ('notice'),
 - successful permission checks, value fetches -- severity 6 ('info').
 
-### Version
+#### Version
 
 `1` as specified by the RFC.
 
-### Timestamp
+#### Timestamp
 
 Conjur will always emit UTC timestamps with at least millisecond precision.
 
-### Hostname
+#### Hostname
 
 The full host name of the Conjur server as best can be determined.
 
-### Application name
+#### Application name
 
 `conjur`
 
-### Process ID
+#### Process ID
 
 For messages generated in response to web request, this is a web request GUID. For messages generated for local action, it's the OS process identifier of the originator.
 
-### Message ID
+#### Message ID
 
 This field is the type of event. Allowed values:
 - `authn` for authentication events,
@@ -43,18 +45,18 @@ This field is the type of event. Allowed values:
 - `policy` for policy changes,
 - `update` for value changes.
 
-### Structured data
+#### Structured data
 
 Note: 43868 is the IANA-assigned Private Enterprise Number for Conjur.
 
-#### policy@43868
+##### policy@43868
 
 This SD-ID is used in `policy` messages. All parameters are required.
 
 - `id`: fully-qualified policy id,
 - `version`: numeric policy version.
 
-#### subject@43868
+##### subject@43868
 
 This SD-ID specifies the Conjur entity that is the subject of this message. 
 All parameters are optional and depend on the specific event.
@@ -68,14 +70,14 @@ All identifiers are fully-qualified.
 - `role`: subject role id,
 - `version`: when fetching a secret given explicit version, that version.
 
-#### action@43868
+##### action@43868
 
 This SD-ID specifies the action performed and/or its result. 
 
 - `operation`: optional, one of: `add`, `authenticate`, `remove`, `change`, `update`, `check`, `fetch`,
 - `result`: on authentication or permission check, one of: `success`, `failure`.
 
-#### auth@43868
+##### auth@43868
 
 This SD-ID is used on every event log caused by an authenticated user or on
 attempted authentication.
@@ -87,39 +89,39 @@ attempted authentication.
 - `authenticator`: when authenticating, the name of the authenticator being used.
 - `service`: when authenticating, the fully qualified id of the service requested.
 
-### Message
+#### Message
 
 The body of the message should provide English-language summary of the event.
 
-## Message types
+### Message types
 
-### `authn` messages
+#### `authn` messages
 
 These messages always have subject@43868/role parameter set to the role on which
 authentication is attempted. The facility number is 10.
 
-#### Examples
+##### Examples
 
         <86>1 - - conjur - authn [subject@43868 role="example:user:alice"][auth@43868 authenticator="authn-ldap" service="example:webservice:bacon"][action@43868 operation="authenticate" result="success"] example:user:alice successfully authenticated with authenticator authn-ldap service example:webservice:bacon
 
-### `check` messages
+#### `check` messages
 
 Permission checks (whether failed or successful) emit these messages. Failed
 checks carry _warning_ (4) severity, successful _info_ (6).
 
-#### Examples
+##### Examples
 
         <38>1 - - conjur - check [auth@43868 user="cucumber:user:charlie"][subject@43868 role="cucumber:user:bob" resource="cucumber:chunky:bacon" privilege="fry"][action@43868 operation="check" result="success"] cucumber:user:charlie checked if cucumber:user:bob can fry cucumber:chunky:bacon (success)
 
-### `fetch` messages
+#### `fetch` messages
 
 If a specific version of a secret was requested, `version` parameter will be present in the `subject@43868` field.
 
-#### Examples
+##### Examples
 
         <38>1 - - conjur - fetch [subject@43868 resource="example:variable:dbpass"][auth@43868 user="example:user:alice"][action@43868 operation="fetch"] example:user:alice fetched example:variable:dbpass
 
-### `update` messages
+#### `update` messages
 
 These messages are generated when a secret value is changed. They have
 _subject@43868/resource_ pointing to the resource that was modified.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,5 +1,39 @@
 # Conjur v5 Audit
 
+Conjur audit is a Rails engine that adds support to Conjur for storing audit records in a PostgreSQL
+database.
+
+## Developing
+
+To start a development environment that includes and enables Conjur audit:
+
+1. Navigate to the development environment directory
+    ```sh-session
+    cd dev
+    ```
+
+2. Start the development environment with the audit flag
+    ```sh-session
+    ./start --audit
+    ```
+
+## Testing
+
+To run the audit RSpec tests:
+
+1. Start the development environment as described in the previous section.
+
+2. Open a CLI session in the development environment
+    ```sh-session
+    ./cli exec
+    ```
+3. Run the rspec tests from the engine directory
+    ```sh-session
+    pushd engines/conjur_audit
+    rake
+    popd
+    ```
+
 ## RFC5424 event specification
 
 ### Entry structure

--- a/engines/conjur_audit/spec/db_helper.rb
+++ b/engines/conjur_audit/spec/db_helper.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 shared_context "database setup" do
-  let(:db) { Sequel::Model.db }
 
-  before { db[:messages].truncate }
+  let(:db_uri) { ENV['AUDIT_DATABASE_URL'] || 'postgres://postgres@pg/postgres' }
+  let(:db) { Sequel.connect db_uri }
+
+  before do
+    db.extension :pg_json
+    ConjurAudit::Message.set_dataset db[:messages]
+    db[:messages].truncate 
+  end
 
   around do |ex|
     db.transaction do


### PR DESCRIPTION
#### What does this PR do?
This PR updates the development environment tools to include an option to configure the audit Rails engine for development and testing.

#### Any background context you want to provide?
This is in support of #754. In order to add the tests and make any necessary changes for special character handling, I first need a way to easily run the audit tests.

#### What ticket does this PR close?
Connected to #803 

#### Where should the reviewer start?
See the new instructions in `docs/AUDIT.md` for starting a dev environment with audit and running the RSpec tests.

#### How should this be manually tested?
See above

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/803-audit-dev-env/

#### Has the Version and Changelog been updated?
No. Nothing outside of the dev/test environment has changed.

#### Questions:
> Does this work have automated integration and unit tests?
No. There is a follow-up issue to add these tests to CI here: #574 

> Can we make a blog post, video, or animated GIF of this?
I don't think so.

> Has this change been documented (Readme, docs, etc.)?
Yes

> Does the knowledge base need an update?
I don't think so.