### PR TITLE
Verify type before doing an integer comparison

### DIFF
--- a/app/domain/rotation/password.rb
+++ b/app/domain/rotation/password.rb
@@ -18,7 +18,7 @@ module Rotation
 
     def self.base58(length:)
 
-      valid = length > 0 && length.is_a?(Integer)
+      valid =  length.is_a?(Integer) && length > 0
       raise ArgumentError, "length must be a positive integer" unless valid
 
       # Here's what we're doing:

--- a/app/domain/rotation/password.rb
+++ b/app/domain/rotation/password.rb
@@ -18,7 +18,7 @@ module Rotation
 
     def self.base58(length:)
 
-      valid =  length.is_a?(Integer) && length > 0
+      valid = length.is_a?(Integer) && length > 0
       raise ArgumentError, "length must be a positive integer" unless valid
 
       # Here's what we're doing:


### PR DESCRIPTION
#### What does this PR do?
Fixes a minor bug. `length.is_a?(Integer)` must be checked first or the comparison will raise an exception if `length` is not an integer.
#### Any background context you want to provide?

#### What ticket does this PR close?
n/a
#### Where should the reviewer start?
Line 21
#### How should this be manually tested?
Test the line in `irb`:

```
irb(main):001:0> length = 'foo'
=> "foo"
irb(main):002:0> valid =  length.is_a?(Integer) && length > 0
=> false
irb(main):003:0> valid = length > 0 && length.is_a?(Integer)
Traceback (most recent call last):
        5: from /home/jodawill/.rbenv/versions/2.6.3/bin/irb:23:in `<main>'
        4: from /home/jodawill/.rbenv/versions/2.6.3/bin/irb:23:in `load'
        3: from /home/jodawill/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        2: from (irb):3
        1: from (irb):3:in `>'
ArgumentError (comparison of String with 0 failed)
irb(main):004:0>
```

#### Screenshots (if appropriate)
n/a
#### Has the Version and Changelog been updated?
No
#### Questions:
> Does this work have automated integration and unit tests?

No

> Can we make a blog post, video, or animated GIF of this?

I'd love to see that.

> Has this change been documented (Readme, docs, etc.)?

No

> Does the knowledge base need an update?

No