### PR TITLE
Allow defining application identity in host annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- K8s hosts' application identity is extracted from annotations or id. If it is
+  defined in annotations it will taken from there and if not, it will be taken 
+  from the id.
+
 ## [1.4.5] - 2019-12-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [quay]: https://quay.io/repository/cyberark/conjur "Conjur container image on Quay.io"
 [twitter]: https://twitter.com/intent/user?screen_name=ConjurInc "Follow Conjur on Twitter"
 
-Conjur provides secrets management and machine identity for modern infrastructure:
+Conjur provides secrets management and application identity for modern infrastructure:
 
 * **Machine Authorization Markup Language ("MAML")**, a role-based
   access policy language to define system components & their roles,

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -4,7 +4,7 @@ module Authentication
     Log = LogMessages::Authentication::AuthnK8s
     Err = Errors::Authentication::AuthnK8s
     # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
-    # ScopeNotSupported, ArgumentError
+    # ScopeNotSupported, InvalidHostId
 
     # This class defines an application identity of a given conjur host.
     # The constructor initializes an ApplicationIdentity object and validates that
@@ -149,10 +149,7 @@ module Authentication
         Rails.logger.debug(Log::ValidatingHostId.new(@host_id))
 
         valid_host_id = host_id_suffix.length == 3
-        unless valid_host_id
-          raise ArgumentError, "Invalid K8s host id: #{@host_id}. " \
-          "Must end with namespace/resource_type/resource_id"
-        end
+        raise Err::InvalidHostId, @host_id unless valid_host_id
 
         return if host_id_namespace_scoped?
 

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -1,0 +1,175 @@
+module Authentication
+  module AuthnK8s
+
+    Err = Errors::Authentication::AuthnK8s
+    # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
+    # ScopeNotSupported, ArgumentError
+
+    # This class defines an application identity of a given conjur host.
+    # The constructor initializes an ApplicationIdentity object and validates that
+    # it is configured correctly.
+    # The difference between the validation in this constructor and
+    # the validation in ValidateApplicationIdentity is that here we validate that
+    # the application identity is configured correctly, and thus is a valid application
+    # identity. In ValidateApplicationIdentity we validate that the defined application
+    # identity is actually the correct one in kubernetes.
+    # For example, an application identity `some-namepsace/blah/some-value` is not
+    # valid and will fail the validation here. However, an application identity
+    # `some-namespace/service-account/some-value` is a valid application identity
+    # and will pass the validation here. If the host is actually running from
+    # a pod with service account `some-other-value` then it will fail the
+    # validation of ValidateApplicationIdentity
+    class ApplicationIdentity
+
+      def initialize(host_id:, host_annotations:, service_id:)
+        @host_id          = host_id
+        @host_annotations = host_annotations
+        @service_id       = service_id
+
+        validate
+      end
+
+      def namespace
+        @namespace ||= application_identity_in_annotations? ? constraint_from_annotation("namespace") : host_id_suffix[-3]
+      end
+
+      def constraints
+        @constraints ||= {
+          pod:               constraint_value("pod"),
+          service_account:   constraint_value("service_account"),
+          deployment:        constraint_value("deployment"),
+          deployment_config: constraint_value("deployment_config"),
+          stateful_set:      constraint_value("stateful_set")
+        }.compact
+      end
+
+      def container_name
+        annotation_name = "authentication-container-name"
+        annotation_value("authn-k8s/#{@service_id}/#{annotation_name}") ||
+          annotation_value("authn-k8s/#{annotation_name}") ||
+          annotation_value("kubernetes/#{annotation_name}") ||
+          "authenticator"
+      end
+
+      # returns true if the only constraint is on the namespace, false otherwise
+      def namespace_scoped?
+        constraints.empty?
+      end
+
+      private
+
+      # Validates that the application identity is defined correctly
+      def validate
+        validate_permitted_scope
+
+        # validate that a constraint exists on the namespace
+        raise Err::MissingNamespaceConstraint unless namespace
+
+        validate_constraint_combinations
+      end
+
+      # If the application identity is defined in:
+      #   - annotations: validates that all the constraints are
+      #                  valid (e.g there is no "authn-k8s/blah" annotation)
+      #   - host id: validates that the host-id has 3 parts and that the given
+      #              constraint is valid (e.g the host id is not
+      #              "namespace/blah/some-value")
+      def validate_permitted_scope
+        application_identity_in_annotations? ? validate_permitted_annotations : validate_host_id
+      end
+
+      # Validates that the application identity doesn't include logical constraint
+      # combinations (e.g deployment & deploymentConfig)
+      def validate_constraint_combinations
+        controllers = %i(deployment deployment_config stateful_set)
+
+        controller_constraints = constraints.keys & controllers
+        unless controller_constraints.length <= 1
+          raise Err::IllegalConstraintCombinations, controller_constraints
+        end
+      end
+
+      def constraint_value constraint_name
+        application_identity_in_annotations? ? constraint_from_annotation(constraint_name) : constraint_from_id(constraint_name)
+      end
+
+      def constraint_from_annotation constraint_name
+        annotation_value("authn-k8s/#{@service_id}/#{constraint_name}") ||
+          annotation_value("authn-k8s/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @host_annotations.find { |a| a.values[:name] == name }
+        annotation ? annotation[:value] : nil
+      end
+
+      def constraint_from_id constraint_name
+        host_id_suffix[-2] == constraint_name ? host_id_suffix[-1] : nil
+      end
+
+      def host_id_suffix
+        @host_id_suffix ||= @host_id.split('/').last(3)
+      end
+
+      def validate_permitted_annotations
+        validate_prefixed_permitted_annotations("authn-k8s/")
+        validate_prefixed_permitted_annotations("authn-k8s/#{@service_id}/")
+      end
+
+      def validate_prefixed_permitted_annotations prefix
+        prefixed_k8s_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          unless prefixed_permitted_annotations(prefix).include?(annotation_name)
+            raise Err::ScopeNotSupported, annotation_name
+          end
+        end
+      end
+
+      def prefixed_k8s_annotations prefix
+        @host_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+            # Verify we take only annotations from the same level
+            annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      def prefixed_permitted_annotations prefix
+        permitted_annotations.map { |k| "#{prefix}#{k}" }
+      end
+
+      def validate_host_id
+        valid_host_id = host_id_suffix.length == 3
+        unless valid_host_id
+          raise ArgumentError, "Invalid K8s host id: #{@host_id}. " \
+          "Must end with namespace/resource_type/resource_id"
+        end
+
+        return if host_id_namespace_scoped?
+
+        constraint       = host_id_suffix[-2]
+        valid_constraint = permitted_constraints.include?(constraint)
+        raise Err::ScopeNotSupported, constraint unless valid_constraint
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          namespace service_account pod deployment stateful_set deployment_config
+        )
+      end
+
+      def permitted_annotations
+        @permitted_annotations ||= permitted_constraints << "authentication-container-name"
+      end
+
+      def application_identity_in_annotations?
+        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
+      end
+
+      def host_id_namespace_scoped?
+        host_id_suffix[-2] == '*' && host_id_suffix[-1] == '*'
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_k8s/common_name.rb
+++ b/app/domain/authentication/authn_k8s/common_name.rb
@@ -16,43 +16,14 @@ module Authentication
 
       def initialize(common_name)
         @common_name  = common_name
-        validate!
-      end
-
-      def namespace
-        host_name_suffix[-3]
-      end
-
-      def controller
-        host_name_suffix[-2]
-      end
-
-      def object
-        host_name_suffix[-1]
       end
 
       def k8s_host_name
-        full_host_name.join('/')
+        @k8s_host_name ||= @common_name.split('.').join('/')
       end
 
       def to_s
-        full_host_name.join('.')
-      end
-
-      private
-
-      def validate!
-        valid = host_name_suffix.length == 3
-        raise ArgumentError, "Invalid K8s host CN: #{@common_name}. " +
-              "Must end with namespace.controller.id" unless valid
-      end
-
-      def host_name_suffix
-        @host_name_suffix ||= full_host_name.last(3)
-      end
-
-      def full_host_name
-        @full_host_name ||= @common_name.split('.')
+        @common_name
       end
     end
   end

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -6,7 +6,7 @@ module Authentication
     Log = LogMessages::Authentication::AuthnK8s
     Err = Errors::Authentication::AuthnK8s
     # Possible Errors Raised:
-    # CSRIsMissingSpiffeId, CSRNamespaceMismatch, CertInstallationError
+    # CSRIsMissingSpiffeId, CertInstallationError
 
     InjectClientCert = CommandClass.new(
       dependencies: {
@@ -103,10 +103,6 @@ module Authentication
 
       def validate_csr
         raise Err::CSRIsMissingSpiffeId unless smart_csr.spiffe_id
-
-        spiffe_namespace = spiffe_id.namespace
-        cn_namespace = common_name.namespace
-        raise Err::CSRNamespaceMismatch.new(cn_namespace, spiffe_namespace) unless cn_namespace == spiffe_namespace
       end
 
       def smart_csr

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -11,7 +11,7 @@ module Authentication
     InjectClientCert = CommandClass.new(
       dependencies: {
         logger: Rails.logger,
-        resource_repo: Resource,
+        resource_class: Resource,
         conjur_ca_repo: Repos::ConjurCA,
         kubectl_exec: KubectlExec,
         validate_pod_request: ValidatePodRequest.new
@@ -98,7 +98,7 @@ module Authentication
       end
 
       def host
-        @host ||= @resource_repo[host_id]
+        @host ||= @resource_class[host_id]
       end
 
       def validate_csr

--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -1,9 +1,7 @@
 # Represents a K8s host, typically created from a CSR or a Cert.
 #
 # This is not to be confused with Conjur model host.  It exists purely to
-# encapsulate logic about how to translate K8s host info into a Conjur host id,
-# and how to break a K8s host into its component parts: namespace, controller,
-# object
+# encapsulate logic about how to translate K8s host info into a Conjur host id.
 #
 require 'forwardable'
 
@@ -18,9 +16,6 @@ module Authentication
       extend Forwardable
 
       attr_reader :account, :service_name, :csr
-
-      def_delegators :@common_name, :namespace, :controller, :object,
-        :k8s_host_name
 
       def self.from_csr(account:, service_name:, csr:)
         cn = csr.common_name
@@ -43,27 +38,7 @@ module Authentication
       end
 
       def conjur_host_id
-        "#{@account}:" + host_name.sub('host/', 'host:')
-      end
-
-      def host_name
-        @common_name.k8s_host_name
-      end
-
-      def namespace_scoped?
-        controller == '*' && object == '*'
-      end
-
-      def permitted_scope?
-        permitted_controllers.include?(controller)
-      end
-
-      private
-
-      def permitted_controllers
-        @permitted_controllers ||= %w(
-          pod service_account deployment stateful_set deployment_config
-        )
+        "#{@account}:" + @common_name.k8s_host_name.sub('host/', 'host:')
       end
     end
   end

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -104,17 +104,17 @@ module Authentication
         k8s_client_for_method("get_pods").get_pods(label_selector: label_selector, namespace: namespace)
       end
 
-      # Look up an object according to the controller name. In Kubernetes, the 
-      # "controller" means something like ReplicaSet, Job, Deployment, etc.
+      # Look up an object according to the resource name. In Kubernetes, the
+      # "resource" means something like ReplicaSet, Job, Deployment, etc.
       #
-      # Here, controller_name should be the underscore-ized controller, e.g.
+      # Here, resource_name should be the underscore-ized resource, e.g.
       # "replica_set".
       #
       # @return nil if no such object exists.
-      def find_object_by_name controller_name, name, namespace
+      def find_object_by_name resource_name, name, namespace
         begin
           handle_object_not_found do
-            invoke_k8s_method "get_#{controller_name}", name, namespace
+            invoke_k8s_method "get_#{resource_name}", name, namespace
           end
         rescue KubeException => e
           # This error message can be a bit confusing when multiple authorizers are

--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -17,8 +17,6 @@
 module Authentication
   module AuthnK8s
     module K8sResolver
-      class ValidationError < StandardError
-      end
 
       Err = Errors::Authentication::AuthnK8s
 
@@ -45,7 +43,7 @@ module Authentication
         # +block+ returns a falsey value.
         def verify message, &block
           yield.tap do |result|
-            raise ValidationError, message unless result
+            raise Err::ValidationError, message unless result
           end
         end
 

--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -2,18 +2,18 @@
 # K8sResolver is too ambiguous, and per the explanation below should probably
 # be changed to `ValidateK8sResource`. Since its used only for validation, we
 # could use that name, inject the K8sObjectLookup dependency, and give it a
-# `.call(controller, object, pod)` method.
+# `.call(resource, object, pod)` method.
 #
 # A resolver looks up a logical application in the Kubernetes object store.
-# A logical application is a K8s "controller" such as a Deployment or StatefulSet.
+# A logical application is a K8s resource such as a Deployment or StatefulSet.
 # When a request arrives at authn-k8s, the request IP identifies a Pod, and the
 # "username" request parameter identifies the Conjur role. The Conjur role 
-# is named according to the scheme "<namespace>/<controller-name>/<object-name>". For
+# is named according to the scheme "<namespace>/<resource-name>/<object-name>". For
 # example, the role Id of the "myapp" Deployment in the "default" namespace 
 # would end with "/default/deployment/myapp".
 #
 # The K8sResolver determines if the Pod, identified by the request Id, is a 
-# member of the Conjur role (= Kubernetes controller) that it wants to authenticate as.
+# member of the Conjur role (= Kubernetes resource) that it wants to authenticate as.
 module Authentication
   module AuthnK8s
     module K8sResolver
@@ -23,22 +23,22 @@ module Authentication
       Err = Errors::Authentication::AuthnK8s
 
       class << self
-        # Gets a resolver class for a controller type.
-        def for_controller controller_type
-          const_get(controller_type.classify)
+        # Gets a resolver class for a resource type.
+        def for_resource resource_type
+          const_get(resource_type.classify)
         rescue NameError
-          raise Err::UnknownControllerType, controller_type.inspect
+          raise Err::UnknownK8sResourceType, resource_type.inspect
         end
       end
 
-      # Determines if a Kubernetes controller exists and contains a specified Pod. 
+      # Determines if a Kubernetes resource exists and contains a specified Pod.
       #
       # Subclasses implement the resolution logic, which inspects the Kubernetes metadata
-      # of the controller and the Pod.
+      # of the resource and the Pod.
       #
-      # * +controller+ the controller API object (e.g. a Deployment)
+      # * +resource+ the resource API object (e.g. a Deployment)
       # * +pod+ the Pod API object.
-      Base = Struct.new(:controller, :pod, :k8s_object_lookup) do
+      Base = Struct.new(:resource, :pod, :k8s_object_lookup) do
         # Verifies that a condition, specified by a block, is truthy.
         #
         # @exception ValidationError with the specified +message+ is raised if the
@@ -50,11 +50,11 @@ module Authentication
         end
 
         def name
-          controller.metadata.name
+          resource.metadata.name
         end
 
         def namespace
-          controller.metadata.namespace
+          resource.metadata.namespace
         end
 
         def pod_name
@@ -65,9 +65,9 @@ module Authentication
           pod.metadata.ownerReferences
         end
 
-        # Validates that the +pod+ belongs to the controller object.
+        # Validates that the +pod+ belongs to the resource object.
         #
-        # @exception ValidationError if the +pod+ does not belong to the controller object.
+        # @exception ValidationError if the +pod+ does not belong to the resource object.
         def validate_pod
           raise "validate_pod is not implemented"
         end
@@ -98,16 +98,16 @@ module Authentication
 
       class DeploymentConfig < Base
         def validate_pod
-          replication_controller_ref = verify "Pod #{pod_name} does not belong to a ReplicationController (or DeploymentConfig)" do
+          replication_resource_ref = verify "Pod #{pod_name} does not belong to a ReplicationController (or DeploymentConfig)" do
             pod_owner_refs &&
-              pod_owner_refs.find{|ref| ref.kind == "ReplicationController"}
+              pod_owner_refs.find{|ref| ref.kind == "Replicationresource"}
           end
           
-          replication_controller = k8s_object_lookup.find_object_by_name "replication_controller", replication_controller_ref.name, namespace
+          replication_resource = k8s_object_lookup.find_object_by_name "replication_resource", replication_resource_ref.name, namespace
 
           deployment_config_ref = verify "Pod #{pod_name} does not belong to a DeploymentConfig" do
-            replication_controller.metadata.ownerReferences &&
-              replication_controller.metadata.ownerReferences.find{|ref| ref.kind == "DeploymentConfig"}
+            replication_resource.metadata.ownerReferences &&
+              replication_resource.metadata.ownerReferences.find{|ref| ref.kind == "DeploymentConfig"}
           end
 
           deployment_config = k8s_object_lookup.find_object_by_name "deployment_config", deployment_config_ref.name, namespace

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -10,7 +10,7 @@ module Authentication
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
-        resource_repo:              Resource,
+        resource_class:              Resource,
         k8s_resolver:               K8sResolver,
         k8s_object_lookup_class:    K8sObjectLookup,
         application_identity_class: ApplicationIdentity
@@ -71,7 +71,7 @@ module Authentication
       end
 
       def host
-        @host ||= @resource_repo[k8s_host.conjur_host_id]
+        @host ||= @resource_class[k8s_host.conjur_host_id]
       end
 
       # @return The Conjur resource for the webservice.

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -38,7 +38,7 @@ module Authentication
       end
 
       def validate_container
-        raise Err::ContainerNotFound, application_identity.container_name unless container
+        raise Err::ContainerNotFound, application_identity.container_name, @host_id unless container
       end
 
       def validate_pod_metadata

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -1,0 +1,120 @@
+require 'forwardable'
+require 'command_class'
+
+module Authentication
+  module AuthnK8s
+
+    Err = Errors::Authentication::AuthnK8s
+    # Possible Errors Raised: NamespaceMismatch, ContainerNotFound,
+    # K8sResourceNotFound
+
+    ValidateApplicationIdentity = CommandClass.new(
+      dependencies: {
+        resource_repo:              Resource,
+        k8s_resolver:               K8sResolver,
+        k8s_object_lookup_class:    K8sObjectLookup,
+        application_identity_class: ApplicationIdentity
+      },
+      inputs:       %i(host_id host_annotations account service_id spiffe_id)
+    ) do
+
+      def call
+        validate_namespace
+        validate_pod_properties
+        validate_container
+      end
+
+      private
+
+      def validate_namespace
+        return if application_identity.namespace == @spiffe_id.namespace
+        raise Err::NamespaceMismatch.new(@spiffe_id.namespace, application_identity.namespace)
+      end
+
+      def validate_pod_properties
+        return if application_identity.namespace_scoped?
+
+        validate_pod_metadata
+      end
+
+      def validate_container
+        raise Err::ContainerNotFound, application_identity.container_name unless container
+      end
+
+      def validate_pod_metadata
+        application_identity.constraints.each do |constraint|
+          resource_type   = constraint[0].to_s
+          resource_name   = constraint[1]
+          resource_object = k8s_resource_object(
+            resource_type,
+            resource_name,
+            application_identity.namespace
+          )
+
+          unless resource_object
+            raise Err::K8sResourceNotFound.new(resource_type, resource_name, application_identity.namespace)
+          end
+
+          @k8s_resolver
+            .for_resource(resource_type)
+            .new(
+              resource_object,
+              pod,
+              k8s_object_lookup
+            )
+            .validate_pod
+        end
+      end
+
+      def k8s_object_lookup
+        @k8s_object_lookup ||= @k8s_object_lookup_class.new(webservice)
+      end
+
+      def host
+        @host ||= @resource_repo[k8s_host.conjur_host_id]
+      end
+
+      # @return The Conjur resource for the webservice.
+      def webservice
+        @webservice ||= ::Authentication::Webservice.new(
+          account:            @account,
+          authenticator_name: 'authn-k8s',
+          service_id:         @service_id
+        )
+      end
+
+      def container
+        (pod.spec.containers || []).find { |c| c.name == application_identity.container_name } ||
+          (pod.spec.initContainers || []).find { |c| c.name == application_identity.container_name }
+      end
+
+      def pod
+        @pod ||= k8s_object_lookup.pod_by_name(pod_name, pod_namespace)
+      end
+
+      def pod_name
+        @spiffe_id.name
+      end
+
+      def pod_namespace
+        @spiffe_id.namespace
+      end
+
+      def k8s_resource_object resource_type, resource_name, namespace
+        @k8s_resource_object = k8s_object_lookup.find_object_by_name(
+          resource_type,
+          resource_name,
+          namespace
+        )
+      end
+
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+          host_id:          @host_id,
+          host_annotations: @host_annotations,
+          service_id:       @service_id
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -8,7 +8,7 @@ module Authentication
     Err = Errors::Authentication::AuthnK8s
     # Possible Errors Raised:
     # WebserviceNotFound, HostNotAuthorized, PodNotFound
-    # ContainerNotFound, ScopeNotSupported, ControllerNotFound
+    # ContainerNotFound, ScopeNotSupported, K8sResourceNotFound
 
     ValidatePodRequest = CommandClass.new(
       dependencies: {

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -12,7 +12,7 @@ module Authentication
 
     ValidatePodRequest = CommandClass.new(
       dependencies: {
-        resource_repo:                 Resource,
+        resource_class:                 Resource,
         k8s_object_lookup_class:       K8sObjectLookup,
         validate_application_identity: ValidateApplicationIdentity.new
       },
@@ -72,7 +72,7 @@ module Authentication
       end
 
       def host
-        @host ||= @resource_repo[k8s_host.conjur_host_id]
+        @host ||= @resource_class[k8s_host.conjur_host_id]
       end
 
       def pod

--- a/app/domain/conjur/fetch_required_secrets.rb
+++ b/app/domain/conjur/fetch_required_secrets.rb
@@ -6,7 +6,7 @@ module Conjur
   Err = Errors::Conjur
 
   FetchRequiredSecrets = ::CommandClass.new(
-    dependencies: { resource_repo: ::Resource },
+    dependencies: { resource_class: ::Resource },
     inputs: [:resource_ids]
   ) do
 
@@ -35,7 +35,7 @@ module Conjur
     end
 
     def resources
-      @resources ||= @resource_ids.map { |id| [id, @resource_repo[id]] }.to_h
+      @resources ||= @resource_ids.map { |id| [id, @resource_class[id]] }.to_h
     end
 
     def secrets

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -178,12 +178,6 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00022E"
         )
 
-        CSRNamespaceMismatch = ::Util::TrackableErrorClass.new(
-          msg: "Namespace in SPIFFE ID '{0-cn-namespace}' must match namespace " \
-            "implied by common name '{1-spiffe-namespace}'",
-          code: "CONJ00023E"
-        )
-
         PodNotFound = ::Util::TrackableErrorClass.new(
           msg: "No pod found for '{0-pod-name}' in namespace '{1}'",
           code: "CONJ00024E"

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -190,8 +190,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         ScopeNotSupported = ::Util::TrackableErrorClass.new(
-          msg: "Resource type '{0}' identity scope is not supported in this version " \
-            "of authn-k8s",
+          msg: "Resource type '{0}' is not a supported application identity",
           code: "CONJ00025E"
         )
 
@@ -259,6 +258,22 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         MissingCertificate = ::Util::TrackableErrorClass.new(
           msg: "No Kubernetes API certificate available",
           code: "CONJ00043E"
+        )
+
+        IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
+          msg: "Application identity includes an illegal combination - '{0-controller-constraints}'",
+          code: "CONJ00044E"
+        )
+
+        MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
+          msg: "Conjur host does not have a namespace constraint",
+          code: "CONJ00045E"
+        )
+
+        NamespaceMismatch = ::Util::TrackableErrorClass.new(
+          msg: "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
+            "implied by application identity '{1-application-identity-namespace}'",
+          code: "CONJ00023E"
         )
       end
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -199,7 +199,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         ContainerNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Container {0} was not found for requesting pod",
+          msg: "Container {0} was not found in the pod. Host id: {1}",
           code: "CONJ00028E"
         )
 
@@ -255,12 +255,12 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
-          msg: "Application identity includes an illegal combination - '{0-controller-constraints}'",
+          msg: "Application identity includes an illegal Kubernetes resource constraint combination - '{0-controller-constraints}'",
           code: "CONJ00044E"
         )
 
         MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
-          msg: "Conjur host does not have a namespace constraint",
+          msg: "Host does not have a namespace constraint",
           code: "CONJ00045E"
         )
 
@@ -273,6 +273,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         ValidationError = ::Util::TrackableErrorClass.new(
           msg: "{0-message}",
           code: "CONJ00047E"
+        )
+
+        InvalidHostId = ::Util::TrackableErrorClass.new(
+          msg: "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
+          code: "CONJ00048E"
         )
       end
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -195,8 +195,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00025E"
         )
 
-        ControllerNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Kubernetes {0-controller-name} {1-object-name} not found in namespace {2}",
+        K8sResourceNotFound = ::Util::TrackableErrorClass.new(
+          msg: "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
           code: "CONJ00026E"
         )
 
@@ -246,8 +246,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00035E"
         )
 
-        UnknownControllerType = ::Util::TrackableErrorClass.new(
-          msg: "Unknown Kubernetes controller type '{0}'",
+        UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
+          msg: "Unknown Kubernetes resource type '{0}'",
           code: "CONJ00041E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -269,6 +269,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
             "implied by application identity '{1-application-identity-namespace}'",
           code: "CONJ00023E"
         )
+
+        ValidationError = ::Util::TrackableErrorClass.new(
+          msg: "{0-message}",
+          code: "CONJ00047E"
+        )
       end
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -110,6 +110,20 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00015D"
         )
 
+        RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+          msg: "Retrieved value of annotation {0-annotation-name}",
+          code: "CONJ00024D"
+        )
+
+        ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating annotations with prefix {0-prefix}",
+          code: "CONJ00025D"
+        )
+
+        ValidatingHostId = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating host id {0}",
+          code: "CONJ00026D"
+        )
       end
     end
 

--- a/ci/authn-k8s/dev/dev_inventory_pod.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_pod.template.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: inventory-pod-only
 ---
+# This service account is used for testing authentication with an incorrect service-account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: other-service-account
+---
 apiVersion: v1
 kind: Pod
 metadata:

--- a/ci/authn-k8s/dev/policies/entitlements.template.yml
+++ b/ci/authn-k8s/dev/policies/entitlements.template.yml
@@ -6,5 +6,4 @@
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/deployment/inventory-deployment
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/deployment_config/inventory-deployment-cfg
   - !host conjur/authn-k8s/minikube/apps/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/stateful_set/inventory-stateful
-  - !host some-policy/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
-  - !host some-policy/{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-pod
+  - !layer some-policy

--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -71,6 +71,11 @@
         annotations:
           kubernetes/authentication-container-name: authenticator
 
+      - !host
+        id: incorrect-namespace/*/*
+        annotations:
+          kubernetes/authentication-container-name: authenticator
+
     - !host
       id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-unauthorized
       annotations:
@@ -84,7 +89,8 @@
     role: !group clients
     member: !layer apps
 
-# This policy is for testing that we can authenticate from any policy branch
+# This policy is for testing that we can authenticate from any policy branch &
+# that hosts can have their application ID defined in annotations
 - !policy
   id: some-policy
   body:
@@ -100,6 +106,88 @@
       id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/pod/inventory-pod
       annotations:
         kubernetes/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-namespace
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-service-account
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/service_account: inventory-pod-only
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-deployment
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/deployment: inventory-deployment
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-deployment-config
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/deployment_config: inventory-deployment-cfg
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-pod
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/pod: inventory-pod
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-stateful-set
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/stateful_set: inventory-stateful
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-non-permited-scope
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/node: inventory-node
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-multiple-constraints
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/service_account: inventory-pod-only
+        authn-k8s/pod: inventory-pod
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-service-id-constraint
+      annotations:
+        authn-k8s/minikube/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-incorrect-namespace
+      annotations:
+        authn-k8s/namespace: incorrect-namespace
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-non-existing-resource
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/service_account: non-existing-service-account
+        authn-k8s/authentication-container-name: authenticator
+
+    - !host
+      id: test-app-incorrect-resource
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/service_account: other-service-account
+        authn-k8s/authentication-container-name: authenticator
 
   - !grant
     role: !layer

--- a/cucumber/kubernetes/features/authenticate.feature
+++ b/cucumber/kubernetes/features/authenticate.feature
@@ -1,4 +1,5 @@
-Feature: An authorized client can authenticate as a permitted role
+Feature: A permitted Conjur host can authenticate with a valid application identity
+  that is defined in the id
 
   Scenario: Authenticate as a Pod.
     Given I login to authn-k8s as "pod/inventory-pod"

--- a/cucumber/kubernetes/features/authenticate_errors.feature
+++ b/cucumber/kubernetes/features/authenticate_errors.feature
@@ -2,17 +2,17 @@ Feature: Errors emitted by the authenticate method.
 
   # Skip this test as we're not currently doing IP verification.
   @skip
-  Scenario: It's an error to authenticate as a different host than the one that sent the request.
+  Scenario: it raises an error when authenticating as a different host than the one that sent the request.
     Given I login to authn-k8s as "stateful_set/inventory-stateful"
     And I use the IP address of a pod in "pod/inventory-pod"
     When I authenticate with authn-k8s as "stateful_set/inventory-stateful"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to authenticate as a host which does not hold "authenticate" privilege 
+  Scenario: it raises an error when authenticating as a host which does not hold "authenticate" privilege 
     on the webservice.
     When I authenticate with authn-k8s as "pod/inventory-unauthorized" without cert and key
     Then the HTTP status is "403"
 
-  Scenario: It's an error to authenticate without providing a cert and key.
+  Scenario: it raises an error when authenticating without providing a cert and key.
     When I authenticate with authn-k8s as "pod/inventory-pod" without cert and key
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -1,5 +1,5 @@
-Feature: An authorized client can authenticate as a permitted role with the host's
-  application identity defined in its annotations
+Feature: A permitted Conjur host can login with a valid application identity
+  that is defined in annotations
 
   Scenario: Authenticate as a Pod.
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -1,0 +1,27 @@
+Feature: An authorized client can authenticate as a permitted role with the host's
+  application identity defined in its annotations
+
+  Scenario: Authenticate as a Pod.
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-pod" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a Namespace.
+    Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-namespace" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a ServiceAccount.
+    Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-account" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-service-account" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a Deployment.
+    Given I can login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-deployment" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-deployment" with authn-k8s as "test-app-deployment" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a StatefulSet.
+    Given I can login to pod matching "app=inventory-stateful" to authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-stateful" with authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
+
+  @k8s_skip
+  Scenario: Authenticate as a DeploymentConfig.
+    Given I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-deployment-cfg" with authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"

--- a/cucumber/kubernetes/features/login.feature
+++ b/cucumber/kubernetes/features/login.feature
@@ -1,11 +1,8 @@
-Feature: An authorized client can login as a permitted role
+Feature: A permitted Conjur host can login with a valid application identity
+  that is defined in the id
 
   Scenario: Login as the namespace a pod belongs to.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
-
-  Scenario: Login for unsupported resource type identity scope throws an AuthenticationError .
-    Given I login to pod matching "app=inventory-deployment" to authn-k8s as "node/inventory-node"
-    Then the HTTP status is "401"
 
   Scenario: Login as a Pod.
     Then I can login to authn-k8s as "pod/inventory-pod"

--- a/cucumber/kubernetes/features/login_errors.feature
+++ b/cucumber/kubernetes/features/login_errors.feature
@@ -1,27 +1,31 @@
 Feature: Errors emitted by the login method.
 
+  Scenario: Login for unsupported resource type identity scope throws an AuthenticationError .
+    Given I login to pod matching "app=inventory-deployment" to authn-k8s as "node/inventory-node"
+    Then the HTTP status is "401"
+
   # Skip this test as we're not currently doing IP verification.
   @skip
-  Scenario: It's an error to login as a different host than the one that sent the request.
+  Scenario: it raises an error when logging in as a different host than the one that sent the request.
     Given I login to authn-k8s as "stateful_set/inventory-stateful"
     And I use the IP address of "pod/inventory-pod"
     When I login to authn-k8s as "stateful_set/inventory-stateful"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login as a host which does not hold "authenticate" privilege
+  Scenario: it raises an error when logging in as a host which does not hold "authenticate" privilege
     on the webservice.
     When I login to authn-k8s as "pod/inventory-unauthorized"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login with a custom prefix as a host which does not
+  Scenario: it raises an error when logging in with a custom prefix as a host which does not
     hold "authenticate" privilege on the webservice.
     When I login to authn-k8s as "@namespace@/pod/inventory-unauthorized" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login with a service account which does not match the calling pod.
+  Scenario: it raises an error when logging in with a service account which does not match the calling pod.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "service_account/inventory-pod-only"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login from a namespace which does not match the one configured in the host.
+  Scenario: it raises an error when logging in from a namespace which does not match the one configured in the host.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "incorrect-namespace/*/*" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/login_errors.feature
+++ b/cucumber/kubernetes/features/login_errors.feature
@@ -18,6 +18,10 @@ Feature: Errors emitted by the login method.
     When I login to authn-k8s as "@namespace@/pod/inventory-unauthorized" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login as a service account host which does not match the calling pod.
+  Scenario: It's an error to login with a service account which does not match the calling pod.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "service_account/inventory-pod-only"
+    Then the HTTP status is "401"
+
+  Scenario: It's an error to login from a namespace which does not match the one configured in the host.
+    When I login to pod matching "app=inventory-deployment" to authn-k8s as "incorrect-namespace/*/*" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/login_with_annotations.feature
+++ b/cucumber/kubernetes/features/login_with_annotations.feature
@@ -1,0 +1,47 @@
+Feature: An authorized client can login as a permitted role with the host's
+  application identity defined in its annotations
+
+  Scenario: Login as the namespace a pod belongs to.
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
+
+  Scenario: Login for unsupported resource type identity scope throws an AuthenticationError .
+    Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
+    Then the HTTP status is "401"
+
+  Scenario: Login as a Pod.
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"
+
+  Scenario: Login as a ServiceAccount.
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-account" with prefix "host/some-policy"
+
+  @k8s_skip
+  Scenario: Login as a DeploymentConfig.
+    Then I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
+
+  Scenario: Login as a Deployment.
+    Then I can login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-deployment" with prefix "host/some-policy"
+
+  Scenario: Login as a StatefulSet.
+    Then I can login to pod matching "app=inventory-stateful" to authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
+
+  Scenario: Login as a Pod and a ServiceAccount
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-multiple-constraints" with prefix "host/some-policy"
+
+  Scenario: Login as the namespace a pod belongs to when the constraint is on the authenticator.
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-constraint" with prefix "host/some-policy"
+
+  Scenario: It's an error to login with a host that has an unsupported resource type
+    Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
+    Then the HTTP status is "401"
+
+  Scenario: It's an error to login from a namespace which does not match the one configured in the host
+    When I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-incorrect-namespace" with prefix "host/some-policy"
+    Then the HTTP status is "401"
+
+  Scenario: It's an error to login with a non-existing K8s resource
+    When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-non-existing-resource" with prefix "host/some-policy"
+    Then the HTTP status is "401"
+
+  Scenario: It's an error to login from a K8s resource which does not match the one configured in the host
+    When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-resource" with prefix "host/some-policy"
+    Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/login_with_annotations.feature
+++ b/cucumber/kubernetes/features/login_with_annotations.feature
@@ -1,5 +1,5 @@
-Feature: An authorized client can login as a permitted role with the host's
-  application identity defined in its annotations
+Feature: A permitted Conjur host can login with a valid application identity
+  that is defined in annotations
 
   Scenario: Login as the namespace a pod belongs to.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
@@ -30,18 +30,18 @@ Feature: An authorized client can login as a permitted role with the host's
   Scenario: Login as the namespace a pod belongs to when the constraint is on the authenticator.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-constraint" with prefix "host/some-policy"
 
-  Scenario: It's an error to login with a host that has an unsupported resource type
+  Scenario: it raises an error when logging in with a host that has an unsupported resource type
     Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login from a namespace which does not match the one configured in the host
+  Scenario: it raises an error when logging in from a namespace which does not match the one configured in the host
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-incorrect-namespace" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login with a non-existing K8s resource
+  Scenario: it raises an error when logging in with a non-existing K8s resource
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-non-existing-resource" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
-  Scenario: It's an error to login from a K8s resource which does not match the one configured in the host
+  Scenario: it raises an error when logging in from a K8s resource which does not match the one configured in the host
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-resource" with prefix "host/some-policy"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/step_definitions/authenticate_steps.rb
+++ b/cucumber/kubernetes/features/step_definitions/authenticate_steps.rb
@@ -56,10 +56,14 @@ Then(/^I( can)? authenticate with authn-k8s as "([^"]*)"( without cert and key)?
   end
 end
 
-Then(/^I( can)? authenticate pod matching "([^"]*)" with authn-k8s as "([^"]*)"( without cert and key)?$/) do |success, objectid, hostid, nocertkey|
+Then(/^I( can)? authenticate pod matching "([^"]*)" with authn-k8s as "([^"]*)"( with prefix "([^"]*)")?( without cert and key)?$/) do |success, objectid, hostid_suffix, has_custom_prefix, hostid_prefix, nocertkey|
   @request_ip ||= detect_request_ip(objectid)
 
-  conjur_id = conjur_resource_id(namespace, hostid)
+  if has_custom_prefix
+    conjur_id = "#{hostid_prefix}/#{hostid_suffix}"
+  else
+    conjur_id = conjur_resource_id(namespace, hostid_suffix)
+  end
 
   cert = nocertkey ? nil : OpenSSL::X509::Certificate.new(@cert)
   key = nocertkey ? nil : @pkey

--- a/cucumber/kubernetes/features/step_definitions/login_steps.rb
+++ b/cucumber/kubernetes/features/step_definitions/login_steps.rb
@@ -28,7 +28,7 @@ end
 
 def login_with_custom_prefix request_ip, host_id_suffix, host_id_prefix, success
   headers = { 'Host-Id-Prefix' => host_id_prefix.tr('/', '.') }
-  username = substitute(host_id_suffix)
+  username = substitute!(host_id_suffix)
 
   login_with_username(request_ip, username, success, headers)
 end
@@ -94,7 +94,7 @@ end
 
 When(/^the certificate subject name is "([^"]*)"$/) do |subject_name|
   certificate = OpenSSL::X509::Certificate.new(@cert)
-  expect(certificate.subject.to_s).to eq(substitute(subject_name))
+  expect(certificate.subject.to_s).to eq(substitute!(subject_name))
 end
 
 When(/^the certificate is valid for 3 days$/) do ||

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -21,7 +21,7 @@ module AuthnK8sWorld
     last_response.body
   end
 
-  def substitute pattern
+  def substitute! pattern
     pattern.gsub! "@pod_ip@", @pod.status.podIP if @pod
     pattern.gsub! "@pod_ip_dashes@", @pod.status.podIP.gsub('.', '-') if @pod
     pattern.gsub! "@namespace@", @pod.metadata.namespace if @pod

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -99,7 +99,7 @@ module AuthnK8sWorld
       begin
         resolver.validate_pod
         true
-      rescue Authentication::AuthnK8s::K8sResolver::ValidationError
+      rescue Errors::Authentication::AuthnK8s::ValidationError
         false
       end
     end

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -95,7 +95,7 @@ module AuthnK8sWorld
     raise "#{objectid.inspect} not found" unless controller
 
     @pod = pod = kubectl_client.get_pods(namespace: namespace).find do |pod|
-      resolver = Authentication::AuthnK8s::K8sResolver.for_controller(controller_type).new(controller, pod, k8s_object_lookup)
+      resolver = Authentication::AuthnK8s::K8sResolver.for_resource(controller_type).new(controller, pod, k8s_object_lookup)
       begin
         resolver.validate_pod
         true

--- a/design/CERTIFICATE_SIGNING.md
+++ b/design/CERTIFICATE_SIGNING.md
@@ -5,7 +5,7 @@ host certificates using a CA certificate and private key stored in
 Conjur.
 
 A primary use case this supports is configuring mutual TLS between
-hosts with machine identity provisioned in Conjur. In this scenario,
+hosts with application identity provisioned in Conjur. In this scenario,
 Conjur operators can configure a signing CA in conjur with a key and
 issuer certificate created outside of Conjur. Hosts may be granted
 the privilege to sign their own short-lived certificate through the CA.

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           let(:host_id) { "HostId" }
 
           it "raises an error" do
-            expect { subject }.to raise_error(ArgumentError)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
           end
         end
 

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -1,0 +1,511 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
+  include_context "running outside kubernetes"
+
+  let(:namespace) { "K8sNamespace" }
+
+  let(:k8s_resource_name) { "K8sResourceName" }
+  let(:k8s_resource_value) { "K8sResourceValue" }
+
+  let(:namespace_annotation) { double("NamespaceAnnotation") }
+  let(:namespace_annotation_service_id_scoped) { double("NamespaceServiceIdAnnotation") }
+
+  let(:container_name_annotation) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_service_id_prefix) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_kubernetes_prefix) { double("ContainerNameAnnotation") }
+
+  let(:service_account_annotation) { double("ServiceAccountAnnotation") }
+  let(:pod_annotation) { double("PodAnnotation") }
+  let(:deployment_annotation) { double("DeploymentAnnotation") }
+  let(:stateful_set_annotation) { double("StatefulSetAnnotation") }
+  let(:deployment_config_annotation) { double("DeploymentConfigAnnotation") }
+
+  let(:invalid_annotation) { double("InvalidAnnotation") }
+
+  let(:good_service_id) { "MockService" }
+
+  before(:each) do
+    allow(namespace_annotation).to receive(:values)
+                                     .and_return(namespace_annotation)
+    allow(namespace_annotation).to receive(:[])
+                                     .with(:name)
+                                     .and_return("authn-k8s/namespace")
+    allow(namespace_annotation).to receive(:[])
+                                     .with(:value)
+                                     .and_return("K8sNamespace")
+
+    allow(namespace_annotation_service_id_scoped).to receive(:values)
+                                                       .and_return(namespace_annotation_service_id_scoped)
+    allow(namespace_annotation_service_id_scoped).to receive(:[])
+                                                       .with(:name)
+                                                       .and_return("authn-k8s/#{good_service_id}/namespace")
+    allow(namespace_annotation_service_id_scoped).to receive(:[])
+                                                       .with(:value)
+                                                       .and_return("K8sNamespaceServiceIdScoped")
+
+    allow(container_name_annotation).to receive(:values)
+                                          .and_return(container_name_annotation)
+    allow(container_name_annotation).to receive(:[])
+                                          .with(:name)
+                                          .and_return("authn-k8s/authentication-container-name")
+    allow(container_name_annotation).to receive(:[])
+                                          .with(:value)
+                                          .and_return("ContainerName")
+
+    allow(container_name_annotation_service_id_prefix).to receive(:values)
+                                                            .and_return(container_name_annotation_service_id_prefix)
+    allow(container_name_annotation_service_id_prefix).to receive(:[])
+                                                            .with(:name)
+                                                            .and_return("authn-k8s/#{good_service_id}/authentication-container-name")
+    allow(container_name_annotation_service_id_prefix).to receive(:[])
+                                                            .with(:value)
+                                                            .and_return("ServiceIdContainerName")
+
+    allow(container_name_annotation_kubernetes_prefix).to receive(:values)
+                                                            .and_return(container_name_annotation_kubernetes_prefix)
+    allow(container_name_annotation_kubernetes_prefix).to receive(:[])
+                                                            .with(:name)
+                                                            .and_return("kubernetes/authentication-container-name")
+    allow(container_name_annotation_kubernetes_prefix).to receive(:[])
+                                                            .with(:value)
+                                                            .and_return("KubernetesContainerName")
+
+    allow(service_account_annotation).to receive(:values)
+                                           .and_return(service_account_annotation)
+    allow(service_account_annotation).to receive(:[])
+                                           .with(:name)
+                                           .and_return("authn-k8s/service_account")
+    allow(service_account_annotation).to receive(:[])
+                                           .with(:value)
+                                           .and_return("K8sServiceAccount")
+
+    allow(pod_annotation).to receive(:values)
+                               .and_return(pod_annotation)
+    allow(pod_annotation).to receive(:[])
+                               .with(:name)
+                               .and_return("authn-k8s/pod")
+    allow(pod_annotation).to receive(:[])
+                               .with(:value)
+                               .and_return("K8sPod")
+
+    allow(deployment_annotation).to receive(:values)
+                                      .and_return(deployment_annotation)
+    allow(deployment_annotation).to receive(:[])
+                                      .with(:name)
+                                      .and_return("authn-k8s/deployment")
+    allow(deployment_annotation).to receive(:[])
+                                      .with(:value)
+                                      .and_return("K8sDeployment")
+
+    allow(stateful_set_annotation).to receive(:values)
+                                        .and_return(stateful_set_annotation)
+    allow(stateful_set_annotation).to receive(:[])
+                                        .with(:name)
+                                        .and_return("authn-k8s/stateful_set")
+    allow(stateful_set_annotation).to receive(:[])
+                                        .with(:value)
+                                        .and_return("K8sStatefulSet")
+
+    allow(deployment_config_annotation).to receive(:values)
+                                             .and_return(deployment_config_annotation)
+    allow(deployment_config_annotation).to receive(:[])
+                                             .with(:name)
+                                             .and_return("authn-k8s/deployment_config")
+    allow(deployment_config_annotation).to receive(:[])
+                                             .with(:value)
+                                             .and_return("K8sDeploymentConfig")
+
+    allow(invalid_annotation).to receive(:values)
+                                   .and_return(invalid_annotation)
+    allow(invalid_annotation).to receive(:[])
+                                   .with(:name)
+                                   .and_return("authn-k8s/non_existing")
+  end
+
+  context "initialization" do
+    subject(:application_identity) {
+      Authentication::AuthnK8s::ApplicationIdentity.new(
+        host_id:          host_id,
+        host_annotations: host_annotations,
+        service_id:       good_service_id
+      )
+    }
+
+    context "Application identity in host id" do
+      let(:host_annotations) { [] }
+      let(:host_id) { "#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+
+      context "with a valid application identity" do
+        context "when is namespace scoped" do
+          let(:k8s_resource_name) { "*" }
+          let(:k8s_resource_value) { "*" }
+
+          it "does not raise an error" do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+        context "when is not namespace scoped" do
+          let(:k8s_resource_name) { "service_account" }
+
+          it "does not raise an error" do
+            expect { subject }.not_to raise_error
+          end
+        end
+
+
+      end
+
+      context "with an invalid application identity" do
+        context "where the id isn't a 3 part string" do
+          let(:host_id) { "HostId" }
+
+          it "raises an error" do
+            expect { subject }.to raise_error(ArgumentError)
+          end
+        end
+
+        context "with a non existing resource" do
+          let(:k8s_resource_name) { "non_existing_resource" }
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+          end
+        end
+      end
+    end
+
+    context "Application identity in annotations" do
+      let(:host_id) { "HostId" }
+
+      context "with a valid application identity" do
+        context "when is namespace scoped" do
+          context "in a global constraint" do
+            let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "in service-id constraint" do
+            let(:host_annotations) { [namespace_annotation_service_id_scoped, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "in both global & service-id constraints" do
+            let(:host_annotations) { [namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the service-id constraint" do
+              expect(subject.namespace).to eq("K8sNamespaceServiceIdScoped")
+            end
+
+            it "does not choose the service-id constraint if it is from another service-id" do
+              allow(namespace_annotation_service_id_scoped).to receive(:[])
+                                                                 .with(:name)
+                                                                 .and_return("authn-k8s/another-service-id/namespace")
+              expect(subject.namespace).to eq("K8sNamespace")
+            end
+          end
+        end
+
+        context "when is not namespace scoped" do
+          context "has only a service account constraint" do
+            let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "has only a pod constraint" do
+            let(:host_annotations) { [namespace_annotation, pod_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "has only a deployment constraint" do
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "has only a stateful set constraint" do
+            let(:host_annotations) { [namespace_annotation, stateful_set_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "has only a deployment config constraint" do
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
+
+          context "has a valid constraint combination" do
+            context "with a deployment constraint" do
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation] }
+
+              it "does not raise an error" do
+                expect { subject }.not_to raise_error
+              end
+            end
+
+            context "with a deployment config constraint" do
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation] }
+
+              it "does not raise an error" do
+                expect { subject }.not_to raise_error
+              end
+            end
+
+            context "with a stateful_set constraint" do
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation] }
+
+              it "does not raise an error" do
+                expect { subject }.not_to raise_error
+              end
+            end
+          end
+        end
+
+        context "with different annotations for container name" do
+          context "all possible options exist" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the service-id annotation" do
+              expect(subject.container_name).to eq("ServiceIdContainerName")
+            end
+          end
+
+          context "only global and service-id exist" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the service-id annotation" do
+              expect(subject.container_name).to eq("ServiceIdContainerName")
+            end
+          end
+
+          context "only service-id & kubernetes exist" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the service-id annotation" do
+              expect(subject.container_name).to eq("ServiceIdContainerName")
+            end
+          end
+
+          context "only global & kubernetes exist" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the global annotation" do
+              expect(subject.container_name).to eq("ContainerName")
+            end
+          end
+
+          context "only service-id exists" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the service-id annotation" do
+              expect(subject.container_name).to eq("ServiceIdContainerName")
+            end
+          end
+
+          context "only global exists" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the global annotation" do
+              expect(subject.container_name).to eq("ContainerName")
+            end
+          end
+
+          context "only kubernetes exists" do
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the container name from the kubernetes annotation" do
+              expect(subject.container_name).to eq("KubernetesContainerName")
+            end
+          end
+
+          context "no annotation exists for container name" do
+            let(:host_annotations) { [namespace_annotation] }
+
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+
+            it "chooses the default container name" do
+              expect(subject.container_name).to eq("authenticator")
+            end
+          end
+        end
+      end
+
+      context "with an invalid application identity" do
+
+        context "where namespace constraint doesn't exist" do
+          let(:host_annotations) { [service_account_annotation, container_name_annotation] }
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+          end
+        end
+
+        context "with a non existing resource" do
+          context "in a global constraint" do
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            end
+          end
+
+          context "in service-id constraint" do
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+
+            before(:each) do
+              allow(invalid_annotation).to receive(:[])
+                                             .with(:name)
+                                             .and_return("authn-k8s/#{good_service_id}/non_existing")
+            end
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            end
+          end
+        end
+
+        context "with an invalid constraint combination" do
+          context "deployment and deployment_config" do
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation] }
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+            end
+          end
+
+          context "deployment and stateful_set" do
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation] }
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+            end
+          end
+
+          context "deployment_config and stateful_set" do
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+            end
+          end
+
+          context "deployment, deployment_config and stateful_set" do
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+
+            it "raises an error" do
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+            end
+          end
+        end
+
+        context "where a constraint is missing a slash after authn-k8s" do
+          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+
+          before(:each) do
+            allow(namespace_annotation).to receive(:[])
+                                             .with(:name)
+                                             .and_return("authn-k8sSomething/namespace")
+          end
+
+          it "ignores the annotation" do
+            # the namespace annotation is not present
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+          end
+        end
+      end
+    end
+
+    context "Application identity in host id and in annotations" do
+      let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+      let(:k8s_resource_name) { "service_account" }
+      let(:host_id) { "#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+
+      before(:each) do
+        allow(namespace_annotation).to receive(:[])
+                                         .with(:value)
+                                         .and_return("OtherK8sNamespace")
+
+        allow(service_account_annotation).to receive(:[])
+                                               .with(:value)
+                                               .and_return("OtherK8sServiceAccount")
+      end
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "takes the application identity from the annotations" do
+        expect(subject.namespace).to eq("OtherK8sNamespace")
+        expect(subject.constraints[:service_account]).to eq("OtherK8sServiceAccount")
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
 
   let(:account) { "SomeAccount" }
   let(:service_id) { "ServiceName" }
-  let(:common_name) { "CommonName.#{spiffe_namespace}.Controller.Id" }
+  let(:common_name) { "CommonName.#{spiffe_namespace}.Resource.Id" }
   let(:host_id_prefix) { "host.some-policy" }
   let(:nil_host_id_prefix) { nil }
   let(:csr) { "CSR" }
@@ -50,7 +50,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
 
   let(:bad_cn_namespace_smart_csr_mock) {
     double("SmartCSR",
-      common_name: "CommonName.WrongNamespace.Controller.Id",
+      common_name: "CommonName.WrongNamespace.Resource.Id",
       spiffe_id: spiffe_id)
   }
 

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -153,22 +153,6 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                            csr: csr,
                            host_id_prefix: host_id_prefix) }.to raise_error(error_type, missing_spiffe_id_error)
       end
-
-      it "throws CSRNamespaceMismatch when common_name does not match spiffe_id.namespace" do
-        error_type = Errors::Authentication::AuthnK8s::CSRNamespaceMismatch
-        wrong_cn_error = /Namespace in SPIFFE ID 'WrongNamespace' must match namespace implied by common name 'SpiffeNamespace'/
-
-        allow(Util::OpenSsl::X509::SmartCsr)
-          .to receive(:new)
-          .with(csr)
-          .and_return(bad_cn_namespace_smart_csr_mock)
-        allow(bad_cn_namespace_smart_csr_mock).to receive(:common_name=)
-
-        expect { injector.(conjur_account: account,
-                           service_id: service_id,
-                           csr: csr,
-                           host_id_prefix: host_id_prefix) }.to raise_error(error_type, wrong_cn_error)
-      end
     end
 
     it "raises RuntimeError when validate_pod_request fails" do

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
 
   let(:validate_pod_request) { double("ValidatePodRequest") }
 
-  let(:dependencies) { { resource_repo: double(),
+  let(:dependencies) { { resource_class: double(),
                          conjur_ca_repo: double(),
                          k8s_object_lookup: double(),
                          kubectl_exec: double(),

--- a/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
+  include_context "running outside kubernetes"
+
+  let(:k8s_resolver) { double("K8sResolver") }
+
+  let(:account) { "SomeAccount" }
+
+  let(:host_id) { "HostId" }
+  let(:host_role) { double("HostRole", :id => host_id) }
+
+  let(:k8s_authn_container_name) { 'kubernetes/authentication-container-name' }
+
+  let(:host_annotation_1) { double("Annot1", :values => { :name => "first" }) }
+  let(:host_annotation_2) { double("Annot2") }
+  let(:host_annotations) { [host_annotation_1, host_annotation_2] }
+
+  let(:host) { double("Host", :role => host_role,
+                      :annotations  => host_annotations) }
+
+  let(:k8s_host_namespace) { "SpiffeNamespace" }
+  let(:k8s_host) { double("K8sHost", :account => account,
+                          :conjur_host_id     => host_id) }
+
+  let(:container_name) { "ContainerName" }
+  let(:default_container_name) { 'authenticator' }
+
+
+  let(:bad_service_name) { "BadMockService" }
+  let(:good_service_id) { "MockService" }
+
+  let(:good_webservice) { Authentication::Webservice.new(
+    account:            account,
+    authenticator_name: 'authn-k8s',
+    service_id:         good_service_id
+  ) }
+
+  let(:k8s_resource_name) { "K8sResourceName" }
+  let(:k8s_resource_value) { "K8sResourceValue" }
+  let(:k8s_resource_name_2) { "K8sResourceName2" }
+  let(:k8s_resource_value_2) { "K8sResourceValue2" }
+
+  let(:no_constraints) { {} }
+  let(:one_constraint_list) { [[k8s_resource_name, k8s_resource_value]] }
+  let(:two_constraints_list) { [[k8s_resource_name, k8s_resource_value], [k8s_resource_name_2, k8s_resource_value_2]] }
+
+  let(:spiffe_name) { "SpiffeName" }
+  let(:spiffe_namespace) { "SpiffeNamespace" }
+  let(:spiffe_id) { double("SpiffeId", :name => spiffe_name,
+                           :namespace        => spiffe_namespace) }
+  let(:pod_spec) { double("PodSpec") }
+  let(:pod) { double("Pod", :spec => pod_spec) }
+  let(:pod_request) { double("PodRequest", :k8s_host => k8s_host,
+                             :spiffe_id              => spiffe_id) }
+
+  let(:k8s_object_lookup_class) { double("K8sObjectLookup") }
+
+  let(:application_identity_class) { double("ApplicationIdentity") }
+
+  let(:dependencies) { { resource_repo:           double(),
+                         k8s_object_lookup_class: k8s_object_lookup_class,
+                         k8s_resolver:            k8s_resolver,
+                         application_identity_class:  application_identity_class } }
+
+  before(:each) do
+    allow(Resource).to receive(:[])
+                         .with(host_id)
+                         .and_return(host)
+
+    allow(Resource).to receive(:[])
+                         .with("#{account}:webservice:conjur/authn-k8s/#{good_service_id}")
+                         .and_return(good_webservice)
+    allow(Resource).to receive(:[])
+                         .with("#{account}:webservice:conjur/authn-k8s/#{bad_service_name}")
+                         .and_return(nil)
+
+    allow(Authentication::AuthnK8s::K8sObjectLookup)
+      .to receive(:new)
+            .and_return(k8s_object_lookup_class)
+
+    allow(Authentication::AuthnK8s::ApplicationIdentity)
+      .to receive(:new)
+            .and_return(application_identity_class)
+
+    allow(pod_request).to receive(:service_id).and_return(good_service_id)
+    allow(host_role).to receive(:allowed_to?)
+                          .with("authenticate", good_webservice)
+                          .and_return(true)
+    allow(k8s_object_lookup_class).to receive(:pod_by_name)
+                                        .with(spiffe_name, spiffe_namespace)
+                                        .and_return(pod)
+    allow(application_identity_class).to receive(:container_name)
+                                       .and_return(default_container_name)
+    allow(application_identity_class).to receive(:constraints)
+                                       .and_return(no_constraints)
+    allow(application_identity_class).to receive(:namespace)
+                                       .and_return(k8s_host_namespace)
+  end
+
+  context "invocation" do
+    subject(:validator) { Authentication::AuthnK8s::ValidateApplicationIdentity
+                            .new(dependencies: dependencies) }
+
+    context "when application identity namespace doesn't match the spiffe id namespace" do
+      before(:each) do
+        allow(application_identity_class).to receive(:namespace)
+                                           .and_return("WrongNamespace")
+      end
+
+      it "raises a NamespaceMismatch error" do
+        expected_message = /Namespace in SPIFFE ID 'SpiffeNamespace' must match namespace implied by application identity 'WrongNamespace'/
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }
+          .to raise_error(Errors::Authentication::AuthnK8s::NamespaceMismatch, expected_message)
+      end
+    end
+
+    context 'when namespace scoped' do
+      before(:each) do
+        allow(application_identity_class).to receive(:namespace_scoped?)
+                                           .and_return(true)
+      end
+
+      it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
+        allow(pod_spec).to receive(:initContainers)
+                             .and_return({})
+        allow(pod_spec).to receive(:containers)
+                             .and_return({})
+        allow(host_annotation_2).to receive(:values)
+                                      .and_return({ :name => k8s_authn_container_name })
+        allow(host_annotation_2).to receive(:[])
+                                      .with(:value)
+                                      .and_return(nil)
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
+        allow(pod_spec).to receive(:initContainers)
+                             .and_return({})
+        allow(pod_spec).to receive(:containers)
+                             .and_return({})
+        allow(host_annotation_2).to receive(:values)
+                                      .and_return({ :name => "notimportant" })
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'raises ContainerNotFound if initContainers is nil' do
+        allow(pod_spec).to receive(:initContainers)
+                             .and_return({})
+        allow(pod_spec).to receive(:containers)
+                             .and_return(nil)
+        allow(host_annotation_2).to receive(:values)
+                                      .and_return({ :name => "notimportant" })
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'raises ContainerNotFound if containers is nil' do
+        allow(pod_spec).to receive(:initContainers)
+                             .and_return(nil)
+        allow(pod_spec).to receive(:containers)
+                             .and_return({})
+        allow(host_annotation_2).to receive(:values)
+                                      .and_return({ :name => "notimportant" })
+
+        expected_message = /Container authenticator was not found for requesting pod/
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }
+          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+      end
+
+      it 'does not raise errors if all checks pass' do
+        allow(pod_spec).to receive(:initContainers)
+                             .and_return({})
+        allow(pod_spec).to receive(:containers)
+                             .and_return([double("Container1", :name => "notimportant"),
+                                          double("Container2", :name => container_name)])
+        allow(host_annotation_2).to receive(:values)
+                                      .and_return({ :name => k8s_authn_container_name })
+        allow(host_annotation_2).to receive(:[])
+                                      .with(:value)
+                                      .and_return(container_name)
+        allow(application_identity_class).to receive(:container_name)
+                                           .and_return(container_name)
+
+        expect { validator.(
+          host_id: host_id,
+            host_annotations: host_annotations,
+            service_id: good_service_id,
+            account: account,
+            spiffe_id: spiffe_id
+        ) }.to_not raise_error
+      end
+    end
+
+    context 'when not namespace scoped' do
+      let(:k8s_resolver_for_resource) { double("K8sResolverForResource") }
+      let(:k8s_resource) { double("K8sResource") }
+      let(:k8s_instantiated_resource) { double("K8sHostInstantiatedResource") }
+
+      before(:each) do
+        allow(application_identity_class).to receive(:namespace_scoped?)
+                                           .and_return(false)
+        allow(application_identity_class).to receive(:constraints)
+                                           .and_return(one_constraint_list)
+      end
+
+      context "when the resource in the application identity is not found" do
+        before(:each) do
+          allow(k8s_object_lookup_class).to receive(:find_object_by_name)
+                                              .with(k8s_resource_name, k8s_resource_value, k8s_host_namespace)
+                                              .and_return(nil)
+        end
+
+        it "raises K8sResourceNotFound" do
+          expected_message = /Kubernetes K8sResourceName K8sResourceValue not found in namespace SpiffeNamespace/
+          expect { validator.(
+            host_id: host_id,
+              host_annotations: host_annotations,
+              service_id: good_service_id,
+              account: account,
+              spiffe_id: spiffe_id
+          ) }
+            .to raise_error(Errors::Authentication::AuthnK8s::K8sResourceNotFound, expected_message)
+        end
+      end
+
+      context 'when the resource in the application identity is found' do
+        before(:each) do
+          allow(k8s_object_lookup_class).to receive(:find_object_by_name)
+                                              .with(k8s_resource_name, k8s_resource_value, k8s_host_namespace)
+                                              .and_return(k8s_resource)
+          allow(Authentication::AuthnK8s::K8sResolver).to receive(:for_resource)
+                                                            .with(k8s_resource_name)
+                                                            .and_return(k8s_resolver_for_resource)
+          allow(k8s_resolver_for_resource).to receive(:new)
+                                                .with(k8s_resource, pod, k8s_object_lookup_class)
+                                                .and_return(k8s_instantiated_resource)
+          allow(k8s_instantiated_resource).to receive(:validate_pod)
+                                                .and_return(false)
+        end
+
+        it 'raises error if pod metadata fails validation' do
+          expected_message = "PodValidationFailed"
+
+          allow(k8s_object_lookup_class)
+            .to receive(:find_object_by_name)
+                  .with(k8s_resource_name, k8s_resource_value, k8s_host_namespace)
+                  .and_raise(expected_message)
+
+          expect { validator.(
+            host_id: host_id,
+              host_annotations: host_annotations,
+              service_id: good_service_id,
+              account: account,
+              spiffe_id: spiffe_id
+          ) }.to raise_error(RuntimeError,
+                             expected_message)
+        end
+
+        it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
+          allow(pod_spec).to receive(:initContainers)
+                               .and_return({})
+          allow(pod_spec).to receive(:containers)
+                               .and_return({})
+          allow(host_annotation_2).to receive(:values)
+                                        .and_return({ :name => k8s_authn_container_name })
+          allow(host_annotation_2).to receive(:[])
+                                        .with(:value)
+                                        .and_return(nil)
+
+          expected_message = /Container authenticator was not found for requesting pod/
+          expect { validator.(
+            host_id: host_id,
+              host_annotations: host_annotations,
+              service_id: good_service_id,
+              account: account,
+              spiffe_id: spiffe_id
+          ) }
+            .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+        end
+
+        it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
+          allow(pod_spec).to receive(:initContainers)
+                               .and_return({})
+          allow(pod_spec).to receive(:containers)
+                               .and_return({})
+          allow(host_annotation_2).to receive(:values)
+                                        .and_return({ :name => "notimportant" })
+
+          expected_message = /Container authenticator was not found for requesting pod/
+          expect { validator.(
+            host_id: host_id,
+              host_annotations: host_annotations,
+              service_id: good_service_id,
+              account: account,
+              spiffe_id: spiffe_id
+          ) }
+            .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
+        end
+
+        it 'does not raise errors if all checks pass' do
+          allow(pod_spec).to receive(:initContainers)
+                               .and_return({})
+          allow(pod_spec).to receive(:containers)
+                               .and_return([double("Container1", :name => "notimportant"),
+                                            double("Container2", :name => container_name)])
+          allow(host_annotation_2).to receive(:values)
+                                        .and_return({ :name => k8s_authn_container_name })
+          allow(host_annotation_2).to receive(:[])
+                                        .with(:value)
+                                        .and_return(container_name)
+          allow(application_identity_class).to receive(:container_name)
+                                             .and_return(container_name)
+
+          begin
+            validator.(
+              host_id: host_id,
+                host_annotations: host_annotations,
+                service_id: good_service_id,
+                account: account,
+                spiffe_id: spiffe_id
+            )
+          rescue => err
+            puts err
+          end
+
+          expect { validator.(
+            host_id: host_id,
+              host_annotations: host_annotations,
+              service_id: good_service_id,
+              account: account,
+              spiffe_id: spiffe_id
+          ) }.to_not raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
                                       .with(:value)
                                       .and_return(nil)
 
-        expected_message = /Container authenticator was not found for requesting pod/
+        expected_message = /Container authenticator was not found in the pod/
         expect { validator.(
           host_id: host_id,
             host_annotations: host_annotations,
@@ -159,7 +159,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
         allow(host_annotation_2).to receive(:values)
                                       .and_return({ :name => "notimportant" })
 
-        expected_message = /Container authenticator was not found for requesting pod/
+        expected_message = /Container authenticator was not found in the pod/
         expect { validator.(
           host_id: host_id,
             host_annotations: host_annotations,
@@ -178,7 +178,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
         allow(host_annotation_2).to receive(:values)
                                       .and_return({ :name => "notimportant" })
 
-        expected_message = /Container authenticator was not found for requesting pod/
+        expected_message = /Container authenticator was not found in the pod/
         expect { validator.(
           host_id: host_id,
             host_annotations: host_annotations,
@@ -197,7 +197,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
         allow(host_annotation_2).to receive(:values)
                                       .and_return({ :name => "notimportant" })
 
-        expected_message = /Container authenticator was not found for requesting pod/
+        expected_message = /Container authenticator was not found in the pod/
         expect { validator.(
           host_id: host_id,
             host_annotations: host_annotations,
@@ -280,12 +280,11 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
         end
 
         it 'raises error if pod metadata fails validation' do
-          expected_message = "PodValidationFailed"
-
+          validation_error_message = "PodValidationFailed"
           allow(k8s_object_lookup_class)
             .to receive(:find_object_by_name)
                   .with(k8s_resource_name, k8s_resource_value, k8s_host_namespace)
-                  .and_raise(expected_message)
+                  .and_raise(validation_error_message)
 
           expect { validator.(
             host_id: host_id,
@@ -294,7 +293,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
               account: account,
               spiffe_id: spiffe_id
           ) }.to raise_error(RuntimeError,
-                             expected_message)
+                             validation_error_message)
         end
 
         it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
@@ -308,7 +307,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
                                         .with(:value)
                                         .and_return(nil)
 
-          expected_message = /Container authenticator was not found for requesting pod/
+          expected_message = /Container authenticator was not found in the pod/
           expect { validator.(
             host_id: host_id,
               host_annotations: host_annotations,
@@ -327,7 +326,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
           allow(host_annotation_2).to receive(:values)
                                         .and_return({ :name => "notimportant" })
 
-          expected_message = /Container authenticator was not found for requesting pod/
+          expected_message = /Container authenticator was not found in the pod/
           expect { validator.(
             host_id: host_id,
               host_annotations: host_annotations,

--- a/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_application_identity_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Authentication::AuthnK8s::ValidateApplicationIdentity do
 
   let(:application_identity_class) { double("ApplicationIdentity") }
 
-  let(:dependencies) { { resource_repo:           double(),
+  let(:dependencies) { { resource_class:           double(),
                          k8s_object_lookup_class: k8s_object_lookup_class,
                          k8s_resolver:            k8s_resolver,
                          application_identity_class:  application_identity_class } }

--- a/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
 
   let(:validate_application_identity) { double("ValidateApplicationIdentity") }
 
-  let(:dependencies) { { resource_repo:             double(),
+  let(:dependencies) { { resource_class:             double(),
                          k8s_object_lookup_class:   k8s_object_lookup_class,
                          validate_application_identity: validate_application_identity } }
 

--- a/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
@@ -7,66 +7,85 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
 
   let(:error_template) { "An error occured" }
 
-  let(:k8s_resolver) { double("K8sResolver") }
-
   let(:account) { "SomeAccount" }
 
   let(:host_id) { "HostId" }
   let(:host_role) { double("HostRole", :id => host_id) }
 
-  let(:k8s_authn_container_name) { 'kubernetes/authentication-container-name' }
   let(:host_annotation_1) { double("Annot1", :values => { :name => "first" }) }
   let(:host_annotation_2) { double("Annot2") }
 
-  let(:host_annotations) { [ host_annotation_1, host_annotation_2 ] }
+  let(:host_annotations) { [host_annotation_1, host_annotation_2] }
 
   let(:host) { double("Host", :role => host_role,
-                              :annotations => host_annotations) }
+                      :annotations  => host_annotations) }
 
   let(:k8s_host_object) { "K8sHostObject" }
   let(:k8s_host_namespace) { "K8sHostNamespace" }
   let(:k8s_host) { double("K8sHost", :account => account,
-                                     :conjur_host_id => host_id,
-                                     :namespace => k8s_host_namespace,
-                                     :object => k8s_host_object) }
-
-  let(:container_name) { "ContainerName" }
+                          :conjur_host_id     => host_id) }
 
   let(:bad_service_name) { "BadMockService" }
-  let(:good_service_name) { "MockService" }
+  let(:good_service_id) { "MockService" }
 
   let(:good_webservice) { Authentication::Webservice.new(
-    account: account,
+    account:            account,
     authenticator_name: 'authn-k8s',
-    service_id: good_service_name
-  )}
+    service_id:         good_service_id
+  ) }
 
   let(:spiffe_name) { "SpiffeName" }
   let(:spiffe_namespace) { "SpiffeNamespace" }
   let(:spiffe_id) { double("SpiffeId", :name => spiffe_name,
-                                       :namespace => spiffe_namespace) }
+                           :namespace        => spiffe_namespace) }
   let(:pod_request) { double("PodRequest", :k8s_host => k8s_host,
-                                           :spiffe_id => spiffe_id) }
+                             :spiffe_id              => spiffe_id) }
+  let(:pod_spec) { double("PodSpec") }
+  let(:pod) { double("Pod", :spec => pod_spec) }
+  
+  let(:k8s_object_lookup_class) { double("K8sObjectLookup") }
 
-  let(:dependencies) { { resource_repo: double(),
-                         k8s_resolver: k8s_resolver } }
+  let(:validate_application_identity) { double("ValidateApplicationIdentity") }
+
+  let(:dependencies) { { resource_repo:             double(),
+                         k8s_object_lookup_class:   k8s_object_lookup_class,
+                         validate_application_identity: validate_application_identity } }
 
   before(:each) do
     allow(Resource).to receive(:[])
-      .with(host_id)
-      .and_return(host)
+                         .with(host_id)
+                         .and_return(host)
 
     allow(Resource).to receive(:[])
-      .with("#{account}:webservice:conjur/authn-k8s/#{good_service_name}")
-      .and_return(good_webservice)
+                         .with("#{account}:webservice:conjur/authn-k8s/#{good_service_id}")
+                         .and_return(good_webservice)
     allow(Resource).to receive(:[])
-      .with("#{account}:webservice:conjur/authn-k8s/#{bad_service_name}")
-      .and_return(nil)
+                         .with("#{account}:webservice:conjur/authn-k8s/#{bad_service_name}")
+                         .and_return(nil)
+
+    allow(pod_request).to receive(:service_id).and_return(good_service_id)
+    allow(host_role).to receive(:allowed_to?)
+                          .with("authenticate", good_webservice)
+                          .and_return(true)
+
+    allow(k8s_object_lookup_class).to receive(:pod_by_name)
+                                        .with(spiffe_name, spiffe_namespace)
+                                        .and_return(pod)
+
+    allow(Authentication::AuthnK8s::K8sObjectLookup)
+      .to receive(:new)
+            .and_return(k8s_object_lookup_class)
+
+    allow(Authentication::AuthnK8s::ValidateApplicationIdentity)
+      .to receive(:new)
+            .and_return(validate_application_identity)
+    allow(validate_application_identity).to receive(:call)
+                                          .and_return(true)
   end
 
   context "invocation" do
     subject(:validator) { Authentication::AuthnK8s::ValidatePodRequest
-      .new(dependencies: dependencies) }
+                            .new(dependencies: dependencies) }
 
     it 'raises WebserviceNotFound error when webservice is missing' do
       allow(pod_request).to receive(:service_id).and_return(bad_service_name)
@@ -77,25 +96,25 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
     end
 
     it 'raises HostNotAuthorized when host is not allowed to authenticate to service' do
-      allow(pod_request).to receive(:service_id).and_return(good_service_name)
+      allow(pod_request).to receive(:service_id).and_return(good_service_id)
       allow(host_role).to receive(:allowed_to?)
-        .with("authenticate", good_webservice)
-        .and_return(false)
+                            .with("authenticate", good_webservice)
+                            .and_return(false)
 
-      expected_message = /'#{host_id}' does not have 'authenticate' privilege on #{good_service_name}/
+      expected_message = /'#{host_id}' does not have 'authenticate' privilege on #{good_service_id}/
 
       expect { validator.(pod_request: pod_request) }
         .to raise_error(Errors::Authentication::AuthnK8s::HostNotAuthorized, expected_message)
     end
 
     it 'raises PodNotFound when pod is not known' do
-      allow(pod_request).to receive(:service_id).and_return(good_service_name)
+      allow(pod_request).to receive(:service_id).and_return(good_service_id)
       allow(host_role).to receive(:allowed_to?)
-        .with("authenticate", good_webservice)
-        .and_return(true)
-      allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
-        .with(spiffe_name, spiffe_namespace)
-        .and_return(nil)
+                            .with("authenticate", good_webservice)
+                            .and_return(true)
+      allow(k8s_object_lookup_class).to receive(:pod_by_name)
+                                          .with(spiffe_name, spiffe_namespace)
+                                          .and_return(nil)
 
       expected_message = /CONJ00024E.*'#{spiffe_name}'.*'#{spiffe_namespace}'/
 
@@ -103,215 +122,12 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
         .to raise_error(Errors::Authentication::AuthnK8s::PodNotFound, expected_message)
     end
 
-    context 'when namespace scoped' do
-      let (:pod_spec) { double("PodSpec") }
-      let (:pod) { double("Pod", :spec => pod_spec) }
+    it 'raises an error when application identity validation fails' do
+      allow(validate_application_identity).to receive(:call)
+                                            .and_raise('FAKE_application_identity_ERROR')
 
-      before(:each) do
-        allow(pod_request).to receive(:service_id).and_return(good_service_name)
-        allow(host_role).to receive(:allowed_to?)
-          .with("authenticate", good_webservice)
-          .and_return(true)
-        allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
-          .with(spiffe_name, spiffe_namespace)
-          .and_return(pod)
-        allow(k8s_host).to receive(:namespace_scoped?)
-          .and_return(true)
-      end
-
-      it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
-        allow(pod_spec).to receive(:initContainers)
-          .and_return({})
-        allow(pod_spec).to receive(:containers)
-          .and_return({})
-        allow(host_annotation_2).to receive(:values)
-          .and_return({ :name => k8s_authn_container_name })
-        allow(host_annotation_2).to receive(:[])
-          .with(:value)
-          .and_return(nil)
-
-        expected_message = /Container authenticator was not found for requesting pod/
-        expect { validator.(pod_request: pod_request) }
-          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-      end
-
-      it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
-        allow(pod_spec).to receive(:initContainers)
-          .and_return({})
-        allow(pod_spec).to receive(:containers)
-          .and_return({})
-        allow(host_annotation_2).to receive(:values)
-          .and_return({ :name => "notimportant" })
-
-        expected_message = /Container authenticator was not found for requesting pod/
-        expect { validator.(pod_request: pod_request) }
-          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-      end
-
-      it 'raises ContainerNotFound if initContainers is nil' do
-        allow(pod_spec).to receive(:initContainers)
-          .and_return({})
-        allow(pod_spec).to receive(:containers)
-          .and_return(nil)
-        allow(host_annotation_2).to receive(:values)
-          .and_return({ :name => "notimportant" })
-
-        expected_message = /Container authenticator was not found for requesting pod/
-        expect { validator.(pod_request: pod_request) }
-          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-      end
-
-      it 'raises ContainerNotFound if containers is nil' do
-        allow(pod_spec).to receive(:initContainers)
-          .and_return(nil)
-        allow(pod_spec).to receive(:containers)
-          .and_return({})
-        allow(host_annotation_2).to receive(:values)
-          .and_return({ :name => "notimportant" })
-
-        expected_message = /Container authenticator was not found for requesting pod/
-        expect { validator.(pod_request: pod_request) }
-          .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-      end
-
-      it 'does not raise errors if all checks pass' do
-        allow(pod_spec).to receive(:initContainers)
-          .and_return({})
-        allow(pod_spec).to receive(:containers)
-          .and_return([ double("Container1", :name => "notimportant"),
-                        double("Container2", :name => container_name) ])
-        allow(host_annotation_2).to receive(:values)
-          .and_return({ :name => k8s_authn_container_name })
-        allow(host_annotation_2).to receive(:[])
-          .with(:value)
-          .and_return(container_name)
-
-        expect { validator.(pod_request: pod_request) }.to_not raise_error
-      end
-    end
-
-    context 'when not namespace scoped' do
-      let (:pod_spec) { double("PodSpec") }
-      let (:pod) { double("Pod", :spec => pod_spec) }
-      let (:k8s_host_controller) { "K8sHostController" }
-
-      before(:each) do
-        allow(pod_request).to receive(:service_id).and_return(good_service_name)
-        allow(host_role).to receive(:allowed_to?)
-          .with("authenticate", good_webservice)
-          .and_return(true)
-        allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup).to receive(:pod_by_name)
-          .with(spiffe_name, spiffe_namespace)
-          .and_return(pod)
-        allow(k8s_host).to receive(:namespace_scoped?)
-          .and_return(false)
-        allow(k8s_host).to receive(:controller)
-          .and_return(k8s_host_controller)
-      end
-
-      it 'raises ScopeNotSupported if host is not in permitted scope' do
-        allow(k8s_host).to receive(:permitted_scope?)
-          .and_return(false)
-
-        expected_message = /Resource type '#{k8s_host_controller}' identity scope is not supported in this version of authn-k8s/
-        expect { validator.(pod_request: pod_request) }
-          .to raise_error(Errors::Authentication::AuthnK8s::ScopeNotSupported, expected_message)
-      end
-
-      context 'in permitted scope' do
-        let (:k8s_resolver_for_controller) { double("K8sResoverForController") }
-        let (:k8s_host_controller_object) { double("K8sHostControllerObject") }
-        let (:k8s_host_instantiated_controller) { double("K8sHostInstantiatedController") }
-
-        before(:each) do
-          allow(k8s_host).to receive(:permitted_scope?)
-            .and_return(true)
-          allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup).to receive(:find_object_by_name)
-            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
-            .and_return(k8s_host_controller_object)
-          allow(Authentication::AuthnK8s::K8sResolver).to receive(:for_controller)
-            .with(k8s_host_controller)
-            .and_return(k8s_resolver_for_controller)
-          allow(k8s_resolver_for_controller).to receive(:new)
-            .with(k8s_host_controller_object, pod, Authentication::AuthnK8s::K8sObjectLookup)
-            .and_return(k8s_host_instantiated_controller)
-          allow(k8s_host_instantiated_controller).to receive(:validate_pod)
-            .and_return(false)
-        end
-
-        it 'raises ControllerNotFound if controller object cannot be found' do
-          allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup)
-            .to receive(:find_object_by_name)
-            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
-            .and_return(nil)
-
-          expected_message = /Kubernetes K8sHostController K8sHostObject not found in namespace K8sHostNamespace/
-          expect { validator.(pod_request: pod_request) }
-            .to raise_error(Errors::Authentication::AuthnK8s::ControllerNotFound, expected_message)
-        end
-
-        it 'raises error if pod metadata fails validation' do
-          expected_message = "PodValidationFailed"
-
-          allow_any_instance_of(Authentication::AuthnK8s::K8sObjectLookup)
-            .to receive(:find_object_by_name)
-            .with(k8s_host_controller, k8s_host_object, k8s_host_namespace)
-            .and_raise(expected_message)
-
-          expect { validator.(pod_request: pod_request) }.to raise_error(RuntimeError,
-                                                                         expected_message)
-        end
-
-        it 'raises ContainerNotFound if container cannot be found and container name is defaulted' do
-          allow(pod_spec).to receive(:initContainers)
-            .and_return({})
-          allow(pod_spec).to receive(:containers)
-            .and_return({})
-          allow(host_annotation_2).to receive(:values)
-            .and_return({ :name => k8s_authn_container_name })
-          allow(host_annotation_2).to receive(:[])
-            .with(:value)
-            .and_return(nil)
-
-          expected_message = /Container authenticator was not found for requesting pod/
-          expect { validator.(pod_request: pod_request) }
-            .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-        end
-
-        it 'raises ContainerNotFound if container cannot be found and container name annotation is missing' do
-          allow(pod_spec).to receive(:initContainers)
-            .and_return({})
-          allow(pod_spec).to receive(:containers)
-            .and_return({})
-          allow(host_annotation_2).to receive(:values)
-            .and_return({ :name => "notimportant" })
-
-          expected_message = /Container authenticator was not found for requesting pod/
-          expect { validator.(pod_request: pod_request) }
-            .to raise_error(Errors::Authentication::AuthnK8s::ContainerNotFound, expected_message)
-        end
-
-        it 'does not raise errors if all checks pass' do
-          allow(pod_spec).to receive(:initContainers)
-            .and_return({})
-          allow(pod_spec).to receive(:containers)
-            .and_return([ double("Container1", :name => "notimportant"),
-                          double("Container2", :name => container_name) ])
-          allow(host_annotation_2).to receive(:values)
-            .and_return({ :name => k8s_authn_container_name })
-          allow(host_annotation_2).to receive(:[])
-            .with(:value)
-            .and_return(container_name)
-
-          begin
-            validator.(pod_request: pod_request)
-          rescue => err
-            puts err
-          end
-
-          expect { validator.(pod_request: pod_request) }.to_not raise_error
-        end
-      end
+      expect { validator.(pod_request: pod_request) }
+        .to raise_error(/FAKE_application_identity_ERROR/)
     end
   end
 end

--- a/spec/app/domain/conjur/fetch_required_secrets_spec.rb
+++ b/spec/app/domain/conjur/fetch_required_secrets_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Conjur::FetchRequiredSecrets' do
 
   def fetch_secrets(repo)
     Conjur::FetchRequiredSecrets
-      .new(resource_repo: repo)
+      .new(resource_class: repo)
       .(resource_ids: ['resource1', 'resource2'])
   end
 


### PR DESCRIPTION
#### What does this PR do?
Prior to this commit, the application identity (formerly known as `machine identity`)
was defined only in the host id. This commit enables users to define the application identity
in the host's annotations.

As part of this PR, the application identity is not extracted from
the CSR (that has the host id in it) but is extracted from either the
host's annotation or the host id.

#### What ticket does this PR close?
Connected to #1244 
