### PR TITLE
Not setting CONJUR_LOG_LEVEL to info by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ COPY . .
 RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
 
 ENV RAILS_ENV production
-ENV CONJUR_LOG_LEVEL info
 
 # The Rails initialization expects the database configuration
 # and data key to exist. We supply placeholder values so that


### PR DESCRIPTION
The log level is set by default by the rails environment. In is set in the environment setup to the value of CONJUR_LOG_LEVEL and if this variable
doesn't exist it is set to the environment's default  (debug for development, info for appliance & production). Having CONJUR_LOG_LEVEL set by default
to `info` may cause confusion for customers who change the RAILS_ENV variable to `development` and expect to see debug level logs.

To improve UX, now a user should explicitly add the CONJUR_LOG_LEVEL in order to set the log level to its value, rather than it appears "under the hood"
without the user noticing it.

Connected to #1098 