### PR TITLE
Run apt update before installing packages

### DIFF
--- a/ci/authn-k8s/dev/Dockerfile.test
+++ b/ci/authn-k8s/dev/Dockerfile.test
@@ -4,7 +4,8 @@ RUN mkdir -p /src
 WORKDIR /src
 
 # Install Docker client
-RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
     curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
     apt-get update && \


### PR DESCRIPTION
Without updating we've a chance to try retrieving packages which no
longer exist.