### PR TITLE
Validate that the given account exists in Conjur with authn oidc

### DIFF
--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -13,6 +13,7 @@ module Authentication
         enabled_authenticators:     ENV['CONJUR_AUTHENTICATORS'],
         fetch_oidc_secrets:         AuthnOidc::Util::FetchOidcSecrets.new,
         token_factory:              TokenFactory.new,
+        validate_account_exists:    ::Authentication::Security::ValidateAccountExists.new,
         validate_security:          ::Authentication::Security::ValidateSecurity.new,
         validate_origin:            ValidateOrigin.new,
         audit_event:                AuditEvent.new,
@@ -23,6 +24,7 @@ module Authentication
     ) do
 
       def call
+        validate_account_exists
         decode_and_verify_id_token
         validate_conjur_username
         add_username_to_input
@@ -36,6 +38,12 @@ module Authentication
       end
 
       private
+
+      def validate_account_exists
+        @validate_account_exists.(
+          account: @authenticator_input.account
+        )
+      end
 
       def decode_and_verify_id_token
         @id_token_attributes = @decode_and_verify_id_token.(

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -128,15 +128,13 @@ Feature: Users can authneticate with OIDC authenticator
     Errors::Authentication::RequestBody::MissingRequestParam
     """
 
-  # Should crash in GA, update the message to "account does not exists"
   Scenario: non-existing account in request is denied
-    And I fetch an ID Token for username "alice" and password "alice"
-    And I save my place in the log file
+    Given I save my place in the log file
     When I authenticate via OIDC with id token and account "non-existing"
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Conjur::RequiredResourceMissing
+    Errors::Authentication::Security::AccountNotDefined
     """
 
   Scenario: admin user is denied

--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe 'Authentication::Oidc' do
             enabled_authenticators: oidc_authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
+            validate_account_exists: mocked_account_validator,
             validate_origin: mocked_origin_validator,
             decode_and_verify_id_token: mocked_decode_and_verify_id_token
           ).call(
@@ -91,6 +92,7 @@ RSpec.describe 'Authentication::Oidc' do
 
         it_behaves_like "raises an error when security validation fails"
         it_behaves_like "raises an error when origin validation fails"
+        it_behaves_like "raises an error when account validation fails"
 
         it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
         it_behaves_like "it fails when variable is missing or has no value", "id-token-user-property"
@@ -112,6 +114,7 @@ RSpec.describe 'Authentication::Oidc' do
             enabled_authenticators: oidc_authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
+            validate_account_exists: mocked_account_validator,
             validate_origin: mocked_origin_validator,
             decode_and_verify_id_token: mocked_decode_and_verify_id_token
           ).call(
@@ -140,6 +143,7 @@ RSpec.describe 'Authentication::Oidc' do
             enabled_authenticators: oidc_authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
+            validate_account_exists: mocked_account_validator,
             validate_origin: mocked_origin_validator,
             decode_and_verify_id_token: mocked_decode_and_verify_id_token
           ).call(

--- a/spec/support/oidc_spec_helper.rb
+++ b/spec/support/oidc_spec_helper.rb
@@ -56,6 +56,7 @@ shared_context "oidc setup" do
 
   let (:mocked_security_validator) { double("MockSecurityValidator") }
   let (:mocked_origin_validator) { double("MockOriginValidator") }
+  let (:mocked_account_validator) { double("MockAccountValidator") }
 
   before(:each) do
     allow(Resource).to receive(:[])
@@ -66,6 +67,9 @@ shared_context "oidc setup" do
                                           .and_return(true)
 
     allow(mocked_origin_validator).to receive(:call)
+                                        .and_return(true)
+
+    allow(mocked_account_validator).to receive(:call)
                                         .and_return(true)
   end
 end
@@ -106,6 +110,17 @@ shared_examples_for "raises an error when origin validation fails" do
 
     expect { subject }.to raise_error(
                             /FAKE_ORIGIN_ERROR/
+                          )
+  end
+end
+
+shared_examples_for "raises an error when account validation fails" do
+  it 'raises an error when account validation fails' do
+    allow(mocked_account_validator).to receive(:call)
+                                          .and_raise('ACCOUNT_NOT_EXIST_ERROR')
+
+    expect { subject }.to raise_error(
+                            /ACCOUNT_NOT_EXIST_ERROR/
                           )
   end
 end


### PR DESCRIPTION
When users try to authenticate with Conjur using the authn-oidc they
might give a non-existing account in the request URL. This PR adds
validation that the account exists to the beginning of the authentication
flow so that the users will get the correct reason for the error in the
log.

Before this change, the users would have seen the following message
in the log: Authentication Error: #<Errors::Conjur::RequiredResourceMissing:
CONJ00036E Missing required resource:
non-existing:variable:conjur/authn-oidc/keycloak/provider-uri>

The error above is not a good indicator the the account "non-existing"
doesn't exist in Conjur.