### PR TITLE
874 oidc authn e2e

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -70,7 +70,7 @@ class AuthenticateController < ApplicationController
   #
   # Returns Conjur access token
   def authenticate_oidc
-    authentication_token = ::Authentication::AuthnOidc::Authenticate.new.(
+    authentication_token = ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new.(
       authenticator_input: oidc_authenticator_input
     )
     render json: authentication_token

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -69,8 +69,17 @@ class AuthenticateController < ApplicationController
   # - Introspect ID Token
   #
   # Returns Conjur access token
-  def authenticate_oidc
+  def authenticate_oidc_conjur_token
     authentication_token = ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new.(
+      authenticator_input: oidc_authenticator_input
+    )
+    render json: authentication_token
+  rescue => e
+    handle_authentication_error(e)
+  end
+
+  def authenticate_oidc
+    authentication_token = ::Authentication::AuthnOidc::Authenticate.new.(
       authenticator_input: oidc_authenticator_input
     )
     render json: authentication_token

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -1,0 +1,56 @@
+require 'command_class'
+
+module Authentication
+  module AuthnOidc
+    Authenticate = CommandClass.new(
+      dependencies: {
+        enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+        token_factory:          OidcTokenFactory.new,
+        validate_security:      ::Authentication::ValidateSecurity.new,
+        validate_origin:        ::Authentication::ValidateOrigin.new,
+        audit_event:            ::Authentication::AuditEvent.new
+      },
+      inputs:       %i(authenticator_input)
+    ) do
+
+      def call
+        access_token(@authenticator_input)
+      end
+
+      private
+
+      def access_token(input)
+        # Prepare ID token introspect request
+
+        # send id token to OIDC Provider
+
+        # Get JSON from OIDC Provider
+
+        # Validate ID Token is active
+
+        # Retrieve mail from response
+        conjur_username = response.mail
+
+        input = input.update(username: conjur_username)
+
+        @validate_security.(input: input, enabled_authenticators: @enabled_authenticators)
+
+        @validate_origin.(input: input)
+
+        @audit_event.(input: input, success: true, message: nil)
+
+        new_token(input)
+      rescue => e
+        @audit_event.(input: input, success: false, message: e.message)
+        raise e
+      end
+
+      def new_token(input)
+        @token_factory.signed_token(
+          account:  input.account,
+          username: input.username
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -29,7 +29,7 @@ module Authentication
         # Validate ID Token is active
 
         # Retrieve mail from response
-        conjur_username = response.mail
+        conjur_username = "alice"
 
         input = input.update(username: conjur_username)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
         #post '/authn-oidc(/:service_id)/:account/login' => 'authenticate#login_oidc'
 
         # authn-oidc has to be first as it can be ambgiuous with the optional :service_id & :id
-        #post '/authn-oidc(/:service_id)/:account/authenticate' => 'authenticate#authenticate_oidc'
+        post '/authn-oidc(/:service_id)/:account/authenticate' => 'authenticate#authenticate_oidc'
         post '/:authenticator(/:service_id)/:account/:id/authenticate' => 'authenticate#authenticate'
 
         # Update password is only relevant when using the default authenticator

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -1,0 +1,41 @@
+Feature: Users can authneticate with OIDC authenticator
+
+  Background:
+    Given a policy:
+    """
+    - !user alice
+
+    - !policy
+      id: conjur/authn-oidc/keycloak
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for Keycloak, based on Open ID Connect.
+
+      - !variable
+        id: client-id
+
+      - !variable
+        id: client-secret
+
+      - !variable
+        id: provider-uri
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !grant
+      role: !group conjur/authn-oidc/keycloak/users
+      member: !user alice
+    """
+
+    And I am the super-user
+    And I successfully set OIDC variables
+
+  Scenario: A valid id token to get Conjur access token
+    When I successfully authenticate via OIDC
+    Then "alice" is authorized

--- a/cucumber/authenticators/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/authn_oidc_steps.rb
@@ -11,5 +11,5 @@ When(/I successfully login via OIDC/) do
 end
 
 When(/I successfully authenticate via OIDC/) do
-  authenticate_with_oidc(service_id: 'keycloak', account: 'cucumber')
+  authenticate_id_token_with_oidc(service_id: 'keycloak', account: 'cucumber')
 end

--- a/cucumber/authenticators/features/support/authenticator_helpers.rb
+++ b/cucumber/authenticators/features/support/authenticator_helpers.rb
@@ -42,17 +42,25 @@ module AuthenticatorHelpers
     @ldap_ca_certificate_value ||= File.read('/ldap-certs/root.cert.pem')
   end
 
-  def login_with_oidc(service_id:, account:)
-    path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/login"
-    payload = { code: oidc_auth_code, redirect_uri: oidc_redirect_uri }
-    post(path, payload)
-    @login_oidc_conjur_token = @response_body
-  end
+  # relevant for original oidc flow
+  # def login_with_oidc(service_id:, account:)
+  #   path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/login"
+  #   payload = { code: oidc_auth_code, redirect_uri: oidc_redirect_uri }
+  #   post(path, payload)
+  #   @login_oidc_conjur_token = @response_body
+  # end
 
-  def authenticate_with_oidc(service_id:, account:)
+  # # relevant for oidc flow for Conjur oidc token retrieved in oidc login flow
+  # def authenticate_conjur_oidc_token_with_oidc(service_id:, account:)
+  #   path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/authenticate"
+  #   # TODO: Since the input going to change to a base64 signed token, i didnt invest time to extract the real values
+  #   payload = { id_token_encrypted: "login_oidc_conjur_token", user_name: "alice", expiration_time: "1231" }
+  #   post(path, payload)
+  # end
+
+  def authenticate_id_token_with_oidc(service_id:, account:)
     path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/authenticate"
-    # TODO: Since the input going to change to a base64 signed token, i didnt invest time to extract the real values
-    payload = { id_token_encrypted: "login_oidc_conjur_token", user_name: "alice", expiration_time: "1231" }
+    payload = { id_token: "some_id_token" }
     post(path, payload)
   end
 

--- a/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe 'Authentication::Oidc' do
           request:            oidc_authenticate_request
         )
 
-        ::Authentication::AuthnOidc::Authenticate.new(
+        ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new(
           enabled_authenticators: oidc_authenticator_name,
           token_factory:          token_factory,
           validate_security:      mocked_security_validator,
@@ -284,7 +284,7 @@ RSpec.describe 'Authentication::Oidc' do
           request:            oidc_authenticate_request
         )
 
-        ::Authentication::AuthnOidc::Authenticate.new(
+        ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new(
           get_oidc_conjur_token: failing_get_oidc_conjur_token,
           enabled_authenticators: oidc_authenticator_name,
           token_factory:          token_factory,

--- a/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/oidc_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Authentication::Oidc' do
     end
   end
 
-  let (:oidc_authenticate_request) do
+  let (:oidc_authenticate_conjur_oidc_token_request) do
     request_body = StringIO.new
     request_body.puts "id_token_encrypted=some-id-token-encrypted&user_name=my-user&expiration_time=1234567"
     request_body.rewind
@@ -143,6 +143,15 @@ RSpec.describe 'Authentication::Oidc' do
     end
   end
 
+  let (:oidc_authenticate_id_token_request) do
+    request_body = StringIO.new
+    request_body.puts "id_token=some-id-token"
+    request_body.rewind
+
+    double('Request').tap do |request|
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
@@ -236,7 +245,7 @@ RSpec.describe 'Authentication::Oidc' do
           username:           nil,
           password:           nil,
           origin:             '127.0.0.1',
-          request:            oidc_authenticate_request
+          request:            oidc_authenticate_conjur_oidc_token_request
         )
 
         ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new(
@@ -281,7 +290,7 @@ RSpec.describe 'Authentication::Oidc' do
           username:           nil,
           password:           nil,
           origin:             '127.0.0.1',
-          request:            oidc_authenticate_request
+          request:            oidc_authenticate_conjur_oidc_token_request
         )
 
         ::Authentication::AuthnOidc::AuthenticateOidcConjurToken.new(
@@ -298,6 +307,51 @@ RSpec.describe 'Authentication::Oidc' do
       it "raises the actual oidc error" do
         expect { subject }.to raise_error(
                                 /FAKE_OIDC_ERROR/
+                              )
+      end
+    end
+
+    context "that receives authenticate request with valid id token" do
+      subject do
+        input_ = Authentication::AuthenticatorInput.new(
+          authenticator_name: 'authn-oidc-test',
+          service_id:         'my-service',
+          account:            'my-acct',
+          username:           nil,
+          password:           nil,
+          origin:             '127.0.0.1',
+          request:            oidc_authenticate_id_token_request
+        )
+
+        ::Authentication::AuthnOidc::Authenticate.new(
+          enabled_authenticators: oidc_authenticator_name,
+          token_factory:          token_factory,
+          validate_security:      mocked_security_validator,
+          validate_origin:        mocked_origin_validator
+        ).(
+          authenticator_input: input_
+        )
+      end
+
+      it "returns a new access token" do
+        expect(subject).to equal(a_new_token)
+      end
+
+      it "raises an error when security validation fails" do
+        allow(mocked_security_validator).to receive(:call)
+                                              .and_raise('FAKE_SECURITY_ERROR')
+
+        expect { subject }.to raise_error(
+                                /FAKE_SECURITY_ERROR/
+                              )
+      end
+
+      it "raises an error when origin validation fails" do
+        allow(mocked_origin_validator).to receive(:call)
+                                            .and_raise('FAKE_ORIGIN_ERROR')
+
+        expect { subject }.to raise_error(
+                                /FAKE_ORIGIN_ERROR/
                               )
       end
     end


### PR DESCRIPTION
#### What does this PR do?
Enables e2e development in parallel on the oidc authenticate. I refactored the old authenticate flow and it is not accessed now. I also created the template for the new authn oidc flow with hardcoded username so developers can code in parallel on different parts of the feature.

#### What ticket does this PR close?
closes #874 

#### Where should the reviewer start?
authenticate_controller -> authn_oidc/authenticate.rb

#### How should this be manually tested?
start the server with the `--authn-oidc` flag
Run the `authenticate-oidc` request in the Postman Collection
