### PR TITLE
initialize platform in a separate file

### DIFF
--- a/ci/authn-k8s/dev/utils.sh
+++ b/ci/authn-k8s/dev/utils.sh
@@ -35,3 +35,15 @@ delete_image() {
         gcloud container images delete --force-delete-tags -q $image_and_tag
     fi
 }
+
+function initialize_gke() {
+  # setup kubectl
+  gcloud auth activate-service-account --key-file $GCLOUD_SERVICE_KEY
+  gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME --zone $GCLOUD_ZONE --project $GCLOUD_PROJECT_NAME
+}
+
+function initialize_oc() {
+  # setup kubectl, oc and docker
+  oc login $OPENSHIFT_URL --username=$OPENSHIFT_USERNAME --password=$OPENSHIFT_PASSWORD --insecure-skip-tls-verify=true
+  docker login -u _ -p $(oc whoami -t) $OPENSHIFT_REGISTRY_URL
+}

--- a/ci/authn-k8s/init_k8s.sh
+++ b/ci/authn-k8s/init_k8s.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+
+# This script is used for developer debugging and isn't part of the main ci flow.
+#
+# Given platform as a positional argument, the script performs a login to a live K8S cluster.
+# Expects environment variables to be passed in via summon.
+# After running this script you will be able to perform kubectl/oc operations.
+#
+# Usage: summon ./init_k8s [platform]
+#     gke          login to gcloud cluster
+#     openshift    login to OpenShift cluster
+
+# source the init functions
+source dev/utils.sh
+
+PLATFORM="$1"
+
+case "$PLATFORM" in
+  gke)
+    initialize_gke
+    ;;
+  openshift*)
+    initialize_oc
+    ;;
+  *)
+    echo "'$PLATFORM' is not a supported test platform"
+    exit 1
+esac

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -60,7 +60,7 @@ function main() {
   sourceFunctions
   renderResourceTemplates
   
-  initialize
+  initialize_gke
   createNamespace
 
   pushDockerImages
@@ -86,12 +86,6 @@ function sourceFunctions() {
 function renderResourceTemplates() {
   cleanuptemplatescmd $TEMPLATE_TAG
   compiletemplatescmd <(echo '') $TEMPLATE_TAG
-}
-
-function initialize() {
-  # setup kubectl
-  gcloud auth activate-service-account --key-file $GCLOUD_SERVICE_KEY
-  gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME --zone $GCLOUD_ZONE --project $GCLOUD_PROJECT_NAME
 }
 
 function createNamespace() {

--- a/ci/authn-k8s/test_oc_entrypoint.sh
+++ b/ci/authn-k8s/test_oc_entrypoint.sh
@@ -47,7 +47,7 @@ function main() {
   sourceFunctions
   renderResourceTemplates
   
-  initialize
+  initialize_oc
   createNamespace
 
   pushDockerImages
@@ -70,12 +70,6 @@ function sourceFunctions() {
 function renderResourceTemplates() {
   cleanuptemplatescmd $TEMPLATE_TAG
   compiletemplatescmd <(echo '') $TEMPLATE_TAG
-}
-
-function initialize() {
-  # setup kubectl, oc and docker
-  oc login $OPENSHIFT_URL --username=$OPENSHIFT_USERNAME --password=$OPENSHIFT_PASSWORD --insecure-skip-tls-verify=true
-  docker login -u _ -p $(oc whoami -t) $OPENSHIFT_REGISTRY_URL
 }
 
 function createNamespace() {


### PR DESCRIPTION
In order to locally login to GKE/OCP to get pods, exec, etc. we want to
have the ability to do that with a built-in script.

Now to do that we can run `summon ./ci/authn-k8s/init_k8s.sh gke`.

Note: This ability was not added to the README as we don't even have a section for GKE tests. I created [an issue](https://github.com/cyberark/conjur/issues/1258) for it.