### PR TITLE
Killing conjur server process after loading variables in dev/start

### DIFF
--- a/dev/files/killConjurServer
+++ b/dev/files/killConjurServer
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+kill $(ps aux | grep '[r]uby /usr/local/bin/conjurctl server' | awk '{print $2}')

--- a/dev/start
+++ b/dev/start
@@ -114,6 +114,9 @@ if [[ $ENABLE_AUTHN_OIDC = true ]]; then
   docker-compose exec client conjur variable values add conjur/authn-oidc/okta/provider-uri https://dev-842018.oktapreview.com
   docker-compose exec client conjur variable values add conjur/authn-oidc/okta/id-token-user-property "preferred_username"
 
+  echo "killing the conjur server process"
+  docker-compose exec conjur /src/conjur-server/dev/files/killConjurServer
+
   echo "Creating OpenID client in keycloack OpenID provider"
   docker-compose exec oidc-keycloak /authn-oidc/keycloak/scripts/create_client
   echo "keycloak admin console url: http://0.0.0.0:7777/auth/admin"


### PR DESCRIPTION
#### What does this PR do?
Killing the conjur server process after using it for loading variables.

#### Any background context you want to provide?
In the oidc development we needed to start the server in order to load variables and values. This made the container start with the server already started which caused problems.

#### What ticket does this PR close?
Connected to #907 

#### How should this be manually tested?
run `dev/start --authn-oidc` and inside the container run `ps -ef` to verify the server is down.