### PR TITLE
Rework PR template to improve quality

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Connected to [relevant GitHub issues, eg #76]
 ### Code
 - [ ] The code works.
 - [ ] The code performs its intended function and the logic is correct.
-- [ ] The code easy to understand.
+- [ ] The code is easy to understand.
 - [ ] Redundant or duplicate code has been removed.
 - [ ] All debugging code has been removed.
 - [ ] The code is as modular as possible.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Connected to [relevant GitHub issues, eg #76]
 - [ ] The code performs its intended function and the logic is correct.
 - [ ] The code is easy to understand.
 - [ ] Redundant or duplicate code has been removed.
-- [ ] All debugging code has been removed.
+- [ ] All debugging or commented out code has been removed.
 - [ ] The code is as modular as possible.
 - [ ] All code follows the defined architecture.
 - [ ] The feature implementation follows the Feature Spec.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,40 @@
-#### What does this PR do?
-#### Any background context you want to provide?
 #### What ticket does this PR close?
 Connected to [relevant GitHub issues, eg #76]
-#### Where should the reviewer start?
-#### How should this be manually tested?
-#### Screenshots (if appropriate)
-#### Has the Version and Changelog been updated?
-#### Questions:
-> Does this work have automated integration and unit tests?
 
-> Can we make a blog post, video, or animated GIF of this?
+## Checklist
+### Code
+- [ ] The code works.
+- [ ] The code performs its intended function and the logic is correct.
+- [ ] The code easy to understand.
+- [ ] Redundant or duplicate code has been removed.
+- [ ] All debugging code has been removed.
+- [ ] The code is as modular as possible.
+- [ ] All code follows the defined architecture.
+- [ ] The feature implementation follows the Feature Spec.
+- [ ] Good names are used for classes, methods, and variables.
+- [ ] Code Climate linting issues have been resolved.
 
-> Has this change been documented (Readme, docs, etc.)?
+### Logging
+- [ ] Logging is available.
+- [ ] All logging code provides the correct visibility for the appropriate logging level (ex. DEBUG is verbose, FATAL shows only catastrophic events)
+- [ ] No credentials or secrets are visible through logs.
 
-> Does the knowledge base need an update?
+### Testing
+- [ ] The code is testable.
+- [ ] The code does not add any hidden dependencies.
+- [ ] Tests exist and are they comprehensive.
+- [ ] Unit tests actually test that the code is performing the intended functionality.
+
+### Commit History
+- [ ] Commit messages accurately describe the changes.
+- [ ] Each commit delivers a discrete set of value.
+- [ ] A review can step through the PR commit by commit to gain a complete understanding of the functionality.
+
+### Code Documentation
+- [ ] All edge-case handling is described.
+- [ ] The use and function of any new third-party libraries is documented.
+- [ ] The Version and Changelog has been updated.
+
+### Functional Documentation
+- [ ] The Readme has been updated (if relevant).
+- [ ] A PR is opened for any documentation changes (or, if large, a story has been created to capture these document changes).


### PR DESCRIPTION
This change adds a list of checks tasks an engineers should have performed before opening a PR and requesting a code review.

The goal is improve the quality of code as well as ease PR reviews.

`cyberark/conjur` is intended to be the first repository for this change.  Assuming it's accepted, we'll roll this out to the other repositories.
