### PR TITLE
Verify OIDC authenticate returns a token that is valid for secret retrieval

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -13,6 +13,9 @@ authenticators: >
   -r cucumber/api/features/support/rest_helpers.rb
   -r cucumber/api/features/step_definitions/request_steps.rb
   -r cucumber/api/features/step_definitions/user_steps.rb
+  -r cucumber/api/features/step_definitions/authz_steps.rb
+  -r cucumber/policy/features/support/policy_helpers.rb
+  -r cucumber/policy/features/step_definitions/policy_steps.rb
   -r cucumber/authenticators
   cucumber/authenticators
 

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -13,6 +13,7 @@ authenticators: >
   -r cucumber/api/features/support/rest_helpers.rb
   -r cucumber/api/features/step_definitions/request_steps.rb
   -r cucumber/api/features/step_definitions/user_steps.rb
+  -r cucumber/api/features/support/authz_helpers.rb
   -r cucumber/api/features/step_definitions/authz_steps.rb
   -r cucumber/policy/features/support/policy_helpers.rb
   -r cucumber/policy/features/step_definitions/policy_steps.rb

--- a/cucumber/api/features/step_definitions/authz_steps.rb
+++ b/cucumber/api/features/step_definitions/authz_steps.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 Given(/^I create a new(?: "([^"]*)")? resource(?: called "([^"]*)")?$/) do |kind, identifier|
-  kind ||= "test-resource"
-  identifier ||= random_hex
-  identifier = denormalize identifier
-  resource_id = "cucumber:#{kind}:#{identifier}"
+  i_have_a_resource kind, identifier, must_be_new: true
+end
 
-  @resources ||= {}
-  
-  @current_resource =
-    Resource.create(resource_id: resource_id,
-                    owner: @current_user || admin_user)
-
-  @resources[resource_id] = @current_resource
+Given(/^I have a(?: "([^"]*)")? resource(?: called "([^"]*)")?$/) do |kind, identifier|
+  i_have_a_resource kind, identifier
 end
 
 Given(/^I add an annotation value of(?: "([^"]*)")? to the resource$/) do |annotation_value|
@@ -95,7 +88,9 @@ end
 Given(/^I permit user "([^"]*)" to "([^"]*)" it$/) do |grantee, privilege|
   grantee = lookup_user(grantee)
   target = @current_resource
-  target.permit privilege, grantee
+  unless grantee.allowed_to?(privilege, target)
+    target.permit privilege, grantee
+  end
 end
 
 Given(/^I grant my role to user "([^"]*)"$/) do |login|

--- a/cucumber/api/features/step_definitions/authz_steps.rb
+++ b/cucumber/api/features/step_definitions/authz_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Given(/^I create a new(?: "([^"]*)")? resource(?: called "([^"]*)")?$/) do |kind, identifier|
-  i_have_a_resource kind, identifier, must_be_new: true
+  i_have_a_new_resource kind, identifier
 end
 
 Given(/^I have a(?: "([^"]*)")? resource(?: called "([^"]*)")?$/) do |kind, identifier|

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -27,6 +27,12 @@ When(/^I( (?:can|successfully))? DELETE "([^"]*)"$/) do |can, path|
   end
 end
 
+When(/^I( (?:can|successfully))? GET "([^"]*)" with user "([^"]*)"$/) do |can, path, username|
+  try_request can do
+    get_json path, user: username
+  end
+end
+
 When(/^I( (?:can|successfully))? GET "([^"]*)" with parameters:$/) do |can, path, parameters|
   params = YAML.load(parameters)
   path = [ path, params.to_query ].join("?")

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -27,9 +27,9 @@ When(/^I( (?:can|successfully))? DELETE "([^"]*)"$/) do |can, path|
   end
 end
 
-When(/^I( (?:can|successfully))? GET "([^"]*)" with user "([^"]*)"$/) do |can, path, username|
+When(/^I( (?:can|successfully))? GET "([^"]*)" with authorized user$/) do |can, path|
   try_request can do
-    get_json path, user: username
+    get_json path, token: ConjurToken.new(@response_body)
   end
 end
 

--- a/cucumber/api/features/step_definitions/user_steps.rb
+++ b/cucumber/api/features/step_definitions/user_steps.rb
@@ -12,6 +12,12 @@ Given(/^I create a new user "([^"]*)"$/) do |login|
   create_user login, @current_user || admin_user
 end
 
+Given(/^I have user "([^"]*)"$/) do |login|
+  unless user_exists?(login)
+    create_user login, @current_user || admin_user
+  end
+end
+
 Given(/^I create a new admin-owned user "(.*?)"$/) do |login|
   create_user login, admin_user
 end

--- a/cucumber/api/features/support/authz_helpers.rb
+++ b/cucumber/api/features/support/authz_helpers.rb
@@ -11,12 +11,9 @@ module AuthzHelpers
 
     @resources ||= {}
 
-    @current_resource = if Resource[resource_id: resource_id] &&
-      Resource[resource_id: resource_id]
-                        else
-                          Resource.create(resource_id: resource_id,
-                                          owner:       @current_user || admin_user)
-                        end
+    @current_resource = Resource[resource_id: resource_id]
+    @current_resource = Resource.create(resource_id: resource_id,
+                                        owner: @current_user || admin_user) unless @current_resource
 
     @resources[resource_id] = @current_resource
   end

--- a/cucumber/api/features/support/authz_helpers.rb
+++ b/cucumber/api/features/support/authz_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Utility methods for Authz steps
+#
+module AuthzHelpers
+  def i_have_a_resource(kind, identifier, must_be_new: false)
+    kind ||= "test-resource"
+    identifier ||= random_hex
+    identifier = denormalize identifier
+    resource_id = "cucumber:#{kind}:#{identifier}"
+
+    @resources ||= {}
+
+    if Resource[resource_id: resource_id] && !must_be_new
+      @current_resource = Resource[resource_id: resource_id]
+    else
+      @current_resource =
+        Resource.create(resource_id: resource_id,
+                        owner: @current_user || admin_user)
+    end
+
+    @resources[resource_id] = @current_resource
+  end
+end
+
+World(AuthzHelpers)

--- a/cucumber/api/features/support/authz_helpers.rb
+++ b/cucumber/api/features/support/authz_helpers.rb
@@ -12,8 +12,10 @@ module AuthzHelpers
     @resources ||= {}
 
     @current_resource = Resource[resource_id: resource_id]
-    @current_resource = Resource.create(resource_id: resource_id,
-                                        owner: @current_user || admin_user) unless @current_resource
+    unless @current_resource
+      @current_resource = Resource.create(resource_id: resource_id,
+                                          owner: @current_user || admin_user)
+    end
 
     @resources[resource_id] = @current_resource
   end

--- a/cucumber/api/features/support/authz_helpers.rb
+++ b/cucumber/api/features/support/authz_helpers.rb
@@ -3,21 +3,34 @@
 # Utility methods for Authz steps
 #
 module AuthzHelpers
-  def i_have_a_resource(kind, identifier, must_be_new: false)
-    kind ||= "test-resource"
-    identifier ||= random_hex
-    identifier = denormalize identifier
+  def i_have_a_resource(kind, identifier)
+    kind        ||= "test-resource"
+    identifier  ||= random_hex
+    identifier  = denormalize identifier
     resource_id = "cucumber:#{kind}:#{identifier}"
 
     @resources ||= {}
 
-    if Resource[resource_id: resource_id] && !must_be_new
-      @current_resource = Resource[resource_id: resource_id]
-    else
-      @current_resource =
-        Resource.create(resource_id: resource_id,
-                        owner: @current_user || admin_user)
-    end
+    @current_resource = if Resource[resource_id: resource_id] &&
+      Resource[resource_id: resource_id]
+                        else
+                          Resource.create(resource_id: resource_id,
+                                          owner:       @current_user || admin_user)
+                        end
+
+    @resources[resource_id] = @current_resource
+  end
+
+  def i_have_a_new_resource(kind, identifier)
+    kind        ||= "test-resource"
+    identifier  ||= random_hex
+    identifier  = denormalize identifier
+    resource_id = "cucumber:#{kind}:#{identifier}"
+
+    @resources ||= {}
+
+    @current_resource = Resource.create(resource_id: resource_id,
+                                        owner:       @current_user || admin_user)
 
     @resources[resource_id] = @current_resource
   end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -183,6 +183,11 @@ module RestHelpers
     end
   end
 
+  def user_exists? login
+    roleid = "cucumber:user:#{login}"
+    Role[role_id: roleid]
+  end
+
   def current_user?
     !!@current_user
   end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -262,9 +262,8 @@ module RestHelpers
   def rest_resource options
     args = [Conjur.configuration.appliance_url]
 
-    if options[:user]
-      token = JSON.parse(@response_body)
-      args << user_credentials(options[:user], token)
+    if options[:token]
+      args << user_credentials(options[:token].username, options[:token].token)
     elsif current_user?
       args << current_user_credentials
     end

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -36,19 +36,40 @@ Feature: Users can authneticate with OIDC authenticator
       member: !user alice
 
     - !user alice@conjur.net
-
-    - !grant
-      role: !group conjur/authn-oidc/keycloak/users
-      member: !user alice@conjur.net
     """
     And I am the super-user
     And I successfully set OIDC variables
 
   Scenario: A valid id token to get Conjur access token
-    When I successfully authenticate via OIDC
+    When I successfully authenticate via OIDC with id token:
+    """
+    {"preferred_username": "alice","email": "alice@conjur.net"}
+    """
+
     Then "alice" is authorized
 
+    # Verify the returned access token is valid for retrieving a secret
+    Given a policy:
+    """
+    - !variable test-variable
+    - !user alice
+
+    - !permit
+      role: !user alice
+      privilege: [ read, execute ]
+      resource: !variable test-variable
+    """
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+
+    Then I successfully GET "/secrets/cucumber/variable/test-variable" with user "alice"
+
   Scenario: A valid id token with email as id-token-user-property
+    # Add user `alice@conjur.net` to keycloak-users group
+    Given I successfully POST "/roles/cucumber/group/conjur%2Fauthn-oidc%2Fkeycloak%2Fusers?members&member=cucumber:user:alice@conjur.net"
+
     When I add the secret value "email" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/id-token-user-property"
-    And I successfully authenticate via OIDC
+    And I successfully authenticate via OIDC with id token:
+    """
+    {"preferred_username": "alice","email": "alice@conjur.net"}
+    """
     Then "alice@conjur.net" is authorized

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -61,7 +61,7 @@ Feature: Users can authneticate with OIDC authenticator
     """
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
 
-    Then I successfully GET "/secrets/cucumber/variable/test-variable" with user "alice"
+    Then I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
 
   Scenario: A valid id token with email as id-token-user-property
     # Add user `alice@conjur.net` to keycloak-users group

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -34,39 +34,26 @@ Feature: Users can authneticate with OIDC authenticator
     - !grant
       role: !group conjur/authn-oidc/keycloak/users
       member: !user alice
-
-    - !user alice@conjur.net
     """
     And I am the super-user
     And I successfully set OIDC variables
 
   Scenario: A valid id token to get Conjur access token
+    # We want to verify the returned access token is valid for retrieving a secret
+    Given I have a "variable" resource called "test-variable"
+    And I permit user "alice" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     When I successfully authenticate via OIDC with id token:
     """
     {"preferred_username": "alice","email": "alice@conjur.net"}
     """
-
     Then "alice" is authorized
-
-    # Verify the returned access token is valid for retrieving a secret
-    Given a policy:
-    """
-    - !variable test-variable
-    - !user alice
-
-    - !permit
-      role: !user alice
-      privilege: [ read, execute ]
-      resource: !variable test-variable
-    """
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
-
-    Then I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
 
   Scenario: A valid id token with email as id-token-user-property
+    Given I have user "alice@conjur.net"
     # Add user `alice@conjur.net` to keycloak-users group
-    Given I successfully POST "/roles/cucumber/group/conjur%2Fauthn-oidc%2Fkeycloak%2Fusers?members&member=cucumber:user:alice@conjur.net"
-
+    And I successfully POST "/roles/cucumber/group/conjur%2Fauthn-oidc%2Fkeycloak%2Fusers?members&member=cucumber:user:alice@conjur.net"
     When I add the secret value "email" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/id-token-user-property"
     And I successfully authenticate via OIDC with id token:
     """

--- a/cucumber/authenticators/features/step_definitions/authn_common_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/authn_common_steps.rb
@@ -5,12 +5,3 @@ end
 Then(/^login response token is valid$/) do
   expect(token_for_keys(["user_name","expiration_time","id_token_encrypted"], @response_body)).to be
 end
-
-# TODO: find a good way to share steps between cucumber profiles
-Given(/^a policy:$/) do |policy|
-  load_root_policy(policy)
-end
-
-Given(/^I add the secret value(?: "([^"]*)")? to the resource(?: "([^"]*)")?$/) do |value, resource_id|
-  Secret.create resource_id: resource_id, value: value
-end

--- a/cucumber/authenticators/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators/features/step_definitions/authn_oidc_steps.rb
@@ -1,15 +1,15 @@
-Given(/I get authorization code/) do
+Given(/^I get authorization code$/) do
   oidc_authorization_code
 end
 
-Given(/I successfully set OIDC variables/) do
+Given(/^I successfully set OIDC variables$/) do
   set_oidc_variables
 end
 
-When(/I successfully login via OIDC/) do
+When(/^I successfully login via OIDC$/) do
   login_with_oidc(service_id: 'keycloak', account: 'cucumber')
 end
 
-When(/I successfully authenticate via OIDC/) do
-  authenticate_id_token_with_oidc(service_id: 'keycloak', account: 'cucumber')
+When(/^I successfully authenticate via OIDC with id token:$/) do |id_token|
+  authenticate_id_token_with_oidc(service_id: 'keycloak', account: 'cucumber', id_token: id_token)
 end

--- a/cucumber/authenticators/features/support/authenticator_helpers.rb
+++ b/cucumber/authenticators/features/support/authenticator_helpers.rb
@@ -58,9 +58,9 @@ module AuthenticatorHelpers
   #   post(path, payload)
   # end
 
-  def authenticate_id_token_with_oidc(service_id:, account:)
+  def authenticate_id_token_with_oidc(service_id:, account:, id_token:)
     path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/authenticate"
-    payload = { id_token: "{\"preferred_username\": \"alice\",\"email\": \"alice@conjur.net\"}" }
+    payload = { id_token: id_token }
     post(path, payload)
   end
 

--- a/cucumber/authenticators/features/support/conjur_token.rb
+++ b/cucumber/authenticators/features/support/conjur_token.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ConjurToken
+  attr_reader :token
+
   def initialize(raw_token)
     @token = JSON.parse(raw_token)
   end


### PR DESCRIPTION
#### What does this PR do?
I added to the OIDC authenticate integration test a validation that the retrieved token is valid also for secret retrieval.

#### Any background context you want to provide?
At this point the Conjur OIDC token factory inherits the regular Conjur token. In case sometime in the future this will change we want to verify the token is still a valid conjur token

#### What ticket does this PR close?
Connected to #896 

#### Where should the reviewer start?
authn_oidc.feature

#### How should this be manually tested?
run the authenticators cukes
