### PR TITLE
fix exception message - second argument to exception was discarded

### DIFF
--- a/app/domain/authentication/authn_oidc/authenticate_id_token/provider_certificate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/provider_certificate.rb
@@ -14,7 +14,7 @@ module Authentication
           begin
             discovered_provider.jwks
           rescue => e
-            raise ProviderFetchCertificateFailed, provider_uri, e.inspect
+            raise ProviderFetchCertificateFailed.new(provider_uri, e.inspect)
           end
         end
 
@@ -23,9 +23,9 @@ module Authentication
         def discover_provider(provider_uri)
           OpenIDConnect::Discovery::Provider::Config.discover!(provider_uri)
         rescue HTTPClient::ConnectTimeoutError => e
-          raise ProviderDiscoveryTimeout, provider_uri, e.inspect
+          raise ProviderDiscoveryTimeout.new(provider_uri, e.inspect)
         rescue => e
-          raise ProviderDiscoveryFailed, provider_uri, e.inspect
+          raise ProviderDiscoveryFailed.new(provider_uri, e.inspect)
         end
       end
     end


### PR DESCRIPTION
#### What does this PR do?
Fix exception instantiation that receives two arguments. More precisely, fixing "Reason:" argument of the exception in log.

#### Any background context you want to provide?
#### What ticket does this PR close?
Connected to #876 
