### PR TITLE
Re-raise unexpected KubeExceptions

### DIFF
--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -143,7 +143,8 @@ module Authentication
         k8s_clients.find do |client|
           begin
             client.respond_to?(method_name)
-          rescue KubeException
+          rescue KubeException => e
+            raise e unless e.error_code == 404
             false
           end
         end


### PR DESCRIPTION
`k8s_client_for_method` will now re-raise any exception that is not
HTTP 404. This change will allow for easier debugging of other network
or stack related issues.