### PR TITLE
Upgrade the container base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Flattening of OSS container layers.
+
+### Changed
+- Upgraded Nokogiri to 1.10.5.
+- Upgrade base image of OSS to `ubuntu:20.20`.
+- Enablement work to get OSS container to work on OpenShift as-is.
+
 ## [1.4.2] - 2019-09-13
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-ENV PORT 80
+ENV DEBIAN_FRONTEND=noninteractive \
+    PORT=80
 
 EXPOSE 80
 
@@ -15,8 +14,6 @@ RUN apt-get update -y && \
                        postgresql-client \
                        ruby2.5 ruby2.5-dev \
                        tzdata \
-                       unattended-upgrades \
-                       update-notifier-common \
                        # needed to build some gem native extensions:
                        libz-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -41,6 +38,6 @@ ENV RAILS_ENV production
 # the asset compilation can complete.
 RUN DATABASE_URL=postgresql:does_not_exist \
     CONJUR_DATA_KEY=$(openssl rand -base64 32) \
-    bundle exec rake assets:precompile 
+    bundle exec rake assets:precompile
 
 ENTRYPOINT [ "conjurctl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    PORT=80
+    PORT=80 \
+    LOG_DIR=/opt/conjur-server/log \
+    TMP_DIR=/opt/conjur-server/tmp \
+    SSL_CERT_DIRECTORY=/opt/conjur/etc/ssl
 
 EXPOSE 80
 
@@ -21,6 +24,13 @@ RUN apt-get update -y && \
 RUN gem install -N -v 1.17.3 bundler
 
 WORKDIR /opt/conjur-server
+
+# Ensure few required GID0-owned folders to run as a random UID (OpenShift requirement)
+RUN mkdir -p $TMP_DIR \
+             $LOG_DIR \
+             $SSL_CERT_DIRECTORY/ca \
+             $SSL_CERT_DIRECTORY/cert \
+             /run/authn-local
 
 COPY Gemfile \
      Gemfile.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,9 +21,7 @@ RUN apt-get update -y && \
                        libz-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN gem install -N -v 1.16.1 bundler
-
-RUN mkdir -p /opt/conjur-server
+RUN gem install -N -v 1.17.3 bundler
 
 WORKDIR /opt/conjur-server
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,4 +2,3 @@ ARG VERSION=latest
 FROM conjur:${VERSION}
 
 RUN bundle --no-deployment --without ''
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
     multi_test (0.1.2)
     net-ldap (0.16.1)
     netrc (0.11.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     openid_connect (1.1.6)
       activemodel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (13.0.1)
     rake_shared_context (0.3.0)
     random_password_generator (1.0.0)
     rb-fsevent (0.9.8)
@@ -524,4 +524,4 @@ DEPENDENCIES
   websocket-client-simple
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,30 @@ esac
 shift # past argument or value
 done
 
+# Flatten resulting image.
+function flatten() {
+  local image="$1"
+  echo "Flattening image '$image'..."
+
+  # Since `--squash` is still experimental, we have to flatten the image
+  # by exporting and importing a container based on the source image. By
+  # doing this though, we lose a lot of the Dockerfile variables that are
+  # required for running the image (ENV, EXPOSE, WORKDIR, etc) so we
+  # manually rebuild them.
+  # See here for more details: https://github.com/moby/moby/issues/8334
+  local container=`docker create $image`
+  docker export $container | docker import \
+    --change "EXPOSE 80" \
+    --change "ENV RAILS_ENV=production" \
+    --change "WORKDIR /opt/conjur-server" \
+    --change 'ENTRYPOINT ["conjurctl"]' \
+    - $image
+  docker rm $container
+}
+
 echo "Building image conjur:$TAG"
 docker build -t "conjur:$TAG" .
+flatten "conjur:$TAG"
 
 echo "Building image conjur-test:$TAG container"
 docker build --build-arg "VERSION=$TAG" -t "conjur-test:$TAG" -f Dockerfile.test .


### PR DESCRIPTION
This change upgrades the base image that Conjur OSS depends on and flattens the image as well to reduce layers. Small cleanups were done as part of this process since the Dockerfile seemed neglected for a while. Nokogiri + bundler were also upgraded to remove a security CVE issue.

#### What ticket does this PR close?
Connected to https://github.com/conjurinc/container-dap/issues/137

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--conjur/job/upgrade-base-image/)

#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
