### PR TITLE
Add external Kubernetes authentication

### DIFF
--- a/app/domain/authentication/authn_k8s/k8s_context_value.rb
+++ b/app/domain/authentication/authn_k8s/k8s_context_value.rb
@@ -1,0 +1,14 @@
+module Authentication
+  module AuthnK8s
+    # K8sContextValue attempts to retrieve a value from a file, falling back to
+    # a value stored in a Conjur variable.
+    class K8sContextValue
+      def self.get webservice, file_name, variable_id
+        return File.read(file_name) if File.exist?(file_name)
+        webservice.variable(variable_id).secret.value if webservice.present?
+      rescue
+        nil
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -36,7 +36,7 @@ module Authentication
       #
       # * +controller+ the controller API object (e.g. a Deployment)
       # * +pod+ the Pod API object.
-      Base = Struct.new(:controller, :pod) do
+      Base = Struct.new(:controller, :pod, :k8s_object_lookup) do
         # Verifies that a condition, specified by a block, is truthy.
         #
         # @exception ValidationError with the specified +message+ is raised if the
@@ -79,14 +79,14 @@ module Authentication
               pod_owner_refs.find{|ref| ref.kind == "ReplicaSet"}
           end
           
-          replica_set = K8sObjectLookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
+          replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
 
           deployment_ref = verify "Pod #{pod_name} does not belong to a Deployment" do
             replica_set.metadata.ownerReferences &&
               replica_set.metadata.ownerReferences.find{|ref| ref.kind == "Deployment"}
           end
 
-          deployment = K8sObjectLookup.find_object_by_name "deployment", deployment_ref.name, namespace
+          deployment = k8s_object_lookup.find_object_by_name "deployment", deployment_ref.name, namespace
 
           verify "Pod #{pod_name} Deployment is #{deployment.metadata.name.inspect}, not #{self.name.inspect}" do
             self.name == deployment.metadata.name
@@ -101,14 +101,14 @@ module Authentication
               pod_owner_refs.find{|ref| ref.kind == "ReplicationController"}
           end
           
-          replication_controller = K8sObjectLookup.find_object_by_name "replication_controller", replication_controller_ref.name, namespace
+          replication_controller = k8s_object_lookup.find_object_by_name "replication_controller", replication_controller_ref.name, namespace
 
           deployment_config_ref = verify "Pod #{pod_name} does not belong to a DeploymentConfig" do
             replication_controller.metadata.ownerReferences &&
               replication_controller.metadata.ownerReferences.find{|ref| ref.kind == "DeploymentConfig"}
           end
 
-          deployment_config = K8sObjectLookup.find_object_by_name "deployment_config", deployment_config_ref.name, namespace
+          deployment_config = k8s_object_lookup.find_object_by_name "deployment_config", deployment_config_ref.name, namespace
 
           verify "Pod #{pod_name} DeploymentConfig is #{deployment_config.metadata.name.inspect}, not #{self.name.inspect}" do
             self.name == deployment_config.metadata.name
@@ -123,7 +123,7 @@ module Authentication
               pod_owner_refs.find{|ref| ref.kind == "ReplicaSet"}
           end
 
-          replica_set = K8sObjectLookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
+          replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
 
           verify "Pod #{pod_name} ReplicaSet is #{replica_set.metadata.name.inspect}, not #{self.name.inspect}" do
             self.name == replica_set.metadata.name
@@ -146,7 +146,7 @@ module Authentication
               pod_owner_refs.find{|ref| ref.kind == "StatefulSet"}
           end
 
-          stateful_set = K8sObjectLookup.find_object_by_name "stateful_set", stateful_set_ref.name, namespace      
+          stateful_set = k8s_object_lookup.find_object_by_name "stateful_set", stateful_set_ref.name, namespace      
 
           verify "Pod #{pod_name} StatefulSet name is #{stateful_set.metadata.name.inspect}, not #{self.name.inspect}" do
             self.name == stateful_set.metadata.name

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -55,9 +55,9 @@ module Authentication
 
     KubectlExec = CommandClass.new(
       dependencies: { logger: Rails.logger,
-                      k8s_object_lookup: K8sObjectLookup,
                       timeout: 5.seconds },
-      inputs: %i( pod_namespace
+      inputs: %i( k8s_object_lookup
+                  pod_namespace
                   pod_name
                   container
                   cmds
@@ -175,8 +175,15 @@ module Authentication
       #
       # This is needed because we need these methods to exist on the class,
       # but that class contains only a metaprogramming generated `call()`.
-      def execute(pod_namespace:, pod_name:, cmds:, container: 'authenticator', body: "", stdin: false)
+      def execute(k8s_object_lookup:,
+        pod_namespace:,
+        pod_name:,
+        cmds:,
+        container: 'authenticator',
+        body: "",
+        stdin: false)
         call(
+          k8s_object_lookup: k8s_object_lookup,
           pod_namespace: pod_namespace,
           pod_name: pod_name,
           container: container,
@@ -186,8 +193,15 @@ module Authentication
         )
       end
 
-      def copy(pod_namespace:, pod_name:, path:, content:, mode:, container: 'authenticator')
+      def copy(k8s_object_lookup:,
+        pod_namespace:,
+        pod_name:,
+        path:,
+        content:,
+        mode:,
+        container: 'authenticator')
         execute(
+          k8s_object_lookup: k8s_object_lookup,
           pod_namespace: pod_namespace,
           pod_name: pod_name,
           container: container,

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -17,6 +17,7 @@ Before do
 
     pod.spec.containers.each do |container|
       exec.execute(
+        k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,
         pod_namespace: pod.metadata.namespace,
         pod_name: pod.metadata.name,
         container: container.name,

--- a/lib/test/audit_sink.rb
+++ b/lib/test/audit_sink.rb
@@ -2,10 +2,24 @@
 
 module Test
   class AuditSink
+    SOCKET_PATH="audit.sock"
+
     def initialize
-      @socket = UNIXServer.new ''
+      delete_socket
+
+      begin
+        @socket = UNIXServer.new SOCKET_PATH
+      ensure
+        at_exit { delete_socket }
+      end
+
       @messages = []
       listen
+    end
+
+    def delete_socket
+      @socket.close if @socket
+      File.delete(SOCKET_PATH) if File.exist?(SOCKET_PATH)
     end
 
     def listen backlog = 1

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Authentication::AuthnK8s::InjectClientCert do
+  include_context "running in kubernetes"
+
   let(:spiffe_name) { "SpiffeName" }
   let(:spiffe_namespace) { "SpiffeNamespace" }
 

--- a/spec/app/domain/authentication/authn_k8s/k8s_context_value_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/k8s_context_value_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnK8s::K8sContextValue do
+
+  let(:file_contents) { "MockFileContents" }
+  let(:good_file) { double("MockExistentFile") }
+  let(:bad_file) { double("MockNonexistentFile") }
+
+  let(:good_resource_id) { "MockSecretIdGood" }
+  let(:bad_resource_id) { "MockSecretIdBad" }
+
+  let(:webservice) { double("MockWebservice") }
+  let(:secret) { double("MockSecret", value: "MockSecret") }
+  let(:resource) { double("MockResource", secret: secret) }
+
+  before(:each) do
+    allow(File).to receive(:exist?)
+      .with(good_file)
+      .and_return(true)
+
+    allow(File).to receive(:exist?)
+      .with(bad_file)
+      .and_return(false)
+
+    allow(File).to receive(:read)
+      .with(good_file)
+      .and_return(file_contents)
+
+    allow(webservice).to receive(:variable)
+      .with(good_resource_id)
+      .and_return(resource)
+
+    allow(webservice).to receive(:variable)
+      .with(bad_resource_id)
+      .and_return(nil)
+  end
+
+  subject { Authentication::AuthnK8s::K8sContextValue }
+
+  describe "get" do
+    it "returns the value of a file if it exists" do
+      expect(subject.get(webservice, good_file, good_resource_id)).to eq(file_contents)
+    end
+
+    it "returns the value of a variable if the file does not exist" do
+      expect(subject.get(webservice, bad_file, good_resource_id)).to eq(secret.value)
+    end
+
+    it "returns nil when neither exist" do
+      expect(subject.get(webservice, bad_file, bad_resource_id)).to be_nil
+    end
+
+    it "returns nil when file doesnt exist and variable does but webservice is nil" do
+      expect(subject.get(nil, bad_file, good_resource_id)).to be_nil
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_k8s/k8s_object_lookup_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/k8s_object_lookup_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnK8s::K8sObjectLookup do
+
+  let(:webservice) { Authentication::Webservice.new(
+    account: 'MockAccount',
+    authenticator_name: 'authn-k8s',
+    service_id: 'MockService'
+  )}
+
+  context "inside of kubernetes" do
+    include_context "running in kubernetes"
+
+    context "instantiation" do
+      it "does not require a webservice" do
+        expect { Authentication::AuthnK8s::K8sObjectLookup.new }.not_to raise_error
+      end
+    end
+
+    subject { Authentication::AuthnK8s::K8sObjectLookup.new(webservice) }
+
+    it "gets the correct api url" do
+      expect(subject.api_url).to eq("https://#{kubernetes_api_url}:#{kubernetes_api_port}")
+    end
+
+    it "has the correct ssl options" do
+      expect(subject.options[:ssl_options]).to include(:cert_store, :verify_ssl => OpenSSL::SSL::VERIFY_PEER)
+    end
+
+    it "has the correct auth options" do
+      expect(subject.options[:auth_options]).to include(:bearer_token => kubernetes_service_token)
+    end
+  end
+
+  context "outside of kubernetes" do
+    include_context "running outside kubernetes"
+
+    context "instantiation" do
+      it "requires a webservice" do
+        allow(Authentication::AuthnK8s::K8sContextValue).to receive(:get)
+          .with(nil,
+            Authentication::AuthnK8s::SERVICEACCOUNT_CA_PATH,
+            Authentication::AuthnK8s::VARIABLE_CA_CERT)
+          .and_return(nil)
+
+        expect { Authentication::AuthnK8s::K8sObjectLookup.new }.to raise_error(Authentication::AuthnK8s::MissingCertificate)
+      end
+    end
+
+    subject { Authentication::AuthnK8s::K8sObjectLookup.new(webservice) }
+
+    it "gets the correct api url" do
+      expect(subject.api_url).to eq(kubernetes_api_url)
+    end
+
+    it "has the correct ssl options" do
+      expect(subject.options[:ssl_options]).to include(:cert_store, :verify_ssl => OpenSSL::SSL::VERIFY_PEER)
+    end
+
+    it "has the correct auth options" do
+      expect(subject.options[:auth_options]).to include(:bearer_token => kubernetes_service_token)
+    end
+  end
+end

--- a/spec/support/k8s_spec_helper.rb
+++ b/spec/support/k8s_spec_helper.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+def self_signed_certificate
+  key = OpenSSL::PKey::RSA.new 2048
+  ca = OpenSSL::X509::Certificate.new
+  subject = OpenSSL::X509::Name.parse "/DC=mock/CN=rspec"
+
+  ca.public_key = key.public_key
+  ca.subject = subject
+  ca.issuer = subject
+  ca.version = 2
+  ca.serial = 1
+  ca.not_before = Time.now
+  ca.not_after = Time.now + 60 * 60
+  ca.sign(key, OpenSSL::Digest::SHA256.new)
+
+  ca.to_pem
+end
+
+shared_context "running in kubernetes" do
+  let(:kubernetes_ca_cert) { self_signed_certificate }
+  let(:kubernetes_service_token) { "MockServiceToken" }
+  let(:kubernetes_api_url) { "api.mock.internal" }
+  let(:kubernetes_api_port) { "443" }
+  
+  before(:each) do
+    allow(Authentication::AuthnK8s::K8sContextValue).to receive(:get)
+      .with(anything,
+        Authentication::AuthnK8s::SERVICEACCOUNT_CA_PATH,
+        Authentication::AuthnK8s::VARIABLE_CA_CERT)
+      .and_return(kubernetes_ca_cert)
+    
+    allow(Authentication::AuthnK8s::K8sContextValue).to receive(:get)
+      .with(anything,
+        Authentication::AuthnK8s::SERVICEACCOUNT_TOKEN_PATH,
+        Authentication::AuthnK8s::VARIABLE_BEARER_TOKEN)
+      .and_return(kubernetes_service_token)
+
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[])
+      .with("KUBERNETES_SERVICE_HOST")
+      .and_return(kubernetes_api_url)
+
+    allow(ENV).to receive(:[])
+      .with("KUBERNETES_SERVICE_PORT")
+      .and_return(kubernetes_api_port)
+  end
+end
+
+shared_context "running outside kubernetes" do
+  let(:kubernetes_ca_cert) { self_signed_certificate }
+  let(:kubernetes_service_token) { "MockServiceToken" }
+  let(:kubernetes_api_url) { "https://api.mock.internal:1443" }
+
+  let(:secret_api_url) { double("MockSecretApiUrl", value: kubernetes_api_url) }
+  let(:resource_api_url) { double("MockApiUrl", secret: secret_api_url) }
+
+  before(:each) do
+    allow(Authentication::AuthnK8s::K8sContextValue).to receive(:get)
+      .with(an_instance_of(Authentication::Webservice),
+        Authentication::AuthnK8s::SERVICEACCOUNT_CA_PATH,
+        Authentication::AuthnK8s::VARIABLE_CA_CERT)
+      .and_return(kubernetes_ca_cert)
+    
+    allow(Authentication::AuthnK8s::K8sContextValue).to receive(:get)
+      .with(an_instance_of(Authentication::Webservice),
+        Authentication::AuthnK8s::SERVICEACCOUNT_TOKEN_PATH,
+        Authentication::AuthnK8s::VARIABLE_BEARER_TOKEN)
+      .and_return(kubernetes_service_token)
+
+    allow_any_instance_of(Authentication::Webservice).to receive(:variable)
+      .with(Authentication::AuthnK8s::VARIABLE_API_URL)
+      .and_return(resource_api_url)
+  end
+end


### PR DESCRIPTION
Conjur can now connect to the Kubernetes API externally using a
service account token for authentication.

Connected to #939