### PR TITLE
Oidc loadinvalid test

### DIFF
--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -257,5 +257,13 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
       end
     end
+
+    module Util
+
+      ConcurrencyLimitReachedBeforeCacheInitialization = ::Util::TrackableErrorClass.new(
+          msg: "Concurrency limited cache reached before cache initialized",
+          code: "CONJ00044E"
+      )
+    end
   end
 end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -121,8 +121,23 @@ unless defined? LogMessages::Authentication::OriginValidated
       )
 
       RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
-        msg: "Rate limited cache reached limit and will not call target",
+        msg: "Rate limited cache reached the '{0-limit}' limit and will not call target for the next '{1-seconds}' ",
         code: "CONJ00020D"
+      )
+
+      ConcurrencyLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
+          msg: "Concurrency limited cache updated successfully",
+          code: "CONJ00021D"
+      )
+
+      ConcurrencyLimitedCacheReached = ::Util::TrackableLogMessageClass.new(
+          msg: "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
+          code: "CONJ00022D"
+      )
+
+      ConcurrencyLimitedCacheConcurrentRequestsUpdated = ::Util::TrackableLogMessageClass.new(
+          msg: "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
+          code: "CONJ00023D"
       )
 
     end

--- a/app/domain/util/concurrency_limited_cache.rb
+++ b/app/domain/util/concurrency_limited_cache.rb
@@ -1,0 +1,64 @@
+module Util
+
+  Log = LogMessages::Util
+  Err = Errors::Util
+
+  class ConcurrencyLimitedCache
+
+    # NOTE: "callable" is anything with a "call" method
+    def initialize(
+        callable,
+        max_concurrent_requests:,
+        logger:
+    )
+      @target = callable
+      @cache = {}
+      @semaphore = Mutex.new
+      @concurrency_mutex = Mutex.new
+      @max_concurrent_requests = max_concurrent_requests
+      @concurrent_requests = 0
+      @logger = logger
+    end
+
+    # This  method is passed exactly the same named arguments you'd pass to the
+    # callable object, but you can optionally include the `refresh: true` to
+    # force recalculation.
+    def call(**args)
+
+      @concurrency_mutex.synchronize do
+        if @concurrent_requests >= @max_concurrent_requests
+          @logger.debug(Log::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests).to_s)
+          raise Err::ConcurrencyLimitReachedBeforeCacheInitialization unless @cache.key?(args)
+          return @cache[args]
+        end
+
+        @concurrent_requests += 1
+        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests).to_s)
+      end
+
+      @semaphore.synchronize do
+        recalculate(args)
+        @cache[args]
+      end
+    end
+
+    private
+
+    def recalculate(args)
+      @cache[args] = @target.call(**args)
+      @logger.debug(Log::ConcurrencyLimitedCacheUpdated.new.to_s)
+      decrease_concurrent_requests
+
+      rescue => e
+        decrease_concurrent_requests
+        raise e
+    end
+
+    def decrease_concurrent_requests
+      unless @concurrent_requests == 0
+        @concurrent_requests -= 1
+        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests).to_s)
+      end
+    end
+  end
+end

--- a/app/domain/util/rate_limited_cache.rb
+++ b/app/domain/util/rate_limited_cache.rb
@@ -56,7 +56,7 @@ module Util
 
     def recalculate(args)
       if too_many_requests?(args)
-        @logger.debug(Log::RateLimitedCacheLimitReached.new.to_s)
+        @logger.debug(Log::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval).to_s)
         return
       end
       @cache[args] = @target.call(**args)

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -157,31 +157,6 @@ Feature: Users can authneticate with OIDC authenticator
     Errors::Authentication::AuthnOidc::AdminAuthenticationDenied
     """
 
-  Scenario: provider-uri dynamic change
-    Given I get authorization code for username "alice" and password "alice"
-    And I fetch an ID Token
-    And I authenticate via OIDC with id token
-    And user "alice" is authorized
-    # Update provider uri to an unreachable hostname
-    When I add the secret value "http://unreachable.com/" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/provider-uri"
-    And I save my place in the log file
-    And I authenticate via OIDC with id token
-    Then it is gateway timeout
-    And The following appears in the log after my savepoint:
-    """
-    504 Gateway Timeout
-    """
-    # Update provider uri to reachable but invalid hostname
-    When I add the secret value "http://127.0.0.1.com/" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/provider-uri"
-    And I authenticate via OIDC with id token
-    Then it is bad gateway
-    # Check recovery to a valid provider uri
-    When I successfully set OIDC variables
-    And I get authorization code for username "alice" and password "alice"
-    And I fetch an ID Token
-    And I authenticate via OIDC with id token
-    Then user "alice" is authorized
-
   Scenario: Performance test
     Given I get authorization code for username "alice" and password "alice"
     And I fetch an ID Token
@@ -189,21 +164,30 @@ Feature: Users can authneticate with OIDC authenticator
     Then The "max" response time should be less than "1" seconds
     And The "avg" response time should be less than "0.25" seconds
 
-  Scenario: Load with cache
+  Scenario: Load test
     Given I get authorization code for username "alice" and password "alice"
     And I fetch an ID Token
-    # Make sure cache contains a valid certificate
-    And I authenticate via OIDC with id token
-    And user "alice" is authorized
     And I save my place in the log file
-    # Load while the cache contains OIDC provider certificate
     When I authenticate "2000" times in "20" threads via OIDC with id token
     Then The following appears "2000" times in the log after my savepoint:
     """
     Completed 200 OK
     """
-    # Validate cache functionality
-    And The following appears "0" times in the log after my savepoint:
+
+  Scenario: Load unreachable provider-uri requests
+    # i have valid certificate in cache
+    Given I get authorization code for username "alice" and password "alice"
+    And I fetch an ID Token
+    And I authenticate via OIDC with id token
+    And user "alice" is authorized
+    # load of invalid requests above the "refreshes_per_interval"
+    When I add the secret value "http://unreachable.com/" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/provider-uri"
+    And I save my place in the log file
+    And I authenticate "20" times in "20" threads via OIDC with id token
+    Then The following appears in the log after my savepoint:
     """
-    CONJ00016D Rate limited cache updated successfully
+    CONJ00022D Concurrency limited cache reached
     """
+    # The server is available (the multiple timeouts errors blocked by concurrency cache limit)
+    And I authenticate as "alice" with account "cucumber"
+    And the HTTP response status code is 200

--- a/spec/app/domain/util/concurrency_limited_cache_spec.rb
+++ b/spec/app/domain/util/concurrency_limited_cache_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+@@is_threads_blocked = false
+@@is_threads_failed = false
+TARGET_EXCEPTION = "dummy exception"
+
+class ConcurrencyCount
+
+  def initialize
+    @count = 0
+  end
+
+  def call(**args)
+    @count += 1
+    # Simulate thread failure
+    raise TARGET_EXCEPTION if @@is_threads_failed
+    # Simulate threads work
+    while @@is_threads_blocked
+    end
+    @count
+  end
+end
+
+RSpec.describe 'Util::ConcurrencyLimitedCache' do
+  before (:each) do
+    @@is_threads_blocked = false
+    @@is_threads_failed = false
+    @currentConcurrencyCount = ConcurrencyCount.new
+  end
+
+  context "Multiple calls within concurrency limit" do
+
+    subject(:cached_count_unlimit) do
+      Util::ConcurrencyLimitedCache.new(
+          @currentConcurrencyCount,
+          max_concurrent_requests: 100,
+          logger: Rails.logger
+      )
+    end
+
+    it "it should work the same as what it's wrapping" do
+      @@is_threads_failed = false
+      expect(cached_count_unlimit.call).to eq(1)
+
+      @@is_threads_failed = true
+      expect{ cached_count_unlimit.call }.to raise_error(TARGET_EXCEPTION)
+    end
+
+    it "it should return cached values" do
+      cached_count_unlimit.call(key: "key1")
+      cached_count_unlimit.call(key: "key2")
+      cached_count_unlimit.call(key: "key3")
+      cached_count_unlimit.call(key: "key4")
+      expect(cached_count_unlimit.call).to eq(5)
+    end
+
+    it "it should work the same as what it's wrapping in concurrency" do
+      # Simulate concurrency work
+      queue = (1..10).inject(Queue.new, :push)
+      all_threads = Array.new(10) do
+        Thread.new do
+          until queue.empty? do
+            queue.shift
+            cached_count_unlimit.call
+          end
+        end
+      end
+
+      # Wait for threads to be stuck on target call
+      all_threads.each(&:join)
+
+      # The above threads died before updating the cache value
+      expect(cached_count_unlimit.call).to eq(11)
+    end
+
+  end
+
+  context "Multiple calls across concurrency limit" do
+
+    subject(:cached_count) do
+      Util::ConcurrencyLimitedCache.new(
+          @currentConcurrencyCount,
+          max_concurrent_requests: 4,
+          logger: Rails.logger
+      )
+    end
+
+    it "should throw error when we reached concurrency limit and cache uninitialized" do
+      # Simulate concurrency work
+      queue = (1..4).inject(Queue.new, :push)
+      @@is_threads_blocked = true
+      all_threads = Array.new(4) do
+        Thread.new do
+          until queue.empty? do
+            queue.shift
+            cached_count.call
+          end
+        end
+      end
+
+      # Wait for threads to be stuck on target call
+      sleep(2.second)
+      all_threads.each(&:kill)
+
+      expect{ cached_count.call }.to raise_error(Errors::Util::ConcurrencyLimitReachedBeforeCacheInitialization)
+    end
+
+    it "should return the cache value when we reached concurrency limit" do
+      # Initialize cache
+      @@is_threads_blocked = false
+
+      expect(cached_count.call).to eq(1)
+
+      # Simulate concurrency work
+      queue = (1..4).inject(Queue.new, :push)
+      @@is_threads_blocked = true
+      all_threads = Array.new(4) do
+        Thread.new do
+          until queue.empty? do
+            queue.shift
+            cached_count.call
+          end
+        end
+      end
+
+      # Wait for threads to be stuck on target call
+      sleep(2.second)
+      all_threads.each(&:kill)
+
+      # The above threads died before updating the cache value
+      expect(cached_count.call).to eq(1)
+    end
+
+  end
+end

--- a/spec/app/domain/util/rate_limited_cache_spec.rb
+++ b/spec/app/domain/util/rate_limited_cache_spec.rb
@@ -20,7 +20,7 @@ end
 
 RSpec.describe 'Util::RateLimitedCache' do
 
-  context "Mulitple calls within the rate limit interval" do
+  context "Multiple calls within the rate limit interval" do
 
     subject(:cached_count) do
       Util::RateLimitedCache.new(
@@ -57,7 +57,7 @@ RSpec.describe 'Util::RateLimitedCache' do
   #TODO another example with differet params, to test
   #     that keys are cached independently
 
-  context "Mulitple calls across rate limit intervals" do
+  context "Multiple calls across rate limit intervals" do
 
     def new_cached_count(time)
       Util::RateLimitedCache.new(


### PR DESCRIPTION
#### What does this PR do?
Fix BUG #1036,
by adding concurrency cache limit functionality which wraps the current cache implementation  
#### Any background context you want to provide?
We want the capability to limit the number of requests that accessing the cache and fetching the certificate, in order to fix the above BUG

The BUG in short:  with multiple unreachable provider-uri requests the authenticator catches all the available threads on timeout error, and cause to the server to be unresponsive  
#### What ticket does this PR close?
Connected to #1036  , #1030 
#### Where should the reviewer start?
with the concurrency cache UT & implementation  

#### How should this be manually tested?
to run the following:

1. start the server `./start --authn-oidc`

2. from another session `./cli exec --authn-oidc`

3. run rspec: `rspec spec/app/domain/util/concurrency_limited_cache_spec.rb`
Note:
logs reside : `/src/conjur-server/log/test.log`

4. run cucumber: `cucumber --profile authenticators cucumber/authenticators/features/authn_oidc.feature`
Note:
logs reside : `/src/conjur-server/log/development.log`

#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

Yes

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
