### PR TITLE
Oss add audit deployment directly to db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,6 @@ ci/authn-k8s/dev/policies/*.yml
 # Vim backup files
 *.sw[po]
 
-
+# Ignore link files sourced at audit engine DB migration 
+db/migrate/20180530210739_create_messages_table.rb
+db/migrate/20180704132624_add_indexes.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN bundle --without test development
 COPY . .
 
 RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
+RUN ln -sf /opt/conjur-server/engines/conjur_audit/db/migrate/* /opt/conjur-server/db/migrate
 
 ENV RAILS_ENV production
 

--- a/app/models/audit/event.rb
+++ b/app/models/audit/event.rb
@@ -15,15 +15,17 @@ module Audit
     end
 
     def log_to_db
-      ConjurAudit::Message.create({facility: facility,
-                                   severity: severity,
-                                   timestamp: Time.now.iso8601,
-                                   hostname: Socket.gethostname,
-                                   appname: progname,
-                                   procid: Process.pid,
-                                   msgid: message_id,
-                                   sdata: Sequel.pg_jsonb(structured_data),
-                                   message: message})
+      ConjurAudit::Message.create(
+        facility: facility,
+        severity: severity,
+        timestamp: Time.now.iso8601,
+        hostname: Socket.gethostname,
+        appname: progname,
+        procid: Process.pid,
+        msgid: message_id,
+        sdata: Sequel.pg_jsonb(structured_data),
+        message: message
+      )
     end
 
     def to_s

--- a/app/models/audit/event.rb
+++ b/app/models/audit/event.rb
@@ -10,7 +10,20 @@ module Audit
     progname 'conjur'
 
     def log_to logger
+      log_to_db
       logger.log logger_severity, self, progname
+    end
+
+    def log_to_db
+      ConjurAudit::Message.create({facility: facility,
+                                   severity: severity,
+                                   timestamp: Time.now.iso8601,
+                                   hostname: Socket.gethostname,
+                                   appname: progname,
+                                   procid: Process.pid,
+                                   msgid: message_id,
+                                   sdata: Sequel.pg_jsonb(structured_data),
+                                   message: message})
     end
 
     def to_s

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: cucumber
       DATABASE_URL: postgres://postgres@pg/postgres
-      AUDIT_DATABASE_URL:
       RAILS_ENV: test
       CONJUR_LOG_LEVEL: debug
       CONJUR_DATA_KEY:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -3,9 +3,6 @@ services:
   pg:
     image: postgres:9.4
 
-  audit:
-    image: postgres:9.4
-
   testdb:
     image: postgres:9.4
 

--- a/ci/rspec-audit/migratedb
+++ b/ci/rspec-audit/migratedb
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 # Run DB migration for audit database
 BUNDLE_GEMFILE=./Gemfile \
-  bundle exec sequel $AUDIT_DATABASE_URL \
+  bundle exec sequel $DATABASE_URL \
   -E -m ./engines/conjur_audit/db/migrate/

--- a/ci/test
+++ b/ci/test
@@ -115,7 +115,6 @@ rspec_audit() {
 
   _wait_for_pg audit
 
-  AUDIT_DATABASE_URL=postgres://postgres@audit/postgres \
     docker-compose run -T --rm --no-deps  -w /src/conjur-server cucumber -ec "
       pwd
       ci/rspec-audit/migratedb

--- a/ci/test
+++ b/ci/test
@@ -110,10 +110,10 @@ rspec() {
 rspec_audit() {
   : DOC - Runs RSpecs for the Audit engine
   
-  # Start Conjur with the audit database
-  docker-compose up --no-deps -d audit pg
+  # Start Conjur with the postgres database
+  docker-compose up --no-deps -d pg
 
-  _wait_for_pg audit
+  _wait_for_pg pg
 
     docker-compose run -T --rm --no-deps  -w /src/conjur-server cucumber -ec "
       pwd

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,8 @@ module Possum
     config.autoload_paths << Rails.root.join('lib')
 
     config.sequel.after_connect = proc do
-      Sequel.extension :core_extensions, :postgres_schemata
-      Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore
+      Sequel.extension :core_extensions, :postgres_schemata, :pg_json_ops
+      Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore, :pg_json
     rescue
       raise unless is_asset_precompile?
     end

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       CONJUR_DATA_KEY:
       RAILS_ENV:
       CONJUR_LOG_LEVEL: debug
-      AUDIT_DATABASE_URL:
     ports:
       - "3000:3000"
       - "1234:1234"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     - pg:pg
     - ldap-server
     - oidc-keycloak:keycloak
+    command:
+    - dev/init.sh
 
   cucumber:
     image: conjur-dev

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -3,9 +3,6 @@ services:
   pg:
     image: postgres:9.4
 
-  audit:
-    image: postgres:9.4
-
   testdb:
     image: postgres:9.4
     environment:

--- a/dev/init.sh
+++ b/dev/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+ln -sf /src/conjur-server/engines/conjur_audit/db/migrate/* /src/conjur-server/db/migrate
+/sbin/my_init

--- a/engines/conjur_audit/lib/conjur_audit/engine.rb
+++ b/engines/conjur_audit/lib/conjur_audit/engine.rb
@@ -3,11 +3,10 @@
 module ConjurAudit
   class Engine < ::Rails::Engine
     isolate_namespace ConjurAudit
-    config.audit_database = ENV['AUDIT_DATABASE_URL']
 
     initializer :connect_audit_database do
-      if (db = config.audit_database)
-        db = Sequel.connect db
+      if config.try(:audit_database)
+        db = Sequel.connect config.audit_database
         db.extension :pg_json
         Message.db.extension :pg_json
         Message.set_dataset db[:messages]

--- a/engines/conjur_audit/spec/db_helper.rb
+++ b/engines/conjur_audit/spec/db_helper.rb
@@ -2,8 +2,7 @@
 
 shared_context "database setup" do
 
-  let(:db_uri) { ENV['AUDIT_DATABASE_URL'] || 'postgres://postgres@pg/postgres' }
-  let(:db) { Sequel.connect db_uri }
+  let(:db) { Sequel.connect ENV['DATABASE_URL'] }
 
   before do
     db.extension :pg_json


### PR DESCRIPTION
#### What does this PR do?
#### Any background context you want to provide?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?




Why hard coded: 
`procid: "procid"`

    columns (
      "facility", "severity", "timestamp", "hostname", "appname",
      "procid", "msgid", "sdata", "message")
    values (
      "${FACILITY_NUM}", "${LEVEL_NUM}", "${ISODATE}", "${FULLHOST}", "${PROGRAM}",
      "${PID}", "${MSGID}",
      "$(format-json --key .SDATA.* --shift 7)", # filter out just SDATA, cut off the _SDATA_ prefix with --shift
      "${MESSAGE}"

syslog-ng macro 
PID
Description: The PID of the program sending the message.
https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/58
is giving different format result of what we currently have. don't know why, and what is the correct method.




Example from previous implementation:
<86>1 2019-09-18T12:04:02.850+00:00 1a66733a36e7 conjur 651ad36e-88d9-44b3-a57e-00ebb3505c13 authn [action@43868 result="success" operation="authenticate"][subject@43868 role="cyberark:user:admin"][auth@43868 authenticator="authn"][meta sequenceId="1"] cyberark:user:admin successfully authenticated with authenticator authn

you can see pid is '651ad36e-88d9-44b3-a57e-00ebb3505c13'


 facility | severity |          timestamp           |   hostname   | appname | procid | msgid |                                                                              sdata                                                     
                          |                                 message                                 
----------+----------+------------------------------+--------------+---------+--------+-------+----------------------------------------------------------------------------------------------------------------------------------------
--------------------------+-------------------------------------------------------------------------
       80 |        6 | 2019-09-18 11:39:39.66631+00 | 63d6c03d99d5 | conjur  | procid | authn | {"auth@43868": {"authenticator": "authn"}, "action@43868": {"result": "success", "operation": "authenticate"}, "subject@43868": {"role"
: "cucumber:user:admin"}} | cucumber:user:admin successfully authenticated with authenticator authn
