### PR TITLE
Rearrange primary key on permissions table

### DIFF
--- a/db/migrate/20190307154241_change_permissions_primary_key.rb
+++ b/db/migrate/20190307154241_change_permissions_primary_key.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  # The primary key used to be (privilege, resource_id, role_id) which
+  # is not very useful for how some queries are structured.
+  # Nothing seems to search primarily by privilege; OTOH eg. visibility check
+  # searches by resource_id and extracts role_id which should be possible with
+  # an index only scan after this rearrangement.
+  up do
+    alter_table :permissions do
+      drop_constraint :permissions_pkey
+      add_primary_key %i(resource_id role_id privilege)
+    end
+  end
+
+  down do
+    alter_table :permissions do
+      drop_constraint :permissions_pkey
+      add_primary_key %i(privilege resource_id role_id)
+    end
+  end
+end


### PR DESCRIPTION
The primary key used to be (privilege, resource_id, role_id) which is not very useful for how some queries are structured and this mismatch led to abysmal performance of some of them with a lot of permissions present.

Nothing seems to search primarily by privilege; OTOH eg. visibility check searches by resource_id and extracts role_id which should be possible with an index only scan after rearranging to (resource_id, role_id, privilege).