### PR TITLE
Oidc in info

### DIFF
--- a/app/domain/authentication/audit_event.rb
+++ b/app/domain/authentication/audit_event.rb
@@ -25,15 +25,11 @@ module Authentication
     def role
       return nil if username.nil?
 
-      @role_cls.by_login(username, account: account)
+      @role_cls.by_login(username, account: @input.account)
     end
 
     def username
       @input.username
-    end
-
-    def account
-      @input.account
     end
   end
 end

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -1,0 +1,20 @@
+module Authentication
+  module AuthnOidc
+    class Authenticator
+      # This class is a workaround so that authn-oidc will show in the
+      # "installed authenticators"
+      #
+      # TODO: Change the way we define the installed authenticators so that
+      # a change in design (such as the one that happened) will not break this
+      #
+      #
+
+      def initialize(env:)
+        @env = env
+      end
+
+      def valid?
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -1,13 +1,14 @@
 module Authentication
   module AuthnOidc
+
+    # This class is a workaround so that authn-oidc will show in the
+    # "installed authenticators"
+    #
+    # TODO: Change the way we define the installed authenticators so that
+    # a change in design (such as the one that happened) will not break this
+    #
+    #
     class Authenticator
-      # This class is a workaround so that authn-oidc will show in the
-      # "installed authenticators"
-      #
-      # TODO: Change the way we define the installed authenticators so that
-      # a change in design (such as the one that happened) will not break this
-      #
-      #
 
       def initialize(env:)
         @env = env


### PR DESCRIPTION
#### What does this PR do?
fixes a bug where the `/authenticators` endpoint (and the `/info` endpoint) stated that authn-oidc is not implemented in conjur

The implementation here is a workaround and not the proper fix which will be handled with along with the `/authenticators` endpoint development as we will change the way we list authenticators there. Tests will also be done in that effort (i didn't want to test here something that may change in the near future).

You may ignore the `audit_event.rb` change as it is not part of this PR. It is already in master.

Connected to #985 