### PR TITLE
GKE coverage report is reliably generated

### DIFF
--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -32,7 +32,7 @@ function finish {
       echo "Killing conjur so that coverage report is written"
       # The container is kept alive using an infinite sleep in the at_exit hook
       # (see .simplecov) so that the kubectl cp below works.
-      kubectl exec -it $pod_name -- bash -c "pkill -f 'puma 3'"
+      kubectl exec $pod_name -- bash -c "pkill -f 'puma 3'"
 
       echo "Retrieving coverage report"
       kubectl cp $pod_name:/opt/conjur-server/coverage/.resultset.json output/simplecov-resultset-authnk8s-gke.json


### PR DESCRIPTION
#### What does this PR do?
This commit removes the unnecessary `-it` flags to a kubectl exec
command for killing puma in the conjur container.

Conjur must be killed to ensure the simplecov report is written by
an at_exit hook. `-it` doesn't work in a Jenkins environment
as a tty isn't allocated for each executor.

#### Any background context you want to provide?
This was bug was introduced by my recent coverage pr #1234 

#### What ticket does this PR close?
Related: conjurinc/ops#470