### PR TITLE
Make log level configurable in the `follower` environment

### DIFF
--- a/config/environments/follower.rb
+++ b/config/environments/follower.rb
@@ -7,7 +7,7 @@ load File.expand_path '../production.rb', __FILE__
 require 'rack/remember_uuid'
 
 Rails.application.configure do
-  config.log_level = :info
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :info
   config.middleware.use Rack::RememberUuid
   config.audit_socket = '/run/conjur/audit.socket'
 end


### PR DESCRIPTION
Each of the other Conjur environments support modifying the log level using
the `CONJUR_LOG_LEVEL` environment variable. We add it here as well to
support easier debugging of Conjur follower containers.