### PR TITLE
Upgrade baseimages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update -y && \
                        unattended-upgrades \
                        update-notifier-common \
                        # needed to build some gem native extensions:
-                       libz-dev
+                       libz-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN gem install -N -v 1.16.1 bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV PORT 80
 
 EXPOSE 80
-
-RUN apt-get update -y && \
-    apt-get install -y software-properties-common && \
-    apt-add-repository -y ppa:brightbox/ruby-ng
 
 RUN apt-get update -y && \
     apt-get install -y build-essential \
@@ -20,7 +16,9 @@ RUN apt-get update -y && \
                        ruby2.5 ruby2.5-dev \
                        tzdata \
                        unattended-upgrades \
-                       update-notifier-common
+                       update-notifier-common \
+                       # needed to build some gem native extensions:
+                       libz-dev
 
 RUN gem install -N -v 1.16.1 bundler
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,7 +15,7 @@ RUN echo Installing phantomjs && \
                        libxft-dev \
                        wget
 
-ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+ENV PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
 
 RUN cd ~ && \
     wget https://bitbucket.org/ariya/phantomjs/downloads/${PHANTOM_JS}.tar.bz2 && \

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,9 +1,4 @@
-FROM phusion/baseimage:0.9.22
-
-RUN apt-get update -y && \
-    apt-get install -y software-properties-common && \
-    apt-add-repository -y ppa:brightbox/ruby-ng && \
-    apt-get update -y
+FROM phusion/baseimage:0.11
 
 RUN apt-get update -y && \
     apt-get install -y \


### PR DESCRIPTION
#### What does this PR do?

Upgrade the docker base images.

#### Any background context you want to provide?

Ubuntu 16.04 is EOL. We've been using a third-party brightbox PPA to bring in modern rubies into it, but it has been removed, breaking our builds.