### PR TITLE
[POC - DON'T MERGE] Example of rake task to move migrations out of engine

### DIFF
--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -208,8 +208,9 @@ command :db do |cgrp|
   cgrp.desc "Create and/or upgrade the database schema"
   cgrp.command :migrate do |c|
     c.action do |global_options,options,args|
-      connect
 
+      connect
+      exec "rake conjur_audit:install:migrations"
       exec "rake db:migrate"
     end
   end
@@ -267,7 +268,7 @@ command :wait do |c|
     if conjur_ready.call
       puts " Conjur is ready!"
     else
-      exit_now! " Conjur is not ready after #{retries} seconds" 
+      exit_now! " Conjur is not ready after #{retries} seconds"
     end
   end
 end

--- a/engines/conjur_audit/lib/tasks/conjur_audit.rake
+++ b/engines/conjur_audit/lib/tasks/conjur_audit.rake
@@ -1,0 +1,11 @@
+namespace :railties do
+  namespace :install do
+    task migrations: :environment do
+      Dir["#{__dir__}/../../db/migrate/*.rb"].each do |file|
+        filename = file.split('/').last
+        timestampless_name = filename.match(/\d+_(.+)/)[1]
+        FileUtils.cp(file, "db/migrate/#{Time.now.strftime('%Y%m%d%H%M%S')}_#{timestampless_name}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
@uCatu, @aloncarmel111 (cc. @rrefael): this brings `rake conjur_audit:install:migrations` support, follows the engine pattern, and keeps responsibility out of the docker files.