### PR TITLE
Authenticate specific jenkins jobs during run time (authn-jenkins)

### DIFF
--- a/app/domain/authentication/authn_jenkins/README.md
+++ b/app/domain/authentication/authn_jenkins/README.md
@@ -22,6 +22,7 @@ Authenticate jenkins jobs without api keys.
   - !variable jenkinsURL
   - !variable jenkinsUsername
   - !variable jenkinsPassword
+  - !variable jenkinsCertificate
 
   # create a group that can authenticate to this jenkins instance
   - !permit

--- a/app/domain/authentication/authn_jenkins/README.md
+++ b/app/domain/authentication/authn_jenkins/README.md
@@ -92,7 +92,7 @@ node {
 19. Set ```ID``` to ```SECRET_ID```
 20. It should look like:
 
-21. No run the job and it should fetch the secret successfully. When looking at the job console the password should be scrubbed automatically
+21. Now run the job and it should fetch the secret successfully. When looking at the job console the password should be scrubbed automatically
 
 ```
 

--- a/app/domain/authentication/authn_jenkins/README.md
+++ b/app/domain/authentication/authn_jenkins/README.md
@@ -1,0 +1,98 @@
+# authn-jenkins
+Authenticate jenkins jobs without api keys.
+
+### Prerequistes
+1. Conjur server
+2. Jenkins server
+
+
+## Setup
+### Conjur
+1. Make sure the environment variable is set on the conjur server ```CONJUR_AUTHENTICATORS=authn-jenkins/prod```.
+2. Log into conjur cli
+3. Create a file called ```policy.yml``` with the contents of:
+```yaml
+- !policy
+  id: conjur/authn-jenkins/prod
+  body:
+  - !webservice
+  - !group clients
+  
+  # these will be used to connect to the jenkins server and see if a specific job is running
+  - !variable jenkinsURL
+  - !variable jenkinsUsername
+  - !variable jenkinsPassword
+
+  # create a group that can authenticate to this jenkins instance
+  - !permit
+    role: !group clients
+    privilege: [ read, authenticate ]
+    resource: !webservice
+```
+4. Execute ```conjur policy load root policy.yml```. Now the authenticator is configured.
+5. Create a file called ```job.yml``` (in this case the job will be called 'testJob' within jenkins) with the contents of:
+```yaml
+---
+# This is creating a policy for 'team1' that has 1 jenkins job of 'testJob'
+# This jenkins job will have access to the 'team1/secret' secret.
+- !policy
+  id: team1
+  body:
+  - !host testJob
+  - !variable secret
+  
+  - !permit
+    role: !host testJob
+    resources:
+    - !variable secret
+    privilege: [ read, execute ]
+
+# This is giving the jenkinsJob the ability to authenticate as a jenkins job
+- !grant
+  role: !group conjur/authn-jenkins/prod/clients
+  member: !host team1/testJob
+```
+6. Execute ```conjur policy load root job.yml```. Now 'testJob' will have the ability to authenticate without an API key and will use the jenkins authenticator.
+7. Execute ```conjur variable values add team1/secret "someSecret"``` to populate the secret with a dummy value
+
+### Jenkins
+1. Import the [Jenkins Conjur Credential Plugin](https://github.com/cyberark/conjur-credentials-plugin)
+2. Create a service account for this jenkins instance. (Remember the username and password since it will be used in a future step #4)
+3. Setup the jenkins authentication URL. Execute ```conjur variable values add conjur/authn-jenkins/prod/jenkinsURL "http://<jenkinsURL>:<jenkinsPort>"```
+4. Setup the jenkins authentication service account credentials. Execute ```conjur variable values add conjur/authn-jenkins/prod/jenkinsUsername "<serviceAccountUsername>"``` & ```conjur variable values add conjur/authn-jenkins/prod/jenkinsPassword "<serviceAccountPassword>"```
+5. Create a folder in jenkins called ```team1```.
+6. Within this folder create a pipeline called ```testJob```.
+7. Uncheck ```Inherit for parent?```
+8. Check ```Use Just-In-Time --JIT-- Secret Access```
+9. Set ```Auth WebService ID``` to ```prod```
+10. Skip ```Host Authentication Prefix```
+11. Set ```Account``` to ```cucumber``` or the account you configured conjur with
+12. Set ```Appliance URL``` to ```http://<conjur-ip-or-hostname>:<port>```. It should look like:
+
+
+13. Scroll down and set your ```Pipeline Script``` to:
+```
+node {
+   stage('Work') {
+      withCredentials([conjurSecretCredential(credentialsId: 'SECRET_ID', 
+                                              variable: 'SECRET')]) {
+         echo "Hello World $SECRET"
+      }
+   }
+   stage('Results') {
+      echo "Finished!"
+   }
+}
+```
+14. In the pipeline we are fetching our conjur credential by ID ```SECRET_ID```.
+15. Navigate to the Jenkins main page and select ```Credentials```
+16. Select ```Add Credentials```
+17. Set kind to ```Conjur Secret Credential```
+18. Set ```Variable Path``` to ```team1/secret```
+19. Set ```ID``` to ```SECRET_ID```
+20. It should look like:
+
+21. No run the job and it should fetch the secret successfully. When looking at the job console the password should be scrubbed automatically
+
+```
+

--- a/app/domain/authentication/authn_jenkins/authenticator.rb
+++ b/app/domain/authentication/authn_jenkins/authenticator.rb
@@ -30,22 +30,6 @@ module Authentication
         JSON.parse(body)['building']
       end
 
-      def parse_metadata(username, message_body)
-        json_body = JSON.parse message_body
-
-        build_number = json_body["buildNumber"]
-        signature = Base64.decode64(json_body["signature"])
-        job_property_host_prefix = json_body["jobProperty_hostPrefix"]
-        if json_body.key?("jobProperty_hostPrefix")
-          job_name = username.sub("host/#{job_property_host_prefix}/", "")
-        else
-          job_name = username.sub("host/", "")
-        end
-        job_path = job_name.split("/").join("/job/")
-
-        return job_name, job_path, build_number, signature
-      end
-
       def jenkins_client(account, authenticator_name, service_id)
         @jenkins_client ||= begin
           variables = webservice(

--- a/app/domain/authentication/authn_jenkins/authenticator.rb
+++ b/app/domain/authentication/authn_jenkins/authenticator.rb
@@ -29,7 +29,8 @@ module Authentication
             variables.variable("jenkinsURL").secret.value,
             variables.variable("jenkinsUsername").secret.value,
             variables.variable("jenkinsPassword").secret.value,
-            variables.variable("jenkinsCertificate").secret.value
+            variables.variable("jenkinsCertificate").secret.value,
+            variables.annotation("allow-http")
           )
         end
       end
@@ -63,7 +64,7 @@ module Authentication
           raise Err::InvalidSignature
         end
       
-        # Validate job is running and signature was signed with the jenkins identities private key
+        # Validate job is currently running
         unless build_running?(@jenkins_client.build(load.job_path, load.build_number))
           Rails.logger.error("AUTHENTICATION FAILED: Job '#{load.job_name} ##{load.build_number}' is currently not running.")
           raise Err::RunningJobNotFound "#{load.job_name} ##{load.build_number}"

--- a/app/domain/authentication/authn_jenkins/authenticator.rb
+++ b/app/domain/authentication/authn_jenkins/authenticator.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+require 'json'
+module Authentication
+  module AuthnJenkins
+    class Authenticator
+
+      Err = Errors::Authentication::AuthnJenkins
+      def initialize(env:)
+        @env = env
+      end
+
+      def webservice
+        @webservice ||= ::Authentication::Webservice.new(
+          account:            @account,
+          authenticator_name: @authenticator_name,
+          service_id:         @service_id
+        )
+      end
+
+      def httpGetRequest(url, username, password) 
+        begin
+          uri = URI.parse(url)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.read_timeout = 5
+          request = Net::HTTP::Get.new(uri.request_uri)
+          request.basic_auth(username, password)
+          response = http.request(request)
+        rescue Net::OpenTimeout => e
+          Rails.logger.error("Timeout to Jenkins host Exception #{e.to_s}")
+          Rails.logger.error("Jenkins host '#{url}' is most likely invalid. Validate this url can be accessed from the conjur server.")
+          raise Err::HostNotFound, url
+        end
+
+        return response
+      end
+
+      def buildRunning?(jenkinsURL, jobPath, buildNumber, username, password)
+        jenkinsBuildEndpoint = "/job/#{jobPath}/#{buildNumber}/api/json"
+        jenkinsBuildURL = "#{jenkinsURL}#{jenkinsBuildEndpoint}"
+        response = httpGetRequest(jenkinsBuildURL, username, password)
+
+        Rails.logger.debug("Jenkins Build Response: #{response.body}")
+
+        if response.code != '200'
+          raise Err::BuildInfoError.new(jenkinsBuildURL, "#{response.code} - #{response.body}")
+        end
+
+        json = JSON.parse(response.body)
+        return json['building']
+      end
+
+      def getPublicKey(jenkinsURL, username, password)
+        response = httpGetRequest(jenkinsURL, username, password)
+        publicKey = response['X-Instance-Identity']
+
+        publicKey = "-----BEGIN PUBLIC KEY-----\n#{publicKey}\n-----END PUBLIC KEY-----"
+        Rails.logger.debug("Returned public key: #{publicKey}")
+        return OpenSSL::PKey::RSA.new(publicKey)
+      end
+
+      def valid?(input)
+        # Needed to create the webservice object
+        @account = input.account
+        @service_id = input.service_id
+        @authenticator_name = input.authenticator_name
+
+        # Get needed secrets to connect into the jenkins API
+        jenkinsUsername = webservice.variable("jenkinsUsername").secret.value
+        jenkinsPassword = webservice.variable("jenkinsPassword").secret.value
+        jenkinsURL = webservice.variable("jenkinsURL").secret.value
+
+        # Parse the body
+        # e.g {"buildNumber": 5, "signature": "<base64 signature>", "jobProperty_hostPrefix": "myapp"}
+        jsonBody = JSON.parse input.password
+        buildNumber = jsonBody["buildNumber"]
+        signature = Base64.decode64(jsonBody["signature"])
+        jobProperty_hostPrefix = jsonBody["jobProperty_hostPrefix"]
+        if jsonBody.key?("jobProperty_hostPrefix")
+          jobName = input.username.sub("host/#{jobProperty_hostPrefix}/", "")
+        else
+          jobName = input.username.sub("host/", "")
+        end
+        jobPath = jobName.split("/").join("/job/")
+
+
+        Rails.logger.debug("Jenkins job name: #{jobName}")
+        Rails.logger.debug("Jenkins build number: #{buildNumber}")
+        Rails.logger.debug("Jenkins signature: #{signature}")
+
+        # Validate job is running and signature was signed with the jenkins identities private key
+        if buildRunning?(jenkinsURL, jobPath, buildNumber, jenkinsUsername, jenkinsPassword)
+          jenkinsPublicKey = getPublicKey(jenkinsURL, jenkinsUsername, jenkinsPassword)
+          message = "#{jobName}-#{buildNumber}"
+
+          if jenkinsPublicKey.verify(OpenSSL::Digest::SHA256.new, signature, message)
+              return true
+          else
+            Rails.logger.error("AUTHENTICATION FAILED: Data tampered or private-public key mismatch.")
+            raise Err::InvalidSignature
+          end
+        else
+          Rails.logger.error("AUTHENTICATION FAILED: Job '#{jobName} ##{buildNumber}' is currently not running.")
+          raise Err::RunningJobNotFound "#{jobName} ##{buildNumber}"
+        end
+        false
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jenkins/authenticator.rb
+++ b/app/domain/authentication/authn_jenkins/authenticator.rb
@@ -10,11 +10,11 @@ module Authentication
         @env = env
       end
 
-      def webservice
+      def webservice(account, authenticator_name, service_id)
         @webservice ||= ::Authentication::Webservice.new(
-          account:            @account,
-          authenticator_name: @authenticator_name,
-          service_id:         @service_id
+          account:            account,
+          authenticator_name: authenticator_name,
+          service_id:         service_id
         )
       end
 
@@ -75,14 +75,16 @@ module Authentication
       end
 
       def valid?(input)
-        @account = input.account
-        @service_id = input.service_id
-        @authenticator_name = input.authenticator_name
+        variables = webservice(
+          input.account,
+          input.authenticator_name,
+          input.service_id
+        )
         
         # Get needed secrets to connect into the jenkins API
-        jenkins_username = webservice.variable("jenkinsUsername").secret.value
-        jenkins_password = webservice.variable("jenkinsPassword").secret.value
-        jenkins_url = webservice.variable("jenkinsURL").secret.value
+        jenkins_username = variables.variable("jenkinsUsername").secret.value
+        jenkins_password = variables.variable("jenkinsPassword").secret.value
+        jenkins_url = variables.variable("jenkinsURL").secret.value
 
         # Parse the body
         # e.g {"buildNumber": 5, "signature": "<base64 signature>", "jobProperty_hostPrefix": "myapp"}

--- a/app/domain/authentication/authn_jenkins/jenkins_client.rb
+++ b/app/domain/authentication/authn_jenkins/jenkins_client.rb
@@ -1,0 +1,41 @@
+module Authentication
+  module AuthnJenkins
+    class JenkinsClient
+      def initialize(url, username, password)
+        @url = url
+        @username = username
+        @password = password
+      end
+      
+      def public_key()
+        response = request('')
+        create_public_key(response['X-Instance-Identity'])
+      end
+      
+      def build(job, build_number)
+        request("job/#{job}/#{build_number}/api/json")
+      end
+      
+      private
+      def create_public_key(identity)
+        public_key = [
+        "-----BEGIN PUBLIC KEY-----",
+        identity,
+        "-----END PUBLIC KEY-----"
+        ].join("\n")
+        Rails.logger.debug("Returned public key: #{public_key}")
+        OpenSSL::PKey::RSA.new(public_key)
+      end
+        
+      def request(path)
+        # Uses the HTTP gem: https://github.com/httprb/http
+        begin
+          HTTP.basic_auth(user: @username, pass: @password).get("#{@url}/#{path}")
+        rescue Net::OpenTimeout => e
+          Rails.logger.error("Timeout to Jenkins host Exception #{e}. Jenkins host '#{url}' is most likely invalid. Validate this url can be accessed from the conjur server.")
+          raise Err::HostNotFound, url
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jenkins/jenkins_client.rb
+++ b/app/domain/authentication/authn_jenkins/jenkins_client.rb
@@ -1,10 +1,11 @@
 module Authentication
   module AuthnJenkins
     class JenkinsClient
-      def initialize(url, username, password)
+      def initialize(url, username, password, public_key)
         @url = url
         @username = username
         @password = password
+        @public_key = public_key
       end
       
       def public_key()
@@ -18,11 +19,15 @@ module Authentication
       
       private
       def create_public_key(identity)
-        public_key = [
-        "-----BEGIN PUBLIC KEY-----",
-        identity,
-        "-----END PUBLIC KEY-----"
-        ].join("\n")
+        public_key = @public_key
+        if !public_key.starts_with('-----BEGIN PUBLIC KEY-----') && !public_key.ends_with('-----END PUBLIC KEY-----')
+          public_key = [
+            "-----BEGIN PUBLIC KEY-----",
+            identity,
+            "-----END PUBLIC KEY-----"
+            ].join("\n")
+        end
+
         Rails.logger.debug("Returned public key: #{public_key}")
         OpenSSL::PKey::RSA.new(public_key)
       end

--- a/app/domain/authentication/authn_jenkins/jenkins_client.rb
+++ b/app/domain/authentication/authn_jenkins/jenkins_client.rb
@@ -1,16 +1,19 @@
 module Authentication
   module AuthnJenkins
     class JenkinsClient
-      def initialize(url, username, password, public_key)
+      Err = Errors::Authentication::AuthnJenkins
+      def initialize(url, username, password, public_key, allow_http)
         @url = url
         @username = username
         @password = password
         @public_key = public_key
+        if allow_http != 'true' && !@url.starts_with('https')
+          raise Err::InvalidURL, @url
+        end
       end
       
       def public_key()
-        response = request('')
-        create_public_key(response['X-Instance-Identity'])
+        create_public_key
       end
       
       def build(job, build_number)
@@ -18,7 +21,7 @@ module Authentication
       end
       
       private
-      def create_public_key(identity)
+      def create_public_key()
         public_key = @public_key
         if !public_key.starts_with('-----BEGIN PUBLIC KEY-----') && !public_key.ends_with('-----END PUBLIC KEY-----')
           public_key = [

--- a/app/domain/authentication/authn_jenkins/jenkins_load.rb
+++ b/app/domain/authentication/authn_jenkins/jenkins_load.rb
@@ -1,0 +1,19 @@
+module Authentication
+  module AuthnJenkins
+    class JenkinsLoad
+      attr_reader :build_number, :signature, :job_name, :job_path
+    
+      def initialize(raw_body, username)
+        body = JSON.parse(raw_body)
+        @build_number = body['buildNumber']
+        @signature = Base64.decode64(body['signature'])
+        @job_name = if body['jobProperty_hostPrefix']
+          username.sub("host/#{body['jobProperty_hostPrefix']}/", '')
+        else
+          username.sub('host/', '')
+        end
+        @job_path = @job_name.split('/').join('/job/')
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -179,7 +179,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         BuildInfoError=::Util::TrackableErrorClass.new(
-          msg: "Failed to retrieve build info from '{0}'. Recieved {1}",
+          msg: "Failed to retrieve build info from. Recieved {0}",
           code: "CONJ00049E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -156,6 +156,35 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       end
 
+      module AuthnJenkins
+
+        InvalidJenkinsCred = ::Util::TrackableErrorClass.new(
+          msg: "'Invalid Jenkins Cred: {0}",
+          code: "CONJ00045E"
+        )
+
+        HostNotFound=::Util::TrackableErrorClass.new(
+          msg: "Host '{0}' wasn't found'",
+          code: "CONJ00046E"
+        )
+
+        RunningJobNotFound=::Util::TrackableErrorClass.new(
+          msg: "Job '{0}' is not running and cannot be authenticated",
+          code: "CONJ00047E"
+        )
+        
+        InvalidSignature=::Util::TrackableErrorClass.new(
+          msg: "Invalid signature provided by jenkins. Data tampered or private-public key mismatch",
+          code: "CONJ00048E"
+        )
+
+        BuildInfoError=::Util::TrackableErrorClass.new(
+          msg: "Failed to retrieve build info from '{0}'. Recieved {1}",
+          code: "CONJ00049E"
+        )
+
+      end
+
       module AuthnK8s
 
         WebserviceNotFound = ::Util::TrackableErrorClass.new(

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -183,6 +183,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00049E"
         )
 
+        InvalidURL=::Util::TrackableErrorClass.new(
+          msg: "Invalid URL '{0}' http is not allowed unless the webservice annotation 'allow-http' is set to 'true'",
+          code: "CONJ00050E"
+        )
+
       end
 
       module AuthnK8s

--- a/dev/files/authn-jenkins/entitlements.yml
+++ b/dev/files/authn-jenkins/entitlements.yml
@@ -1,0 +1,3 @@
+- !grant
+  role: !group conjur/authn-jenkins/prod/clients
+  member: !host myapp/jenkins/testJob

--- a/dev/files/authn-jenkins/myapp.yml
+++ b/dev/files/authn-jenkins/myapp.yml
@@ -17,17 +17,14 @@
   # Create a layer to hold this application's hosts
   - !layer
 
-  # Create a host using the namespace `aws` to identify this as an AWS resource.
-  # The host ID needs to match the AWS ARN of the role we wish to to authenticate.
+  # The host ID matches the job name in jenkins
   - !host jenkins/testJob
-  - !host jenkins/anotherJob
 
   # Add our host into our layer
   - !grant
     role: !layer
     members: 
     - !host jenkins/testJob
-    - !host jenkins/anotherJob
 
   # Give the host in our layer permission to retrieve variables
   - !grant

--- a/dev/files/authn-jenkins/myapp.yml
+++ b/dev/files/authn-jenkins/myapp.yml
@@ -1,0 +1,32 @@
+- !policy
+  id: myapp
+  body:
+  - &variables
+    - !variable database/username
+    - !variable database/password
+
+  # Create a group that will have permission to retrieve variables
+  - !group secrets-users
+
+  # Give the `secrets-users` group permission to retrieve variables
+  - !permit
+    role: !group secrets-users
+    privilege: [ read, execute ]
+    resource: *variables
+
+  # Create a layer to hold this application's hosts
+  - !layer
+
+  # Create a host using the namespace `aws` to identify this as an AWS resource.
+  # The host ID needs to match the AWS ARN of the role we wish to to authenticate.
+  - !host jenkins/testJob
+
+  # Add our host into our layer
+  - !grant
+    role: !layer
+    member: !host jenkins/testJob
+
+  # Give the host in our layer permission to retrieve variables
+  - !grant
+    member: !layer
+    role: !group secrets-users

--- a/dev/files/authn-jenkins/myapp.yml
+++ b/dev/files/authn-jenkins/myapp.yml
@@ -20,11 +20,14 @@
   # Create a host using the namespace `aws` to identify this as an AWS resource.
   # The host ID needs to match the AWS ARN of the role we wish to to authenticate.
   - !host jenkins/testJob
+  - !host jenkins/anotherJob
 
   # Add our host into our layer
   - !grant
     role: !layer
-    member: !host jenkins/testJob
+    members: 
+    - !host jenkins/testJob
+    - !host jenkins/anotherJob
 
   # Give the host in our layer permission to retrieve variables
   - !grant

--- a/dev/files/authn-jenkins/policy.yml
+++ b/dev/files/authn-jenkins/policy.yml
@@ -7,6 +7,7 @@
   - !variable jenkinsURL
   - !variable jenkinsUsername
   - !variable jenkinsPassword
+  - !variable jenkinsCertificate
 
 
   - !permit

--- a/dev/files/authn-jenkins/policy.yml
+++ b/dev/files/authn-jenkins/policy.yml
@@ -1,0 +1,15 @@
+- !policy
+  id: conjur/authn-jenkins/prod
+  body:
+  - !webservice
+  - !group clients
+  # these will be used to connect to the jenkins server and see if a specific job is running
+  - !variable jenkinsURL
+  - !variable jenkinsUsername
+  - !variable jenkinsPassword
+
+
+  - !permit
+    role: !group clients
+    privilege: [ read, authenticate ]
+    resource: !webservice

--- a/dev/start
+++ b/dev/start
@@ -20,6 +20,8 @@ Usage: start [options]
     --oidc-adfs     Adds to authn-oidc adfs static env configuration
 
     --oidc-okta     Adds to authn-oidc okta static env configuration
+    
+    --authn-jenkins Starts with authn-jenkins/prod as authenticator
 
     -h, --help      Shows this help message.
 EOF
@@ -72,6 +74,7 @@ unset COMPOSE_PROJECT_NAME
 ENABLE_AUTHN_LDAP=false
 ENABLE_AUTHN_IAM=false
 ENABLE_AUTHN_OIDC=false
+ENABLE_AUTHN_JENKINS=false
 ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
@@ -80,6 +83,7 @@ while true ; do
     --authn-iam ) ENABLE_AUTHN_IAM=true ; shift ;;
     --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
     --authn-oidc ) ENABLE_AUTHN_OIDC=true ; shift ;;
+    --authn-jenkins ) ENABLE_AUTHN_JENKINS=true ; shift ;;
     --oidc-adfs ) ENABLE_OIDC_ADFS=true ; shift ;;
     --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
     --rotators ) ENABLE_ROTATORS=true ; shift ;;
@@ -211,6 +215,12 @@ if [[ $ENABLE_AUTHN_IAM = true ]]; then
   enabled_authenticators="$enabled_authenticators,authn-iam/prod"
 
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-iam/policy.yml
+fi
+
+if [[ $ENABLE_AUTHN_JENKINS = true ]]; then
+  enabled_authenticators="$enabled_authenticators,authn-jenkins/prod"
+  
+  docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-jenkins/policy.yml
 fi
 
 echo "Setting CONJUR_AUTHENTICATORS to: $enabled_authenticators"

--- a/spec/app/domain/authentication/authn_jenkins/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_jenkins/authenticator_spec.rb
@@ -55,14 +55,6 @@ RSpec.describe Authentication::AuthnIam::Authenticator do
     )
   end
 
-  def valid_login
-    "host/myapp/jenkins/testJob"
-  end
-
-  def invalid_login
-    "host/myapp/invalidJenkins/invalidJob"
-  end
-
   let (:authenticator_instance) do
     Authentication::AuthnJenkins::Authenticator.new(env:[])
   end

--- a/spec/app/domain/authentication/authn_jenkins/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_jenkins/authenticator_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnIam::Authenticator do
+
+  def valid_password
+    '{"keyAlgorithm":"RSA","signature":"RES28Uu9cmFfh8gipU4Vg2OvkwNnvUF25DQC5a+qcjVqHtxlR5+yjxTBBraip+0VZ+1GraHabln9XowQ9mH17CNTee+1PhxrqBEbFs+M19VYgb04qKeAYWnJXcCWm8DSP/EAScW5JcmKRb/eBWN3P9a4f7qv/3UDe2gLYeImhRCLRqnsfHRa2x9ptNfEogX3hy24KhKCWFBjDfTDIdrTnqiE+Dn37clXPJGmSELTvrQVL/cgXVJkmcTW+0L/fGgZOp00mjqyO7M7Xl2FKc2RrRYgTTS1WWMtAJ0em2j4IDyNvsJLOviCPRRUOs/5HPf/+Bfk3EJ+9ypyx5VUdjZQmg==","jobProperty_hostPrefix":"myapp/jenkins","buildNumber":"15"}'
+  end
+
+  def invalid_password
+    '{"keyAlgorithm":"RSA","signature":"RES28Uu9cmFfh8gipU4Vg2OvkwNnvUF25DQC5a+qcjVqHtxlR5+yjxTBBraip+0VZ+1GraHabln9XowQ9mH17CNTee+1PhxrqBEbFs+M19VYgb04qKeAYWnJXcCWm8DSP/EAScW5JcmKRb/eBWN3P9a4f7qv/3UDe2gLYeImhRCLRqnsfHRa2x9ptNfEogX3hy24KhKCWFBjDfTDIdrTnqiE+Dn37clXPJGmSELTvrQVL/cgXVJkmcTW+0L/fGgZOp00mjqyO7M7Xl2FKc2RrRYgTTS1WWMtAJ0em2j4IDyNvsJLOviCPRRUOs/5HPf/+Bfk3EJ+9ypyx5VUdjZQmg==","jobProperty_hostPrefix":"myapp/jenkins"}'
+  end
+
+  def valid_build_response 
+    double('HTTPResponse', 
+            code: 200, 
+            body: '{"_class":"org.jenkinsci.plugins.workflow.job.WorkflowRun","actions":[{"_class":"hudson.model.CauseAction","causes":[{"_class":"hudson.model.Cause$UserIdCause","shortDescription":"Started by user Admin","userId":"admin","userName":"Admin"}]},{},{},{},{},{},{"_class":"org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"},{},{},{},{"_class":"org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"},{},{},{}],"artifacts":[],"building":true,"description":null,"displayName":"#15","duration":0,"estimatedDuration":372,"executor":{"_class":"hudson.model.OneOffExecutor"},"fullDisplayName":"testJob #15","id":"15","keepLog":false,"number":15,"queueId":104,"result":null,"timestamp":1571239175624,"url":"http://10.32.64.101:8080/job/testJob/15/","changeSets":[],"culprits":[],"nextBuild":null,"previousBuild":{"number":14,"url":"http://10.32.64.101:8080/job/testJob/14/"}}'
+    )
+  end
+
+  def invalid_build_response_build_false
+    double('HTTPResponse', 
+            code: 200,
+            body: '{"_class":"org.jenkinsci.plugins.workflow.job.WorkflowRun","actions":[{"_class":"hudson.model.CauseAction","causes":[{"_class":"hudson.model.Cause$UserIdCause","shortDescription":"Started by user Admin","userId":"admin","userName":"Admin"}]},{},{},{},{},{},{"_class":"org.jenkinsci.plugins.pipeline.modeldefinition.actions.RestartDeclarativePipelineAction"},{},{},{},{"_class":"org.jenkinsci.plugins.workflow.job.views.FlowGraphAction"},{},{},{}],"artifacts":[],"building":false,"description":null,"displayName":"#15","duration":0,"estimatedDuration":372,"executor":{"_class":"hudson.model.OneOffExecutor"},"fullDisplayName":"testJob #15","id":"15","keepLog":false,"number":15,"queueId":104,"result":null,"timestamp":1571239175624,"url":"http://10.32.64.101:8080/job/testJob/15/","changeSets":[],"culprits":[],"nextBuild":null,"previousBuild":{"number":14,"url":"http://10.32.64.101:8080/job/testJob/14/"}}'
+    )
+  end
+
+  def invalid_build_response_not_200
+    double('HTTPResponse', 
+            code: 400,
+            body: ''
+    )
+  end
+
+  def invalid_public_key
+    double('HTTPResponse', 
+            code: 200,
+            body: '',
+            headers: {'X-Instance-Identity' => 'notreal'}
+    )
+  end
+
+  def invalid_public_key_not_available
+    double('HTTPResponse', 
+            code: 200,
+            body: ''
+    )
+  end
+
+  def valid_public_key
+    double('HTTPResponse', 
+            code: 200,
+            body: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhU/Sg1ubdTES9qVSj45US8SRKh3PCvXwezMzJ8Xp7Rhi0qpPQmSKireaJ+R7+yUkY9xsZ7eTxFw2gCJz5fQyWoryjwJaA9ZsDU6jFZIv+SYHvTf3LTZ+TWeYi6A/gxF6JMckawgviQ1MV9VuBan5D8B/P4GR7TbmqiZIvBWfjSayz3Yj+85/PraBJJNC8lTYK61XjDd981nGNddcJ1KG1ZUarsBKXEX45cNEQJ21ZpisELVpXySk4czOSA52bADsaLJDX5MKNjbQgG+jd9tWo+8w3J7rKPThLRroMGukqMT7l535YnwQ0IocbvrM5uX3okydwcEADNYr8QCW1BhxUwIDAQAB'
+    )
+  end
+
+  def valid_login
+    "host/myapp/jenkins/testJob"
+  end
+
+  def invalid_login
+    "host/myapp/invalidJenkins/invalidJob"
+  end
+
+  let (:authenticator_instance) do
+    Authentication::AuthnJenkins::Authenticator.new(env:[])
+  end
+
+  # Test build info endpoint
+  it "validate build is running" do
+    subject = authenticator_instance
+    expect { subject.build_running?(valid_build_response) }.to_not raise_error
+
+    expect { subject.build_running?(valid_build_response) }.to eq(true)
+  end
+
+  it "validate build is not running" do
+    subject = authenticator_instance
+    expect { subject.build_running?(invalid_build_response_build_false) }.to_not raise_error
+
+    expect { subject.build_running?(invalid_build_response_build_false) }.to eq(false)
+  end
+
+  it "failed to get build info" do
+    subject = authenticator_instance
+    expect { subject.build_running?(invalid_build_response_not_200) }.to raise_error
+  end
+
+
+  # Test getting the public key from jenkins
+  it "fail invalid public key" do
+    subject = authenticator_instance
+    expect { subject.jenkins_public_key?(invalid_public_key) }.to raise_error
+  end
+
+  it "fail non existant public key" do
+    subject = authenticator_instance
+    expect { subject.jenkins_public_key?(invalid_public_key_not_available) }.to raise_error
+  end
+
+  it "gets public key" do
+    subject = authenticator_instance
+    public_key_content = "-----BEGIN PUBLIC KEY-----\n#{valid_public_key['X-Instance-Identity']}\n-----END PUBLIC KEY-----"
+    expect { subject.jenkins_public_key?(valid_public_key) }.to include(public_key_content)
+  end
+
+
+  # Test getting password
+  it "parses invalid password" do
+    subject = authenticator_instance
+    subject.parse_password(invalid_password).to raise_error
+  end
+
+  it "parses valid password" do
+    subject = authenticator_instance
+    subject.parse_password(valid_password).to_not raise_error
+  end
+
+end


### PR DESCRIPTION
#### What does this PR do?
It allows jenkins jobs to authenticate to conjur without the need of a stored api key. Also it allows the ability to specifically authenticate a job rather than an entire host.

#### Any background context you want to provide?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### How should this be manually tested?
Open jenkins, import the jenkins plugin that supports Jenkins JIT authentication.
Create a jenkins 'conjur authn' user.
Load the authn-jenkins policy and populate the variables 'jenkinsURL', 'jenkinsUsername' & 'jenkinsPassword'.
Create a host that has access to use the authn-jenkins policy and ends with the appropriate job name.
Create this job in jenkins and enter in the correct conjur metadata (URL, account, ssl cert, etc)
Create a pipeline that fetches a secret using the Conjur Credential Plugin.
Run the pipeline. 

#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
No
#### Questions:
> Does this work have automated integration and unit tests?
It has unit tests, integration tests have not been created
> Can we make a blog post, video, or animated GIF of this?
Yes
> Has this change been documented (Readme, docs, etc.)?
No
> Does the knowledge base need an update?
Yes (integration/authentication)