### PR TITLE
Remove expired links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.7] - 2019-03-27
 ### Changed
+- Updated links to Policy & Cryptography reference in API documentation
 - Updated conjur-policy-parser to
   [v3.0.3](https://github.com/conjurinc/conjur-policy-parser/blob/possum/CHANGELOG.md#v303).
 - Replaced `changelog` entrypoint in `ci/test` with a separate script. Building

--- a/apidocs/src/api.md
+++ b/apidocs/src/api.md
@@ -1,12 +1,8 @@
 FORMAT: 1A
 
-# Conjur V5 API
+# Conjur API
 
-This is official documentation of the Conjur V5 API. It
-allows you tremendous flexibility to control and manipulate your
-Conjur software.
-
-Looking for the Conjur Enterprise (V4) API? https://conjur.docs.apiary.io
+This is official documentation of the Conjur V5 API. It allows you tremendous flexibility to control and manipulate your Conjur software.
 
 # Group Authentication
 

--- a/apidocs/src/append_policy.md
+++ b/apidocs/src/append_policy.md
@@ -2,7 +2,7 @@
 
 ### Append to a policy [POST]
 
-Adds data to the existing [Conjur policy](/reference/policy.html).
+Adds data to the existing [Conjur policy](https://docs.conjur.org/Latest/en/Content/Operations/Policy/policy-intro.html).
 Deletions are not allowed. Any policy objects that exist on the server but
 are omitted from the policy file will not be deleted and any explicit deletions in
 the policy file will result in an error.

--- a/apidocs/src/authenticate.md
+++ b/apidocs/src/authenticate.md
@@ -2,7 +2,7 @@
 
 ### Authenticate [POST]
 
-Gets a [short-lived access token](/reference/cryptography.html#authentication-tokens), which can be used to authenticate requests to (most of) the rest of the Conjur API. A client can obtain an access token by presenting a valid login name and API key.
+Gets a [short-lived access token](https://docs.conjur.org/Latest/en/Content/Get%20Started/cryptography.html?Highlight=cryptography#Authenticationtokens), which can be used to authenticate requests to (most of) the rest of the Conjur API. A client can obtain an access token by presenting a valid login name and API key.
 
 The login must be [URL encoded][percent-encoding]. For example, `alice@devops`
 must be encoded as `alice%40devops`.
@@ -18,7 +18,7 @@ Authorization: Token token="eyJkYX...Rhb="
 ```
 
 Therefore, before the access token can be used to make subsequent calls to the API, a raw token must be formatted.
-Take the response from this method and base64-encode it, stripping out newlines.
+Take the response from this method and base64-encode it, stripping out newlines. 
 
 ```
 token=$(echo -n $response | base64 | tr -d '\r\n')

--- a/apidocs/src/replace_policy.md
+++ b/apidocs/src/replace_policy.md
@@ -2,7 +2,7 @@
 
 ### Replace a policy [PUT]
 
-Loads or replaces a [Conjur policy](/reference/policy.html)
+Loads or replaces a [Conjur policy](https://docs.conjur.org/Latest/en/Content/Operations/Policy/policy-intro.html)
 document. 
 
 Any policy data which already exists on the server but is **not** explicitly specified in the new policy file **will be deleted**. 

--- a/apidocs/src/update_policy.md
+++ b/apidocs/src/update_policy.md
@@ -2,7 +2,7 @@
 
 ### Update a policy [PATCH]
 
-Modifies an existing [Conjur policy](/reference/policy.html).
+Modifies an existing [Conjur policy](https://docs.conjur.org/Latest/en/Content/Operations/Policy/policy-intro.html).
 Data may be explicitly deleted using the `!delete`, `!revoke`, and `!deny` statements. Unlike "replace" mode, no data is ever implicitly deleted.
 
 <!-- include(partials/url_encoding.md) -->


### PR DESCRIPTION
#### What does this PR do?
Removes links to out of date /reference pages in conur.org documentation.

#### Any background context you want to provide?
We are removing the /reference pages from conjur.org, but some of those pages are linked in the API documentation. This PR removes those old links and updates w/ new links to docs.conjur.org

#### What ticket does this PR close?
connected to cyberark/conjur-org#347

#### Where should the reviewer start?
#### How should this be manually tested?
Run the API docs locally, and confirm that links to Conjur policy are updated in the policy pages:
https://www.conjur.org/api.html#policies

#### Screenshots (if appropriate)n/a
#### Link to build in Jenkins (if appropriate)
https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/remove-expired-links/1/pipeline

#### Has the Version and Changelog been updated? yes

#### Questions:
> Does this work have automated integration and unit tests? no
> Can we make a blog post, video, or animated GIF of this? no
> Has this change been documented (Readme, docs, etc.)? no
> Does the knowledge base need an update? no
