### PR TITLE
Change SLA of maximum of AVG OIDC request from 0.25 to 0.75

### DIFF
--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -175,7 +175,7 @@ Feature: Users can authneticate with OIDC authenticator
   Scenario: Performance test
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate 1000 times in 10 threads via OIDC with id token
-    Then The "avg" response time should be less than "0.25" seconds
+    Then The "avg" response time should be less than "0.75" seconds
 
   Scenario: Load with cache
     And I fetch an ID Token for username "alice" and password "alice"


### PR DESCRIPTION
#### What does this PR do?
Change SLA maximum allowed value of AVG OIDC request from 0.25sec to 0.75sec

#### Any background context you want to provide?
Sometimes test got failed with AVG value behind 0.25sec. In addition our Declared performance is not worse than average of 1sec.

#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
