### PR TITLE
Log level env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY . .
 RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
 
 ENV RAILS_ENV production
+ENV CONJUR_LOG_LEVEL info
 
 # The Rails initialization expects the database configuration
 # and data key to exist. We supply placeholder values so that

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       CONJUR_ACCOUNT: cucumber
       CONJUR_DATA_KEY:
       RAILS_ENV:
+      CONJUR_LOG_LEVEL: debug
       CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
@@ -46,6 +47,7 @@ services:
       DATABASE_URL: postgres://postgres@pg/postgres
       AUDIT_DATABASE_URL:
       RAILS_ENV: test
+      CONJUR_LOG_LEVEL: debug
       CONJUR_DATA_KEY:
       REPORT_ROOT:
       CUCUMBER_NETWORK:

--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -6,7 +6,7 @@ require 'syslog/logger'
 
 Rails.application.configure do
   config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new('conjur-possum'))
-  config.log_level = :info
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :info
   config.middleware.use Rack::RememberUuid
   config.audit_socket = '/run/conjur/audit.socket'
   config.audit_database ||= 'postgres://:5433/audit'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :debug
   config.log_formatter = ConjurFormatter.new
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Use log level "warn" in prod to avoid logging parameters.
-  config.log_level = :warn
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :warn
   config.log_formatter = ConjurFormatter.new
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :debug
   config.log_formatter = ConjurFormatter.new
 
   # Raises error for missing translations

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -2,6 +2,7 @@
 
 ENV['CONJUR_ACCOUNT'] = 'cucumber'
 ENV['RAILS_ENV'] ||= 'test'
+ENV['CONJUR_LOG_LEVEL'] ||= 'debug'
 
 # so that we can require relative to the project root
 $LOAD_PATH.unshift File.expand_path '../../../..', __dir__

--- a/cucumber/rotators/features/support/env.rb
+++ b/cucumber/rotators/features/support/env.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(Dir.pwd)
 require 'config/environment'
 
 ENV['RAILS_ENV'] ||= 'test'
+ENV['CONJUR_LOG_LEVEL'] ||= 'debug'
 
 Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://possum'
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       CONJUR_PASSWORD_ALICE: secret
       CONJUR_DATA_KEY:
       RAILS_ENV:
+      CONJUR_LOG_LEVEL: debug
       AUDIT_DATABASE_URL:
     ports:
       - "3000:3000"

--- a/engines/conjur_audit/spec/rails_helper.rb
+++ b/engines/conjur_audit/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
+ENV['CONJUR_LOG_LEVEL'] ||= 'debug'
 require File.expand_path('../dummy/config/environment', __FILE__)
 
 # Prevent database truncation if the environment is production

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+ENV["CONJUR_LOG_LEVEL"] ||= 'debug'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 


### PR DESCRIPTION
#### What does this PR do?
Set log level to the value defined under the `CONJUR_LOG_LEVEL` env var. 
If the var doesn't exist it defaults to its current value.

#### Any background context you want to provide?
Until now, the only way to enable debug logs was to change the `RAILS_ENV` var. 
this had 2 caveats:
1. It had side effects other than changing the log level
2. It wrote the logs to a different location than in appliance RAILS_ENV

With this PR the user can change only the log level.

#### What ticket does this PR close?
Connected to #1098 1098
