### PR TITLE
Fix Escaping for Audit Log Formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed Syslog formatting to properly escape the closing square bracket (]) per RFC 5424
 
 ### Changed
 - Updated dependencies and Ruby version of Docker image

--- a/lib/logger/formatter/rfc5424_formatter.rb
+++ b/lib/logger/formatter/rfc5424_formatter.rb
@@ -74,7 +74,11 @@ class Logger
         end
 
         def self.sd_parameters params
-          params.map { |parameter, value| [parameter, value.to_s.inspect].join('=') }
+          # Ensure quote, backslash, and closing square bracket are all escaped per:
+          # https://tools.ietf.org/html/rfc5424#section-6.3.3
+          #
+          # `inspect` handles quote and backslash, gsub handles the square bracket
+          params.map { |parameter, value| [parameter, value.to_s.inspect.gsub("]", "\\]")].join('=') }
         end
       end
     end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -8,5 +8,27 @@ describe Logger::Formatter::RFC5424Formatter do
     expect(formatter.call(3, Time.now, nil, msg)).to start_with '<43>'
   end
 
+  describe "with structured data" do
+    describe "escapes" do
+      it "quote" do
+        params = { quote: '"' }
+        formatted = described_class::Format.sd_parameters params
+        expect(formatted).to eq ["quote=\"\\\"\""]
+      end
+
+      it "backslash" do
+        params = { backslash: '\\' }
+        formatted = described_class::Format.sd_parameters params
+        expect(formatted).to eq ["backslash=\"\\\\\""]
+      end
+
+      it "bracket" do
+        params = { bracket: ']' }
+        formatted = described_class::Format.sd_parameters params
+        expect(formatted).to eq ["bracket=\"\\]\""]
+      end
+    end
+  end
+
   subject(:formatter) { described_class }
 end


### PR DESCRIPTION
#### What does this PR do?

This PR adds tests for the RFC 5424 (syslog) formatter to verify the character escaping for double-quote, backslash, and closing square bracket. It also fixes a bug in the formatter where it did not escape the closing square bracket.

#### Any background context you want to provide?

RFC 5424 specifies that the double quote ("), backslash (\) and closing square bracket (]) must be escaped in the structured data parameters of the syslog protocol [1]. The audit log RFC 5424 was escaping quote and backslash by using the `.inspect` method on Ruby strings. This did not escape closing bracket, which leads to audit log errors if a structured data parameter (e.g. Conjur Resource ID) contained this character.

See #754 for me details on the original error.

[1] https://tools.ietf.org/html/rfc5424#section-6.3.3

#### What ticket does this PR close?
Connected to #804 

#### Where should the reviewer start?

* See the new tests in `spec/logger_spec.rb`
* See the code change for the formatter in `lib/logger/formatter/rfc5424_formatter.rb`

#### How should this be manually tested?

This can be manually tested by running the rspec tests for conjur:
```sh-session
cd ci && ./test --rspec
```

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/804-audit-test-escaping/

#### Has the Version and Changelog been updated?
The changelog has been updated.

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
I'm not sure, but I don't think so.

> Has this change been documented (Readme, docs, etc.)?
No

> Does the knowledge base need an update?
I don't think so