### PR TITLE
Added a pre-generated dhparam file for ldap test server

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       LDAP_ORGANISATION: CyberArk
       LDAP_DOMAIN: conjur.net
       LDAP_ADMIN_PASSWORD: ldapsecret
+      LDAP_TLS_DH_PARAM_FILENAME: "dhparam.pem"
       LDAP_TLS_CA_CRT_FILENAME: "ca-chain.cert.pem"
       LDAP_TLS_CRT_FILENAME: "ldap-server.cert.pem"
       LDAP_TLS_KEY_FILENAME: "ldap-server.key.pem"

--- a/ci/ldap-certs/.gitignore
+++ b/ci/ldap-certs/.gitignore
@@ -1,0 +1,1 @@
+!dhparam.pem

--- a/ci/ldap-certs/dhparam.pem
+++ b/ci/ldap-certs/dhparam.pem
@@ -1,0 +1,8 @@
+-----BEGIN DH PARAMETERS-----
+MIIBCAKCAQEAqtJnSpSax/oGFs7LnFsQ3m6oshC9la+uu53+aHBzT2XElLhVzFRe
+e91P87ezsE0R6frF45zzznYzfwRg/UDfBptbywa5mW6e2SJMWSggn43RA1rBezY2
+sYc8692HUX+opsMNBZMPqs7hN7cD1EbBo5fHDyRyhVlhHUZgavvDLIbjuSSVdGVw
+f6goxhkvBy6ft65rULzzZV/CidS6Y/KFi7NV0fwfi/Uog8wdQOH/4vu6GgsQwyJn
+/a2k/x4R3N5oBvs15MUSNuZcDmFooqZxdC+9FyjLL9/J3bdmnJpC20oaxr6Ul7/Q
+JQBPS9oag6saT7UAaaycejFkrhsGwKJt+wIBAg==
+-----END DH PARAMETERS-----


### PR DESCRIPTION
Given that the server keeps regenerating the dhparams on each start and
they can take a really long time, we now just set a pre-genearted one to
ensure that we don't take time to start the test server up.

#### Any background context you want to provide?
Test runs were failing to build due to ldap timout

#### What ticket does this PR close?
Connected to https://github.com/cyberark/conjur/issues/849

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--conjur/job/fix-slow-ldap-test-server-start/)

#### How should this be manually tested?
Running tests manually

#### Link to build in Jenkins (if appropriate)
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--conjur/job/fix-slow-ldap-test-server-start/)

#### Has the Version and Changelog been updated?
No changelog worthy change

#### Questions:
> Does this work have automated integration and unit tests?
Yes

> Can we make a blog post, video, or animated GIF of this?
No

> Has this change been documented (Readme, docs, etc.)?
No

> Does the knowledge base need an update?
No