### PR TITLE
Verifying that username exists before auditing in OIDC

### DIFF
--- a/app/domain/authentication/audit_event.rb
+++ b/app/domain/authentication/audit_event.rb
@@ -16,6 +16,8 @@ module Authentication
     private
 
     def role(username, account)
+      return nil if username.nil?
+
       @get_role_by_login.(username: username, account: account)
     end
 

--- a/app/domain/authentication/authn_oidc/oidc_authenticate.rb
+++ b/app/domain/authentication/authn_oidc/oidc_authenticate.rb
@@ -34,7 +34,9 @@ module Authentication
 
         new_token(input)
       rescue => e
-        @audit_event.(input: input, success: false, message: e.message)
+        unless input.username.nil?
+          @audit_event.(input: input, success: false, message: e.message)
+        end
         raise e
       end
 

--- a/app/domain/authentication/authn_oidc/oidc_authenticate.rb
+++ b/app/domain/authentication/authn_oidc/oidc_authenticate.rb
@@ -5,6 +5,7 @@ module Authentication
 
     Authenticate = CommandClass.new(
       dependencies: {
+        get_oidc_conjur_token: AuthnOidc::GetOidcConjurToken.new,
         enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
         token_factory:          OidcTokenFactory.new,
         validate_security:      ::Authentication::ValidateSecurity.new,
@@ -34,16 +35,12 @@ module Authentication
 
         new_token(input)
       rescue => e
-        unless input.username.nil?
-          @audit_event.(input: input, success: false, message: e.message)
-        end
+        @audit_event.(input: input, success: false, message: e.message)
         raise e
       end
 
       def oidc_conjur_token(input)
-        AuthnOidc::GetOidcConjurToken.new.(
-          request_body: input.request.body.read
-        )
+        @get_oidc_conjur_token.(request_body: input.request.body.read)
       end
 
       def new_token(input)

--- a/app/domain/authentication/authn_oidc/oidc_login.rb
+++ b/app/domain/authentication/authn_oidc/oidc_login.rb
@@ -45,9 +45,7 @@ module Authentication
 
         new_oidc_conjur_token(oidc_id_token_details)
       rescue => e
-        unless input.username.nil?
-          @audit_event.(input: input, success: false, message: e.message)
-        end
+        @audit_event.(input: input, success: false, message: e.message)
         raise e
       end
 

--- a/app/domain/authentication/authn_oidc/oidc_login.rb
+++ b/app/domain/authentication/authn_oidc/oidc_login.rb
@@ -45,7 +45,9 @@ module Authentication
 
         new_oidc_conjur_token(oidc_id_token_details)
       rescue => e
-        @audit_event.(input: input, success: false, message: e.message)
+        unless input.username.nil?
+          @audit_event.(input: input, success: false, message: e.message)
+        end
         raise e
       end
 

--- a/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe 'Authentication::Oidc' do
       end
     end
 
-    context "that receives authenticate request" do
+    context "that receives authenticate request and fails on oidc details retrieval" do
       subject do
         input_ = Authentication::Input.new(
           authenticator_name: 'authn-oidc-test',
@@ -295,7 +295,7 @@ RSpec.describe 'Authentication::Oidc' do
         )
       end
 
-      it "raises the actual oidc error when it fails on oidc details retrieval" do
+      it "raises the actual oidc error" do
         expect { subject }.to raise_error(
                                 /FAKE_OIDC_ERROR/
                               )

--- a/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'Authentication::Oidc' do
   let (:mocked_oidc_authenticator) { double("MockOidcAuthenticator") }
   let (:mocked_security_validator) { double("MockSecurityValidator") }
   let (:mocked_origin_validator) { double("MockOriginValidator") }
+  let (:failing_get_oidc_conjur_token) { double("MockGetOidcConjurToken") }
 
   before(:each) do
     allow(Resource).to receive(:[])
@@ -66,6 +67,9 @@ RSpec.describe 'Authentication::Oidc' do
 
     allow(mocked_origin_validator).to receive(:call)
                                         .and_return(true)
+
+    allow(failing_get_oidc_conjur_token).to receive(:call)
+                                             .and_raise('FAKE_OIDC_ERROR')
   end
 
   ####################################
@@ -100,6 +104,18 @@ RSpec.describe 'Authentication::Oidc' do
   let (:oidc_client_class) do
     double('OidcClientClass').tap do |client_class|
       allow(client_class).to receive(:new).and_return(oidc_client)
+    end
+  end
+
+  let (:failing_oidc_client) do
+    double('OidcClient').tap do |client|
+      allow(client).to receive(:oidc_id_token_details!).and_raise('FAKE_OIDC_ERROR')
+    end
+  end
+
+  let (:failing_oidc_client_class) do
+    double('OidcClientClass').tap do |client_class|
+      allow(client_class).to receive(:new).and_return(failing_oidc_client)
     end
   end
 
@@ -180,6 +196,37 @@ RSpec.describe 'Authentication::Oidc' do
       end
     end
 
+    context "that receives login request and fails on oidc details retrieval" do
+      subject do
+        input_ = Authentication::Input.new(
+          authenticator_name: 'authn-oidc-test',
+          service_id:         'my-service',
+          account:            'my-acct',
+          username:           nil,
+          password:           nil,
+          origin:             '127.0.0.1',
+          request:            oidc_login_request
+        )
+
+        ::Authentication::AuthnOidc::Login.new(
+          oidc_authenticator:     mocked_oidc_authenticator,
+          oidc_client_class:      failing_oidc_client_class,
+          enabled_authenticators: oidc_authenticator_name,
+          token_factory:          oidc_token_factory,
+          validate_security:      mocked_security_validator,
+          validate_origin:        mocked_origin_validator
+        ).(
+          authenticator_input: input_
+        )
+      end
+
+      it "raises the actual oidc error" do
+        expect { subject }.to raise_error(
+                                /FAKE_OIDC_ERROR/
+                              )
+      end
+    end
+
     context "that receives authenticate request with valid oidc conjur token" do
       subject do
         input_ = Authentication::Input.new(
@@ -221,6 +268,36 @@ RSpec.describe 'Authentication::Oidc' do
 
         expect { subject }.to raise_error(
                                 /FAKE_ORIGIN_ERROR/
+                              )
+      end
+    end
+
+    context "that receives authenticate request" do
+      subject do
+        input_ = Authentication::Input.new(
+          authenticator_name: 'authn-oidc-test',
+          service_id:         'my-service',
+          account:            'my-acct',
+          username:           nil,
+          password:           nil,
+          origin:             '127.0.0.1',
+          request:            oidc_authenticate_request
+        )
+
+        ::Authentication::AuthnOidc::Authenticate.new(
+          get_oidc_conjur_token: failing_get_oidc_conjur_token,
+          enabled_authenticators: oidc_authenticator_name,
+          token_factory:          token_factory,
+          validate_security:      mocked_security_validator,
+          validate_origin:        mocked_origin_validator
+        ).(
+          authenticator_input: input_
+        )
+      end
+
+      it "raises the actual oidc error when it fails on oidc details retrieval" do
+        expect { subject }.to raise_error(
+                                /FAKE_OIDC_ERROR/
                               )
       end
     end


### PR DESCRIPTION
#### What does this PR do?
fixes a bug in which the user got an indiscriptive exception of nul pointer rather than the real problem. This happens  when we have an exception before we get the username from the OIDC provider.

#### What ticket does this PR close?
closes #887 

#### Where should the reviewer start?
oidc-login
oidc-authenticate

#### How should this be manually tested?
Run oidc flow with an invalid grant and verify the message says that 
