### PR TITLE
Add ability to test log output in GKE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,10 @@
 # 
 cucumber
 
-# Make an exception for kubernetes, though
+# Make an exception for kubernetes features and its required helpers
 !cucumber/kubernetes/features
+!cucumber/api/features/support/logs_helpers.rb
+!cucumber/api/features/step_definitions/logs_steps.rb
 
 *.deb
 .git

--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -93,10 +93,15 @@ spec:
         volumeMounts:
           - mountPath: /run/authn-local
             name: authn-local
+          - mountPath: /opt/conjur-server/log
+            name: conjur-log
       volumes:
         - name: authn-local
           emptyDir:
             medium: Memory
+        - name: conjur-log
+          persistentVolumeClaim:
+            claimName: conjur-log-pv-claim
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -127,6 +132,14 @@ spec:
           value: test
         - name: CONJUR_AUTHN_K8S_TEST_NAMESPACE
           value: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        volumeMounts:
+          # We mount the log to this path so logs_helpers.rb will work seamlessly
+          - mountPath: /src/conjur-server/log
+            name: conjur-log
+      volumes:
+        - name: conjur-log
+          persistentVolumeClaim:
+            claimName: conjur-log-pv-claim
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/ci/authn-k8s/dev/dev_conjur_log_volume.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur_log_volume.template.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ LOG_VOLUME_NAME }}
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/tmp/conjur-log"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: conjur-log-pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
#### What does this PR do?
In order to test log output in our GKE tests we first need to:
1. Create a PersistentVolume & a PersistentVolumeClaim so we have
   a shared volume between the Conjur & Cucumber deployments. This
   enables us to run tests in cucumber that read the Conjur log.
2. Add the logs helper files to the docker image so they are present
   in the cucumber container.