### PR TITLE
Add STDOUT logger to follower environment

### DIFF
--- a/config/environments/follower.rb
+++ b/config/environments/follower.rb
@@ -7,6 +7,7 @@ load File.expand_path '../production.rb', __FILE__
 require 'rack/remember_uuid'
 
 Rails.application.configure do
+  config.logger = Logger.new(STDOUT)
   config.log_level = ENV['CONJUR_LOG_LEVEL'] || :info
   config.middleware.use Rack::RememberUuid
   config.audit_socket = '/run/conjur/audit.socket'


### PR DESCRIPTION
#### What does this PR do?

This PR configures rails to log to STDOUT when running in the Follower environment.

#### Any background context you want to provide?

Prior to this, the rails log in a Follower container is written to the file `log/follower.log`.

Connected to conjurinc/container-dap#165
