### PR TITLE
ErrorClass & LogMessageClass have UTs

### DIFF
--- a/app/domain/util/trackable_error_class.rb
+++ b/app/domain/util/trackable_error_class.rb
@@ -4,9 +4,9 @@
 #
 module Util
 
-  class TrackableErrorClass < ErrorClass
+  class TrackableErrorClass
     def self.new(msg:, code:)
-      super("#{code} #{msg}")
+      ErrorClass.new("#{code} #{msg}")
     end
   end
 end

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -86,7 +86,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Authentication::NotDefinedInConjur
+    Errors::Authentication::Security::UserNotDefinedInConjur
     """
 
   Scenario: User that is not permitted to webservice in ID token is denied
@@ -101,7 +101,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    User 'bob' is not authorized to authenticate with webservice 'cucumber:webservice:conjur/authn-oidc/keycloak'
+    Errors::Authentication::Security::UserNotAuthorizedInConjur
     """
 
   Scenario: ID token without value of variable id-token-user-property is denied
@@ -113,7 +113,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty
+    Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty
     """
 
   Scenario: Missing id token is a bad request
@@ -122,7 +122,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is a bad request
     And The following appears in the log after my savepoint:
     """
-    Authentication::MissingRequestParam
+    Errors::Authentication::RequestBody::MissingRequestParam
     """
 
   Scenario: Empty id token is a bad request
@@ -131,10 +131,10 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is a bad request
     And The following appears in the log after my savepoint:
     """
-    Authentication::MissingRequestParam
+    Errors::Authentication::RequestBody::MissingRequestParam
     """
 
-    # Should be crashed in GA, update the message to "account does not exists"
+  # Should crash in GA, update the message to "account does not exists"
   Scenario: non-existing account in request is denied
     Given I get authorization code for username "alice" and password "alice"
     And I fetch an ID Token
@@ -143,7 +143,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Conjur::RequiredResourceMissing
+    Errors::Conjur::RequiredResourceMissing
     """
 
   Scenario: admin user is denied
@@ -154,5 +154,5 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Authentication::AuthnOidc::AdminAuthenticationDenied
+    Errors::Authentication::AuthnOidc::AdminAuthenticationDenied
     """

--- a/cucumber/authenticators/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators/features/authn_oidc_bad_policy.feature
@@ -73,7 +73,7 @@ Feature: Users can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Conjur::RequiredResourceMissing
+    Errors::Conjur::RequiredResourceMissing
     """
 
   Scenario: webservice missing in policy is denied
@@ -106,7 +106,7 @@ Feature: Users can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Authentication::ServiceNotDefined
+    Errors::Authentication::Security::ServiceNotDefined
     """
 
   Scenario: webservice with read and no authenticate permission in policy is denied
@@ -147,5 +147,5 @@ Feature: Users can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Authentication::NotAuthorizedInConjur
+    Errors::Authentication::Security::UserNotAuthorizedInConjur
     """

--- a/spec/app/domain/util/error_spec.rb
+++ b/spec/app/domain/util/error_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Util::ErrorClass' do
   context 'object' do
-    let(:error_template) { "An error occured" }
+    let(:error_template) { 'An error occured' }
 
     subject(:error_class) { Util::ErrorClass.new(error_template) }
 
@@ -18,72 +18,72 @@ RSpec.describe 'Util::ErrorClass' do
   end
 
   context 'templating' do
-    let(:error_template) { "Variable is \#{0}." }
+    let(:error_template) { 'Variable is {0}.' }
 
     subject(:error_class) { Util::ErrorClass.new(error_template) }
 
     it 'works for nil' do
-      expect { raise error_class.new(nil) }.to raise_error("Variable is #nil.")
+      expect { raise error_class.new(nil) }.to raise_error('Variable is nil.')
     end
 
     it 'works for strings' do
-      expect { raise error_class.new("") }.to raise_error("Variable is #.")
-      expect { raise error_class.new("ABC") }.to raise_error("Variable is #ABC.")
+      expect { raise error_class.new('') }.to raise_error('Variable is .')
+      expect { raise error_class.new('ABC') }.to raise_error('Variable is ABC.')
     end
 
     it 'works for Fixnums' do
-      expect { raise error_class.new(9) }.to raise_error("Variable is #9.")
-      expect { raise error_class.new(0) }.to raise_error("Variable is #0.")
+      expect { raise error_class.new(9) }.to raise_error('Variable is 9.')
+      expect { raise error_class.new(0) }.to raise_error('Variable is 0.')
     end
 
     it 'works for booleans' do
-      expect { raise error_class.new(false) }.to raise_error("Variable is #false.")
-      expect { raise error_class.new(true) }.to raise_error("Variable is #true.")
+      expect { raise error_class.new(false) }.to raise_error('Variable is false.')
+      expect { raise error_class.new(true) }.to raise_error('Variable is true.')
     end
 
     it 'works for objects' do
-      expect { raise error_class.new(Class) }.to raise_error("Variable is #Class.")
-      expect { raise error_class.new(Util::ErrorClass) }.to raise_error("Variable is #Util::ErrorClass.")
+      expect { raise error_class.new(Class) }.to raise_error('Variable is Class.')
+      expect { raise error_class.new(Util::ErrorClass) }.to raise_error('Variable is Util::ErrorClass.')
     end
 
     it 'works for arrays' do
-      expect { raise error_class.new(["aA", "bB"]) }.to raise_error("Variable is #[\"aA\", \"bB\"].")
+      expect { raise error_class.new(['aA', 'bB']) }.to raise_error('Variable is ["aA", "bB"].')
     end
 
     it 'handles overflow args' do
-      expect { raise error_class.new("AA", "BB") }.to raise_error("Variable is #AA.")
+      expect { raise error_class.new('AA', 'BB') }.to raise_error('Variable is AA.')
     end
 
     it 'handles underflow args' do
-      expect { raise error_class.new() }.to raise_error("Variable is #\{0\}.")
+      expect { raise error_class.new() }.to raise_error('Variable is {0}.')
     end
 
     context 'with multiple args' do
-      let(:non_repeating_error_template) { "Variables are \#{0} \#{1} \#{2} \#{3} \#{4} \#{5}." }
-      let(:mixed_error_template) { "Variables are \#{2} \#{1} \#{2} \#{0} \#{4} \#{4}." }
+      let(:non_repeating_error_template) { 'Variables are {0} {1} {2} {3} {4} {5}.' }
+      let(:mixed_error_template) { 'Variables are {2} {1} {2} {0} {4} {4}.' }
 
       subject(:non_repeating_error_class) { Util::ErrorClass.new(non_repeating_error_template) }
       subject(:mixed_error_class) { Util::ErrorClass.new(mixed_error_template) }
 
       it 'handles multiple args' do
-        expect { raise non_repeating_error_class.new("00", "11", "22", "33", "44", "55") }
-          .to raise_error("Variables are #00 #11 #22 #33 #44 #55.")
+        expect { raise non_repeating_error_class.new('00', '11', '22', '33', '44', '55') }
+          .to raise_error('Variables are 00 11 22 33 44 55.')
       end
 
       it 'handles repeating and mixed args' do
-        expect { raise mixed_error_class.new("00", "11", "22", "33", "44", "55") }
-          .to raise_error("Variables are #22 #11 #22 #00 #44 #44.")
+        expect { raise mixed_error_class.new('00', '11', '22', '33', '44', '55') }
+          .to raise_error('Variables are 22 11 22 00 44 44.')
       end
     end
 
     context 'with arg description' do
-      let(:descriptive_error_template) { "Variable is {0-var-description}." }
+      let(:descriptive_error_template) { 'Variable is {0-var-description}.' }
 
       subject(:descriptive_error_class) { Util::ErrorClass.new(descriptive_error_template) }
 
       it 'ignores the description' do
-        expect { raise descriptive_error_class.new("var") }
-          .to raise_error("Variable is var.")
+        expect { raise descriptive_error_class.new('var') }
+          .to raise_error('Variable is var.')
       end
     end
   end

--- a/spec/app/domain/util/error_spec.rb
+++ b/spec/app/domain/util/error_spec.rb
@@ -75,5 +75,16 @@ RSpec.describe 'Util::ErrorClass' do
           .to raise_error("Variables are #22 #11 #22 #00 #44 #44.")
       end
     end
+
+    context 'with arg description' do
+      let(:descriptive_error_template) { "Variable is {0-var-description}." }
+
+      subject(:descriptive_error_class) { Util::ErrorClass.new(descriptive_error_template) }
+
+      it 'ignores the description' do
+        expect { raise descriptive_error_class.new("var") }
+          .to raise_error("Variable is var.")
+      end
+    end
   end
 end

--- a/spec/app/domain/util/log_message_spec.rb
+++ b/spec/app/domain/util/log_message_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe 'Util::LogMessageClass' do
-  context 'object' do
-    let(:log_message) { "some log message" }
+  context 'pre-determined, static log message' do
+    let(:log_message) { 'some log message' }
     subject(:log_message_class) { Util::LogMessageClass.new(log_message) }
 
     it 'has the expected message' do
@@ -13,72 +13,72 @@ RSpec.describe 'Util::LogMessageClass' do
   end
 
   context 'templating' do
-    let(:log_message_template) { "Variable is \#{0}." }
+    let(:log_message_template) { 'Variable is {0}.' }
 
     subject(:log_message_class) { Util::LogMessageClass.new(log_message_template) }
 
     it 'works for nil' do
-      expect(log_message_class.new(nil).to_s).to eq("Variable is #nil.")
+      expect(log_message_class.new(nil).to_s).to eq('Variable is nil.')
     end
 
     it 'works for strings' do
-      expect(log_message_class.new("").to_s).to eq("Variable is #.")
-      expect(log_message_class.new("ABC").to_s).to eq("Variable is #ABC.")
+      expect(log_message_class.new('').to_s).to eq('Variable is .')
+      expect(log_message_class.new('ABC').to_s).to eq('Variable is ABC.')
     end
 
     it 'works for Fixnums' do
-      expect(log_message_class.new(9).to_s).to eq("Variable is #9.")
-      expect(log_message_class.new(0).to_s).to eq("Variable is #0.")
+      expect(log_message_class.new(9).to_s).to eq('Variable is 9.')
+      expect(log_message_class.new(0).to_s).to eq('Variable is 0.')
     end
 
     it 'works for booleans' do
-      expect(log_message_class.new(false).to_s).to eq("Variable is #false.")
-      expect(log_message_class.new(true).to_s).to eq("Variable is #true.")
+      expect(log_message_class.new(false).to_s).to eq('Variable is false.')
+      expect(log_message_class.new(true).to_s).to eq('Variable is true.')
     end
 
     it 'works for objects' do
-      expect(log_message_class.new(Class).to_s).to eq("Variable is #Class.")
-      expect(log_message_class.new(Util::LogMessageClass).to_s).to eq("Variable is #Util::LogMessageClass.")
+      expect(log_message_class.new(Class).to_s).to eq('Variable is Class.')
+      expect(log_message_class.new(Util::LogMessageClass).to_s).to eq('Variable is Util::LogMessageClass.')
     end
 
     it 'works for arrays' do
-      expect(log_message_class.new(["aA", "bB"]).to_s).to eq("Variable is #[\"aA\", \"bB\"].")
+      expect(log_message_class.new(%w(aA bB)).to_s).to eq('Variable is ["aA", "bB"].')
     end
 
     it 'handles overflow args' do
-      expect(log_message_class.new("AA", "BB").to_s).to eq("Variable is #AA.")
+      expect(log_message_class.new('AA', 'BB').to_s).to eq('Variable is AA.')
     end
 
     it 'handles underflow args' do
-      expect(log_message_class.new.to_s).to eq("Variable is #\{0\}.")
+      expect(log_message_class.new.to_s).to eq('Variable is {0}.')
     end
 
     context 'with multiple args' do
-      let(:non_repeating_log_message_template) { "Variables are \#{0} \#{1} \#{2} \#{3} \#{4} \#{5}." }
-      let(:mixed_log_message_template) { "Variables are \#{2} \#{1} \#{2} \#{0} \#{4} \#{4}." }
+      let(:non_repeating_log_message_template) { 'Variables are {0} {1} {2} {3} {4} {5}.' }
+      let(:mixed_log_message_template) { 'Variables are {2} {1} {2} {0} {4} {4}.' }
 
       subject(:non_repeating_log_message_class) { Util::LogMessageClass.new(non_repeating_log_message_template) }
       subject(:mixed_log_message_class) { Util::LogMessageClass.new(mixed_log_message_template) }
 
       it 'handles multiple args' do
-        expect(non_repeating_log_message_class.new("00", "11", "22", "33", "44", "55").to_s)
-          .to eq("Variables are #00 #11 #22 #33 #44 #55.")
+        expect(non_repeating_log_message_class.new('00', '11', '22', '33', '44', '55').to_s)
+          .to eq('Variables are 00 11 22 33 44 55.')
       end
 
       it 'handles repeating and mixed args' do
-        expect(mixed_log_message_class.new("00", "11", "22", "33", "44", "55").to_s)
-          .to eq("Variables are #22 #11 #22 #00 #44 #44.")
+        expect(mixed_log_message_class.new('00', '11', '22', '33', '44', '55').to_s)
+          .to eq('Variables are 22 11 22 00 44 44.')
       end
     end
 
     context 'with arg description' do
-      let(:descriptive_log_message_template) { "Variable is {0-var-description}." }
+      let(:descriptive_log_message_template) { 'Variable is {0-var-description}.' }
 
       subject(:descriptive_log_message_class) { Util::LogMessageClass.new(descriptive_log_message_template) }
 
       it 'ignores the description' do
-        expect(descriptive_log_message_class.new("var").to_s)
-          .to eq("Variable is var.")
+        expect(descriptive_log_message_class.new('var').to_s)
+          .to eq('Variable is var.')
       end
     end
   end

--- a/spec/app/domain/util/log_message_spec.rb
+++ b/spec/app/domain/util/log_message_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Util::LogMessageClass' do
+  context 'object' do
+    let(:log_message) { "some log message" }
+    subject(:log_message_class) { Util::LogMessageClass.new(log_message) }
+
+    it 'has the expected message' do
+      expect(log_message_class.new.to_s).to eq(log_message)
+    end
+  end
+
+  context 'templating' do
+    let(:log_message_template) { "Variable is \#{0}." }
+
+    subject(:log_message_class) { Util::LogMessageClass.new(log_message_template) }
+
+    it 'works for nil' do
+      expect(log_message_class.new(nil).to_s).to eq("Variable is #nil.")
+    end
+
+    it 'works for strings' do
+      expect(log_message_class.new("").to_s).to eq("Variable is #.")
+      expect(log_message_class.new("ABC").to_s).to eq("Variable is #ABC.")
+    end
+
+    it 'works for Fixnums' do
+      expect(log_message_class.new(9).to_s).to eq("Variable is #9.")
+      expect(log_message_class.new(0).to_s).to eq("Variable is #0.")
+    end
+
+    it 'works for booleans' do
+      expect(log_message_class.new(false).to_s).to eq("Variable is #false.")
+      expect(log_message_class.new(true).to_s).to eq("Variable is #true.")
+    end
+
+    it 'works for objects' do
+      expect(log_message_class.new(Class).to_s).to eq("Variable is #Class.")
+      expect(log_message_class.new(Util::LogMessageClass).to_s).to eq("Variable is #Util::LogMessageClass.")
+    end
+
+    it 'works for arrays' do
+      expect(log_message_class.new(["aA", "bB"]).to_s).to eq("Variable is #[\"aA\", \"bB\"].")
+    end
+
+    it 'handles overflow args' do
+      expect(log_message_class.new("AA", "BB").to_s).to eq("Variable is #AA.")
+    end
+
+    it 'handles underflow args' do
+      expect(log_message_class.new.to_s).to eq("Variable is #\{0\}.")
+    end
+
+    context 'with multiple args' do
+      let(:non_repeating_log_message_template) { "Variables are \#{0} \#{1} \#{2} \#{3} \#{4} \#{5}." }
+      let(:mixed_log_message_template) { "Variables are \#{2} \#{1} \#{2} \#{0} \#{4} \#{4}." }
+
+      subject(:non_repeating_log_message_class) { Util::LogMessageClass.new(non_repeating_log_message_template) }
+      subject(:mixed_log_message_class) { Util::LogMessageClass.new(mixed_log_message_template) }
+
+      it 'handles multiple args' do
+        expect(non_repeating_log_message_class.new("00", "11", "22", "33", "44", "55").to_s)
+          .to eq("Variables are #00 #11 #22 #33 #44 #55.")
+      end
+
+      it 'handles repeating and mixed args' do
+        expect(mixed_log_message_class.new("00", "11", "22", "33", "44", "55").to_s)
+          .to eq("Variables are #22 #11 #22 #00 #44 #44.")
+      end
+    end
+
+    context 'with arg description' do
+      let(:descriptive_log_message_template) { "Variable is {0-var-description}." }
+
+      subject(:descriptive_log_message_class) { Util::LogMessageClass.new(descriptive_log_message_template) }
+
+      it 'ignores the description' do
+        expect(descriptive_log_message_class.new("var").to_s)
+          .to eq("Variable is var.")
+      end
+    end
+  end
+end

--- a/spec/app/domain/util/trackable_error_spec.rb
+++ b/spec/app/domain/util/trackable_error_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Util::TrackableErrorClass' do
+  context 'object' do
+    let(:error_code) { "ABC123" }
+    let(:error_message) { "An error occured" }
+
+    let(:trackable_error_message) { "#{error_code} #{error_message}" }
+
+    subject(:trackable_error_class) {
+      Util::TrackableErrorClass.new(
+        msg: error_message,
+        code: error_code
+      )
+    }
+
+    it 'has the expected messaged error' do
+      expect { raise trackable_error_class.new }.to raise_error(trackable_error_message)
+    end
+  end
+end

--- a/spec/app/domain/util/trackable_log_message_spec.rb
+++ b/spec/app/domain/util/trackable_log_message_spec.rb
@@ -3,21 +3,19 @@
 require 'spec_helper'
 
 RSpec.describe 'Util::TrackableLogMessageClass' do
-  context 'object' do
-    let(:log_code) { "ABC123" }
-    let(:log_message) { "An error occured" }
+  let(:log_code) { "ABC123" }
+  let(:log_message) { "An error occured" }
 
-    let(:trackable_log_message) { "#{log_code} #{log_message}" }
+  let(:trackable_log_message) { "#{log_code} #{log_message}" }
 
-    subject(:trackable_log_class) {
-      Util::TrackableLogMessageClass.new(
-        msg: log_message,
-        code: log_code
-      )
-    }
+  subject(:trackable_log_class) {
+    Util::TrackableLogMessageClass.new(
+      msg: log_message,
+      code: log_code
+    )
+  }
 
-    it 'has the expected messaged error' do
-      expect(trackable_log_class.new.to_s).to eq(trackable_log_message)
-    end
+  it 'has the expected messaged error' do
+    expect(trackable_log_class.new.to_s).to eq(trackable_log_message)
   end
 end

--- a/spec/app/domain/util/trackable_log_message_spec.rb
+++ b/spec/app/domain/util/trackable_log_message_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Util::TrackableLogMessageClass' do
+  context 'object' do
+    let(:log_code) { "ABC123" }
+    let(:log_message) { "An error occured" }
+
+    let(:trackable_log_message) { "#{log_code} #{log_message}" }
+
+    subject(:trackable_log_class) {
+      Util::TrackableLogMessageClass.new(
+        msg: log_message,
+        code: log_code
+      )
+    }
+
+    it 'has the expected messaged error' do
+      expect(trackable_log_class.new.to_s).to eq(trackable_log_message)
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- Add UTs for templating in ErrorClass 
- Add UTs for LogMessageClass
- Add UTs for TrackableErrorClass 
- Add UTs for TrackableLogMessageClass
- TrackableErrorClass composes ErrorClass instead of inheritance

#### What ticket does this PR close?
Connected to #1000 

