### PR TITLE
Raise proper error if host is nil

### DIFF
--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -73,6 +73,8 @@ module Authentication
 
       def host
         @host ||= @resource_class[k8s_host.conjur_host_id]
+        raise Err::HostNotFound(k8s_host.conjur_host_id) if @host.nil?
+        @host
       end
 
       def pod


### PR DESCRIPTION
In case the host was nil then we got some
`NoMethodError: undefined method 'role' for nil:NilClass`. This Commit
raises a proper error so it is easier to fix issues around this.