### PR TITLE
Audit directly to db

### DIFF
--- a/app/models/audit/event.rb
+++ b/app/models/audit/event.rb
@@ -10,7 +10,22 @@ module Audit
     progname 'conjur'
 
     def log_to logger
+      log_to_db
       logger.log logger_severity, self, progname
+    end
+
+    def log_to_db
+      ConjurAudit::Message.create(
+        facility: facility >> 3,
+        severity: severity,
+        timestamp: Time.now.utc.iso8601(3),
+        hostname: Socket.gethostname,
+        appname: progname,
+        procid: Thread.current[:request_id],
+        msgid: message_id,
+        sdata: Sequel.pg_jsonb(structured_data),
+        message: message
+      )
     end
 
     def to_s

--- a/ci/test
+++ b/ci/test
@@ -101,6 +101,7 @@ rspec() {
   _wait_for_pg pg
 
   docker-compose run -T --rm --no-deps cucumber -ec "
+    bundle exec rake conjur_audit:install:migrations
     bundle exec rake db:migrate
     rm -rf $REPORT_ROOT/spec/reports
     bundle exec env CI_REPORTS=$REPORT_ROOT/spec/reports rspec --format progress --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,8 @@ module Possum
     config.autoload_paths << Rails.root.join('lib')
 
     config.sequel.after_connect = proc do
-      Sequel.extension :core_extensions, :postgres_schemata
-      Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore
+      Sequel.extension :core_extensions, :postgres_schemata, :pg_json_ops
+      Sequel::Model.db.extension :pg_array, :pg_inet, :pg_hstore, :pg_json
     rescue
       raise unless is_asset_precompile?
     end


### PR DESCRIPTION
#### What does this PR do?
- Implement method to write audit directly to DB (bypass syslog)
- Jenkins CI test flow was invoking rake task of copy engine migrations

#### Any background context you want to provide?
Read [Oss add audit deployment #1194](https://github.com/cyberark/conjur/pull/1194) 
This is another milestone of audit atomicity feature, which is implementing audit feature in OSS

#### Where should the reviewer start?
- Comparing new audit flow to previous (none) audit flow.
- Make sure that the format of audit messages are aligned with appliance (syslog) and as we wish it to be.

_Syslog provides us the following column to value (macros):_
"facility": ${FACILITY_NUM}" 
"severity" ${LEVEL_NUM}
"timestamp" ${ISODATE}
"hostname" ${FULLHOST}
"appname" ${PROGRAM}"
"procid" ${PID} 
"msgid" ${MSGID}
"sdata" $(format-json --key .SDATA.* --shift 7)
"message" ${MESSAGE}

_Data example:_
<86>1 2019-09-18T12:04:02.850+00:00 1a66733a36e7 conjur 651ad36e-88d9-44b3-a57e-00ebb3505c13 authn [action@43868 result="success" operation="authenticate"][subject@43868 role="cyberark:user:admin"][auth@43868 authenticator="authn"][meta sequenceId="1"] cyberark:user:admin successfully authenticated with authenticator authn

#### How should this be manually tested?
Since all automation tests are passing it looks like we don't have regression (hopefully)
So one vanilla manual test will be good for now to send REST/UI/CLI authetnciation request and view record in messages table at main PG DB.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/50704381/65704062-856cf900-e08e-11e9-86f9-d0f151ae1f3d.png)

#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?
Not in Conjur, in appliance.

> Can we make a blog post, video, or animated GIF of this?
Yes

> Has this change been documented (Readme, docs, etc.)?
Design docs, documentation will be changed in a separate PR 

> Does the knowledge base need an update?
