### PR TITLE
update conjur-policy-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated conjur-policy-parser to
   [v3.0.3](https://github.com/conjurinc/conjur-policy-parser/blob/possum/CHANGELOG.md#v303).
-  
+- Replaced `changelog` entrypoint in `ci/test` with a separate script. Building
+  the `conjur` and `conjur-test` images just to be able to install and run the
+  `parse_a_changelog` gem seemed a little heavyweight.
+
 ## [1.3.5] - 2019-02-07
 ### Changed
 - Rails version updated to v4.2.11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Updated conjur-policy-parser to
+  [v3.0.3](https://github.com/conjurinc/conjur-policy-parser/blob/possum/CHANGELOG.md#v303).
+  
 ## [1.3.5] - 2019-02-07
 ### Changed
 - Rails version updated to v4.2.11.

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'ruby_dep', '= 1.3.1'
  # Pinned to update for role member search, using ref so merging and removing the branch doesn't
  # immediately break this link
 gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'
-gem 'conjur-policy-parser', '>= 3.0.2',
+gem 'conjur-policy-parser', '>= 3.0.3',
   github: 'conjurinc/conjur-policy-parser', branch: 'possum'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/conjurinc/conjur-policy-parser.git
-  revision: 10baf38207c470ecbea43bc94078f83a81a7117b
+  revision: bfefc5c7a6faec7fa716372d7b7a7233291d839d
   branch: possum
   specs:
-    conjur-policy-parser (3.0.2)
+    conjur-policy-parser (3.0.3)
       activesupport (>= 4.2)
       safe_yaml
 
@@ -454,7 +454,7 @@ DEPENDENCIES
   conjur-api!
   conjur-cli (~> 6.1)
   conjur-debify
-  conjur-policy-parser (>= 3.0.2)!
+  conjur-policy-parser (>= 3.0.3)!
   conjur-rack (~> 3.1)
   conjur-rack-heartbeat
   csr

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
           steps { sh 'ci/test rspec_audit'}
         }
         stage('Changelog') {
-          steps { sh 'ci/test changelog' }
+          steps { sh 'ci/parse-changelog' }
         }
       }
       post {

--- a/ci/parse-changelog
+++ b/ci/parse-changelog
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+cd "$(dirname $0)"
+
+docker run --rm \
+  -v $PWD/..:/src/conjur-server \
+  -w /src/conjur-server \
+  ruby:2.5 bash -ec "
+    gem install -N parse_a_changelog
+    parse ./CHANGELOG.md
+  "

--- a/ci/test
+++ b/ci/test
@@ -139,16 +139,6 @@ rspec_audit() {
     "
 }
 
-changelog() {
-  : DOC - Runs parse-a-changelog gem against CHANGELOG.md to validate format.
-
-  docker-compose run -T --rm --no-deps cucumber -ec "
-    gem install parse_a_changelog
-    parse ./CHANGELOG.md
-  "
-}
-
-
 ### Internal functions
 #
 # Functions with names that start with a character other than [a-z]


### PR DESCRIPTION
#### What does this PR do?
Update to v3.0.3 of the policy parser, to support annotations on policy
objects.

#### Any background context you want to provide?
The lack of this functionality appears to be due to an oversight in the original implementation.

#### What ticket does this PR close?
Connected to conjurinc/conjur-policy-parser#13

#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Link to build in Jenkins (if appropriate)
#### Has the Version and Changelog been updated?
Changelog, yes. I'm not sure whether the version should be updated now or not.

#### Questions:
> Does this work have automated integration and unit tests?
Yes: https://github.com/conjurinc/conjur-policy-parser/blob/possum/spec/types/policy_spec.rb#L3

> Can we make a blog post, video, or animated GIF of this?
no

> Has this change been documented (Readme, docs, etc.)?
no

> Does the knowledge base need an update?
no