### PR TITLE
Handle unset pod spec fields without error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- An unset initContainer field in a deployment config pod spec will no
+  longer cause the k8s authenticator to fail with `undefined method` ([#1182](https://github.com/cyberark/conjur/issues/1182)).
+
 ## [1.4.1] - 2019-06-24
 ### Fixed
 - Make sure the authentication framework only caches Role lookups for the

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -94,8 +94,8 @@ module Authentication
       end
 
       def container
-        pod.spec.containers.find { |c| c.name == container_name } ||
-          pod.spec.initContainers.find { |c| c.name == container_name }
+        (pod.spec.containers || []).find { |c| c.name == container_name } ||
+          (pod.spec.initContainers || []).find { |c| c.name == container_name }
       end
 
       def default_container_name

--- a/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
@@ -148,6 +148,32 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
           .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
       end
 
+      it 'raises ContainerNotFound if initContainers is nil' do
+        allow(pod_spec).to receive(:initContainers)
+          .and_return({})
+        allow(pod_spec).to receive(:containers)
+          .and_return(nil)
+        allow(host_annotation_2).to receive(:values)
+          .and_return({ :name => "notimportant" })
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(pod_request: pod_request) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'raises ContainerNotFound if containers is nil' do
+        allow(pod_spec).to receive(:initContainers)
+          .and_return(nil)
+        allow(pod_spec).to receive(:containers)
+          .and_return({})
+        allow(host_annotation_2).to receive(:values)
+          .and_return({ :name => "notimportant" })
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(pod_request: pod_request) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
       it 'does not raise errors if all checks pass' do
         allow(pod_spec).to receive(:initContainers)
           .and_return({})


### PR DESCRIPTION
Closes #1182

If `initContainers` or `containers` is not included in the deployment config for a pod, then the pod spec attributes for these are `nil` rather than an empty array.

This commit accounts for that possibility when searching for the authenticator container by defaulting to an empty array if the value is `nil`. It also adds spec tests to verify this behavior.