### PR TITLE
Add Audit tests to CI Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dhparam.pem
 .byebug_history
 config/database.yml
 reports
+reports-audit
 demo/run/finished
 demo/run/load
 /run

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,10 +43,13 @@ pipeline {
         stage('Kubernetes 1.7 in GKE') {
           steps { sh 'cd ci/authn-k8s && summon ./test.sh gke' }
         }
+        stage('Audit') {
+          steps { sh 'cd ci && ./test --rspec-audit'}
+        }
       }
       post {
         always {
-          junit 'spec/reports/*.xml,cucumber/api/features/reports/**/*.xml,cucumber/policy/features/reports/**/*.xml,cucumber/authenticators/features/reports/**/*.xml'
+          junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/api/features/reports/**/*.xml,cucumber/policy/features/reports/**/*.xml,cucumber/authenticators/features/reports/**/*.xml'
           publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false])
         }
       }

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   pg:
     image: postgres:9.3
 
+  audit:
+    image: postgres:9.4
+
   testdb:
     image: postgres:9.3
 
@@ -39,6 +42,7 @@ services:
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: cucumber
       DATABASE_URL: postgres://postgres@pg/postgres
+      AUDIT_DATABASE_URL:
       RAILS_ENV: test
       CONJUR_DATA_KEY:
       REPORT_ROOT:

--- a/ci/test
+++ b/ci/test
@@ -25,6 +25,8 @@ GLOBAL OPTIONS
 
     --rspec                                   - Runs RSpec specs
 
+    --rspec-audit                             - Runs RSpecs for the Audit engine
+
 EOF
 exit
 }
@@ -135,6 +137,7 @@ RUN_ROTATORS=false
 RUN_API=false
 RUN_POLICY=false
 RUN_RSPEC=false
+RUN_AUDIT_RSPEC=false
 while true ; do
   case "$1" in
     --cucumber-rotators ) RUN_ALL=false ; RUN_ROTATORS=true ; shift ;;
@@ -142,6 +145,7 @@ while true ; do
     --cucumber-api ) RUN_ALL=false ; RUN_API=true ; shift ;;
     --cucumber-policy ) RUN_ALL=false ; RUN_POLICY=true ; shift ;;
     --rspec ) RUN_ALL=false ; RUN_RSPEC=true ; shift ;;
+    --rspec-audit ) RUN_ALL=false ; RUN_AUDIT_RSPEC=true ; shift ;;
     -h | --help ) print_help ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac
@@ -175,6 +179,32 @@ fi
 
 if [[ $RUN_POLICY = true || $RUN_ALL = true ]]; then
   run_cucumber_tests 'policy'
+fi
+
+if [[ $RUN_AUDIT_RSPEC = true || $RUN_ALL = true ]]; then
+  export AUDIT_DATABASE_URL=postgres://postgres@audit/postgres
+  # Start Conjur with the audit database
+  docker-compose up --no-deps -d audit pg
+
+  # Wait for audit database to be ready
+  until docker-compose run -T --rm audit psql -U postgres -h audit -c "select 1" -d postgres; do sleep 1; done
+
+  #prepare_env_audit
+  docker-compose run -T --rm --no-deps cucumber -c "
+    # Run DB migration for audit database
+    BUNDLE_GEMFILE=/src/conjur-server/Gemfile \
+      bundle exec sequel $AUDIT_DATABASE_URL \
+      -E -m /src/conjur-server/engines/conjur_audit/db/migrate/
+    
+    rm -rf $REPORT_ROOT/spec/reports-audit
+
+    # Run tests from audit engine directory
+    pushd engines/conjur_audit
+    BUNDLE_GEMFILE=/src/conjur-server/Gemfile \
+    CI_REPORTS=$REPORT_ROOT/spec/reports-audit bundle exec rspec \
+      --format progress --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter
+    popd
+  "
 fi
 
 if [[ $RUN_RSPEC = true || $RUN_ALL = true ]]; then


### PR DESCRIPTION
#### What does this PR do?
This PR adds the exist Audit RSpec tests to the CI pipeline for Conjur.

#### Any background context you want to provide?
This is in support of #754. Once tests are added for special character handling, they should be executed during CI to verify correct behavior and to prevent future regression.

#### What ticket does this PR close?
Connected to #574 

#### Where should the reviewer start?
The addition of audit test to the CI pipeline is implemented in `ci/test`. The outcome of this may be reviewed in the Jenkins build: https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/574-ci-audit-tests/2/pipeline

#### How should this be manually tested?
This CI integration may be run locally in the repo by running:
```sh-session
cd ci && ./test --rspec-audit
```

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/574-ci-audit-tests/

#### Has the Version and Changelog been updated?
No, this PR only changes the CI pipeline.

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
I don't think so

> Has this change been documented (Readme, docs, etc.)?
No, the documentation for running the tests manually was previously add in #805

> Does the knowledge base need an update?
No