### PR TITLE
Update gcloud docker image used for testing authn-k8s

### DIFF
--- a/ci/authn-k8s/dev/Dockerfile.test
+++ b/ci/authn-k8s/dev/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:206.0.0
+FROM google/cloud-sdk:241.0.0
 
 RUN mkdir -p /src
 WORKDIR /src

--- a/ci/authn-k8s/dev/Dockerfile.test
+++ b/ci/authn-k8s/dev/Dockerfile.test
@@ -3,10 +3,6 @@ FROM google/cloud-sdk:206.0.0
 RUN mkdir -p /src
 WORKDIR /src
 
-# jessie-updates is no longer available, but it's still referenced in
-# the cloud-sdk image. Remove it here until the image gets updated.
-RUN sed -i '/jessie-updates main/d' /etc/apt/sources.list
-
 # Install Docker client
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
     curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \


### PR DESCRIPTION
#### What does this PR do?
Update the google cloud sdk image used in authn-k8s tests.
#### Any background context you want to provide?
The currently pinned version of the image [fails](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/update-gcloud-sdk-image-944/2/pipeline#step-66-log-334) when attempting to retrieve the index for the [jessie-updates debian repo](http://ftp.us.debian.org/debian/dists/jessie-updates/). A hack was added in 429484f1fdcf2900526f030c674ab3b280abdaeb to remove that repo from the image. This PR updates the image so the hack is no longer required. It also reverts the commit that added the hack.
#### What ticket does this PR close?
Connected to #944
#### Where should the reviewer start?
Looking at the CI results to ensure that all tests pass.
#### How should this be manually tested?
Manual testing not required.
#### Link to build in Jenkins (if appropriate)
Will be automatically linked to the PR.
#### Has the Version and Changelog been updated?
No.
