### PR TITLE
Delete load cache test

### DIFF
--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -176,17 +176,3 @@ Feature: Users can authneticate with OIDC authenticator
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate 1000 times in 10 threads via OIDC with id token
     Then The "avg" response time should be less than "0.75" seconds
-
-  Scenario: Load with cache
-    And I fetch an ID Token for username "alice" and password "alice"
-    # Make sure cache contains a valid certificate
-    And I authenticate via OIDC with id token
-    And user "alice" is authorized
-    And I save my place in the log file
-    # Load while the cache contains OIDC provider certificate
-    When I authenticate 2000 times in 20 threads via OIDC with id token
-    # Validate cache functionality
-    Then The following appears 0 times in the log after my savepoint:
-    """
-    CONJ00016D Rate limited cache updated successfully
-    """


### PR DESCRIPTION
#### What does this PR do?
Delete load cache test and move it to appliance automation since it should run only on worker

Note:
When running this test with 2 workers (puma's default) some of the load
are passed to different workers with not certificate in the cache, and its create an unstable state when sometimes a few requests fail on CONJ00022D - Concurrency limited cache reached

#### Any background context you want to provide?
#### What ticket does this PR close?
Connected to #1200 
#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
