### PR TITLE
Root-based hosts can authenticate with k8s

### DIFF
--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -112,7 +112,13 @@ module Authentication
       end
 
       def host_id_suffix
-        @host_id_suffix ||= @host_id.split('/').last(3)
+        @host_id_suffix ||= hostname.split('/').last(3)
+      end
+
+      # Return the last part of the host id (which is the actual hostname).
+      # The host id is build as "account_name:kind:identifier" (e.g "org:host:some_hostname").
+      def hostname
+        @hostname ||= @host_id.split(':')[2]
       end
 
       def validate_permitted_annotations

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -60,7 +60,10 @@ module Authentication
       # contains the full host-id.
       def update_csr_common_name
         prefix = @host_id_prefix.nil? || @host_id_prefix.empty? ? apps_host_id_prefix : @host_id_prefix
-        smart_csr.common_name = prefix + "." + smart_csr.common_name
+        full_host_name = prefix + "." + smart_csr.common_name
+
+        Rails.logger.debug(Log::SetCommonName.new(full_host_name))
+        smart_csr.common_name = full_host_name
       end
 
       def apps_host_id_prefix

--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -38,7 +38,9 @@ module Authentication
       end
 
       def conjur_host_id
-        "#{@account}:" + @common_name.k8s_host_name.sub('host/', 'host:')
+        host_id = "#{@account}:" + @common_name.k8s_host_name.sub('host/', 'host:')
+        Rails.logger.debug(Log::HostIdFromCommonName.new(host_id))
+        host_id
       end
     end
   end

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -70,10 +70,6 @@ module Authentication
         @k8s_object_lookup ||= @k8s_object_lookup_class.new(webservice)
       end
 
-      def host
-        @host ||= @resource_class[k8s_host.conjur_host_id]
-      end
-
       # @return The Conjur resource for the webservice.
       def webservice
         @webservice ||= ::Authentication::Webservice.new(

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -12,7 +12,7 @@ module Authentication
 
     ValidatePodRequest = CommandClass.new(
       dependencies: {
-        resource_class:                 Resource,
+        resource_class:                Resource,
         k8s_object_lookup_class:       K8sObjectLookup,
         validate_application_identity: ValidateApplicationIdentity.new
       },

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -124,6 +124,16 @@ unless defined? LogMessages::Authentication::OriginValidated
           msg: "Validating host id {0}",
           code: "CONJ00026D"
         )
+
+        HostIdFromCommonName = ::Util::TrackableLogMessageClass.new(
+          msg: "Host id {0} extracted from CSR common name",
+          code: "CONJ00027D"
+        )
+
+        SetCommonName = ::Util::TrackableLogMessageClass.new(
+          msg: "Setting common name to {0-full-host-name}",
+          code: "CONJ00028D"
+        )
       end
     end
 

--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -197,3 +197,23 @@
 - !grant
   role: !group conjur/authn-k8s/minikube/clients
   member: !layer some-policy
+
+# Define hosts under root policy
+- &root-based-hosts
+  # Application identity defined in the host id
+  - !host
+    id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+    annotations:
+      kubernetes/authentication-container-name: authenticator
+
+  # Application identity defined in annotations
+  - !host
+    id: root-based-app
+    annotations:
+      authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+      authn-k8s/authentication-container-name: authenticator
+
+# Permit the hosts above to authenticate with authn-k8s
+- !grant
+  role: !group conjur/authn-k8s/minikube/clients
+  member: *root-based-hosts

--- a/cucumber/kubernetes/features/authenticate.feature
+++ b/cucumber/kubernetes/features/authenticate.feature
@@ -23,3 +23,7 @@ Feature: A permitted Conjur host can authenticate with a valid application ident
 
   Scenario: Authenticate using a certificate signed by a different CA
     Then I cannot authenticate with pod matching "pod/inventory-pod" as "service_account/inventory-pod-only" using a cert signed by a different CA
+
+  Scenario: Authenticate as a host defined under the root policy
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "@namespace@/*/*" with prefix "host"

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -25,3 +25,7 @@ Feature: A permitted Conjur host can login with a valid application identity
   Scenario: Authenticate as a DeploymentConfig.
     Given I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-deployment-cfg" with authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a host defined under the root policy
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "root-based-app" with prefix "host"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "root-based-app" with prefix "host"

--- a/cucumber/kubernetes/features/login.feature
+++ b/cucumber/kubernetes/features/login.feature
@@ -22,3 +22,6 @@ Feature: A permitted Conjur host can login with a valid application identity
 
   Scenario: Login with a custom prefix.
     Then I can login to authn-k8s as "@namespace@/pod/inventory-pod" with prefix "host/some-policy"
+
+  Scenario: Login with a host defined in the root policy
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"

--- a/cucumber/kubernetes/features/login_with_annotations.feature
+++ b/cucumber/kubernetes/features/login_with_annotations.feature
@@ -30,6 +30,9 @@ Feature: A permitted Conjur host can login with a valid application identity
   Scenario: Login as the namespace a pod belongs to when the constraint is on the authenticator.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-constraint" with prefix "host/some-policy"
 
+  Scenario: Login with a host defined in the root policy
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "root-based-app" with prefix "host"
+
   Scenario: it raises an error when logging in with a host that has an unsupported resource type
     Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/step_definitions/authenticate_steps.rb
+++ b/cucumber/kubernetes/features/step_definitions/authenticate_steps.rb
@@ -17,6 +17,8 @@ def gen_cert(host_id)
 end
 
 def authenticate_k8s(host, cert, key, conjur_id)
+  conjur_id = substitute!(conjur_id)
+
   RestClient::Resource.new(
     host,
     ssl_ca_file: './nginx.crt',

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
   include_context "running outside kubernetes"
 
+  let(:host_id_prefix) { "accountName:host:" }
+
   let(:namespace) { "K8sNamespace" }
 
   let(:k8s_resource_name) { "K8sResourceName" }
@@ -136,7 +138,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
     context "Application identity in host id" do
       let(:host_annotations) { [] }
-      let(:host_id) { "#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
@@ -161,7 +163,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
       context "with an invalid application identity" do
         context "where the id isn't a 3 part string" do
-          let(:host_id) { "HostId" }
+          let(:host_id) { "#{host_id_prefix}HostId" }
 
           it "raises an error" do
             expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
@@ -179,7 +181,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     end
 
     context "Application identity in annotations" do
-      let(:host_id) { "HostId" }
+      let(:host_id) { "#{host_id_prefix}HostId" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
@@ -486,7 +488,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     context "Application identity in host id and in annotations" do
       let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
       let(:k8s_resource_name) { "service_account" }
-      let(:host_id) { "#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       before(:each) do
         allow(namespace_annotation).to receive(:[])


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where hosts that are defined in the root policy were not
able to authenticate with k8s.

This PR also adds tests for such hosts.