### PR TITLE
Moved conjur log formatter to lib folder

### DIFF
--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -2,11 +2,11 @@
 
 load File.expand_path '../production.rb', __FILE__
 require 'rack/remember_uuid'
-require './config/conjur_log_formatter'
+require 'logger/formatter/conjur_formatter'
 
 Rails.application.configure do
   config.log_level = :info
-  config.log_formatter = ConjurLogFormatter.new
+  config.log_formatter = ConjurFormatter.new
   config.middleware.use Rack::RememberUuid
   config.audit_socket = '/run/conjur/audit.socket'
   config.audit_database ||= 'postgres://:5433/audit'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './config/conjur_log_formatter'
+require 'logger/formatter/conjur_formatter'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -24,7 +24,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
-  config.log_formatter = ConjurLogFormatter.new
+  config.log_formatter = ConjurFormatter.new
 
   # Don't care if the mailer can't send.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './config/conjur_log_formatter'
+require 'logger/formatter/conjur_formatter'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   # Use log level "warn" in prod to avoid logging parameters.
   config.log_level = :warn
-  config.log_formatter = ConjurLogFormatter.new
+  config.log_formatter = ConjurFormatter.new
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './config/conjur_log_formatter'
+require 'logger/formatter/conjur_formatter'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -44,7 +44,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
-  config.log_formatter = ConjurLogFormatter.new
+  config.log_formatter = ConjurFormatter.new
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/lib/logger/formatter/conjur_formatter.rb
+++ b/lib/logger/formatter/conjur_formatter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ConjurLogFormatter < Logger::Formatter
+class ConjurFormatter < Logger::Formatter
   Format = "%5s [%s] [tid=%s] [pid=%s] %s\n".freeze
 
   def initialize


### PR DESCRIPTION
#### What does this PR do?
Moves the conjur_log_formatter to our `lib` folder to be with the other formatter
