### PR TITLE
Fix cleanup in test_gke_entrypoint/createNamespace

### DIFF
--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -87,7 +87,7 @@ function initialize() {
 function createNamespace() {
   # clean ups namespaces older than minutes or seconds
   old_namespaces=$(kubectl get namespaces | awk '$1 ~ /test-/ && $3 !~ /[m|s]/ { print $1; }')
-  [ ! -z ${old_namespaces} ] && kubectl delete --ignore-not-found=true namespaces ${old_namespaces}
+  [ ! -z "${old_namespaces}" ] && kubectl delete --ignore-not-found=true namespaces ${old_namespaces}
 
   kubectl create namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE
   kubectl config set-context $(kubectl config current-context) --namespace=$CONJUR_AUTHN_K8S_TEST_NAMESPACE


### PR DESCRIPTION
#### What does this PR do?
Fix a quoting issue in the test_gke_entrypoint ci script.

```
  old_namespaces=$(kubectl get namespaces | awk '$1 ~ /test-/ && $3 !~ /[m|s]/ { print $1; }')
  [ ! -z "${old_namespaces}" ] && kubectl delete --ignore-not-found=true namespaces ${old_namespaces}
```

This construction is problematic because old_namespaces may contain multiple values, while `-z` expects a single operand.  Example failure from Jenkins [build](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/allow-hosts-outside-apps/39/pipeline/#step-66-log-849): 
```
[2019-11-27T07:27:40.231Z] ./test_gke_entrypoint.sh: line 90: [: too many arguments
```

To fix this, the old_namespace value must be quoted when passed to `-z` to avoid bash splitting it into multiple words.

#### Any background context you want to provide?
I noticed this when I was [asked](https://conjurhq.slack.com/archives/C8BNMU0KV/p1574840286451100) to investigate the failure of https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/allow-hosts-outside-apps/39/pipeline/#step-66-log-849

#### What ticket does this PR close?
No ticket, observation from build failure.

#### How should this be manually tested?
Test `[ ! -z a b c ]` in a local bash shell to reproduce the problem.
Then test `[ ! -z "a b c" ]`

#### Has the Version and Changelog been updated?
Nope, just a test fix, no use visible change.
#### Questions:
> Does this work have automated integration and unit tests?

Its part of the automated test suite.

> Can we make a blog post, video, or animated GIF of this?

No

> Has this change been documented (Readme, docs, etc.)?

No

> Does the knowledge base need an update?

No