### PR TITLE
Log level assertion

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,7 +3,7 @@
 LOG_LEVELS = ['debug', 'info', 'warn', 'error', 'fatal', 'unknown']
 LOG_LEVEL_ERROR = "Environment variable 'CONJUR_LOG_LEVEL' must be a valid Rails log level: #{LOG_LEVELS.inspect}"
 
-def assert_conjur_log_level
+def assert_valid_conjur_log_level
   log_level_env = ENV['CONJUR_LOG_LEVEL']
   if log_level_env
     raise LOG_LEVEL_ERROR unless LOG_LEVELS.include? log_level_env
@@ -13,7 +13,7 @@ end
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 
-assert_conjur_log_level
+assert_valid_conjur_log_level
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
+LOG_LEVELS = ['debug', 'info', 'warn', 'error', 'fatal', 'unknown']
+LOG_LEVEL_ERROR = "Environment variable 'CONJUR_LOG_LEVEL' must be a valid Rails log level: #{LOG_LEVELS.inspect}"
+
+def assert_conjur_log_level
+  log_level_env = ENV['CONJUR_LOG_LEVEL']
+  if log_level_env
+    raise LOG_LEVEL_ERROR unless LOG_LEVELS.include? log_level_env
+  end
+end
+
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
+
+assert_conjur_log_level
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Use log level "warn" in prod to avoid logging parameters.
-  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :warn
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :info
   config.log_formatter = ConjurFormatter.new
 
   # Specifies the header that your server uses for sending files.


### PR DESCRIPTION
#### What does this PR do?
- Assert environment variable `CONJUR_LOG_LEVEL` is a valid Rails log level (if it exists)
- Set default log level value of production env to info to align with DAP

#### What ticket does this PR close?
Connected to #1098 