### PR TITLE
Add GKE tests logs

### DIFF
--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -32,6 +32,11 @@ function finish {
       # Rails.logger writes the logs to the environment log file
       kubectl exec $pod_name -- bash -c "cat /opt/conjur-server/log/test.log" >> output/gke-authn-k8s-logs.txt
 
+      echo "Printing Logs from Conjur to the console"
+      echo "==========================="
+      cat output/gke-authn-k8s-logs.txt
+      echo "==========================="
+
       echo "Killing conjur so that coverage report is written"
       # The container is kept alive using an infinite sleep in the at_exit hook
       # (see .simplecov) so that the kubectl cp below works.

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -29,6 +29,9 @@ function finish {
       echo "Logs from Conjur Pod $pod_name:"
       kubectl logs $pod_name > output/gke-authn-k8s-logs.txt
 
+      # Rails.logger writes the logs to the environment log file
+      kubectl exec $pod_name -- bash -c "cat /opt/conjur-server/log/test.log" >> output/gke-authn-k8s-logs.txt
+
       echo "Killing conjur so that coverage report is written"
       # The container is kept alive using an infinite sleep in the at_exit hook
       # (see .simplecov) so that the kubectl cp below works.

--- a/ci/authn-k8s/test_oc_entrypoint.sh
+++ b/ci/authn-k8s/test_oc_entrypoint.sh
@@ -26,6 +26,9 @@ function finish {
 
       echo "Logs from Conjur Pod $pod_name:"
       oc logs $pod_name > "output/$PLATFORM-authn-k8s-logs.txt"
+
+      # Rails.logger writes the logs to the environment log file
+      oc exec $pod_name -- bash -c "cat /opt/conjur-server/log/test.log" >> "output/$PLATFORM-authn-k8s-logs.txt"
     fi
   } || {
     echo "Logs could not be extracted from $pod_name"

--- a/ci/authn-k8s/test_oc_entrypoint.sh
+++ b/ci/authn-k8s/test_oc_entrypoint.sh
@@ -29,6 +29,11 @@ function finish {
 
       # Rails.logger writes the logs to the environment log file
       oc exec $pod_name -- bash -c "cat /opt/conjur-server/log/test.log" >> "output/$PLATFORM-authn-k8s-logs.txt"
+
+      echo "Printing Logs from Conjur to the console"
+      echo "==========================="
+      cat "output/$PLATFORM-authn-k8s-logs.txt"
+      echo "==========================="
     fi
   } || {
     echo "Logs could not be extracted from $pod_name"


### PR DESCRIPTION
When running the GKE tests we deploy a Conjur cluster and run "inject_client_cert" & "authenticate" requests against it. To help developers investigate failures, we print the Conjur log to the console.

The logs are wrapped in 2 lines of "===========================" so you can look for that in the console to find the beginning of the Conjur log.