### PR TITLE
Pre-compile Rails Assets on Docker Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Updated Docker build to pre-compile Rails assets for Conjur image
+
 ## [1.3.4] - 2018-12-19
 ### Changed
 - Updated dependencies and Ruby version of Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,11 @@ RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
 
 ENV RAILS_ENV production
 
+# The Rails initialization expects the database configuration
+# and data key to exist. We supply placeholder values so that
+# the asset compilation can complete.
+RUN DATABASE_URL=postgresql:does_not_exist \
+    CONJUR_DATA_KEY=$(openssl rand -base64 32) \
+    bundle exec rake assets:precompile 
+
 ENTRYPOINT [ "conjurctl" ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,9 @@ module Possum
 
     config.sequel.after_connect = proc do
       Sequel.extension :core_extensions, :postgres_schemata
+      Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore
+    rescue
+      raise unless is_asset_precompile?
     end
 
     config.encoding = "utf-8"
@@ -68,5 +71,9 @@ module Possum
     # ParamsParser can cause data from the body to end up in params and then
     # in logs. It's better to explicitly parse the body where needed.
     config.middleware.delete ActionDispatch::ParamsParser
+
+    def self.is_asset_precompile?
+      /assets:precompile/.match?(ARGV.join(' '))
+    end
   end
 end

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -2,7 +2,6 @@
 
 Sequel.split_symbols = true
 Sequel.extension :core_extensions, :postgres_schemata
-Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore
 Sequel::Model.plugin :validation_helpers
 
 class Sequel::Model

--- a/engines/conjur_audit/lib/conjur_audit/engine.rb
+++ b/engines/conjur_audit/lib/conjur_audit/engine.rb
@@ -9,6 +9,7 @@ module ConjurAudit
       if (db = config.audit_database)
         db = Sequel.connect db
         db.extension :pg_json
+        Message.db.extension :pg_json
         Message.set_dataset db[:messages]
       end
     end
@@ -22,7 +23,6 @@ module ConjurAudit
     end
     
     initializer :load_sequel_extensions do
-      Message.db.extension :pg_json
       Sequel.extension :pg_json_ops
     end
   end


### PR DESCRIPTION
#### What does this PR do?
This PR updates the docker build to precompile the Rails assets for Conjur.

#### Any background context you want to provide?
Previously, the initial connection to the Conjur container would take several seconds to complete due to asset compilation. This caused issues in systems such as Kubernetes, where the slow initial connection could surpass the health check timeout and cause the health check to fail. 

#### What ticket does this PR close?
Connected to #830 

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/job/cyberark--conjur/job/830-asset-precompile/

#### Has the Version and Changelog been updated?
Yes