### PR TITLE
Use postgres advisory lock to ensure that only one server does the rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Postgres advisory lock used for rotation
 
 ## [1.4.7] - 2020-03-12
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'rake'
 gem 'sprockets', '~> 3.7.0', '>= 3.7.2'
 
 gem 'pg'
+gem 'sequel-pg_advisory_locking'
 gem 'sequel-postgres-schemata', require: false
 gem 'sequel-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,8 @@ GEM
     sassc (2.2.1)
       ffi (~> 1.9)
     sequel (4.46.0)
+    sequel-pg_advisory_locking (1.0.1)
+      sequel
     sequel-postgres-schemata (0.1.1)
       sequel (~> 4.3)
     sequel-rails (0.9.15)
@@ -508,6 +510,7 @@ DEPENDENCIES
   rubocop-checkstyle_formatter
   ruby_dep (= 1.3.1)
   sass-rails
+  sequel-pg_advisory_locking
   sequel-postgres-schemata
   sequel-rails
   simplecov

--- a/app/domain/rotation/conjur_facade.rb
+++ b/app/domain/rotation/conjur_facade.rb
@@ -76,5 +76,4 @@ module Rotation
       ::Rotation::NextExpiration.new(@rotated_variable)
     end
   end
-
 end

--- a/app/domain/rotation/master_rotator.rb
+++ b/app/domain/rotation/master_rotator.rb
@@ -13,14 +13,13 @@ module Rotation
     def initialize(avail_rotators:,
                    rotation_model: ::Secret,
                    secret_model: ::Secret,
-                   facade_cls: ::Rotation::ConjurFacade,
-                   db: Sequel::Model.db)
+                   facade_cls: ::Rotation::ConjurFacade)
       @avail_rotators = avail_rotators
       @rotation_model = rotation_model
       @secret_model = secret_model
       @facade_cls = facade_cls
-      @db = db
-      @db.extension :pg_advisory_locking
+
+      Sequel::Model.db.extension :pg_advisory_locking
     end
 
     def rotate_every(seconds)
@@ -36,7 +35,7 @@ module Rotation
       # The same `id` needs to be used across all servers talking to the same
       # database, but can be any unused integer.
       id = Rails.configuration.rotator_lock_name.to_i(36)
-      @db.try_advisory_lock(id) do
+      Sequel::Model.db.try_advisory_lock(id) do
         scheduled_rotations.each(&:run)
       end
     end

--- a/config/initializers/rotator.rb
+++ b/config/initializers/rotator.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.rotator_lock_name = "conjur"
+end

--- a/spec/app/domain/rotation/master_rotator_spec.rb
+++ b/spec/app/domain/rotation/master_rotator_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Rotation::MasterRotator' do
+  describe "#rotate_all" do
+    it "successfully performs no rotations when there are no scheduled rotations" do
+      master_rotator = Rotation::MasterRotator.new(avail_rotators: [])
+      master_rotator.rotate_all()
+    end
+    xit "successfully rotates each scheduled rotation" do
+
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
Enable advisory locks around secret rotation to prevent conflicts and race conditions on multiple servers trying to rotate secrets.
#### Any background context you want to provide?
When Conjur does secret rotations, it fetches all secrets that need rotation from the database, then processes the list one by one, rotating each then updating the DB.  If multiple Conjur instances point to the same DB, this allows for race conditions and multiple updates to happen on each rotation, even if each secret is locked individually.  This provides a lock around the rotation process itself so only one server will do the rotation each time.  In the future, the process of determining which secret to rotate, and fetching them from the DB one at a time could remove the need for the advisory lock.
#### How should this be manually tested?
Provide the same CONJUR_DATA_KEY and postgres URL to two different Conjur instances, configure a rotation and observe the secret only being rotated by one server on each increment
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?
Covered by existing tests
> Can we make a blog post, video, or animated GIF of this?
Maybe?  Wouldn't be very exciting
> Has this change been documented (Readme, docs, etc.)?
This particular change doesn't have any needed associated documentation.  What it enables (multiple Conjur instances to a single Postgres db) should be documented once fully verified.
> Does the knowledge base need an update?
No