### PR TITLE
Move Changelog validation up in CI pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Moved changelog validation up in CI pipeline
 
 ## [1.3.7] - 2019-03-27
 ### Changed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,14 @@ pipeline {
       }
     }
 
+    stage('Validate') {
+      parallel {
+        stage('Changelog') {
+          steps { sh 'ci/parse-changelog' }
+        }
+      }
+    }
+
     stage('Build Docker image') {
       steps {
         sh './build.sh -j'
@@ -49,9 +57,6 @@ pipeline {
         }
         stage('Audit') {
           steps { sh 'ci/test rspec_audit'}
-        }
-        stage('Changelog') {
-          steps { sh 'ci/parse-changelog' }
         }
       }
       post {


### PR DESCRIPTION
#### What does this PR do?
This change moves the Changlog validation to the front of the CI
process. We want the build to fail early if the Changlog format isn't
valid.

#### Any background context you want to provide?
Trying to fail earlier in the build process.

#### What ticket does this PR close?
None filed.

#### How should this be manually tested?
Tests are green, so no manual testing is required.

#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/ci-validation/2/pipeline/

#### Has the Version and Changelog been updated?
N/A
