### PR TITLE
Coverage data is submitted to Code Climate

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -12,4 +12,3 @@ SimpleCov.at_exit do
     sleep()
   end
 end
-

--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,15 @@
 SimpleCov.start 'rails' do
+  command_name "SimpleCov #{rand(1000000)}"
   coverage_dir File.join(ENV['REPORT_ROOT'] || __dir__, 'coverage')
   # any custom configs like groups and filters can be here at a central place
+end
+
+SimpleCov.at_exit do
+  puts "Formatting SimpleCov coverage report"
+  SimpleCov.result.format!
+  if ENV['SIMPLECOV_SLEEP']
+    puts "Coverage Report Generated, sleeping forever"
+    sleep()
+  end
 end
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,15 @@ pipeline {
       }
     }
 
+    stage('Prepare For CodeClimate Coverage Report Submission'){
+      steps {
+        script {
+          ccCoverage.dockerPrep()
+          sh 'mkdir -p coverage'
+        }
+      }
+    }
+
     stage('Run Tests') {
       parallel {
         stage('RSpec') {
@@ -62,8 +71,15 @@ pipeline {
       post {
         always {
           junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/api/features/reports/**/*.xml,cucumber/policy/features/reports/**/*.xml,cucumber/authenticators/features/reports/**/*.xml'
-          publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false])
         }
+      }
+    }
+
+    stage('Submit Coverage Report'){
+      steps{
+        sh 'ci/submit-coverage'
+        archiveArtifacts artifacts: "coverage/.resultset.json", fingerprint: false
+        publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ For most development work, the account will be `cucumber`, which is created when
 
 Conjur has `rspec` and `cucumber` tests.
 
+Note on perfomance testing: [ci/docker-compose.yml](ci/docker-compose.yml) and
+[conjur/ci/authn-k8s/dev/dev_conjur.template.yaml](conjur/ci/authn-k8s/dev/dev_conjur.template.yaml)
+set `WEB_CONCURRENCY: 0` a configuration that is useful for recording accurate
+coverage data, but isn't a realistic configuration, so shouldn't be used for
+benchmarking.
+
 ### RSpec
 
 RSpec tests are easy to run from within the `conjur` server container:

--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-if ENV['RAILS_ENV'] == 'test'
+if ENV['REQUIRE_SIMPLECOV'] == 'true'
   require 'simplecov'
   puts "Required simplecov"
 end

--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -77,6 +77,13 @@ spec:
           value: "{{ DATA_KEY }}"
         - name: RAILS_ENV
           value: test
+        # Enable coverage tracking.
+        - name: REQUIRE_SIMPLECOV
+          value: "true"
+        # Sleep after generating the coverage report to keep the pod alive
+        # so the report can be retrieved.
+        - name: SIMPLECOV_SLEEP
+          value: "true"
         - name: CONJUR_AUTHENTICATORS
           value: authn-k8s/minikube
         volumeMounts:

--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -84,6 +84,10 @@ spec:
         # so the report can be retrieved.
         - name: SIMPLECOV_SLEEP
           value: "true"
+        - name: WEB_CONCURRENCY
+          value: "0"
+        - name: RAILS_MAX_THREADS
+          value: "10"
         - name: CONJUR_AUTHENTICATORS
           value: authn-k8s/minikube
         volumeMounts:

--- a/ci/coverage-report-generator/Gemfile
+++ b/ci/coverage-report-generator/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'simplecov', '~> 0.17.1'

--- a/ci/coverage-report-generator/Gemfile.lock
+++ b/ci/coverage-report-generator/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    docile (1.3.2)
+    json (2.2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  simplecov (~> 0.17.1)
+
+BUNDLED WITH
+   1.17.2

--- a/ci/coverage-report-generator/generate_report.rb
+++ b/ci/coverage-report-generator/generate_report.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+# This script generates an html coverage report from simplecov json output.
+# Normally simplecov generates the html report at the end of a run, however
+# the conjur tests produce multiple simplecov reports, each with json data
+# and an html report. The json files are easy enough to merge, the html reports
+# are much harder. So instead we merge the json files then use this script
+# to generate a new html report. See ci/submit-coverage for the merge.
+
+require 'simplecov'
+require 'json'
+
+# Override at_exit callback as we don't want this program to hang forever
+# (.simplecov adds infinite sleep to keep containers alive after writing the
+# coverage report)
+# We also don't actually want a coverage report for this script ;-)
+SimpleCov.at_exit do
+end
+
+if ARGV.size != 2
+  puts "Usage: generate_report.rb <project root dir> <report json file>"
+  exit!
+end
+
+# Simplecov filters exclude all files outside the current project root.
+# The project root defaults to the working directory, so we have to move
+# the root up a couple of levels so all the source files can be included.
+# Use the first argument so the user can specify the approprite dir
+SimpleCov.root ARGV[0]
+
+# Read the result file, path passed in as second arg.
+jsonraw = File.open(ARGV[1]).read
+
+# Parse JSON to create ruby object
+jsonobj = JSON.parse(jsonraw)
+
+# Create result object for each subresult
+resultobjs = jsonobj.keys.map do |key|
+  SimpleCov::Result.from_hash(key => jsonobj[key])
+end
+
+# Merge the sub-results.
+# This is actually the second merge (ci/submit-coverage uses jq to merge
+# multiple result files together, this merges separate sub reports within the
+# one json structure.)
+mergedresult = SimpleCov::ResultMerger.merge_results(*resultobjs)
+
+# Format the result using the html formatter
+formatter = SimpleCov::Formatter::HTMLFormatter.new
+formatter.format(mergedresult)

--- a/ci/coverage-report-generator/generate_report.rb
+++ b/ci/coverage-report-generator/generate_report.rb
@@ -7,8 +7,8 @@
 # are much harder. So instead we merge the json files then use this script
 # to generate a new html report. See ci/submit-coverage for the merge.
 
-require 'simplecov'
 require 'json'
+require 'simplecov'
 
 # Override at_exit callback as we don't want this program to hang forever
 # (.simplecov adds infinite sleep to keep containers alive after writing the

--- a/ci/coverage-report-generator/run.sh
+++ b/ci/coverage-report-generator/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Script to run generate_report.rb within docker so that the gems don't
+# need to be installed locally.
+# generate_report.rb generates an html report from simplecov json output.
+
+set -xeu
+
+repo_root=$(git rev-parse --show-toplevel)
+# Use the first arg, or if not supplied use the simplecov default report location
+report_file="${1:-${repo_root}/coverage/.resultset.json}"
+image="ruby:2.6.5-stretch"
+
+docker run \
+    --rm \
+    -v "${repo_root}":"${repo_root}" \
+    -w "${repo_root}/ci/coverage-report-generator" \
+    "${image}" \
+        bash -cx "bundle install --path gems
+                  bundle list
+                  bundle exec ./generate_report.rb \
+                     ${repo_root} \
+                     ${report_file}
+                 "

--- a/ci/coverage-report-generator/run.sh
+++ b/ci/coverage-report-generator/run.sh
@@ -6,19 +6,21 @@
 
 set -xeu
 
-repo_root=$(git rev-parse --show-toplevel)
+IMAGE="ruby:2.6.5-stretch"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
 # Use the first arg, or if not supplied use the simplecov default report location
-report_file="${1:-${repo_root}/coverage/.resultset.json}"
-image="ruby:2.6.5-stretch"
+REPORT_FILE="${1:-${REPO_ROOT}/coverage/.resultset.json}"
 
 docker run \
     --rm \
-    -v "${repo_root}":"${repo_root}" \
-    -w "${repo_root}/ci/coverage-report-generator" \
-    "${image}" \
-        bash -cx "bundle install --path gems
-                  bundle list
-                  bundle exec ./generate_report.rb \
-                     ${repo_root} \
-                     ${report_file}
-                 "
+    -v "${REPO_ROOT}":"${REPO_ROOT}" \
+    -w "${REPO_ROOT}/ci/coverage-report-generator" \
+    "${IMAGE}" \
+        bash -cex "bundle install --path gems
+                   bundle list
+                   bundle exec ./generate_report.rb \
+                       ${REPO_ROOT} \
+                       ${REPORT_FILE}
+                  "

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       CONJUR_ACCOUNT: cucumber
       CONJUR_DATA_KEY:
       RAILS_ENV:
+      REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
       CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak
       LDAP_URI: ldap://ldap-server:389
@@ -24,12 +25,15 @@ services:
       LDAP_FILTER: '(uid=%s)'
       LDAP_BINDDN: cn=admin,dc=conjur,dc=net
       LDAP_BINDPW: ldapsecret
+      WEB_CONCURRENCY: 0
+      RAILS_MAX_THREADS: 10
     command: server
     volumes:
       - authn-local:/run/authn-local
       - ./authn-oidc/keycloak:/authn-oidc/keycloak/scripts
       - ./ldap-certs:/ldap-certs:ro
       - log-volume:/opt/conjur-server/log
+      - ../coverage:/opt/conjur-server/coverage
     expose:
       - "80"
     links:

--- a/ci/submit-coverage
+++ b/ci/submit-coverage
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Script to submit simplecov coverage report to Code Climate.
+# Only one report can be submitted per commit, so this can only
+# run once pre build, not for each test set.
+
+# The rspec and cucumber reports are all written to repo_root/coverage
+# Simplecov handles locking and merging for parallel tests.
+# The GKE tests can't mount that dir, so they produce a separate report
+# which is merged into repo_root/coverage by this script.
+
+set -eux
+
+dir="coverage"
+bin="cc-test-reporter"
+report="${dir}/.resultset.json"
+
+if [[ ! -e ${report} ]]; then
+    echo "SimpleCov report (${report}) not found"
+    ls -laR ${dir}
+    return 1
+fi
+
+if [[ ! -x ${bin} ]]; then
+    echo "cc-test-reporter binary not found, not reporting coverage data to code climate"
+    ls -laR ${dir}
+    # report is present but reporter binary is not, definitely a bug, exit error.
+    return 1
+fi
+
+gke_report="ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json"
+if [[ -e "${gke_report}" ]]; then
+    echo "GKE Report found"
+
+    # Merge GKE report with the already combined cucumber and rspec results.
+    # -s loads input files into an array
+    # * merges objects
+    jq -s '.[0] * .[1]' "${report}" "${gke_report}" > simplecov_combined
+    # This mv is safe as it happens after all the parallel tests are complete.
+    mv simplecov_combined "${report}"
+
+    # Simplecov excludes files not within the current repo, it also needs to
+    # be able to read all the files referenced within the report. As the reports
+    # are generated in containers, the absolute paths contained in the report
+    # are not valid outside that container. This sed fixes the paths
+    # So they are correct relative to the Jenkins workspace.
+    sed -i -E "s+/(opt|src)/conjur-server+${WORKSPACE}+g" "${dir}/.resultset.json"
+
+    # Now need to regenerate the html report, as it was generated before
+    # the GKE results were merged in.
+    pushd ci/coverage-report-generator
+        ./run.sh
+    popd
+else
+    echo "GKE report not found :("
+    ls -laR ci/authn-k8s/output
+    exit 1
+fi
+
+echo "Coverage reports prepared, submitting to CodeClimate."
+# vars GIT_COMMIT, GIT_BRANCH & TRID are set by ccCoverage.dockerPrep
+
+./${bin} after-build \
+    --coverage-input-type "simplecov"\
+    --id "${TRID}" \
+    && echo "Successfully Reported Coverage Data"
+
+  set +x

--- a/ci/submit-coverage
+++ b/ci/submit-coverage
@@ -11,58 +11,56 @@
 
 set -eux
 
-dir="coverage"
-bin="cc-test-reporter"
-report="${dir}/.resultset.json"
+DIR="coverage"
+BIN="cc-test-reporter"
+REPORT="${DIR}/.resultset.json"
+GKE_REPORT="ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json"
 
-if [[ ! -e ${report} ]]; then
-    echo "SimpleCov report (${report}) not found"
-    ls -laR ${dir}
-    return 1
+if [[ ! -e ${REPORT} ]]; then
+    echo "SimpleCov report (${REPORT}) not found"
+    ls -laR ${DIR}
+    exit 1
 fi
 
-if [[ ! -x ${bin} ]]; then
+if [[ ! -x ${BIN} ]]; then
     echo "cc-test-reporter binary not found, not reporting coverage data to code climate"
-    ls -laR ${dir}
+    ls -laR ${DIR}
     # report is present but reporter binary is not, definitely a bug, exit error.
-    return 1
+    exit 1
 fi
 
-gke_report="ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json"
-if [[ -e "${gke_report}" ]]; then
-    echo "GKE Report found"
-
-    # Merge GKE report with the already combined cucumber and rspec results.
-    # -s loads input files into an array
-    # * merges objects
-    jq -s '.[0] * .[1]' "${report}" "${gke_report}" > simplecov_combined
-    # This mv is safe as it happens after all the parallel tests are complete.
-    mv simplecov_combined "${report}"
-
-    # Simplecov excludes files not within the current repo, it also needs to
-    # be able to read all the files referenced within the report. As the reports
-    # are generated in containers, the absolute paths contained in the report
-    # are not valid outside that container. This sed fixes the paths
-    # So they are correct relative to the Jenkins workspace.
-    sed -i -E "s+/(opt|src)/conjur-server+${WORKSPACE}+g" "${dir}/.resultset.json"
-
-    # Now need to regenerate the html report, as it was generated before
-    # the GKE results were merged in.
-    pushd ci/coverage-report-generator
-        ./run.sh
-    popd
-else
+if [[ ! -e "${GKE_REPORT}" ]]; then
     echo "GKE report not found :("
     ls -laR ci/authn-k8s/output
     exit 1
 fi
+echo "GKE report found"
+
+# Merge GKE report with the already combined cucumber and rspec results.
+# -s loads input files into an array
+# * merges objects
+jq -s '.[0] * .[1]' "${REPORT}" "${GKE_REPORT}" > simplecov_combined
+# This mv is safe as it happens after all the parallel tests are complete.
+mv simplecov_combined "${REPORT}"
+
+# Simplecov excludes files not within the current repo, it also needs to
+# be able to read all the files referenced within the report. As the reports
+# are generated in containers, the absolute paths contained in the report
+# are not valid outside that container. This sed fixes the paths
+# So they are correct relative to the Jenkins workspace.
+sed -i -E "s+/(opt|src)/conjur-server+${WORKSPACE}+g" "${REPORT}"
+
+# Now need to regenerate the html report, as it was generated before
+# the GKE results were merged in.
+pushd ci/coverage-report-generator
+    ./run.sh
+popd
 
 echo "Coverage reports prepared, submitting to CodeClimate."
 # vars GIT_COMMIT, GIT_BRANCH & TRID are set by ccCoverage.dockerPrep
 
-./${bin} after-build \
+./${BIN} after-build \
     --coverage-input-type "simplecov"\
-    --id "${TRID}" \
-    && echo "Successfully Reported Coverage Data"
+    --id "${TRID}"
 
-  set +x
+echo "Successfully Reported Coverage Data"

--- a/ci/test
+++ b/ci/test
@@ -105,6 +105,7 @@ rspec() {
     rm -rf $REPORT_ROOT/spec/reports
     bundle exec env CI_REPORTS=$REPORT_ROOT/spec/reports rspec --format progress --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter
   "
+
 }
 
 rspec_audit() {
@@ -196,7 +197,6 @@ _main() {
   [[ -z "$KEEP_CONTAINERS" ]] && trap _finish EXIT
 
   export TAG=$(_build_conjur "$testdir")
-  
   cd "${testdir}"
   "$@"
 }
@@ -295,7 +295,13 @@ _run_cucumber_tests() {
   _run_cucumber "$cucumber_env_args" \
      "bundle exec cucumber -p $profile --format junit --out cucumber/$profile/features/reports"
 
-  docker-compose down --rmi 'local' --volumes
+  # Simplecov writes its report using an at_exit ruby hook. If the container
+  # is killed before ruby, the report doesn't get written. So here we
+  # kill the process to write the report. The container is kept alive
+  # using an infinite sleep in the at_exit hook (see .simplecov).
+  docker-compose exec -T conjur bash -c "pkill -f 'puma 3'"
+
+  [[ -z "$KEEP_CONTAINERS" ]] && docker-compose down --rmi 'local' --volumes
 }
 
 _run_cucumber_shell() {
@@ -333,6 +339,5 @@ _wait_for_pg() {
 
   until docker-compose exec -T $svc psql -U postgres -c "select 1" -d postgres; do sleep 1; done
 }
-
 
 _main "$(dirname $0)" "$@"

--- a/ci/test
+++ b/ci/test
@@ -105,7 +105,6 @@ rspec() {
     rm -rf $REPORT_ROOT/spec/reports
     bundle exec env CI_REPORTS=$REPORT_ROOT/spec/reports rspec --format progress --require ci/reporter/rspec --format CI::Reporter::RSpecFormatter
   "
-
 }
 
 rspec_audit() {

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV['RAILS_ENV'] == 'test'
+if ENV['REQUIRE_SIMPLECOV'] == 'true'
   require 'simplecov'
   load File.expand_path '../.simplecov', __dir__
 end

--- a/engines/conjur_audit/spec/spec_helper.rb
+++ b/engines/conjur_audit/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.command_name "SimpleCov #{rand(1000000)}"
+SimpleCov.start
+
 require 'db_helper'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.command_name "SimpleCov #{rand(1000000)}"
+SimpleCov.start
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 ENV["CONJUR_LOG_LEVEL"] ||= 'debug'
@@ -35,7 +39,5 @@ end
 # We want full-length error messages since RSpec has a pretty small
 # limit for those when they're printed
 RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 999
-
-require 'simplecov'
 
 require 'stringio'


### PR DESCRIPTION
#### What does this PR do?
**Summary:**
Collect code coverage data from all the tests, merge them, generate an html report to store in Jenkins and also submit the coverage data to code climate.

**Detail:**
* Adds two stages to the Jenkinsfile, one to prepare for coverage data before the tests run, and another to collect results after tests complete.
* Modifies the simplecov configuration `.simplecov`:
  * Adds a custom command name including a random integer to prevent
    collisions between branches when merging reports
  * Overrides the at_exit hook to to add an optional sleep. The sleep is controlled by an environment variable `SIMPLECOV_SLEEP`. The purpose of the sleep is to keep the conjur process running after the simplecov report has been generated, which allows the report to be retrieved from a k8s pod, before the pod is killed.
* Adds a `REQUIRE_SIMPLECOV` env variable, previously this was governed by the `RAILS_ENV` variable but the `cucumber_authenticator` tests fail when `RAILS_ENV` is set to test so a new var was needed to enable coverage recording without changing the rails environment.
* Ensures that conjur is killed before the container its running in is killed. SimpleCov uses an `at_exit` hook to write out the report. If the container is killed the `at_exit` hook doesn't fire and the report isn't written. 
* Adds a new dirctory `ci/coverage-report-generator` which contains a ruby script (`generate_report.rb`) and supporting files for generating an HTML report from SimpleCov JSON output. Normally the HTML report is generated during the `at_exit` hook mentioned above, but this repo requires manually merged test results, so a new HTML report must be generated to reflect the merged JSON results. On merging: SimpleCov locks its storage dir and handles merging of most of the test sets itself, the only test results that require manual merging are the GKE tests as they can't mount the coverage directory from `$WORKSPACE`. 
* Set `WEB_CONCURRENCY: 0`. With this value `>0` `puma` (the webserver conjur uses) creates child processes to handle requests, SimpleCov cannot track calls in those processes, so coverage data is innaccurate. Setting this value to 0 ensures that requests are handled within the main process and SimpleCov tracks code usage succesfully. To compensate for the lack of child processes, `RAILS_MAX_THREADS` is increased to 10 from the default of 5 (previously there were 2x5 threads).
* Updates SimpleCov config in spec_helper files to ensure reports are generated and can be safely merged with other reports.

#### Any background context you want to provide?
This is required for the updated definition-of-done. 
#### What ticket does this PR close?
Connected to conjurinc/container-dap#107
#### Where should the reviewer start?
* [A successful build](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/cyberark-conjur-107/48/pipeline/)
* [JSON report artifact, showing 7 top level keys for each of the 7 parallel test sets](https://jenkins.conjur.net/job/cyberark--conjur/job/cyberark-conjur-107/48/artifact/coverage/.resultset.json): 

    ```
    $ jq keys <resultset.json 
    [
      "SimpleCov 115551",
      "SimpleCov 296886",
      "SimpleCov 348898",
      "SimpleCov 41905",
      "SimpleCov 73534",
      "SimpleCov 799924",
      "SimpleCov 937420"
    ]
    ```
* [HTML report artifact](https://jenkins.conjur.net/job/cyberark--conjur/job/cyberark-conjur-107/48/Coverage_20Report/)

* [Example report received by CodeClimate](https://codeclimate.com/repos/5b460c731a0e37241a000488/settings/test_reports/5ded442c09a64f48f7002a52). Note that this doesn't show in the main coverage section as this is not yet merged to master, and I can't find a way of getting codeclimate to display coverage for non-default branches.

#### Has the Version and Changelog been updated?
Nope, just CI updates here.

#### Questions:
> Does this work have automated integration and unit tests?

This work is entirely improvements to test infrastructure to ensure that coverage data is correctly stored and published.

> Can we make a blog post, video, or animated GIF of this?

Possibly, theres a neat jq dict merge which people might be unfamiliar with, not sure thats enough for a whole blog post though.

> Has this change been documented (Readme, docs, etc.)?

Not oustide the code.

> Does the knowledge base need an update?

Nope.