### PR TITLE
Separated ValidateSecurity to CommandClasses per responsibility

### DIFF
--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -36,7 +36,7 @@ module Authentication
       def install_signed_cert
         pod_namespace = spiffe_id.namespace
         pod_name = spiffe_id.name
-        @logger.debug(Log::CopySSLToPod.new(pod_namespace, pod_name).to_s)
+        @logger.debug(Log::CopySSLToPod.new(pod_namespace, pod_name))
 
         resp = @kubectl_exec.new.copy(
           k8s_object_lookup: k8s_object_lookup,

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -51,7 +51,7 @@ module Authentication
         if hs_error
           ws_client.emit(:error, "Websocket handshake error: #{hs_error.inspect}")
         else
-          @logger.debug(Log::PodChannelOpen.new(@pod_name).to_s)
+          @logger.debug(Log::PodChannelOpen.new(@pod_name))
 
           if stdin
             data = WebSocketMessage.channel_byte('stdin') + body
@@ -68,24 +68,24 @@ module Authentication
         msg_data = wsmsg.data
 
         if msg_type == :binary
-          @logger.debug(Log::PodChannelData.new(@pod_name, wsmsg.channel_name, msg_data).to_s)
+          @logger.debug(Log::PodChannelData.new(@pod_name, wsmsg.channel_name, msg_data))
           @message_log.save_message(wsmsg)
         elsif msg_type == :close
-          @logger.debug(Log::PodMessageData.new(@pod_name, "close", msg_data).to_s)
+          @logger.debug(Log::PodMessageData.new(@pod_name, "close", msg_data))
           ws_client.close
         end
       end
 
       def on_close
         @channel_closed = true
-        @logger.debug(Log::PodChannelClosed.new(@pod_name).to_s)
+        @logger.debug(Log::PodChannelClosed.new(@pod_name))
       end
 
       def on_error(err)
         @channel_closed = true
 
         error_info = err.inspect
-        @logger.debug(Log::PodError.new(@pod_name, error_info).to_s)
+        @logger.debug(Log::PodError.new(@pod_name, error_info))
         @message_log.save_error_string(error_info)
       end
 

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/authenticate.rb
@@ -75,7 +75,7 @@ module Authentication
         def validate_conjur_username
           raise Err::IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
           raise Err::AdminAuthenticationDenied if admin?(conjur_username)
-          @logger.debug(Log::ExtractedUsernameFromIDToked.new(conjur_username, id_token_username_field).to_s)
+          @logger.debug(Log::ExtractedUsernameFromIDToked.new(conjur_username, id_token_username_field))
         end
 
         def conjur_username

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/decode_and_verify_id_token.rb
@@ -43,14 +43,14 @@ module Authentication
             provider_uri: @provider_uri,
               refresh: force_read
           )
-          @logger.debug(Log::OIDCProviderCertificateFetchedFromCache.new.to_s)
+          @logger.debug(Log::OIDCProviderCertificateFetchedFromCache.new)
           @certs
         end
 
         def ensure_certs_are_fresh
           decoded_id_token
         rescue
-          @logger.debug(Log::ValidateProviderCertificateIsUpdated.new.to_s)
+          @logger.debug(Log::ValidateProviderCertificateIsUpdated.new)
           # maybe failed due to certificate rotation. Force cache to read it again
           fetch_certs(force_read: true)
         end
@@ -79,7 +79,7 @@ module Authentication
                        nonce: decoded_attributes[:nonce] }
 
           decoded_id_token.verify!(expected)
-          @logger.debug(Log::IDTokenVerificationSuccess.new.to_s)
+          @logger.debug(Log::IDTokenVerificationSuccess.new)
         rescue OpenIDConnect::ResponseObject::IdToken::ExpiredToken
           raise Err::IdTokenExpired
         rescue => e
@@ -92,10 +92,10 @@ module Authentication
             @id_token_jwt,
             @certs
           )
-          @logger.debug(Log::IDTokenDecodeSuccess.new.to_s)
+          @logger.debug(Log::IDTokenDecodeSuccess.new)
           @decoded_id_token
         rescue => e
-          @logger.debug(Log::IDTokenDecodeFailed.new(e.inspect).to_s)
+          @logger.debug(Log::IDTokenDecodeFailed.new(e.inspect))
           raise e
         end
 

--- a/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate_id_token/fetch_provider_certificate.rb
@@ -29,12 +29,12 @@ module Authentication
         private
 
         def log_provider_uri
-          @logger.debug(Log::OIDCProviderUri.new(@provider_uri).to_s)
+          @logger.debug(Log::OIDCProviderUri.new(@provider_uri))
         end
 
         def discover_provider
           @discovered_provider = @open_id_discovery_service.discover!(@provider_uri)
-          @logger.debug(Log::OIDCProviderDiscoverySuccess.new.to_s)
+          @logger.debug(Log::OIDCProviderDiscoverySuccess.new)
         rescue HTTPClient::ConnectTimeoutError => e
           raise_error(Err::ProviderDiscoveryTimeout, e)
         rescue => e
@@ -43,7 +43,7 @@ module Authentication
 
         def fetch_certs
           @discovered_provider.jwks.tap do
-            @logger.debug(Log::FetchProviderCertsSuccess.new.to_s)
+            @logger.debug(Log::FetchProviderCertsSuccess.new)
           end
         rescue => e
           raise_error(Err::ProviderFetchCertificateFailed, e)

--- a/app/domain/authentication/validate_security.rb
+++ b/app/domain/authentication/validate_security.rb
@@ -2,7 +2,6 @@
 
 require 'authentication/webservices'
 require 'authentication/validate_webservice_access'
-require 'authentication/validate_webservice_access'
 require 'authentication/validate_whitelisted_webservice'
 
 module Authentication

--- a/app/domain/authentication/validate_webservice_access.rb
+++ b/app/domain/authentication/validate_webservice_access.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'authentication/webservices'
+require 'logs'
+
+module Authentication
+
+  module Security
+
+    Log = LogMessages::Authentication::Security
+    Err = Errors::Authentication::Security
+    # Possible Errors Raised:
+    # AccountNotDefined, ServiceNotDefined,
+    # UserNotDefinedInConjur, UserNotAuthorizedInConjur
+
+    ValidateWebserviceAccess = CommandClass.new(
+      dependencies: {
+        role_class: ::Role,
+        resource_class: ::Resource,
+        logger: Rails.logger
+      },
+      inputs: %i(webservice account user_id)
+    ) do
+
+      def call
+        # No checks required for default conjur authn
+        return if default_conjur_authn?
+
+        validate_account_exists
+        validate_webservice_exists
+        validate_user_is_defined
+        validate_user_has_access
+      end
+
+      private
+
+      def default_conjur_authn?
+        @webservice.authenticator_name ==
+          ::Authentication::Common.default_authenticator_name
+      end
+
+      def validate_account_exists
+        raise Err::AccountNotDefined, @account unless account_admin_role
+      end
+
+      def validate_webservice_exists
+        raise Err::ServiceNotDefined, @webservice.name unless webservice_resource
+      end
+
+      def validate_user_is_defined
+        raise Err::UserNotDefinedInConjur, @user_id unless user_role
+      end
+
+      def validate_user_has_access
+        # Ensure user has access to the service
+        has_access = user_role.allowed_to?('authenticate', webservice_resource)
+        unless has_access
+          @logger.debug(Log::UserNotAuthorized
+                          .new(@user_id, webservice_resource_id).to_s)
+          raise Err::UserNotAuthorizedInConjur, @user_id
+        end
+      end
+
+      def user_role_id
+        @user_role_id ||= @role_class.roleid_from_username(@account, @user_id)
+      end
+
+      def user_role
+        @user_role ||= @role_class[user_role_id]
+      end
+
+      def account_admin_role
+        @account_admin_role ||= @role_class["#{@account}:user:admin"]
+      end
+
+      def webservice_resource
+        @resource_class[webservice_resource_id]
+      end
+
+      def webservice_resource_id
+        @webservice.resource_id
+      end
+    end
+  end
+end

--- a/app/domain/authentication/validate_webservice_access.rb
+++ b/app/domain/authentication/validate_webservice_access.rb
@@ -56,7 +56,7 @@ module Authentication
         has_access = user_role.allowed_to?('authenticate', webservice_resource)
         unless has_access
           @logger.debug(Log::UserNotAuthorized
-                          .new(@user_id, webservice_resource_id).to_s)
+                          .new(@user_id, webservice_resource_id))
           raise Err::UserNotAuthorizedInConjur, @user_id
         end
       end

--- a/app/domain/authentication/validate_whitelisted_webservice.rb
+++ b/app/domain/authentication/validate_whitelisted_webservice.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'authentication/webservices'
+
+module Authentication
+
+  module Security
+
+    Err = Errors::Authentication::Security
+    # Possible Errors Raised:
+    # AccountNotDefined, NotWhitelisted
+
+    ValidateWhitelistedWebservice = CommandClass.new(
+      dependencies: {
+        role_class: ::Role,
+        webservices_class: ::Authentication::Webservices,
+      },
+      inputs: %i(webservice account enabled_authenticators)
+    ) do
+
+      def call
+        # No checks required for default conjur authn
+        return if default_conjur_authn?
+
+        validate_account_exists
+        validate_webservice_is_whitelisted
+      end
+
+      private
+
+      def default_conjur_authn?
+        @webservice.authenticator_name ==
+          ::Authentication::Common.default_authenticator_name
+      end
+
+      def validate_account_exists
+        raise Err::AccountNotDefined, @account unless account_admin_role
+      end
+
+      def account_admin_role
+        @account_admin_role ||= @role_class["#{@account}:user:admin"]
+      end
+
+      def validate_webservice_is_whitelisted
+        is_whitelisted = whitelisted_webservices.include?(@webservice)
+        raise Err::NotWhitelisted, @webservice.name unless is_whitelisted
+      end
+
+      def whitelisted_webservices
+        @webservices_class.from_string(
+          @account,
+          @enabled_authenticators || Authentication::Common.default_authenticator_name
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/validate_whitelisted_webservice.rb
+++ b/app/domain/authentication/validate_whitelisted_webservice.rb
@@ -13,7 +13,7 @@ module Authentication
     ValidateWhitelistedWebservice = CommandClass.new(
       dependencies: {
         role_class: ::Role,
-        webservices_class: ::Authentication::Webservices,
+        webservices_class: ::Authentication::Webservices
       },
       inputs: %i(webservice account enabled_authenticators)
     ) do

--- a/app/domain/util/concurrency_limited_cache.rb
+++ b/app/domain/util/concurrency_limited_cache.rb
@@ -26,13 +26,13 @@ module Util
     def call(**args)
       @concurrency_mutex.synchronize do
         if @concurrent_requests >= @max_concurrent_requests
-          @logger.debug(Log::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests).to_s)
+          @logger.debug(Log::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests))
           raise Err::ConcurrencyLimitReachedBeforeCacheInitialization unless @cache.key?(args)
           return @cache[args]
         end
 
         @concurrent_requests += 1
-        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests).to_s)
+        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
       end
 
       @semaphore.synchronize do
@@ -45,7 +45,7 @@ module Util
 
     def recalculate(args)
       @cache[args] = @target.call(**args)
-      @logger.debug(Log::ConcurrencyLimitedCacheUpdated.new.to_s)
+      @logger.debug(Log::ConcurrencyLimitedCacheUpdated.new)
       decrease_concurrent_requests
     rescue => e
       decrease_concurrent_requests
@@ -55,7 +55,7 @@ module Util
     def decrease_concurrent_requests
       unless @concurrent_requests.zero?
         @concurrent_requests -= 1
-        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests).to_s)
+        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
       end
     end
   end

--- a/app/domain/util/rate_limited_cache.rb
+++ b/app/domain/util/rate_limited_cache.rb
@@ -56,11 +56,11 @@ module Util
 
     def recalculate(args)
       if too_many_requests?(args)
-        @logger.debug(Log::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval).to_s)
+        @logger.debug(Log::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval))
         return
       end
       @cache[args] = @target.call(**args)
-      @logger.debug(Log::RateLimitedCacheUpdated.new.to_s)
+      @logger.debug(Log::RateLimitedCacheUpdated.new)
       @refresh_history[args].push(@time.now)
     end
 

--- a/spec/app/domain/authentication/validate_security_spec.rb
+++ b/spec/app/domain/authentication/validate_security_spec.rb
@@ -3,84 +3,40 @@
 require 'spec_helper'
 
 RSpec.describe Authentication::Security::ValidateSecurity do
-  let (:test_account) { 'test-account' }
-  let (:non_existing_account) { 'non-existing' }
-  let (:fake_authenticator_name) { 'authn-x' }
-  
-  # create an example webservice
-  def webservice(service_id, account: test_account, authenticator_name: fake_authenticator_name)
-    ::Authentication::Webservice.new(
-      account: account,
-      authenticator_name: authenticator_name,
-      service_id: service_id
-    )
-  end
+  include_context "security mocks"
 
-  # generates user_role authorized for all or no services
-  def user_role(is_authorized:)
-    double('user_role').tap do |role|
-      allow(role).to receive(:allowed_to?).and_return(is_authorized)
-    end
-  end
-
-  # generates user_role authorized for specific service
-  def user_role_for_service(authorized_service)
-    double('user_role').tap do |role|
-      allow(role).to(receive(:allowed_to?)) do |_, resource|
-        resource == authorized_service
-      end
-    end
-  end
-
-  def role_class(returned_role)
-    double('role_class').tap do |role|
-      allow(role).to receive(:roleid_from_username).and_return('some-role-id')
-      allow(role).to receive(:[]).and_return(returned_role)
-      
-      allow(role).to receive(:[])
-        .with(/#{test_account}:user:admin/)
-        .and_return(user_role(is_authorized: true))
-      
-      allow(role).to receive(:[])
-        .with(/#{non_existing_account}:user:admin/)
-        .and_return(nil)
-    end
-  end
-
-  # generates a Resource class which returns the provided object
-  def resource_class(returned_resource)
-    double('Resource').tap do |resource|
-      allow(resource).to receive(:[]).and_return(returned_resource)
-    end
-  end
-
-  let (:blank_env) { nil }
-
-  let (:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
-
-  let(:default_authenticator_mock) do
+  let(:authenticator_mock) do
     double('authenticator').tap do |authenticator|
-      allow(authenticator).to receive(:authenticator_name).and_return("authn")
+      allow(authenticator).to receive(:authenticator_name).and_return("authn-x")
     end
   end
 
-  let (:full_access_resource_class) { resource_class('some random resource') }
-  let (:no_access_resource_class) { resource_class(nil) }
+  let(:mock_validate_whitelisted_webservice) { double("ValidateWhitelistedWebservice") }
+  let(:mock_validate_webservice_access) { double("ValidateWebserviceAccess") }
 
-  let (:nil_user_role_class) { role_class(nil) }
-  let (:non_existing_account_role_class) { role_class(nil) }
-  let (:full_access_role_class) { role_class(user_role(is_authorized: true)) }
-  let (:no_access_role_class) { role_class(user_role(is_authorized: false)) }
+  before(:each) do
+    allow(Authentication::Security::ValidateWhitelistedWebservice)
+      .to receive(:new)
+            .and_return(mock_validate_whitelisted_webservice)
+    allow(mock_validate_whitelisted_webservice).to receive(:call)
+                                                .and_return(true)
 
-  context "A whitelisted, authorized webservice and authorized user" do
+    allow(Authentication::Security::ValidateWebserviceAccess)
+      .to receive(:new)
+            .and_return(mock_validate_webservice_access)
+    allow(mock_validate_webservice_access).to receive(:call)
+                                           .and_return(true)
+  end
+
+  context "A whitelisted, accessible webservice" do
     subject do
       Authentication::Security::ValidateSecurity.new(
-        role_class: full_access_role_class,
-        webservice_resource_class: full_access_resource_class
+        validate_whitelisted_webservice: mock_validate_whitelisted_webservice,
+        validate_webservice_access: mock_validate_webservice_access
       ).(
-        webservice: webservice('service1'),
+        webservice: authenticator_mock,
           account: test_account,
-          user_id: 'some-user',
+          user_id: test_user_id,
           enabled_authenticators: two_authenticator_env
       )
     end
@@ -90,216 +46,48 @@ RSpec.describe Authentication::Security::ValidateSecurity do
     end
   end
 
-  context "A un-whitelisted, authorized webservice and authorized user" do
+  context "A whitelisted, inaccessible webservice and authorized user" do
     subject do
       Authentication::Security::ValidateSecurity.new(
-        role_class: full_access_role_class,
-        webservice_resource_class: full_access_resource_class
+        validate_whitelisted_webservice: mock_validate_whitelisted_webservice,
+        validate_webservice_access: mock_validate_webservice_access
       ).(
-        webservice: webservice('DOESNT_EXIST'),
+        webservice: authenticator_mock,
           account: test_account,
-          user_id: 'some-user',
+          user_id: test_user_id,
           enabled_authenticators: two_authenticator_env
       )
     end
 
-    it "raises a NotWhitelisted error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::NotWhitelisted)
-    end
-  end
-
-  context "A whitelisted, unauthorized webservice and authorized user" do
-    subject do
-      Authentication::Security::ValidateSecurity.new(
-        role_class: full_access_role_class,
-        webservice_resource_class: no_access_resource_class
-      ).(
-        webservice: webservice('service1'),
-          account: test_account,
-          user_id: 'some-user',
-          enabled_authenticators: two_authenticator_env
-      )
-    end
-
-    it "raises a ServiceNotDefined error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::ServiceNotDefined)
-    end
-  end
-
-  context "A whitelisted, authorized webservice and non-existent user" do
-    subject do
-      Authentication::Security::ValidateSecurity.new(
-        role_class: nil_user_role_class,
-        webservice_resource_class: full_access_resource_class
-      ).(
-        webservice: webservice('service1'),
-          account: test_account,
-          user_id: 'some-user',
-          enabled_authenticators: two_authenticator_env
-      )
-    end
-    it "raises a NotDefinedInConjur error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
-    end
-  end
-
-  context "A whitelisted, authorized webservice and unauthorized user" do
-    subject do
-      Authentication::Security::ValidateSecurity.new(
-        role_class: no_access_role_class,
-        webservice_resource_class: full_access_resource_class
-      ).(
-        webservice: webservice('service1'),
-          account: test_account,
-          user_id: 'some-user',
-          enabled_authenticators: two_authenticator_env
-      )
-    end
-
-    it "raises a NotAuthorizedInConjur error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotAuthorizedInConjur
-      )
-    end
-  end
-
-  context "Two whitelisted, authorized webservices" do
-    context "and a user authorized for only one on them" do
-      let (:webservice_resource) { 'CAN ACCESS ME' }
-      let (:partial_access_role_class) do
-        role_class(user_role_for_service(webservice_resource))
-      end
-      let (:accessible_resource_class) { resource_class(webservice_resource) }
-      let (:inaccessible_resource_class) { resource_class('CANNOT ACCESS ME') }
-
-      context "when accessing the authorized one" do
-        subject do
-          Authentication::Security::ValidateSecurity.new(
-            role_class: partial_access_role_class,
-            webservice_resource_class: accessible_resource_class
-          ).(
-            webservice: webservice('service1'),
-              account: test_account,
-              user_id: 'some-user',
-              enabled_authenticators: two_authenticator_env
-          )
-        end
-
-        it "succeeds" do
-          expect { subject }.to_not raise_error
-        end
-      end
-
-      context "when accessing the blocked one" do
-        subject do
-          Authentication::Security::ValidateSecurity.new(
-            role_class: partial_access_role_class,
-            webservice_resource_class: inaccessible_resource_class
-          ).(
-            webservice: webservice('service1'),
-              account: test_account,
-              user_id: 'some-user',
-              enabled_authenticators: two_authenticator_env
-          )
-        end
-
-        it "fails" do
-          expect { subject }.to raise_error(Errors::Authentication::Security::UserNotAuthorizedInConjur)
-        end
-      end
-    end
-  end
-
-  context "An ENV lacking CONJUR_AUTHENTICATORS" do
-    subject do
-      Authentication::Security::ValidateSecurity.new(
-        role_class: full_access_role_class,
-        webservice_resource_class: full_access_resource_class
-      ).(
-        webservice: default_authenticator_mock,
-          account: test_account,
-          user_id: 'some-user',
-          enabled_authenticators: blank_env
-      )
-    end
-
-    it "the default Conjur authenticator is included in whitelisted webservices" do
-      expect { subject }.to_not raise_error
-    end
-  end
-
-  context "A non-existing account" do
-    subject do
-      Authentication::Security::ValidateSecurity.new(
-        role_class: non_existing_account_role_class,
-        webservice_resource_class: full_access_resource_class
-      ).(
-        webservice: webservice('service1'),
-          account: non_existing_account,
-          user_id: 'some-user',
-          enabled_authenticators: two_authenticator_env
-      )
-    end
-
-    it "raises an AccountNotDefined error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::AccountNotDefined)
-    end
-  end
-
-  context "when validating the same role a second time" do
-    let(:user_id) { 'some-user' }
-    let(:user_roleid) { [test_account, 'user', user_id].join(':') }
-    let(:user_role_double) {
-      double('user_role_double').tap { |ur|
-        allow(ur).to receive(:allowed_to?).and_return(true)
-      }
-    }
-
-    # We can't use the double returned by the +role_class+ function
-    # above, because it doesn't constrain the arguments to +:[]+.
-    let(:role_class) {
-      double('role_class').tap {|rc|
-        allow(rc).to receive(:roleid_from_username).and_return(user_roleid)
-        allow(rc).to receive(:[])
-          .with("#{test_account}:user:admin")
-          .and_return(user_role(is_authorized: true))
-      }
-    }
-
-    subject do
-      described_class
-        .new(
-          role_class: role_class,
-          webservice_resource_class: full_access_resource_class
-        )
-    end
-    
-    it "role lookups are not cached" do
-
-      # Simulate two validations. For the first, the role should not
-      # be found.
-      allow(role_class).to receive(:[]).with(user_roleid).and_return(nil)
-      expect { subject.(
-                 webservice: webservice('service1'),
-                 account: test_account,
-                 user_id: user_id,
-                 enabled_authenticators: two_authenticator_env
-               )
-      }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
-
-      # For the second, the role should be found, and validation
-      # should succeed.
-
-      # Note that, because the arguments are the same, this +allow+
-      # overwrites the previous one.
-      allow(role_class).to receive(:[]).with(user_roleid).and_return(user_role_double)
-      expect { subject.(
-                 webservice: webservice('service1'),
-                 account: test_account,
-                 user_id: user_id,
-                 enabled_authenticators: two_authenticator_env
-               )
-      }.not_to raise_error
+    it "raises the error that is raised by validate_webservice_access" do
+      allow(mock_validate_webservice_access)
+        .to receive(:call)
+              .and_raise("webservice-access-validation-error")
       
+      expect { subject }.to raise_error("webservice-access-validation-error")
+    end
+  end
+
+  context "An un-whitelisted, accessible webservice" do
+    subject do
+      Authentication::Security::ValidateSecurity.new(
+        validate_whitelisted_webservice: mock_validate_whitelisted_webservice,
+        validate_webservice_access: mock_validate_webservice_access
+      ).(
+        webservice: authenticator_mock,
+          account: test_account,
+          user_id: test_user_id,
+          enabled_authenticators: two_authenticator_env
+      )
+    end
+
+    it "raises the error that is raised by validate_whitelisted_webservice" do
+
+      allow(mock_validate_whitelisted_webservice)
+        .to receive(:call)
+              .and_raise("whitelisted-webservice-validation-error")
+
+      expect { subject }.to raise_error("whitelisted-webservice-validation-error")
     end
   end
 end

--- a/spec/app/domain/authentication/validate_webservice_access_spec.rb
+++ b/spec/app/domain/authentication/validate_webservice_access_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::Security::ValidateWebserviceAccess do
+  include_context "security mocks"
+
+  let (:full_access_resource_class) { resource_class('some random resource') }
+  let (:no_access_resource_class) { resource_class(nil) }
+
+  let (:nil_user_role_class) { role_class(nil) }
+  let (:non_existing_account_role_class) { role_class(nil) }
+  let (:full_access_role_class) { role_class(user_role(is_authorized: true)) }
+  let (:no_access_role_class) { role_class(user_role(is_authorized: false)) }
+
+  # generates a Resource class which returns the provided object
+  def resource_class(returned_resource)
+    double('Resource').tap do |resource_class|
+      allow(resource_class).to receive(:[]).and_return(returned_resource)
+    end
+  end
+
+  def role_class(returned_role)
+    double('role_class').tap do |role|
+      allow(role).to receive(:roleid_from_username).and_return('some-role-id')
+      allow(role).to receive(:[]).and_return(returned_role)
+
+      allow(role).to receive(:[])
+                       .with(/#{test_account}:user:admin/)
+                       .and_return(user_role(is_authorized: true))
+
+      allow(role).to receive(:[])
+                       .with(/#{non_existing_account}:user:admin/)
+                       .and_return(nil)
+    end
+  end
+
+  # generates user_role authorized for all or no services
+  def user_role(is_authorized:)
+    double('user_role').tap do |role|
+      allow(role).to receive(:allowed_to?).and_return(is_authorized)
+    end
+  end
+
+  context "An authorized webservice and authorized user" do
+    subject do
+      Authentication::Security::ValidateWebserviceAccess.new(
+        role_class: full_access_role_class,
+        resource_class: full_access_resource_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          user_id: test_user_id
+      )
+    end
+
+    it "validates without error" do
+      expect { subject }.to_not raise_error
+    end
+  end
+
+  context "An unauthorized webservice and authorized user" do
+    subject do
+      Authentication::Security::ValidateWebserviceAccess.new(
+        role_class: full_access_role_class,
+        resource_class: no_access_resource_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          user_id: test_user_id
+      )
+    end
+
+    it "raises a ServiceNotDefined error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::ServiceNotDefined)
+    end
+  end
+
+  context "An authorized webservice and non-existent user" do
+    subject do
+      Authentication::Security::ValidateWebserviceAccess.new(
+        role_class: nil_user_role_class,
+        resource_class: full_access_resource_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          user_id: test_user_id
+      )
+    end
+    it "raises a NotDefinedInConjur error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
+    end
+  end
+
+  context "An authorized webservice and unauthorized user" do
+    subject do
+      Authentication::Security::ValidateWebserviceAccess.new(
+        role_class: no_access_role_class,
+        resource_class: full_access_resource_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          user_id: test_user_id
+      )
+    end
+
+    it "raises a NotAuthorizedInConjur error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotAuthorizedInConjur
+      )
+    end
+  end
+
+  context "A non-existing account" do
+    subject do
+      Authentication::Security::ValidateWebserviceAccess.new(
+        role_class: non_existing_account_role_class,
+        resource_class: full_access_resource_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: non_existing_account,
+          user_id: test_user_id
+      )
+    end
+
+    it "raises an AccountNotDefined error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::AccountNotDefined)
+    end
+  end
+
+  context "when validating the same role a second time" do
+    let(:user_id) { 'some-user' }
+    let(:user_roleid) { [test_account, 'user', user_id].join(':') }
+    let(:user_role_double) {
+      double('user_role_double').tap { |ur|
+        allow(ur).to receive(:allowed_to?).and_return(true)
+      }
+    }
+
+    # We can't use the double returned by the +role_class+ function
+    # above, because it doesn't constrain the arguments to +:[]+.
+    let(:role_class) {
+      double('role_class').tap {|rc|
+        allow(rc).to receive(:roleid_from_username).and_return(user_roleid)
+        allow(rc).to receive(:[])
+          .with("#{test_account}:user:admin")
+          .and_return(user_role(is_authorized: true))
+      }
+    }
+
+    subject do
+      described_class
+        .new(
+          role_class: role_class,
+          resource_class: full_access_resource_class
+        )
+    end
+    
+    it "role lookups are not cached" do
+
+      # Simulate two validations. For the first, the role should not
+      # be found.
+      allow(role_class).to receive(:[]).with(user_roleid).and_return(nil)
+      expect { subject.(
+                 webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+                 account: test_account,
+                 user_id: user_id
+               )
+      }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
+
+      # For the second, the role should be found, and validation
+      # should succeed.
+
+      # Note that, because the arguments are the same, this +allow+
+      # overwrites the previous one.
+      allow(role_class).to receive(:[]).with(user_roleid).and_return(user_role_double)
+      expect { subject.(
+                 webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+                 account: test_account,
+                 user_id: user_id
+               )
+      }.not_to raise_error
+      
+    end
+  end
+end

--- a/spec/app/domain/authentication/validate_whitelisted_webservice_spec.rb
+++ b/spec/app/domain/authentication/validate_whitelisted_webservice_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::Security::ValidateWhitelistedWebservice do
+  include_context "security mocks"
+
+  let (:blank_env) { nil }
+  let (:not_including_env) do
+    "authn-other/service1"
+  end
+
+  let(:default_authenticator_mock) do
+    double('authenticator').tap do |authenticator|
+      allow(authenticator).to receive(:authenticator_name).and_return("authn")
+    end
+  end
+
+  def mock_admin_role_class
+    double('role_class').tap do |role_class|
+      allow(role_class).to receive(:[])
+                             .with(/#{test_account}:user:admin/)
+                             .and_return("admin-role")
+
+      allow(role_class).to receive(:[])
+                             .with(/#{non_existing_account}:user:admin/)
+                             .and_return(nil)
+    end
+  end
+
+  def webservices_dict(includes_authenticator:)
+    double('webservices_dict').tap do |webservices_dict|
+      allow(webservices_dict).to receive(:include?)
+                                   .and_return(includes_authenticator)
+    end
+  end
+
+  def mock_webservices_class
+    double('webservices_class').tap do |webservices_class|
+
+
+      allow(webservices_class).to receive(:from_string)
+                                    .with(anything, two_authenticator_env)
+                                    .and_return(webservices_dict(includes_authenticator: true))
+
+      allow(webservices_class).to receive(:from_string)
+                                    .with(anything, not_including_env)
+                                    .and_return(webservices_dict(includes_authenticator: false))
+
+      allow(webservices_class).to receive(:from_string)
+                                    .with(anything, blank_env)
+                                    .and_return(webservices_dict(includes_authenticator: false))
+    end
+  end
+
+  context "A whitelisted webservice" do
+    subject do
+      Authentication::Security::ValidateWhitelistedWebservice.new(
+        role_class: mock_admin_role_class,
+        webservices_class: mock_webservices_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          enabled_authenticators: two_authenticator_env
+      )
+    end
+
+    it "validates without error" do
+      expect { subject }.to_not raise_error
+    end
+  end
+
+  context "A un-whitelisted webservice" do
+    subject do
+      Authentication::Security::ValidateWhitelistedWebservice.new(
+        role_class: mock_admin_role_class,
+        webservices_class: mock_webservices_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: test_account,
+          enabled_authenticators: not_including_env
+      )
+    end
+
+    it "raises a NotWhitelisted error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::NotWhitelisted)
+    end
+  end
+
+  context "An ENV lacking CONJUR_AUTHENTICATORS" do
+    subject do
+      Authentication::Security::ValidateWhitelistedWebservice.new(
+        role_class: mock_admin_role_class,
+        webservices_class: mock_webservices_class
+      ).(
+        webservice: default_authenticator_mock,
+          account: test_account,
+          enabled_authenticators: blank_env
+      )
+    end
+
+    it "the default Conjur authenticator is included in whitelisted webservices" do
+      expect { subject }.to_not raise_error
+    end
+  end
+
+  context "A non-existing account" do
+    subject do
+      Authentication::Security::ValidateWhitelistedWebservice.new(
+        role_class: mock_admin_role_class,
+        webservices_class: mock_webservices_class
+      ).(
+        webservice: mock_webservice("#{fake_authenticator_name}/service1"),
+          account: non_existing_account,
+          enabled_authenticators: two_authenticator_env
+      )
+    end
+
+    it "raises an AccountNotDefined error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::AccountNotDefined)
+    end
+  end
+end

--- a/spec/support/security_specs_helper.rb
+++ b/spec/support/security_specs_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_context "security mocks" do
+  let (:test_account) { 'test-account' }
+  let (:non_existing_account) { 'non-existing' }
+  let (:fake_authenticator_name) { 'authn-x' }
+  let (:test_user_id) { 'some-user' }
+  let (:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
+
+  def mock_webservice(resource_id)
+    double('webservice').tap do |webservice|
+      allow(webservice).to receive(:authenticator_name)
+                             .and_return("some-string")
+
+      allow(webservice).to receive(:name)
+                             .and_return("some-string")
+
+      allow(webservice).to receive(:resource_id)
+                             .and_return(resource_id)
+    end
+  end
+
+end


### PR DESCRIPTION
#### What does this PR do?
Separated ValidateSecurity to CommandClasses per responsibility

#### Any background context you want to provide?
ValidateSecurity has 2 responsibilities:
- Validate that the webservice is whitelisted in the env
- Validate that the user is defined & authtorized to the webservice

In this commit we separate ValidateSecurity into 2 CommandClass, each with its own
responsibility. This way we can use these CommandClasses in other places where
we want to do only one of the actions (i.e validate a webservice is whitelisted),
instead of copying code.