### PR TITLE
Fix #1202 - Removed duplicate 'account' from L19

### DIFF
--- a/lib/tasks/account.rake
+++ b/lib/tasks/account.rake
@@ -16,7 +16,7 @@ namespace :"account" do
     begin
       api_key = Account.create args[:account]
       account = Account.new args[:account]
-      $stderr.puts "Created new account account '#{account.id}'"
+      $stderr.puts "Created new account '#{account.id}'"
       puts "Token-Signing Public Key: #{account.token_key.to_s}"
       puts "API key for admin: #{api_key}"
     rescue Exceptions::RecordExists


### PR DESCRIPTION
#### What does this PR do?

This PR fixes #1202 by removing the duplicate `account` wording.

#### Any background context you want to provide?

All background context is available in Issue #1202.

#### What ticket does this PR close?

Connected to #1202 

#### Where should the reviewer start?

The only commit listed below.

#### How should this be manually tested?

Assuming the test is following the Conjur Quick-Start procedure:

`docker-compose exec conjur conjurctl account create myConjurAccount`

#### Has the Version and Changelog been updated?

No.

#### Questions:
> Does this work have automated integration and unit tests?

No.

> Can we make a blog post, video, or animated GIF of this?

Okay.

> Has this change been documented (Readme, docs, etc.)?

None needed.

> Does the knowledge base need an update?

No, it does not.
