### PR TITLE
Allow hosts to be defined outside apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The k8s host id does not use the "{@account}:host:conjur/authn-k8s/#{@service_name}/apps"
+  prefix and takes the full host-id from the CSR. We also handle backwards-compatibility and use
+  the prefix in case of an older client.
+
 ## [1.4.4] - 2019-12-19
 
 ### Added
@@ -235,8 +240,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/conjur/compare/v1.4.4...HEAD
-[1.4.4]: https://github.com/cyberark/conjur/compare/v1.4.3...v1.4.4
+[Unreleased]: https://github.com/cyberark/conjur/compare/v1.4.3...HEAD
 [1.4.3]: https://github.com/cyberark/conjur/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/cyberark/conjur/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/cyberark/conjur/compare/v1.4.0...v1.4.1

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -31,7 +31,7 @@ class AuthenticateController < ApplicationController
 
   def update_config
     body_params = Rack::Utils.parse_nested_query(request.body.read)
-    
+
     Authentication::UpdateAuthenticatorConfig.new.(
       account: params[:account],
       authenticator_name: params[:authenticator],
@@ -44,7 +44,7 @@ class AuthenticateController < ApplicationController
   rescue => e
     handle_authentication_error(e)
   end
-  
+
   def status_input
     Authentication::AuthenticatorStatusInput.new(
       authenticator_name: params[:authenticator],
@@ -110,8 +110,11 @@ class AuthenticateController < ApplicationController
     # TODO: add this to initializer
     Authentication::AuthnK8s::InjectClientCert.new.(
       conjur_account: ENV['CONJUR_ACCOUNT'],
-        service_id: params[:service_id],
-        csr: request.body.read
+      service_id: params[:service_id],
+      csr: request.body.read,
+      # The host-id is split in the client where the suffix is in the CSR
+      # and the prefix is in the header. This is done to maintain backwards-compatibility
+      host_id_prefix: request.headers["Host-Id-Prefix"]
     )
     head :ok
   rescue => e

--- a/app/domain/authentication/authn_k8s/common_name.rb
+++ b/app/domain/authentication/authn_k8s/common_name.rb
@@ -20,37 +20,40 @@ module Authentication
       end
 
       def namespace
-        host_name_parts[-3]
+        host_name_suffix[-3]
       end
 
       def controller
-        host_name_parts[-2]
+        host_name_suffix[-2]
       end
 
       def object
-        host_name_parts[-1]
+        host_name_suffix[-1]
       end
 
       def k8s_host_name
-        host_name_parts.join('/')
+        full_host_name.join('/')
       end
 
       def to_s
-        host_name_parts.join('.')
+        full_host_name.join('.')
       end
 
       private
 
       def validate!
-        valid = host_name_parts.length >= 3
+        valid = host_name_suffix.length == 3
         raise ArgumentError, "Invalid K8s host CN: #{@common_name}. " +
               "Must end with namespace.controller.id" unless valid
       end
 
-      def host_name_parts
-        @host_name_parts ||= @common_name.split('.').last(3)
+      def host_name_suffix
+        @host_name_suffix ||= full_host_name.last(3)
       end
 
+      def full_host_name
+        @full_host_name ||= @common_name.split('.')
+      end
     end
   end
 end

--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -23,7 +23,7 @@ module Authentication
         :k8s_host_name
 
       def self.from_csr(account:, service_name:, csr:)
-        cn = Util::OpenSsl::X509::SmartCsr.new(csr).common_name
+        cn = csr.common_name
         raise ArgumentError, 'CSR must have a CN entry' unless cn
 
         new(account: account, service_name: service_name, common_name: cn)
@@ -43,7 +43,7 @@ module Authentication
       end
 
       def conjur_host_id
-        host_id_prefix + '/' + host_name
+        "#{@account}:" + host_name.sub('host/', 'host:')
       end
 
       def host_name
@@ -65,11 +65,6 @@ module Authentication
           pod service_account deployment stateful_set deployment_config
         )
       end
-
-      def host_id_prefix
-        "#{@account}:host:conjur/authn-k8s/#{@service_name}/apps"
-      end
-
     end
   end
 end

--- a/app/domain/conjur/ca_info.rb
+++ b/app/domain/conjur/ca_info.rb
@@ -25,7 +25,7 @@ module Conjur
     end
 
     def common_name
-      @resource_id.gsub('/', '.')
+      @resource_id.tr('/', '.')
     end
 
     def account

--- a/app/domain/util/open_ssl/ca.rb
+++ b/app/domain/util/open_ssl/ca.rb
@@ -33,10 +33,9 @@ module Util
       #
       # Returns an OpenSSL::X509::Certificate
       #
-      def signed_cert(csr, subject_altnames: nil, good_for: 3.days)
-        smart_csr = ::Util::OpenSsl::X509::SmartCsr.new(csr)
+      def signed_cert(smart_csr, subject_altnames: nil, good_for: 3.days)
         Util::OpenSsl::X509::Certificate.from_hash(
-          subject: smart_csr.subject,
+          subject: smart_csr.subject_to_s,
           issuer: @cert.subject,
           public_key: smart_csr.public_key,
           good_for: good_for,

--- a/app/domain/util/open_ssl/x509/smart_csr.rb
+++ b/app/domain/util/open_ssl/x509/smart_csr.rb
@@ -29,6 +29,15 @@ module Util
           smart_subject.common_name
         end
 
+        def common_name=(common_name)
+          smart_subject.common_name = common_name
+        end
+
+        # We don't just return subject as it might have been updated
+        def subject_to_s
+          smart_subject.to_s
+        end
+
         private
 
         def smart_subject

--- a/app/domain/util/open_ssl/x509/smart_subject.rb
+++ b/app/domain/util/open_ssl/x509/smart_subject.rb
@@ -9,10 +9,20 @@ module Util
           parts['CN']
         end
 
-        def parts
-          to_a.each(&:pop).to_h
+        def common_name=(common_name)
+          parts['CN'] = common_name
         end
 
+        def to_s
+          parts.map{|k, v| "#{k}=#{v}" }.join(',')
+        end
+
+        private
+
+        # We have memoization so we can update the common_name
+        def parts
+          @parts ||= to_a.each(&:pop).to_h
+        end
       end
     end
   end

--- a/ci/authn-k8s/dev/policies/authn-k8s.template.yml
+++ b/ci/authn-k8s/dev/policies/authn-k8s.template.yml
@@ -91,3 +91,29 @@
   - !grant
     role: !group clients
     member: !layer apps
+
+# This policy is for testing that we can authenticate from any policy branch
+- !policy
+  id: some-policy
+  body:
+  - !layer
+
+  - &hosts
+    - !host
+      id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+
+    - !host
+      id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-pod
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+
+  - !grant
+    role: !layer
+    members: *hosts
+
+# Permit the host above to authenticate with authn-k8s
+- !grant
+  role: !group conjur/authn-k8s/minikube/clients
+  member: !layer some-policy

--- a/ci/authn-k8s/dev/policies/entitlements.template.yml
+++ b/ci/authn-k8s/dev/policies/entitlements.template.yml
@@ -6,3 +6,5 @@
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/deployment/inventory-deployment
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/deployment_config/inventory-deployment-cfg
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/stateful_set/inventory-stateful
+  - !host some-policy/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+  - !host some-policy/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-pod

--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -83,3 +83,29 @@
   - !grant
     role: !group clients
     member: !layer apps
+
+# This policy is for testing that we can authenticate from any policy branch
+- !policy
+  id: some-policy
+  body:
+  - !layer
+
+  - &some-policy-hosts
+    - !host
+      id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+
+    - !host
+      id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-pod
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+
+  - !grant
+    role: !layer
+    members: *some-policy-hosts
+
+# Permit the host above to authenticate with authn-k8s
+- !grant
+  role: !group conjur/authn-k8s/minikube/clients
+  member: !layer some-policy

--- a/cucumber/kubernetes/features/login.feature
+++ b/cucumber/kubernetes/features/login.feature
@@ -22,3 +22,6 @@ Feature: An authorized client can login as a permitted role
 
   Scenario: Login as a StatefulSet.
     Then I can login to authn-k8s as "stateful_set/inventory-stateful"
+
+  Scenario: Login with a custom prefix.
+    Then I can login to authn-k8s as "@namespace@/pod/inventory-pod" with prefix "host/some-policy"

--- a/cucumber/kubernetes/features/login_errors.feature
+++ b/cucumber/kubernetes/features/login_errors.feature
@@ -13,6 +13,11 @@ Feature: Errors emitted by the login method.
     When I login to authn-k8s as "pod/inventory-unauthorized"
     Then the HTTP status is "401"
 
+  Scenario: It's an error to login with a custom prefix as a host which does not
+    hold "authenticate" privilege on the webservice.
+    When I login to authn-k8s as "@namespace@/pod/inventory-unauthorized" with prefix "host/conjur/authn-k8s/minikube/apps"
+    Then the HTTP status is "401"
+
   Scenario: It's an error to login as a service account host which does not match the calling pod.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "service_account/inventory-pod-only"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/pki.feature
+++ b/cucumber/kubernetes/features/pki.feature
@@ -1,8 +1,16 @@
 Feature: Certificates issued by the login method.
 
-  Scenario: The subject name is the dot-separated relative Conjur host ID.
+  Scenario: The subject name is the dot-separated, with hard-coded apps prefix, Conjur host ID when the "Host-Id-Prefix" header isn't present.
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
-    Then the certificate subject name is "/CN=@namespace@.*.*"
+    Then the certificate subject name is "/CN=host.conjur.authn-k8s.minikube.apps.@namespace@.*.*"
+
+  Scenario: The subject name is the dot-separated given Conjur host ID in apps when the "Host-Id-Prefix" header is present
+    When I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/conjur/authn-k8s/minikube/apps"
+    Then the certificate subject name is "/CN=host.conjur.authn-k8s.minikube.apps.@namespace@.*.*"
+
+  Scenario: The subject name is the dot-separated given Conjur host ID outside of apps when the "Host-Id-Prefix" header is present
+    When I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/some-policy"
+    Then the certificate subject name is "/CN=host.some-policy.@namespace@.*.*"
 
   Scenario: The TTL of the certificate is 3 days.
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -115,7 +115,7 @@ module AuthnK8sWorld
 
   def gen_csr(id, signing_key, altnames)
     # create certificate subject
-    common_name = id.gsub('/', '.')
+    common_name = id.tr('/', '.')
     subject = OpenSSL::X509::Name.new(
       [
         ['CN', common_name],


### PR DESCRIPTION
#### What does this PR do?

In order to authenticate hosts from every policy branch, we need the
authn-client to send the full host-id to the server, and in turn the server builds the conjur host-id 
from the common-name instead of using the prefix `{@account}:host:conjur/authn-k8s/#{@service_name}/apps`.

To maintain backwards compatibility we need to support also client versions that do not send the
full host-id, and assume that the server adds the host-id prefix to it. in this PR we handle this case and add the prefix to the common-name in the server, before validation.

#### Any background context you want to provide?

We want to give our customers the freedom to create hosts anywhere in the policy branch, and not only under the `conjur/authn-k8s/#{@service_name}/apps` branch as we do now.

#### What ticket does this PR close?
Connected to #1189 

#### Has the Version and Changelog been updated?
Yes.