### PR TITLE
Revert command class version

### DIFF
--- a/app/domain/authentication/audit_event.rb
+++ b/app/domain/authentication/audit_event.rb
@@ -1,42 +1,39 @@
 # frozen_string_literal: true
 
 module Authentication
-  class AuditEvent
-    extend CommandClass::Include
 
-    command_class(
-      dependencies: {
-        role_cls: ::Role,
-        audit_log:         ::Authentication::AuditLog
-      },
-      inputs:       %i(input success message)
-    ) do
+  AuditEvent = CommandClass.new(
+    dependencies: {
+      role_cls: ::Role,
+      audit_log: ::Authentication::AuditLog
+    },
+    inputs: %i(input success message)
+  ) do
 
-      def call
-        @audit_log.record_authn_event(
-          role:               role,
-          webservice_id:      @input.webservice.resource_id,
-          authenticator_name: @input.authenticator_name,
-          success:            @success,
-          message:            @message
-        )
-      end
+    def call
+      @audit_log.record_authn_event(
+        role: role,
+        webservice_id: @input.webservice.resource_id,
+        authenticator_name: @input.authenticator_name,
+        success: @success,
+        message: @message
+      )
+    end
 
-      private
+    private
 
-      def role
-        return nil if username.nil?
+    def role
+      return nil if username.nil?
 
-        @role_cls.by_login(username, account: account)
-      end
+      @role_cls.by_login(username, account: account)
+    end
 
-      def username
-        @input.username
-      end
+    def username
+      @input.username
+    end
 
-      def account
-        @input.account
-      end
+    def account
+      @input.account
     end
   end
 end

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -38,11 +38,11 @@ module Authentication
     end
 
     def validate_authenticator_exists
-      raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+      raise Authentication::AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
     end
 
     def validate_credentials
-      raise InvalidCredentials unless authenticator.valid?(@authenticator_input)
+      raise Authentication::InvalidCredentials unless authenticator.valid?(@authenticator_input)
     end
 
     def validate_security

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -4,77 +4,74 @@ require 'command_class'
 require 'authentication/errors'
 
 module Authentication
-  class Authenticate
-    extend CommandClass::Include
 
-    AuthenticatorNotFound = Authentication::AuthenticatorNotFound
-    InvalidCredentials = Authentication::InvalidCredentials
+  # Possible Errors Raised:
+  # AuthenticatorNotFound, InvalidCredentials
 
-    command_class(
-      dependencies: {
-        enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
-        token_factory:          TokenFactory.new,
-        validate_security:      ::Authentication::ValidateSecurity.new,
-        validate_origin:        ::Authentication::ValidateOrigin.new,
-        audit_event:            ::Authentication::AuditEvent.new
-      },
-      inputs:       %i(authenticator_input authenticators)
-    ) do
+  Authenticate = CommandClass.new(
+    dependencies: {
+      enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+      token_factory: TokenFactory.new,
+      validate_security: ::Authentication::ValidateSecurity.new,
+      validate_origin: ::Authentication::ValidateOrigin.new,
+      audit_event: ::Authentication::AuditEvent.new
+    },
+    inputs: %i(authenticator_input authenticators)
+  ) do
 
-      def call
-        validate_authenticator_exists
-        validate_security
-        validate_credentials
-        validate_origin
-        audit_success
-        new_token
-      rescue => e
-        audit_failure(e)
-        raise e
-      end
-
-      private
-
-      def authenticator
-        @authenticator = @authenticators[@authenticator_input.authenticator_name]
-      end
-
-      def validate_authenticator_exists
-        raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
-      end
-
-      def validate_credentials
-        raise InvalidCredentials unless authenticator.valid?(@authenticator_input)
-      end
-
-      def validate_security
-        @validate_security.(
-          webservice: @authenticator_input.webservice,
-            account: @authenticator_input.account,
-            user_id: @authenticator_input.username,
-            enabled_authenticators: @enabled_authenticators
-        )
-      end
-
-      def validate_origin
-        @validate_origin.(input: @authenticator_input)
-      end
-
-      def audit_success
-        @audit_event.(input: @authenticator_input, success: true, message: nil)
-      end
-
-      def audit_failure(err)
-        @audit_event.(input: @authenticator_input, success: false, message: err.message)
-      end
-
-      def new_token
-        @token_factory.signed_token(
-          account:  @authenticator_input.account,
-          username: @authenticator_input.username
-        )
-      end
-
+    def call
+      validate_authenticator_exists
+      validate_security
+      validate_credentials
+      validate_origin
+      audit_success
+      new_token
+    rescue => e
+      audit_failure(e)
+      raise e
     end
+
+    private
+
+    def authenticator
+      @authenticator = @authenticators[@authenticator_input.authenticator_name]
+    end
+
+    def validate_authenticator_exists
+      raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+    end
+
+    def validate_credentials
+      raise InvalidCredentials unless authenticator.valid?(@authenticator_input)
+    end
+
+    def validate_security
+      @validate_security.(
+        webservice: @authenticator_input.webservice,
+          account: @authenticator_input.account,
+          user_id: @authenticator_input.username,
+          enabled_authenticators: @enabled_authenticators
+      )
+    end
+
+    def validate_origin
+      @validate_origin.(input: @authenticator_input)
+    end
+
+    def audit_success
+      @audit_event.(input: @authenticator_input, success: true, message: nil)
+    end
+
+    def audit_failure(err)
+      @audit_event.(input: @authenticator_input, success: false, message: err.message)
+    end
+
+    def new_token
+      @token_factory.signed_token(
+        account: @authenticator_input.account,
+        username: @authenticator_input.username
+      )
+    end
+
   end
 end

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -3,141 +3,137 @@ require 'authentication/errors'
 
 module Authentication
   module AuthnK8s
-    class InjectClientCert
-      extend CommandClass::Include
 
-      CSRIsMissingSpiffeId = Authentication::AuthnK8s::CSRIsMissingSpiffeId
-      CSRNamespaceMismatch = Authentication::AuthnK8s::CSRNamespaceMismatch
-      CertInstallationError = Authentication::AuthnK8s::CertInstallationError
+    # Possible Errors Raised:
+    # CSRIsMissingSpiffeId, CSRNamespaceMismatch, CertInstallationError
 
-      command_class(
-        dependencies: {
-          logger: Rails.logger,
-          resource_repo: Resource,
-          conjur_ca_repo: Repos::ConjurCA,
-          k8s_object_lookup: K8sObjectLookup,
-          kubectl_exec: KubectlExec,
-          validate_pod_request: ValidatePodRequest.new
-        },
-        inputs: [:conjur_account, :service_id, :csr]
-      ) do
+    InjectClientCert = CommandClass.new(
+      dependencies: {
+        logger: Rails.logger,
+        resource_repo: Resource,
+        conjur_ca_repo: Repos::ConjurCA,
+        k8s_object_lookup: K8sObjectLookup,
+        kubectl_exec: KubectlExec,
+        validate_pod_request: ValidatePodRequest.new
+      },
+      inputs: [:conjur_account, :service_id, :csr]
+    ) do
 
-        def call
-          validate
-          install_signed_cert
-        end
+      def call
+        validate
+        install_signed_cert
+      end
 
-        private
+      private
 
-        def validate
-          # We validate the CSR first since the pod_request uses its values
-          validate_csr
+      def validate
+        # We validate the CSR first since the pod_request uses its values
+        validate_csr
 
-          @validate_pod_request.(pod_request: pod_request)
-        end
+        @validate_pod_request.(pod_request: pod_request)
+      end
 
-        def install_signed_cert
-          pod_namespace = spiffe_id.namespace
-          pod_name = spiffe_id.name
-          @logger.debug "Copying SSL cert to #{pod_namespace}/#{pod_name}"
+      def install_signed_cert
+        pod_namespace = spiffe_id.namespace
+        pod_name = spiffe_id.name
+        @logger.debug "Copying SSL cert to #{pod_namespace}/#{pod_name}"
 
-          resp = @kubectl_exec.new.copy(
-            pod_namespace: pod_namespace,
-            pod_name: pod_name,
-            container: container_name,
-            path: "/etc/conjur/ssl/client.pem",
-            content: cert_to_install.to_pem,
-            mode: 0o644
-          )
-          validate_cert_installation(resp)
-        end
+        resp = @kubectl_exec.new.copy(
+          pod_namespace: pod_namespace,
+          pod_name: pod_name,
+          container: container_name,
+          path: "/etc/conjur/ssl/client.pem",
+          content: cert_to_install.to_pem,
+          mode: 0o644
+        )
+        validate_cert_installation(resp)
+      end
 
-        def pod_request
-          PodRequest.new(
-            service_id: @service_id,
-            k8s_host: k8s_host,
-            spiffe_id: spiffe_id
-          )
-        end
+      def pod_request
+        PodRequest.new(
+          service_id: @service_id,
+          k8s_host: k8s_host,
+          spiffe_id: spiffe_id
+        )
+      end
 
-        def k8s_host
-          @k8s_host ||= Authentication::AuthnK8s::K8sHost.from_csr(
-            account: @conjur_account,
-            service_name: @service_id,
-            csr: @csr
-          )
-        end
+      def k8s_host
+        @k8s_host ||= Authentication::AuthnK8s::K8sHost.from_csr(
+          account: @conjur_account,
+          service_name: @service_id,
+          csr: @csr
+        )
+      end
 
-        def host_id
-          k8s_host.conjur_host_id
-        end
+      def host_id
+        k8s_host.conjur_host_id
+      end
 
-        def spiffe_id
-          @spiffe_id ||= SpiffeId.new(smart_csr.spiffe_id)
-        end
+      def spiffe_id
+        @spiffe_id ||= SpiffeId.new(smart_csr.spiffe_id)
+      end
 
-        def pod
-          @pod ||= @k8s_object_lookup.pod_by_name(
-            spiffe_id.name, spiffe_id.namespace
-          )
-        end
+      def pod
+        @pod ||= @k8s_object_lookup.pod_by_name(
+          spiffe_id.name, spiffe_id.namespace
+        )
+      end
 
-        def host
-          @host ||= @resource_repo[host_id]
-        end
+      def host
+        @host ||= @resource_repo[host_id]
+      end
 
-        def container_name
-          name = 'kubernetes/authentication-container-name'
-          annotation = host.annotations.find { |a| a.values[:name] == name }
-          annotation[:value] || 'authenticator'
-        end
+      def container_name
+        name = 'kubernetes/authentication-container-name'
+        annotation = host.annotations.find { |a| a.values[:name] == name }
+        annotation[:value] || 'authenticator'
+      end
 
-        def validate_csr
-          raise CSRIsMissingSpiffeId unless smart_csr.spiffe_id
+      def validate_csr
+        raise CSRIsMissingSpiffeId unless smart_csr.spiffe_id
 
-          spiffe_namespace = spiffe_id.namespace
-          cn_namespace = common_name.namespace
-          raise CSRNamespaceMismatch.new(cn_namespace, spiffe_namespace) unless cn_namespace == spiffe_namespace
-        end
+        spiffe_namespace = spiffe_id.namespace
+        cn_namespace = common_name.namespace
+        raise CSRNamespaceMismatch.new(cn_namespace, spiffe_namespace) unless cn_namespace == spiffe_namespace
+      end
 
-        def smart_csr
-          @smart_csr ||= Util::OpenSsl::X509::SmartCsr.new(@csr)
-        end
+      def smart_csr
+        @smart_csr ||= Util::OpenSsl::X509::SmartCsr.new(@csr)
+      end
 
-        def common_name
-          @common_name ||= CommonName.new(smart_csr.common_name)
-        end
+      def common_name
+        @common_name ||= CommonName.new(smart_csr.common_name)
+      end
 
-        def validate_cert_installation(resp)
-          error_stream = resp[:error]
-          return if error_stream.nil? || error_stream.empty?
-          raise CertInstallationError, cert_error(error_stream)
-        end
+      def validate_cert_installation(resp)
+        error_stream = resp[:error]
+        return if error_stream.nil? || error_stream.empty?
+        raise CertInstallationError, cert_error(error_stream)
+      end
 
-        # In case there's a blank error message...
-        def cert_error(msg)
-          return 'The server returned a blank error message' if msg.blank?
-          msg.to_s
-        end
+      # In case there's a blank error message...
+      def cert_error(msg)
+        return 'The server returned a blank error message' if msg.blank?
+        msg.to_s
+      end
 
-        def ca_for_webservice
-          @conjur_ca_repo.ca(webservice.resource_id)
-        end
+      def ca_for_webservice
+        @conjur_ca_repo.ca(webservice.resource_id)
+      end
 
-        def webservice
-          ::Authentication::Webservice.new(
-            account: @conjur_account,
-            authenticator_name: 'authn-k8s',
-            service_id: @service_id
-          )
-        end
+      def webservice
+        ::Authentication::Webservice.new(
+          account: @conjur_account,
+          authenticator_name: 'authn-k8s',
+          service_id: @service_id
+        )
+      end
 
-        def cert_to_install
-          ca_for_webservice.signed_cert(
-            @csr,
-            subject_altnames: [spiffe_id.to_altname]
-          )
-        end
+      def cert_to_install
+        ca_for_webservice.signed_cert(
+          @csr,
+          subject_altnames: [spiffe_id.to_altname]
+        )
       end
     end
   end

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -90,11 +90,11 @@ module Authentication
       end
 
       def validate_csr
-        raise CSRIsMissingSpiffeId unless smart_csr.spiffe_id
+        raise Authentication::AuthnK8s::CSRIsMissingSpiffeId unless smart_csr.spiffe_id
 
         spiffe_namespace = spiffe_id.namespace
         cn_namespace = common_name.namespace
-        raise CSRNamespaceMismatch.new(cn_namespace, spiffe_namespace) unless cn_namespace == spiffe_namespace
+        raise Authentication::AuthnK8s::CSRNamespaceMismatch.new(cn_namespace, spiffe_namespace) unless cn_namespace == spiffe_namespace
       end
 
       def smart_csr
@@ -108,7 +108,7 @@ module Authentication
       def validate_cert_installation(resp)
         error_stream = resp[:error]
         return if error_stream.nil? || error_stream.empty?
-        raise CertInstallationError, cert_error(error_stream)
+        raise Authentication::AuthnK8s::CertInstallationError, cert_error(error_stream)
       end
 
       # In case there's a blank error message...

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -36,7 +36,7 @@ module Authentication
 
         wait_for_close_message
 
-        raise CommandTimedOut.new(@container, @pod_name) unless @channel_closed
+        raise Authentication::AuthnK8s::CommandTimedOut.new(@container, @pod_name) unless @channel_closed
 
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -10,166 +10,122 @@ require 'authentication/errors'
 module Authentication
   module AuthnK8s
 
-    # Utility class for processing WebSocket messages.
-    class WebSocketMessage
-      class << self
-        def channel_byte(channel_name)
-          channel_number_from_name(channel_name).chr
-        end
+    # Possible Errors Raised:
+    # CommandTimedOut
 
-        def channel_number_from_name(channel_name)
-          channel_names.index(channel_name)
-        end
-
-        def channel_names
-          %w(stdin stdout stderr error resize)
-        end
-      end
-
-      def initialize(msg)
-        @msg = msg
-      end
-
-      def type
-        @msg.type
-      end
-
-      def data
-        @msg.data[1..-1]
-      end
-
-      def channel_name
-        self.class.channel_names[channel_number]
-      end
-
-      def channel_number
-        unless @msg.respond_to?(:data)
-          return self.class.channel_number_from_name('error')
-        end
-
-        @msg.data[0..0].bytes.first
-      end
-    end
-
-    class KubectlExec
-      extend CommandClass::Include
-
-      CommandTimedOut = Authentication::AuthnK8s::CommandTimedOut
-
-      command_class(
-        dependencies: { logger: Rails.logger,
-                        k8s_object_lookup: K8sObjectLookup,
-                        timeout: 5.seconds },
-        inputs: %i( pod_namespace
+    KubectlExec = CommandClass.new(
+      dependencies: { logger: Rails.logger,
+                      k8s_object_lookup: K8sObjectLookup,
+                      timeout: 5.seconds },
+      inputs: %i( pod_namespace
                   pod_name
                   container
                   cmds
                   body
                   stdin )
-      ) do
-        def call
-          @message_log = MessageLog.new
-          @channel_closed = false
+    ) do
+      def call
+        @message_log = MessageLog.new
+        @channel_closed = false
 
-          url = server_url(@cmds, @stdin)
-          headers = kubeclient.headers.clone
-          ws_client = WebSocket::Client::Simple.connect(url, headers: headers)
+        url = server_url(@cmds, @stdin)
+        headers = kubeclient.headers.clone
+        ws_client = WebSocket::Client::Simple.connect(url, headers: headers)
 
-          add_websocket_event_handlers(ws_client, @body, @stdin)
+        add_websocket_event_handlers(ws_client, @body, @stdin)
 
-          wait_for_close_message
+        wait_for_close_message
 
-          raise CommandTimedOut.new(@container, @pod_name) unless @channel_closed
+        raise CommandTimedOut.new(@container, @pod_name) unless @channel_closed
 
-          # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
+        # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 
-          @message_log.messages
-        end
+        @message_log.messages
+      end
 
-        def on_open(ws_client, body, stdin)
-          hs = ws_client.handshake
-          hs_error = hs.error
+      def on_open(ws_client, body, stdin)
+        hs = ws_client.handshake
+        hs_error = hs.error
 
-          if hs_error
-            ws_client.emit(:error, "Websocket handshake error: #{hs_error.inspect}")
-          else
-            @logger.debug("Pod #{@pod_name} : channel open")
+        if hs_error
+          ws_client.emit(:error, "Websocket handshake error: #{hs_error.inspect}")
+        else
+          @logger.debug("Pod #{@pod_name} : channel open")
 
-            if stdin
-              data = WebSocketMessage.channel_byte('stdin') + body
-              ws_client.send(data)
-              ws_client.send(nil, type: :close)
-            end
+          if stdin
+            data = WebSocketMessage.channel_byte('stdin') + body
+            ws_client.send(data)
+            ws_client.send(nil, type: :close)
           end
         end
+      end
 
-        def on_message(msg, ws_client)
-          wsmsg = WebSocketMessage.new(msg)
+      def on_message(msg, ws_client)
+        wsmsg = WebSocketMessage.new(msg)
 
-          msg_type = wsmsg.type
-          msg_data = wsmsg.data
+        msg_type = wsmsg.type
+        msg_data = wsmsg.data
 
-          if msg_type == :binary
-            @logger.debug("Pod #{@pod_name}, channel #{wsmsg.channel_name}: #{msg_data}")
-            @message_log.save_message(wsmsg)
-          elsif msg_type == :close
-            @logger.debug("Pod: #{@pod_name}, message: close, data: #{msg_data}")
-            ws_client.close
-          end
+        if msg_type == :binary
+          @logger.debug("Pod #{@pod_name}, channel #{wsmsg.channel_name}: #{msg_data}")
+          @message_log.save_message(wsmsg)
+        elsif msg_type == :close
+          @logger.debug("Pod: #{@pod_name}, message: close, data: #{msg_data}")
+          ws_client.close
         end
+      end
 
-        def on_close
-          @channel_closed = true
-          @logger.debug("Pod #{@pod_name} : channel closed")
+      def on_close
+        @channel_closed = true
+        @logger.debug("Pod #{@pod_name} : channel closed")
+      end
+
+      def on_error(err)
+        @channel_closed = true
+
+        error_info = err.inspect
+        @logger.debug("Pod #{@pod_name} error : #{error_info}")
+        @message_log.save_error_string(error_info)
+      end
+
+      private
+
+      def kubeclient
+        @kubeclient ||= @k8s_object_lookup.kubectl_client
+      end
+
+      def add_websocket_event_handlers(ws_client, body, stdin)
+        kubectl = self
+
+        ws_client.on(:open) { kubectl.on_open(ws_client, body, stdin) }
+        ws_client.on(:message) { |msg| kubectl.on_message(msg, ws_client) }
+        ws_client.on(:close) { kubectl.on_close }
+        ws_client.on(:error) { |err| kubectl.on_error(err) }
+      end
+
+      def wait_for_close_message
+        (@timeout / 0.1).to_i.times do
+          break if @channel_closed
+          sleep 0.1
         end
+      end
 
-        def on_error(err)
-          @channel_closed = true
+      def query_string(cmds, stdin)
+        stdin_part = stdin ? ['stdin=true'] : []
+        cmds_part = cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
+        (base_query_string_parts + stdin_part + cmds_part).join("&")
+      end
 
-          error_info = err.inspect
-          @logger.debug("Pod #{@pod_name} error : #{error_info}")
-          @message_log.save_error_string(error_info)
-        end
+      def base_query_string_parts
+        ["container=#{CGI.escape(@container)}", "stderr=true", "stdout=true"]
+      end
 
-        private
-
-        def kubeclient
-          @kubeclient ||= @k8s_object_lookup.kubectl_client
-        end
-
-        def add_websocket_event_handlers(ws_client, body, stdin)
-          kubectl = self
-
-          ws_client.on(:open) { kubectl.on_open(ws_client, body, stdin) }
-          ws_client.on(:message) { |msg| kubectl.on_message(msg, ws_client) }
-          ws_client.on(:close) { kubectl.on_close }
-          ws_client.on(:error) { |err| kubectl.on_error(err) }
-        end
-
-        def wait_for_close_message
-          (@timeout / 0.1).to_i.times do
-            break if @channel_closed
-            sleep 0.1
-          end
-        end
-
-        def query_string(cmds, stdin)
-          stdin_part = stdin ? ['stdin=true'] : []
-          cmds_part = cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
-          (base_query_string_parts + stdin_part + cmds_part).join("&")
-        end
-
-        def base_query_string_parts
-          ["container=#{CGI.escape(@container)}", "stderr=true", "stdout=true"]
-        end
-
-        def server_url(cmds, stdin)
-          api_uri = kubeclient.api_endpoint
-          base_url = "wss://#{api_uri.host}:#{api_uri.port}"
-          path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
-          query = query_string(cmds, stdin)
-          "#{base_url}#{path}?#{query}"
-        end
+      def server_url(cmds, stdin)
+        api_uri = kubeclient.api_endpoint
+        base_url = "wss://#{api_uri.host}:#{api_uri.port}"
+        path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
+        query = query_string(cmds, stdin)
+        "#{base_url}#{path}?#{query}"
       end
     end
 
@@ -215,5 +171,47 @@ module Authentication
         tarfile.string
       end
     end
+
+    # Utility class for processing WebSocket messages.
+    class WebSocketMessage
+      class << self
+        def channel_byte(channel_name)
+          channel_number_from_name(channel_name).chr
+        end
+
+        def channel_number_from_name(channel_name)
+          channel_names.index(channel_name)
+        end
+
+        def channel_names
+          %w(stdin stdout stderr error resize)
+        end
+      end
+
+      def initialize(msg)
+        @msg = msg
+      end
+
+      def type
+        @msg.type
+      end
+
+      def data
+        @msg.data[1..-1]
+      end
+
+      def channel_name
+        self.class.channel_names[channel_number]
+      end
+
+      def channel_number
+        unless @msg.respond_to?(:data)
+          return self.class.channel_number_from_name('error')
+        end
+
+        @msg.data[0..0].bytes.first
+      end
+    end
+
   end
 end

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -33,16 +33,16 @@ module Authentication
       private
 
       def validate_webservice_exists
-        raise WebserviceNotFound, service_id unless webservice
+        raise Authentication::AuthnK8s::WebserviceNotFound, service_id unless webservice
       end
 
       def validate_host_can_access_service
         return if host_can_access_service?
-        raise HostNotAuthorized.new(host.role.id, service_id)
+        raise Authentication::AuthnK8s::HostNotAuthorized.new(host.role.id, service_id)
       end
 
       def validate_pod_exists
-        raise PodNotFound.new(pod_name, pod_namespace) unless pod
+        raise Authentication::AuthnK8s::PodNotFound.new(pod_name, pod_namespace) unless pod
       end
 
       def validate_pod_properties
@@ -53,17 +53,17 @@ module Authentication
       end
 
       def validate_container
-        raise ContainerNotFound, container_name unless container
+        raise Authentication::AuthnK8s::ContainerNotFound, container_name unless container
       end
 
       def validate_scope
         return if k8s_host.permitted_scope?
-        raise ScopeNotSupported, k8s_host.controller
+        raise Authentication::AuthnK8s::ScopeNotSupported, k8s_host.controller
       end
 
       def validate_controller
         return if controller_object
-        raise ControllerNotFound.new(k8s_host.controller, k8s_host.object, k8s_host.namespace)
+        raise Authentication::AuthnK8s::ControllerNotFound.new(k8s_host.controller, k8s_host.object, k8s_host.namespace)
       end
 
       def validate_pod_metadata

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -5,139 +5,133 @@ require 'authentication/errors'
 
 module Authentication
   module AuthnK8s
-    class ValidatePodRequest
-      extend CommandClass::Include
 
-      WebserviceNotFound = Authentication::AuthnK8s::WebserviceNotFound
-      HostNotAuthorized = Authentication::AuthnK8s::HostNotAuthorized
-      PodNotFound = Authentication::AuthnK8s::PodNotFound
-      ContainerNotFound = Authentication::AuthnK8s::ContainerNotFound
-      ScopeNotSupported = Authentication::AuthnK8s::ScopeNotSupported
-      ControllerNotFound = Authentication::AuthnK8s::ControllerNotFound
+    # Possible Errors Raised:
+    # WebserviceNotFound, HostNotAuthorized, PodNotFound
+    # ContainerNotFound, ScopeNotSupported, ControllerNotFound
 
-      command_class(
-        dependencies: {
-          resource_repo: Resource,
-          k8s_resolver: K8sResolver,
-          k8s_object_lookup: K8sObjectLookup # K8s API facade
-        },
-        inputs: [:pod_request]
-      ) do
+    ValidatePodRequest = CommandClass.new(
+      dependencies: {
+        resource_repo: Resource,
+        k8s_resolver: K8sResolver,
+        k8s_object_lookup: K8sObjectLookup # K8s API facade
+      },
+      inputs: [:pod_request]
+    ) do
 
-        extend Forwardable
-        def_delegators :@pod_request, :service_id, :k8s_host, :spiffe_id
+      extend Forwardable
+      def_delegators :@pod_request, :service_id, :k8s_host, :spiffe_id
 
-        def call
-          validate_webservice_exists
-          validate_host_can_access_service
-          validate_pod_exists
-          validate_pod_properties
-          validate_container
-        end
+      def call
+        validate_webservice_exists
+        validate_host_can_access_service
+        validate_pod_exists
+        validate_pod_properties
+        validate_container
+      end
 
-        private
+      private
 
-        def validate_webservice_exists
-          raise WebserviceNotFound, service_id unless webservice
-        end
+      def validate_webservice_exists
+        raise WebserviceNotFound, service_id unless webservice
+      end
 
-        def validate_host_can_access_service
-          return if host_can_access_service?
-          raise HostNotAuthorized.new(host.role.id, service_id)
-        end
+      def validate_host_can_access_service
+        return if host_can_access_service?
+        raise HostNotAuthorized.new(host.role.id, service_id)
+      end
 
-        def validate_pod_exists
-          raise PodNotFound.new(pod_name, pod_namespace) unless pod
-        end
+      def validate_pod_exists
+        raise PodNotFound.new(pod_name, pod_namespace) unless pod
+      end
 
-        def validate_pod_properties
-          return if k8s_host.namespace_scoped?
-          validate_scope
-          validate_controller
-          validate_pod_metadata
-        end
+      def validate_pod_properties
+        return if k8s_host.namespace_scoped?
+        validate_scope
+        validate_controller
+        validate_pod_metadata
+      end
 
-        def validate_container
-          raise ContainerNotFound, container_name unless container
-        end
+      def validate_container
+        raise ContainerNotFound, container_name unless container
+      end
 
-        def validate_scope
-          return if k8s_host.permitted_scope?
-          raise ScopeNotSupported, k8s_host.controller
-        end
+      def validate_scope
+        return if k8s_host.permitted_scope?
+        raise ScopeNotSupported, k8s_host.controller
+      end
 
-        def validate_controller
-          return if controller_object
-          raise ControllerNotFound.new(k8s_host.controller, k8s_host.object, k8s_host.namespace)
-        end
+      def validate_controller
+        return if controller_object
+        raise ControllerNotFound.new(k8s_host.controller, k8s_host.object, k8s_host.namespace)
+      end
 
-        def validate_pod_metadata
-          @k8s_resolver
-            .for_controller(k8s_host.controller)
-            .new(controller_object, pod)
-            .validate_pod
-        end
+      def validate_pod_metadata
+        @k8s_resolver
+          .for_controller(k8s_host.controller)
+          .new(controller_object, pod)
+          .validate_pod
+      end
 
-        # @return The Conjur resource for the webservice.
-        def webservice
-          @webservice ||= @resource_repo[logical_webservice.resource_id]
-        end
+      # @return The Conjur resource for the webservice.
+      def webservice
+        @webservice ||= @resource_repo[logical_webservice.resource_id]
+      end
 
-        # @return A value object for the webservice that encapsulates
-        #   string parsing logic for constructing the resource id.
-        def logical_webservice
-          Webservice.new(
-            account: k8s_host.account,
-            authenticator_name: 'authn-k8s',
-            service_id: service_id
-          )
-        end
+      # @return A value object for the webservice that encapsulates
+      #   string parsing logic for constructing the resource id.
+      def logical_webservice
+        Webservice.new(
+          account: k8s_host.account,
+          authenticator_name: 'authn-k8s',
+          service_id: service_id
+        )
+      end
 
-        def host_can_access_service?
-          host.role.allowed_to?("authenticate", webservice)
-        end
+      def host_can_access_service?
+        host.role.allowed_to?("authenticate", webservice)
+      end
 
-        def host
-          @host ||= @resource_repo[k8s_host.conjur_host_id]
-        end
+      def host
+        @host ||= @resource_repo[k8s_host.conjur_host_id]
+      end
 
-        def container
-          pod.spec.containers.find { |c| c.name == container_name } ||
-            pod.spec.initContainers.find { |c| c.name == container_name }
-        end
+      def container
+        pod.spec.containers.find { |c| c.name == container_name } ||
+          pod.spec.initContainers.find { |c| c.name == container_name }
+      end
 
-        def default_container_name
-          'authenticator'
-        end
+      def default_container_name
+        'authenticator'
+      end
 
-        def container_name
-          name = 'kubernetes/authentication-container-name'
-          annotation = host.annotations.find { |a| a.values[:name] == name }
+      def container_name
+        name = 'kubernetes/authentication-container-name'
+        annotation = host.annotations.find { |a| a.values[:name] == name }
 
-          return default_container_name unless annotation
+        return default_container_name unless annotation
 
-          annotation[:value] || default_container_name
-        end
+        annotation[:value] || default_container_name
+      end
 
-        def pod
-          @pod ||= @k8s_object_lookup.pod_by_name(pod_name, pod_namespace)
-        end
+      def pod
+        @pod ||= @k8s_object_lookup.pod_by_name(pod_name, pod_namespace)
+      end
 
-        def pod_name
-          spiffe_id.name
-        end
+      def pod_name
+        spiffe_id.name
+      end
 
-        def pod_namespace
-          spiffe_id.namespace
-        end
+      def pod_namespace
+        spiffe_id.namespace
+      end
 
-        def controller_object
-          @controller_object ||= @k8s_object_lookup.find_object_by_name(
-            k8s_host.controller,
-            k8s_host.object,
-            k8s_host.namespace
-          )
-        end
+      def controller_object
+        @controller_object ||= @k8s_object_lookup.find_object_by_name(
+          k8s_host.controller,
+          k8s_host.object,
+          k8s_host.namespace
+        )
       end
     end
   end

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
@@ -5,115 +5,111 @@ module Authentication
   module AuthnOidc
     module AuthenticateIdToken
 
-      class Authenticate
-        extend CommandClass::Include
+      # Possible Errors Raised:
+      # IdTokenFieldNotFoundOrEmpty, AdminAuthenticationDenied
 
-        IdTokenFieldNotFoundOrEmpty = Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty
-        AdminAuthenticationDenied = Authentication::AuthnOidc::AdminAuthenticationDenied
+      Authenticate = CommandClass.new(
+        dependencies: {
+          enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+          fetch_oidc_secrets: AuthnOidc::Util::FetchOidcSecrets.new,
+          token_factory: OidcTokenFactory.new,
+          validate_security: ValidateSecurity.new,
+          validate_origin: ValidateOrigin.new,
+          audit_event: AuditEvent.new,
+          decode_and_verify_id_token: DecodeAndVerifyIdToken.new,
+          logger: Rails.logger
+        },
+        inputs: %i(authenticator_input)
+      ) do
 
-        command_class(
-          dependencies: {
-            enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
-            fetch_oidc_secrets: AuthnOidc::Util::FetchOidcSecrets.new,
-            token_factory: OidcTokenFactory.new,
-            validate_security: ValidateSecurity.new,
-            validate_origin: ValidateOrigin.new,
-            audit_event: AuditEvent.new,
-            decode_and_verify_id_token: DecodeAndVerifyIdToken.new,
-            logger: Rails.logger
-          },
-          inputs: %i(authenticator_input)
-        ) do
+        def call
+          decode_and_verify_id_token
+          validate_conjur_username
+          add_username_to_input
+          validate_security
+          validate_origin
+          audit_success
+          new_token
+        rescue => e
+          audit_failure(e)
+          raise e
+        end
 
-          def call
-            decode_and_verify_id_token
-            validate_conjur_username
-            add_username_to_input
-            validate_security
-            validate_origin
-            audit_success
-            new_token
-          rescue => e
-            audit_failure(e)
-            raise e
-          end
+        private
 
-          private
+        def decode_and_verify_id_token
+          @id_token_attributes = @decode_and_verify_id_token.(
+            provider_uri: oidc_secrets["provider-uri"],
+              id_token_jwt: request_body.id_token
+          )
+        end
 
-          def decode_and_verify_id_token
-            @id_token_attributes = @decode_and_verify_id_token.(
-              provider_uri: oidc_secrets["provider-uri"],
-                id_token_jwt: request_body.id_token
-            )
-          end
+        def add_username_to_input
+          @authenticator_input = @authenticator_input.update(username: conjur_username)
+        end
 
-          def add_username_to_input
-            @authenticator_input = @authenticator_input.update(username: conjur_username)
-          end
+        def request_body
+          @request_body ||= AuthnOidc::AuthenticateIdToken::AuthenticateRequestBody.new(@authenticator_input.request)
+        end
 
-          def request_body
-            @request_body ||= AuthnOidc::AuthenticateIdToken::AuthenticateRequestBody.new(@authenticator_input.request)
-          end
+        def oidc_secrets
+          @oidc_secrets ||= @fetch_oidc_secrets.(
+            service_id: @authenticator_input.service_id,
+              conjur_account: @authenticator_input.account,
+              required_variable_names: required_variable_names
+          )
+        end
 
-          def oidc_secrets
-            @oidc_secrets ||= @fetch_oidc_secrets.(
-              service_id: @authenticator_input.service_id,
-                conjur_account: @authenticator_input.account,
-                required_variable_names: required_variable_names
-            )
-          end
+        def required_variable_names
+          @required_variable_names ||= %w(provider-uri id-token-user-property)
+        end
 
-          def required_variable_names
-            @required_variable_names ||= %w(provider-uri id-token-user-property)
-          end
+        def new_token
+          @token_factory.signed_token(
+            account: @authenticator_input.account,
+            username: @authenticator_input.username
+          )
+        end
 
-          def new_token
-            @token_factory.signed_token(
+        def validate_conjur_username
+          raise IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
+          raise AdminAuthenticationDenied if admin?(conjur_username)
+          @logger.debug("[OIDC] Extracted username '#{conjur_username}' from ID Token")
+        end
+
+        def conjur_username
+          @conjur_username ||= @id_token_attributes[id_token_username_field]
+        end
+
+        def id_token_username_field
+          oidc_secrets["id-token-user-property"]
+        end
+
+        def validate_security
+          @validate_security.(
+            webservice: @authenticator_input.webservice,
               account: @authenticator_input.account,
-              username: @authenticator_input.username
-            )
-          end
+              user_id: @authenticator_input.username,
+              enabled_authenticators: @enabled_authenticators
+          )
+          @logger.debug("[OIDC] Security validated")
+        end
 
-          def validate_conjur_username
-            raise IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
-            raise AdminAuthenticationDenied if admin?(conjur_username)
-            @logger.debug("[OIDC] Extracted username '#{conjur_username}' from ID Token")
-          end
+        def validate_origin
+          @validate_origin.(input: @authenticator_input)
+          @logger.debug("[OIDC] Origin validated")
+        end
 
-          def conjur_username
-            @conjur_username ||= @id_token_attributes[id_token_username_field]
-          end
+        def audit_success
+          @audit_event.(input: @authenticator_input, success: true, message: nil)
+        end
 
-          def id_token_username_field
-            oidc_secrets["id-token-user-property"]
-          end
+        def audit_failure(err)
+          @audit_event.(input: @authenticator_input, success: false, message: err.message)
+        end
 
-          def validate_security
-            @validate_security.(
-              webservice: @authenticator_input.webservice,
-                account: @authenticator_input.account,
-                user_id: @authenticator_input.username,
-                enabled_authenticators: @enabled_authenticators
-            )
-            @logger.debug("[OIDC] Security validated")
-          end
-
-          def validate_origin
-            @validate_origin.(input: @authenticator_input)
-            @logger.debug("[OIDC] Origin validated")
-          end
-
-          def audit_success
-            @audit_event.(input: @authenticator_input, success: true, message: nil)
-          end
-
-          def audit_failure(err)
-            @audit_event.(input: @authenticator_input, success: false, message: err.message)
-          end
-
-          def admin?(username)
-            username == "admin"
-          end
+        def admin?(username)
+          username == "admin"
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
@@ -72,8 +72,8 @@ module Authentication
         end
 
         def validate_conjur_username
-          raise IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
-          raise AdminAuthenticationDenied if admin?(conjur_username)
+          raise Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
+          raise Authentication::AuthnOidc::AdminAuthenticationDenied if admin?(conjur_username)
           @logger.debug("[OIDC] Extracted username '#{conjur_username}' from ID Token")
         end
 

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
@@ -42,9 +42,9 @@ module Authentication
           decoded_id_token.verify!(expected)
           @logger.debug("[OIDC] ID Token verification succeeded")
         rescue OpenIDConnect::ResponseObject::IdToken::ExpiredToken
-          raise IdTokenExpired
+          raise Authentication::AuthnOidc::IdTokenExpired
         rescue => e
-          raise IdTokenVerifyFailed, e.inspect
+          raise Authentication::AuthnOidc::IdTokenVerifyFailed, e.inspect
         end
 
         def fetch_certs
@@ -61,7 +61,7 @@ module Authentication
             @certs
           )
         rescue => e
-          raise IdTokenInvalidFormat, e.inspect
+          raise Authentication::AuthnOidc::IdTokenInvalidFormat, e.inspect
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
@@ -5,67 +5,63 @@ require 'authentication/errors'
 module Authentication
   module AuthnOidc
     module AuthenticateIdToken
-      class DecodeAndVerifyIdToken
-        extend CommandClass::Include
 
-        IdTokenExpired = ::Authentication::AuthnOidc::IdTokenExpired
-        IdTokenVerifyFailed = ::Authentication::AuthnOidc::IdTokenVerifyFailed
-        IdTokenInvalidFormat = ::Authentication::AuthnOidc::IdTokenInvalidFormat
+      # Possible Errors Raised:
+      # IdTokenExpired, IdTokenVerifyFailed, IdTokenInvalidFormat
 
-        command_class(
-          dependencies: {
-            fetch_provider_certificate: ::Authentication::AuthnOidc::AuthenticateIdToken::FetchProviderCertificate.new,
-            logger: Rails.logger
-          },
-          inputs: %i(provider_uri id_token_jwt)
-        ) do
+      DecodeAndVerifyIdToken = CommandClass.new(
+        dependencies: {
+          fetch_provider_certificate: ::Authentication::AuthnOidc::AuthenticateIdToken::FetchProviderCertificate.new,
+          logger: Rails.logger
+        },
+        inputs: %i(provider_uri id_token_jwt)
+      ) do
 
-          def call
-            # we fetch the certs & decode the id token here to propagate relevant errors
-            fetch_certs
-            decode_id_token
-            verify_decoded_id_token
-            decoded_attributes # return decoded attributes as hash
-          end
+        def call
+          # we fetch the certs & decode the id token here to propagate relevant errors
+          fetch_certs
+          decode_id_token
+          verify_decoded_id_token
+          decoded_attributes # return decoded attributes as hash
+        end
 
-          private
+        private
 
-          def decode_id_token
-            decoded_id_token
-            @logger.debug("[OIDC] Decode ID Token succeeded")
-          end
+        def decode_id_token
+          decoded_id_token
+          @logger.debug("[OIDC] Decode ID Token succeeded")
+        end
 
-          def verify_decoded_id_token
-            # Verify id_token expiration. OpenIDConnect requires to verify few claims.
-            # Mask required claims such that effectively only expiration will be verified
-            expected = { client_id: decoded_attributes[:aud] || decoded_attributes[:client_id],
-                         issuer: decoded_attributes[:iss],
-                         nonce: decoded_attributes[:nonce] }
+        def verify_decoded_id_token
+          # Verify id_token expiration. OpenIDConnect requires to verify few claims.
+          # Mask required claims such that effectively only expiration will be verified
+          expected = { client_id: decoded_attributes[:aud] || decoded_attributes[:client_id],
+                       issuer: decoded_attributes[:iss],
+                       nonce: decoded_attributes[:nonce] }
 
-            decoded_id_token.verify!(expected)
-            @logger.debug("[OIDC] ID Token verification succeeded")
-          rescue OpenIDConnect::ResponseObject::IdToken::ExpiredToken
-            raise IdTokenExpired
-          rescue => e
-            raise IdTokenVerifyFailed, e.inspect
-          end
+          decoded_id_token.verify!(expected)
+          @logger.debug("[OIDC] ID Token verification succeeded")
+        rescue OpenIDConnect::ResponseObject::IdToken::ExpiredToken
+          raise IdTokenExpired
+        rescue => e
+          raise IdTokenVerifyFailed, e.inspect
+        end
 
-          def fetch_certs
-            @certs = @fetch_provider_certificate.(provider_uri: @provider_uri)
-          end
+        def fetch_certs
+          @certs = @fetch_provider_certificate.(provider_uri: @provider_uri)
+        end
 
-          def decoded_attributes
-            @decoded_attributes ||= decoded_id_token.raw_attributes
-          end
+        def decoded_attributes
+          @decoded_attributes ||= decoded_id_token.raw_attributes
+        end
 
-          def decoded_id_token
-            @decoded_id_token ||= OpenIDConnect::ResponseObject::IdToken.decode(
-              @id_token_jwt,
-              @certs
-            )
-          rescue => e
-            raise IdTokenInvalidFormat, e.inspect
-          end
+        def decoded_id_token
+          @decoded_id_token ||= OpenIDConnect::ResponseObject::IdToken.decode(
+            @id_token_jwt,
+            @certs
+          )
+        rescue => e
+          raise IdTokenInvalidFormat, e.inspect
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
@@ -5,51 +5,47 @@ require 'authentication/errors'
 module Authentication
   module AuthnOidc
     module AuthenticateIdToken
-      class FetchProviderCertificate
-        extend CommandClass::Include
 
-        ProviderDiscoveryTimeout = Authentication::AuthnOidc::ProviderDiscoveryTimeout
-        ProviderDiscoveryFailed = Authentication::AuthnOidc::ProviderDiscoveryFailed
-        ProviderFetchCertificateFailed = Authentication::AuthnOidc::ProviderFetchCertificateFailed
+      # Possible Errors Raised:
+      # ProviderDiscoveryTimeout, ProviderDiscoveryFailed, ProviderFetchCertificateFailed
 
-        command_class(
-          dependencies: {
-            logger: Rails.logger
-          },
-          inputs: %i(provider_uri)
-        ) do
+      FetchProviderCertificate = CommandClass.new(
+        dependencies: {
+          logger: Rails.logger
+        },
+        inputs: %i(provider_uri)
+      ) do
 
-          def call
-            # provider discovery might throw exception. Let it propagate upward
-            discover_provider
-            fetch_certs
-          end
+        def call
+          # provider discovery might throw exception. Let it propagate upward
+          discover_provider
+          fetch_certs
+        end
 
-          private
+        private
 
-          def discover_provider
-            @logger.debug("[OIDC] Discovering provider '#{@provider_uri}'")
+        def discover_provider
+          @logger.debug("[OIDC] Discovering provider '#{@provider_uri}'")
 
-            @discovered_provider = OpenIDConnect::Discovery::Provider::Config.discover!(@provider_uri)
-          rescue HTTPClient::ConnectTimeoutError => e
-            raise_error(ProviderDiscoveryTimeout, e)
-          rescue => e
-            raise_error(ProviderDiscoveryFailed, e)
-          end
+          @discovered_provider = OpenIDConnect::Discovery::Provider::Config.discover!(@provider_uri)
+        rescue HTTPClient::ConnectTimeoutError => e
+          raise_error(ProviderDiscoveryTimeout, e)
+        rescue => e
+          raise_error(ProviderDiscoveryFailed, e)
+        end
 
-          def fetch_certs
-            @logger.debug("[OIDC] Fetching provider certificate from '#{@provider_uri}'")
+        def fetch_certs
+          @logger.debug("[OIDC] Fetching provider certificate from '#{@provider_uri}'")
 
-            jwks = @discovered_provider.jwks
-            @logger.debug("[OIDC] Provider certificate was fetched successfully from '#{@provider_uri}'")
-            jwks
-          rescue => e
-            raise_error(ProviderFetchCertificateFailed, e)
-          end
+          jwks = @discovered_provider.jwks
+          @logger.debug("[OIDC] Provider certificate was fetched successfully from '#{@provider_uri}'")
+          jwks
+        rescue => e
+          raise_error(ProviderFetchCertificateFailed, e)
+        end
 
-          def raise_error(error_class, original_error)
-            raise error_class.new(@provider_uri, original_error.inspect)
-          end
+        def raise_error(error_class, original_error)
+          raise error_class.new(@provider_uri, original_error.inspect)
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
@@ -29,9 +29,9 @@ module Authentication
 
           @discovered_provider = OpenIDConnect::Discovery::Provider::Config.discover!(@provider_uri)
         rescue HTTPClient::ConnectTimeoutError => e
-          raise_error(ProviderDiscoveryTimeout, e)
+          raise_error(Authentication::AuthnOidc::ProviderDiscoveryTimeout, e)
         rescue => e
-          raise_error(ProviderDiscoveryFailed, e)
+          raise_error(Authentication::AuthnOidc::ProviderDiscoveryFailed, e)
         end
 
         def fetch_certs
@@ -41,7 +41,7 @@ module Authentication
           @logger.debug("[OIDC] Provider certificate was fetched successfully from '#{@provider_uri}'")
           jwks
         rescue => e
-          raise_error(ProviderFetchCertificateFailed, e)
+          raise_error(Authentication::AuthnOidc::ProviderFetchCertificateFailed, e)
         end
 
         def raise_error(error_class, original_error)

--- a/app/domain/authentication/authn_oidc/authenticate_oidc_conjur_token/authenticate_oidc_conjur_token.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_oidc_conjur_token/authenticate_oidc_conjur_token.rb
@@ -3,75 +3,72 @@ require 'command_class'
 module Authentication
   module AuthnOidc
     module AuthenticateOidcConjurToken
-      class Authenticate
-        extend CommandClass::Include
 
-        command_class(
-          dependencies: {
-            validate_and_decrypt_oidc_conjur_token: ValidateAndDecryptOidcConjurToken.new,
-            enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
-            token_factory: OidcTokenFactory.new,
-            validate_security: ::Authentication::ValidateSecurity.new,
-            validate_origin: ::Authentication::ValidateOrigin.new,
-            audit_event: ::Authentication::AuditEvent.new
-          },
-          inputs: %i(authenticator_input)
-        ) do
+      Authenticate = CommandClass.new(
+        dependencies: {
+          validate_and_decrypt_oidc_conjur_token: ValidateAndDecryptOidcConjurToken.new,
+          enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+          token_factory: OidcTokenFactory.new,
+          validate_security: ::Authentication::ValidateSecurity.new,
+          validate_origin: ::Authentication::ValidateOrigin.new,
+          audit_event: ::Authentication::AuditEvent.new
+        },
+        inputs: %i(authenticator_input)
+      ) do
 
-          def call
-            validate_and_decrypt_oidc_conjur_token
-            add_username_to_input
-            validate_security
-            validate_origin
-            audit_success
-            new_token
-          rescue => e
-            audit_failure(e)
-            raise e
-          end
+        def call
+          validate_and_decrypt_oidc_conjur_token
+          add_username_to_input
+          validate_security
+          validate_origin
+          audit_success
+          new_token
+        rescue => e
+          audit_failure(e)
+          raise e
+        end
 
-          private
+        private
 
-          def validate_and_decrypt_oidc_conjur_token
-            oidc_conjur_token
-          end
+        def validate_and_decrypt_oidc_conjur_token
+          oidc_conjur_token
+        end
 
-          def add_username_to_input
-            username = oidc_conjur_token.user_name
-            @authenticator_input = @authenticator_input.update(username: username)
-          end
+        def add_username_to_input
+          username = oidc_conjur_token.user_name
+          @authenticator_input = @authenticator_input.update(username: username)
+        end
 
-          def oidc_conjur_token
-            @oidc_conjur_token ||= @validate_and_decrypt_oidc_conjur_token.(request_body: @authenticator_input.request.body.read)
-          end
+        def oidc_conjur_token
+          @oidc_conjur_token ||= @validate_and_decrypt_oidc_conjur_token.(request_body: @authenticator_input.request.body.read)
+        end
 
-          def validate_security
-            @validate_security.(
-              webservice: @authenticator_input.webservice,
-                account: @authenticator_input.account,
-                user_id: @authenticator_input.username,
-                enabled_authenticators: @enabled_authenticators
-            )
-          end
-
-          def validate_origin
-            @validate_origin.(input: @authenticator_input)
-          end
-
-          def audit_success
-            @audit_event.(input: @authenticator_input, success: true, message: nil)
-          end
-
-          def audit_failure(err)
-            @audit_event.(input: @authenticator_input, success: false, message: err.message)
-          end
-
-          def new_token
-            @token_factory.signed_token(
+        def validate_security
+          @validate_security.(
+            webservice: @authenticator_input.webservice,
               account: @authenticator_input.account,
-              username: @authenticator_input.username
-            )
-          end
+              user_id: @authenticator_input.username,
+              enabled_authenticators: @enabled_authenticators
+          )
+        end
+
+        def validate_origin
+          @validate_origin.(input: @authenticator_input)
+        end
+
+        def audit_success
+          @audit_event.(input: @authenticator_input, success: true, message: nil)
+        end
+
+        def audit_failure(err)
+          @audit_event.(input: @authenticator_input, success: false, message: err.message)
+        end
+
+        def new_token
+          @token_factory.signed_token(
+            account: @authenticator_input.account,
+            username: @authenticator_input.username
+          )
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/authenticate_oidc_conjur_token/validate_and_decrypt_oidc_conjur_token.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_oidc_conjur_token/validate_and_decrypt_oidc_conjur_token.rb
@@ -12,45 +12,42 @@ module Authentication
       # - Validate input
       # - Validate JWT signing token
       # - Decrypt ID token
-      class ValidateAndDecryptOidcConjurToken
-        extend CommandClass::Include
 
-        command_class(
-          dependencies: {},
-          inputs: %i(request_body)
-        ) do
+      ValidateAndDecryptOidcConjurToken = CommandClass.new(
+        dependencies: {},
+        inputs: %i(request_body)
+      ) do
 
-          def call
-            oidc_conjur_token
-            # validate_signing
-            # decrypt_token
-          end
+        def call
+          oidc_conjur_token
+          # validate_signing
+          # decrypt_token
+        end
 
-          private
+        private
 
-          def oidc_conjur_token
-            ::Authentication::AuthnOidc::ConjurToken.new(
-              id_token_encrypted: id_token_encrypted,
-              user_name: user_name,
-              expiration_time: expiration_time
-            )
-          end
+        def oidc_conjur_token
+          ::Authentication::AuthnOidc::ConjurToken.new(
+            id_token_encrypted: id_token_encrypted,
+            user_name: user_name,
+            expiration_time: expiration_time
+          )
+        end
 
-          def decoded_body
-            @decoded_body ||= URI.decode_www_form(@request_body)
-          end
+        def decoded_body
+          @decoded_body ||= URI.decode_www_form(@request_body)
+        end
 
-          def id_token_encrypted
-            @id_token_encrypted ||= decoded_body.assoc('id_token_encrypted').last
-          end
+        def id_token_encrypted
+          @id_token_encrypted ||= decoded_body.assoc('id_token_encrypted').last
+        end
 
-          def user_name
-            @user_name ||= decoded_body.assoc('user_name').last
-          end
+        def user_name
+          @user_name ||= decoded_body.assoc('user_name').last
+        end
 
-          def expiration_time
-            @expiration_time ||= decoded_body.assoc('expiration_time').last
-          end
+        def expiration_time
+          @expiration_time ||= decoded_body.assoc('expiration_time').last
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/get_conjur_oidc_token/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/get_conjur_oidc_token/authenticator.rb
@@ -3,62 +3,59 @@ require 'command_class'
 module Authentication
   module AuthnOidc
     module GetConjurOidcToken
-      class OIDCAuthenticationError < RuntimeError; end
+      class OIDCAuthenticationError < RuntimeError;
+      end
 
-      class Authenticator
-        extend CommandClass::Include
+      Authenticator = CommandClass.new(
+        dependencies: {
+        },
+        inputs: %i(input oidc_id_token_details)
+      ) do
 
-        command_class(
-          dependencies: {
-          },
-          inputs: %i(input oidc_id_token_details)
-        ) do
+        def call
+          validate_id_token_claims
+          validate_user_info
+          # TODO: validate_nonce
+          true
+        end
 
-          def call
-            validate_id_token_claims
-            validate_user_info
-            # TODO: validate_nonce
-            true
-          end
+        private
 
-          private
+        def validate_id_token_claims
+          expected = { client_id: @oidc_id_token_details.client_id, issuer: @oidc_id_token_details.issuer } # , nonce: 'nonce'}
+          @oidc_id_token_details.id_token.verify!(expected)
+        rescue OpenIDConnect::ResponseObject::IdToken::InvalidToken => e
+          raise OIDCAuthenticationError, e.message
+        end
 
-          def validate_id_token_claims
-            expected = { client_id: @oidc_id_token_details.client_id, issuer: @oidc_id_token_details.issuer } # , nonce: 'nonce'}
-            @oidc_id_token_details.id_token.verify!(expected)
-          rescue OpenIDConnect::ResponseObject::IdToken::InvalidToken => e
-            raise OIDCAuthenticationError, e.message
-          end
+        def validate_user_info
+          raise OIDCAuthenticationError, subject_err_msg unless valid_subject?
+          raise OIDCAuthenticationError, no_username_err_msg unless user_info.preferred_username
+        end
 
-          def validate_user_info
-            raise OIDCAuthenticationError, subject_err_msg unless valid_subject?
-            raise OIDCAuthenticationError, no_username_err_msg unless user_info.preferred_username
-          end
+        def user_info
+          @oidc_id_token_details.user_info
+        end
 
-          def user_info
-            @oidc_id_token_details.user_info
-          end
+        def valid_subject?
+          user_info.sub == id_token_subject
+        end
 
-          def valid_subject?
-            user_info.sub == id_token_subject
-          end
+        def id_token_subject
+          @oidc_id_token_details.id_token.sub
+        end
 
-          def id_token_subject
-            @oidc_id_token_details.id_token.sub
-          end
+        def service
+          @service ||= Resource["#{@input.account}:webservice:conjur/#{@input.authenticator_name}/#{@input.service_id}"]
+        end
 
-          def service
-            @service ||= Resource["#{@input.account}:webservice:conjur/#{@input.authenticator_name}/#{@input.service_id}"]
-          end
+        def no_username_err_msg
+          "username not found in OIDC access token"
+        end
 
-          def no_username_err_msg
-            "username not found in OIDC access token"
-          end
-
-          def subject_err_msg
-            "User info subject [#{user_info.sub}] and id token subject " \
+        def subject_err_msg
+          "User info subject [#{user_info.sub}] and id token subject " \
             "[#{id_token_subject}] are not equal"
-          end
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/get_conjur_oidc_token/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/get_conjur_oidc_token/authenticator.rb
@@ -8,6 +8,7 @@ module Authentication
 
       Authenticator = CommandClass.new(
         dependencies: {
+          resource_repo: ::Resource
         },
         inputs: %i(input oidc_id_token_details)
       ) do
@@ -46,7 +47,7 @@ module Authentication
         end
 
         def service
-          @service ||= Resource["#{@input.account}:webservice:conjur/#{@input.authenticator_name}/#{@input.service_id}"]
+          @service ||= @resource_repo["#{@input.account}:webservice:conjur/#{@input.authenticator_name}/#{@input.service_id}"]
         end
 
         def no_username_err_msg

--- a/app/domain/authentication/authn_oidc/get_conjur_oidc_token/conjur_oidc_token.rb
+++ b/app/domain/authentication/authn_oidc/get_conjur_oidc_token/conjur_oidc_token.rb
@@ -3,105 +3,102 @@ require 'command_class'
 module Authentication
   module AuthnOidc
     module GetConjurOidcToken
-      class ConjurOidcToken
-        extend CommandClass::Include
 
-        command_class(
-          dependencies: {
-            oidc_authenticator: AuthnOidc::GetConjurOidcToken::Authenticator.new,
-            enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
-            fetch_oidc_secrets: AuthnOidc::Util::FetchOidcSecrets.new,
-            oidc_client_class: ::Authentication::AuthnOidc::GetConjurOidcToken::Client,
-            token_factory: OidcTokenFactory.new,
-            validate_security: ::Authentication::ValidateSecurity.new,
-            validate_origin: ::Authentication::ValidateOrigin.new,
-            audit_event: ::Authentication::AuditEvent.new
-          },
-          inputs: %i(authenticator_input)
-        ) do
+      ConjurOidcToken = CommandClass.new(
+        dependencies: {
+          oidc_authenticator: AuthnOidc::GetConjurOidcToken::Authenticator.new,
+          enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+          fetch_oidc_secrets: AuthnOidc::Util::FetchOidcSecrets.new,
+          oidc_client_class: ::Authentication::AuthnOidc::GetConjurOidcToken::Client,
+          token_factory: OidcTokenFactory.new,
+          validate_security: ::Authentication::ValidateSecurity.new,
+          validate_origin: ::Authentication::ValidateOrigin.new,
+          audit_event: ::Authentication::AuditEvent.new
+        },
+        inputs: %i(authenticator_input)
+      ) do
 
-          def call
-            fetch_id_token_details
-            validate_credentials
-            add_username_to_input
-            validate_security
-            validate_origin
-            audit_success
-            new_conjur_oidc_token
-          rescue => e
-            audit_failure(e)
-            raise e
-          end
+        def call
+          fetch_id_token_details
+          validate_credentials
+          add_username_to_input
+          validate_security
+          validate_origin
+          audit_success
+          new_conjur_oidc_token
+        rescue => e
+          audit_failure(e)
+          raise e
+        end
 
-          private
+        private
 
-          def fetch_id_token_details
-            oidc_id_token_details
-          end
+        def fetch_id_token_details
+          oidc_id_token_details
+        end
 
-          def validate_credentials
-            @oidc_authenticator.(input: @authenticator_input,
-              oidc_id_token_details: oidc_id_token_details)
-          end
+        def validate_credentials
+          @oidc_authenticator.(input: @authenticator_input,
+            oidc_id_token_details: oidc_id_token_details)
+        end
 
-          def add_username_to_input
-            username = oidc_id_token_details.user_info.preferred_username
-            @authenticator_input = @authenticator_input.update(username: username)
-          end
+        def add_username_to_input
+          username = oidc_id_token_details.user_info.preferred_username
+          @authenticator_input = @authenticator_input.update(username: username)
+        end
 
-          def oidc_id_token_details
-            @oidc_id_token_details ||= oidc_client.oidc_id_token_details(request_body.authorization_code)
-          end
+        def oidc_id_token_details
+          @oidc_id_token_details ||= oidc_client.oidc_id_token_details(request_body.authorization_code)
+        end
 
-          def oidc_client
-            @oidc_client ||= @oidc_client_class.new(
-              client_id: oidc_secrets["client-id"],
-              client_secret: oidc_secrets["client-secret"],
-              redirect_uri: request_body.redirect_uri,
-              provider_uri: oidc_secrets["provider-uri"]
-            )
-          end
+        def oidc_client
+          @oidc_client ||= @oidc_client_class.new(
+            client_id: oidc_secrets["client-id"],
+            client_secret: oidc_secrets["client-secret"],
+            redirect_uri: request_body.redirect_uri,
+            provider_uri: oidc_secrets["provider-uri"]
+          )
+        end
 
-          def oidc_secrets
-            @oidc_secrets ||= @fetch_oidc_secrets.(
-              service_id: @authenticator_input.service_id,
-                conjur_account: @authenticator_input.account,
-                required_variable_names: required_variable_names
-            )
-          end
+        def oidc_secrets
+          @oidc_secrets ||= @fetch_oidc_secrets.(
+            service_id: @authenticator_input.service_id,
+              conjur_account: @authenticator_input.account,
+              required_variable_names: required_variable_names
+          )
+        end
 
-          def required_variable_names
-            @required_variable_names ||= %w(client-id client-secret provider-uri)
-          end
+        def required_variable_names
+          @required_variable_names ||= %w(client-id client-secret provider-uri)
+        end
 
-          def new_conjur_oidc_token
-            @token_factory.oidc_token(oidc_id_token_details)
-          end
+        def new_conjur_oidc_token
+          @token_factory.oidc_token(oidc_id_token_details)
+        end
 
-          def request_body
-            @request_body ||= AuthnOidc::GetConjurOidcToken::LoginRequestBody.new(@authenticator_input.request)
-          end
+        def request_body
+          @request_body ||= AuthnOidc::GetConjurOidcToken::LoginRequestBody.new(@authenticator_input.request)
+        end
 
-          def validate_security
-            @validate_security.(
-              webservice: @authenticator_input.webservice,
-                account: @authenticator_input.account,
-                user_id: @authenticator_input.username,
-                enabled_authenticators: @enabled_authenticators
-            )
-          end
+        def validate_security
+          @validate_security.(
+            webservice: @authenticator_input.webservice,
+              account: @authenticator_input.account,
+              user_id: @authenticator_input.username,
+              enabled_authenticators: @enabled_authenticators
+          )
+        end
 
-          def validate_origin
-            @validate_origin.(input: @authenticator_input)
-          end
+        def validate_origin
+          @validate_origin.(input: @authenticator_input)
+        end
 
-          def audit_success
-            @audit_event.(input: @authenticator_input, success: true, message: nil)
-          end
+        def audit_success
+          @audit_event.(input: @authenticator_input, success: true, message: nil)
+        end
 
-          def audit_failure(err)
-            @audit_event.(input: @authenticator_input, success: false, message: err.message)
-          end
+        def audit_failure(err)
+          @audit_event.(input: @authenticator_input, success: false, message: err.message)
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/util/fetch_oidc_secrets.rb
+++ b/app/domain/authentication/authn_oidc/util/fetch_oidc_secrets.rb
@@ -4,42 +4,39 @@ require 'conjur/fetch_required_secrets'
 module Authentication
   module AuthnOidc
     module Util
-      # Errors from FetchRequiredSecrets
-      RequiredResourceMissing = ::Conjur::RequiredResourceMissing
-      RequiredSecretMissing = ::Conjur::RequiredSecretMissing
 
-      class FetchOidcSecrets
-        extend CommandClass::Include
+      # Possible Errors Raised:
+      # RequiredResourceMissing, RequiredSecretMissing, NotWhitelisted
 
-        command_class(
-          dependencies: {
-            fetch_secrets: ::Conjur::FetchRequiredSecrets.new
-          },
-          inputs: %i(conjur_account service_id required_variable_names)
-        ) do
 
-          def call
-            secrets = {}
+      FetchOidcSecrets = CommandClass.new(
+        dependencies: {
+          fetch_secrets: ::Conjur::FetchRequiredSecrets.new
+        },
+        inputs: %i(conjur_account service_id required_variable_names)
+      ) do
 
-            required_secrets = @fetch_secrets.(resource_ids: required_resource_ids)
+        def call
+          secrets = {}
 
-            @required_variable_names.each do |variable_name|
-              full_variable_name = full_variable_name(variable_name)
-              secrets[variable_name] = required_secrets[full_variable_name]
-            end
+          required_secrets = @fetch_secrets.(resource_ids: required_resource_ids)
 
-            secrets
+          @required_variable_names.each do |variable_name|
+            full_variable_name = full_variable_name(variable_name)
+            secrets[variable_name] = required_secrets[full_variable_name]
           end
 
-          private
+          secrets
+        end
 
-          def required_resource_ids
-            @required_variable_names.map { |var_name| full_variable_name(var_name) }
-          end
+        private
 
-          def full_variable_name(var_name)
-            "#{@conjur_account}:variable:conjur/authn-oidc/#{@service_id}/#{var_name}"
-          end
+        def required_resource_ids
+          @required_variable_names.map { |var_name| full_variable_name(var_name) }
+        end
+
+        def full_variable_name(var_name)
+          "#{@conjur_account}:variable:conjur/authn-oidc/#{@service_id}/#{var_name}"
         end
       end
     end

--- a/app/domain/authentication/authn_oidc/util/fetch_oidc_secrets.rb
+++ b/app/domain/authentication/authn_oidc/util/fetch_oidc_secrets.rb
@@ -5,10 +5,6 @@ module Authentication
   module AuthnOidc
     module Util
 
-      # Possible Errors Raised:
-      # RequiredResourceMissing, RequiredSecretMissing, NotWhitelisted
-
-
       FetchOidcSecrets = CommandClass.new(
         dependencies: {
           fetch_secrets: ::Conjur::FetchRequiredSecrets.new

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -40,11 +40,11 @@ module Authentication
     end
 
     def validate_authenticator_exists
-      raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+      raise Authentication::AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
     end
 
     def validate_credentials
-      raise InvalidCredentials unless key
+      raise Authentication::InvalidCredentials unless key
     end
 
     def validate_security

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -4,86 +4,83 @@ require 'command_class'
 require 'authentication/errors'
 
 module Authentication
-  class Login
-    extend CommandClass::Include
 
-    AuthenticatorNotFound = Authentication::AuthenticatorNotFound
-    InvalidCredentials = Authentication::InvalidCredentials
+  # Possible Errors Raised:
+  # AuthenticatorNotFound, InvalidCredentials
 
-    command_class(
-      dependencies: {
-        enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
-        validate_security:      ::Authentication::ValidateSecurity.new,
-        audit_event:            ::Authentication::AuditEvent.new,
-        role_cls: ::Role
-      },
-      inputs:       %i(authenticator_input authenticators)
-    ) do
+  Login = CommandClass.new(
+    dependencies: {
+      enabled_authenticators: ENV['CONJUR_AUTHENTICATORS'],
+      validate_security: ::Authentication::ValidateSecurity.new,
+      audit_event: ::Authentication::AuditEvent.new,
+      role_cls: ::Role
+    },
+    inputs: %i(authenticator_input authenticators)
+  ) do
 
-      def call
-        validate_authenticator_exists
-        validate_security
-        validate_credentials
-        audit_success
-        new_login
-      rescue => e
-        audit_failure(e)
-        raise e
-      end
+    def call
+      validate_authenticator_exists
+      validate_security
+      validate_credentials
+      audit_success
+      new_login
+    rescue => e
+      audit_failure(e)
+      raise e
+    end
 
-      private
+    private
 
-      def authenticator
-        @authenticator = @authenticators[@authenticator_input.authenticator_name]
-      end
+    def authenticator
+      @authenticator = @authenticators[@authenticator_input.authenticator_name]
+    end
 
-      def key
-        @key = authenticator.login(@authenticator_input)
-      end
+    def key
+      @key = authenticator.login(@authenticator_input)
+    end
 
-      def validate_authenticator_exists
-        raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
-      end
+    def validate_authenticator_exists
+      raise AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+    end
 
-      def validate_credentials
-        raise InvalidCredentials unless key
-      end
+    def validate_credentials
+      raise InvalidCredentials unless key
+    end
 
-      def validate_security
-        @validate_security.(
-          webservice: @authenticator_input.webservice,
-            account: account,
-            user_id: username,
-            enabled_authenticators: @enabled_authenticators
-        )
-      end
+    def validate_security
+      @validate_security.(
+        webservice: @authenticator_input.webservice,
+          account: account,
+          user_id: username,
+          enabled_authenticators: @enabled_authenticators
+      )
+    end
 
-      def audit_success
-        @audit_event.(input: @authenticator_input, success: true, message: nil)
-      end
+    def audit_success
+      @audit_event.(input: @authenticator_input, success: true, message: nil)
+    end
 
-      def audit_failure(err)
-        @audit_event.(input: @authenticator_input, success: false, message: err.message)
-      end
+    def audit_failure(err)
+      @audit_event.(input: @authenticator_input, success: false, message: err.message)
+    end
 
-      def new_login
-        LoginResponse.new(
-          role_id:            role.id,
-          authentication_key: key
-        )
-      end
+    def new_login
+      LoginResponse.new(
+        role_id: role.id,
+        authentication_key: key
+      )
+    end
 
-      def role
-        @role_cls.by_login(username, account: account)
-      end
+    def role
+      @role_cls.by_login(username, account: account)
+    end
 
-      def username
-        @authenticator_input.username
-      end
+    def username
+      @authenticator_input.username
+    end
 
-      def account
-        @authenticator_input.account
-      end
+    def account
+      @authenticator_input.account
     end
   end
 end

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -15,7 +15,7 @@ module Authentication
   ) do
 
     def call
-      raise InvalidOrigin unless role.valid_origin?(@input.origin)
+      raise Authentication::InvalidOrigin unless role.valid_origin?(@input.origin)
     end
 
     private

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -3,27 +3,25 @@
 require 'authentication/errors'
 
 module Authentication
-  class ValidateOrigin
-    extend CommandClass::Include
 
-    InvalidOrigin = Authentication::InvalidOrigin
+  # Possible Errors Raised:
+  # InvalidOrigin
 
-    command_class(
-      dependencies: {
-        role_cls: ::Role
-      },
-      inputs: %i(input)
-    ) do
+  ValidateOrigin = CommandClass.new(
+    dependencies: {
+      role_cls: ::Role
+    },
+    inputs: %i(input)
+  ) do
 
-      def call
-        raise InvalidOrigin unless role.valid_origin?(@input.origin)
-      end
+    def call
+      raise InvalidOrigin unless role.valid_origin?(@input.origin)
+    end
 
-      private
+    private
 
-      def role
-        @role_cls.by_login(@input.username, account: @input.account)
-      end
+    def role
+      @role_cls.by_login(@input.username, account: @input.account)
     end
   end
 end

--- a/app/domain/authentication/validate_security.rb
+++ b/app/domain/authentication/validate_security.rb
@@ -37,20 +37,20 @@ module Authentication
     end
 
     def validate_account_exists
-      raise AccountNotDefined, @account unless account_admin_role
+      raise Authentication::Security::AccountNotDefined, @account unless account_admin_role
     end
 
     def validate_webservice_exists
-      raise ServiceNotDefined, @webservice.name unless webservice_resource
+      raise Authentication::Security::ServiceNotDefined, @webservice.name unless webservice_resource
     end
 
     def validate_webservice_is_whitelisted
       is_whitelisted = whitelisted_webservices.include?(@webservice)
-      raise NotWhitelisted, @webservice.name unless is_whitelisted
+      raise Authentication::Security::NotWhitelisted, @webservice.name unless is_whitelisted
     end
 
     def validate_user_is_defined
-      raise UserNotDefinedInConjur, @user_id unless user_role
+      raise Authentication::Security::UserNotDefinedInConjur, @user_id unless user_role
     end
 
     def validate_user_has_access
@@ -59,7 +59,7 @@ module Authentication
       unless has_access
         @logger.debug("[OIDC] User '#{@user_id}' is not authorized to " \
           "authenticate with webservice '#{webservice_resource_id}'")
-        raise UserNotAuthorizedInConjur, @user_id
+        raise Authentication::Security::UserNotAuthorizedInConjur, @user_id
       end
     end
 

--- a/app/domain/authentication/validate_security.rb
+++ b/app/domain/authentication/validate_security.rb
@@ -4,95 +4,90 @@ require 'authentication/webservices'
 require 'authentication/errors'
 
 module Authentication
-  class ValidateSecurity
-    extend CommandClass::Include
 
-    AccountNotDefined = Authentication::Security::AccountNotDefined
-    ServiceNotDefined = Authentication::Security::ServiceNotDefined
-    NotWhitelisted = Authentication::Security::NotWhitelisted
-    UserNotDefinedInConjur = Authentication::Security::UserNotDefinedInConjur
-    UserNotAuthorizedInConjur = Authentication::Security::UserNotAuthorizedInConjur
+  # Possible Errors Raised:
+  # AccountNotDefined, ServiceNotDefined, NotWhitelisted,
+  # UserNotDefinedInConjur, UserNotAuthorizedInConjur
 
-    command_class(
-      dependencies: {
-        role_class: ::Authentication::MemoizedRole,
-        webservice_resource_class: ::Resource,
-        logger: Rails.logger
-      },
-      inputs: %i(webservice account user_id enabled_authenticators)
-    ) do
+  ValidateSecurity = CommandClass.new(
+    dependencies: {
+      role_class: ::Authentication::MemoizedRole,
+      webservice_resource_class: ::Resource,
+      logger: Rails.logger
+    },
+    inputs: %i(webservice account user_id enabled_authenticators)
+  ) do
 
-      def call
-        # No checks required for default conjur authn
-        return if default_conjur_authn?
+    def call
+      # No checks required for default conjur authn
+      return if default_conjur_authn?
 
-        validate_account_exists
-        validate_webservice_is_whitelisted
-        validate_webservice_exists
-        validate_user_is_defined
-        validate_user_has_access
-      end
+      validate_account_exists
+      validate_webservice_is_whitelisted
+      validate_webservice_exists
+      validate_user_is_defined
+      validate_user_has_access
+    end
 
-      private
+    private
 
-      def default_conjur_authn?
-        @webservice.authenticator_name ==
-          ::Authentication::Common.default_authenticator_name
-      end
+    def default_conjur_authn?
+      @webservice.authenticator_name ==
+        ::Authentication::Common.default_authenticator_name
+    end
 
-      def validate_account_exists
-        raise AccountNotDefined, @account unless account_admin_role
-      end
+    def validate_account_exists
+      raise AccountNotDefined, @account unless account_admin_role
+    end
 
-      def validate_webservice_exists
-        raise ServiceNotDefined, @webservice.name unless webservice_resource
-      end
+    def validate_webservice_exists
+      raise ServiceNotDefined, @webservice.name unless webservice_resource
+    end
 
-      def validate_webservice_is_whitelisted
-        is_whitelisted = whitelisted_webservices.include?(@webservice)
-        raise NotWhitelisted, @webservice.name unless is_whitelisted
-      end
+    def validate_webservice_is_whitelisted
+      is_whitelisted = whitelisted_webservices.include?(@webservice)
+      raise NotWhitelisted, @webservice.name unless is_whitelisted
+    end
 
-      def validate_user_is_defined
-        raise UserNotDefinedInConjur, @user_id unless user_role
-      end
+    def validate_user_is_defined
+      raise UserNotDefinedInConjur, @user_id unless user_role
+    end
 
-      def validate_user_has_access
-        # Ensure user has access to the service
-        has_access = user_role.allowed_to?('authenticate', webservice_resource)
-        unless has_access
-          @logger.debug("[OIDC] User '#{@user_id}' is not authorized to " \
+    def validate_user_has_access
+      # Ensure user has access to the service
+      has_access = user_role.allowed_to?('authenticate', webservice_resource)
+      unless has_access
+        @logger.debug("[OIDC] User '#{@user_id}' is not authorized to " \
           "authenticate with webservice '#{webservice_resource_id}'")
-          raise UserNotAuthorizedInConjur, @user_id
-        end
+        raise UserNotAuthorizedInConjur, @user_id
       end
+    end
 
-      def user_role_id
-        @user_role_id ||= @role_class.roleid_from_username(@account, @user_id)
-      end
+    def user_role_id
+      @user_role_id ||= @role_class.roleid_from_username(@account, @user_id)
+    end
 
-      def user_role
-        @role_class[user_role_id]
-      end
+    def user_role
+      @role_class[user_role_id]
+    end
 
-      def account_admin_role
-        @role_class["#{@account}:user:admin"]
-      end
+    def account_admin_role
+      @role_class["#{@account}:user:admin"]
+    end
 
-      def webservice_resource
-        @webservice_resource_class[webservice_resource_id]
-      end
+    def webservice_resource
+      @webservice_resource_class[webservice_resource_id]
+    end
 
-      def webservice_resource_id
-        @webservice.resource_id
-      end
+    def webservice_resource_id
+      @webservice.resource_id
+    end
 
-      def whitelisted_webservices
-        ::Authentication::Webservices.from_string(
-          @account,
-          @enabled_authenticators || Authentication::Common.default_authenticator_name
-        )
-      end
+    def whitelisted_webservices
+      ::Authentication::Webservices.from_string(
+        @account,
+        @enabled_authenticators || Authentication::Common.default_authenticator_name
+      )
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Reverts the *usage* of command classes to the old syntax, using CommandClass.new.
We still declare at the beginning of each class which errors it might raise to maintain the command_class clarity. 

This makes our code less flakey and yet, still clear.