### PR TITLE
Removes Anchore.io image scan badge due to service sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![Conjur on DockerHub](https://img.shields.io/docker/pulls/cyberark/conjur.svg)](https://hub.docker.com/r/cyberark/conjur/)
 [![Conjur on Quay.io](https://img.shields.io/badge/quay%20build-automated-0db7ed.svg)](https://quay.io/repository/cyberark/conjur)
-[![Anchore Image Overview](https://img.shields.io/badge/image%20overview-cyberark%2Fconjur-blue.svg)](https://anchore.io/image/dockerhub/cyberark%2Fconjur%3Alatest)
 
 [![Join Conjur Slack](https://img.shields.io/badge/slack-open-e01563.svg)][slack]
 [![Follow Conjur on Twitter](https://img.shields.io/twitter/follow/conjurinc.svg?style=social&label=Follow%20%40ConjurInc)][twitter]


### PR DESCRIPTION
#### What does this PR do?

Removes a badge from README.md, which links to our (now non-existant) anchore.io scan.

#### Any background context you want to provide?

Anchore decided to sunset anchore.io. At the moment we don't have a replacement,
so removing this badge.

#### Where should the reviewer start?

Take a look at the README, make sure it isn't messed up.