### PR TITLE
Read log file of the current environment

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       CONJUR_ADMIN_PASSWORD: admin
       CONJUR_ACCOUNT: cucumber
       CONJUR_DATA_KEY:
-      RAILS_ENV:
+      RAILS_ENV: test
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
       CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-config/env

--- a/cucumber/api/features/support/logs_helpers.rb
+++ b/cucumber/api/features/support/logs_helpers.rb
@@ -2,14 +2,14 @@
 
 # Utility methods for Logs steps
 #
-# In order to be able validating messages in the conjur server log,
+# In order to be able to validate messages in the conjur server log,
 # we chose to filter the log by save points instead of zeroing out the log,
 # due to the following reasons:
 # 1. save the log content for troubleshooting
 # 2. be able to parallelize the tests in the future
 #
 module LogsHelpers
-  LOG_LOCATION = "/src/conjur-server/log/development.log"
+  LOG_LOCATION = "/src/conjur-server/log/#{ENV['RAILS_ENV']}.log"
 
   def num_log_lines
     File.new(LOG_LOCATION).readlines.size


### PR DESCRIPTION
Before this commit we always read the `development.log` file.
In order to read the file when running in test env we need to
extract the filename from the env.