### PR TITLE
Refactor AuthenticatorInput's password field

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -76,12 +76,12 @@ class AuthenticateController < ApplicationController
   def authenticator_input
     Authentication::AuthenticatorInput.new(
       authenticator_name: params[:authenticator],
-      service_id: params[:service_id],
-      account: params[:account],
-      username: params[:id],
-      password: request.body.read,
-      origin: request.ip,
-      request: request
+      service_id:         params[:service_id],
+      account:            params[:account],
+      username:           params[:id],
+      request_body:       request.body.read,
+      origin:             request.ip,
+      request:            request
     )
   end
 
@@ -97,12 +97,12 @@ class AuthenticateController < ApplicationController
   def oidc_authenticator_input
     Authentication::AuthenticatorInput.new(
       authenticator_name: 'authn-oidc',
-      service_id: params[:service_id],
-      account: params[:account],
-      username: nil,
-      password: nil,
-      origin: request.ip,
-      request: request
+      service_id:         params[:service_id],
+      account:            params[:account],
+      username:           nil,
+      request_body:       nil,
+      origin:             request.ip,
+      request:            request
     )
   end
 

--- a/app/controllers/concerns/basic_authenticator.rb
+++ b/app/controllers/concerns/basic_authenticator.rb
@@ -40,7 +40,7 @@ module BasicAuthenticator
       service_id:         params[:service_id],
       account:            params[:account],
       username:           username,
-      password:           password,
+      request_body:       password,
       origin:             request.ip,
       request:            request
     )

--- a/app/domain/authentication/authenticator_input.rb
+++ b/app/domain/authentication/authenticator_input.rb
@@ -9,7 +9,7 @@ module Authentication
     attribute :service_id, ::Types::NonEmptyString.optional
     attribute :account, ::Types::NonEmptyString
     attribute :username, ::Types::NonEmptyString.optional
-    attribute :password, ::Types::String.optional
+    attribute :request_body, ::Types::String.optional
     attribute :origin, ::Types::NonEmptyString
     attribute :request, ::Types::Any
 

--- a/app/domain/authentication/authn/authenticator.rb
+++ b/app/domain/authentication/authn/authenticator.rb
@@ -20,7 +20,7 @@ module Authentication
         creds = credentials(input)
         return nil unless creds
 
-        success = creds.authenticate(input.password)
+        success = creds.authenticate(input.request_body)
         success ? creds.api_key : nil
       end
 
@@ -29,7 +29,7 @@ module Authentication
         creds = credentials(input)
         return nil unless creds
         
-        creds.valid_api_key?(input.password)
+        creds.valid_api_key?(input.request_body)
       end
 
       def credentials(input)

--- a/app/domain/authentication/authn_iam/authenticator.rb
+++ b/app/domain/authentication/authn_iam/authenticator.rb
@@ -15,7 +15,7 @@ module Authentication
       end
 
       def valid?(input)
-        signed_aws_headers = JSON.parse input.password # input.password is JSON holding the AWS signed headers
+        signed_aws_headers = JSON.parse input.request_body # input.request_body is JSON holding the AWS signed headers
 
         response_hash = identity_hash(response_from_signed_request(signed_aws_headers))
         trusted = response_hash != false

--- a/app/domain/authentication/authn_ldap/authenticator.rb
+++ b/app/domain/authentication/authn_ldap/authenticator.rb
@@ -23,7 +23,7 @@ module Authentication
 
       # Login the role using LDAP credentials
       def login(input)
-        login, password = input.username, input.password
+        login, password = input.username, input.request_body
 
         # Prevent anonymous LDAP authentication with username only
         return nil if password.blank?

--- a/design/AUTHENTICATORS.md
+++ b/design/AUTHENTICATORS.md
@@ -141,7 +141,7 @@ module Authentication
         #     input.service_id
         #     input.account
         #     input.username
-        #     input.password
+        #     input.request_body
         #
         # return either
         #   - a `string` containing the authentication key if successful
@@ -155,7 +155,7 @@ module Authentication
         #     input.service_id
         #     input.account
         #     input.username
-        #     input.password
+        #     input.request_body
         #
         # return true for valid credentials, false otherwise
       end

--- a/spec/app/domain/authentication/authenticate_spec.rb
+++ b/spec/app/domain/authentication/authenticate_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Authentication::Authenticate' do
         service_id:         nil,
         account:            'my-acct',
         username:           'my-user',
-        password:           'my-pw',
+        request_body:       'my-pw',
         origin:             '127.0.0.1',
         request:            nil
       )
@@ -105,7 +105,7 @@ RSpec.describe 'Authentication::Authenticate' do
           service_id:         nil,
           account:            'my-acct',
           username:           'my-user',
-          password:           'my-pw',
+          request_body:       'my-pw',
           origin:             '127.0.0.1',
           request:            nil
         )
@@ -133,7 +133,7 @@ RSpec.describe 'Authentication::Authenticate' do
           service_id:         nil,
           account:            'my-acct',
           username:           'my-user',
-          password:           'my-pw',
+          request_body:       'my-pw',
           origin:             '127.0.0.1',
           request:            nil
         )

--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe 'Authentication::Oidc' do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-oidc-test',
-            service_id: 'my-service',
-            account: 'my-acct',
-            username: nil,
-            password: nil,
-            origin: '127.0.0.1',
-            request: oidc_authenticate_id_token_request
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            request_body:       nil,
+            origin:             '127.0.0.1',
+            request:            oidc_authenticate_id_token_request
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(
@@ -102,12 +102,12 @@ RSpec.describe 'Authentication::Oidc' do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-oidc-test',
-            service_id: 'my-service',
-            account: 'my-acct',
-            username: nil,
-            password: nil,
-            origin: '127.0.0.1',
-            request: no_field_oidc_authenticate_id_token_request
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            request_body:       nil,
+            origin:             '127.0.0.1',
+            request:            no_field_oidc_authenticate_id_token_request
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(
@@ -131,12 +131,12 @@ RSpec.describe 'Authentication::Oidc' do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-oidc-test',
-            service_id: 'my-service',
-            account: 'my-acct',
-            username: nil,
-            password: nil,
-            origin: '127.0.0.1',
-            request: no_value_oidc_authenticate_id_token_request
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            request_body:       nil,
+            origin:             '127.0.0.1',
+            request:            no_value_oidc_authenticate_id_token_request
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(

--- a/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Authentication::AuthnIam::Authenticator do
 
   it "valid? with expired AWS headers" do
     subject = authenticator_instance
-    parameters = double('AuthenticationParameters', password: expired_aws_headers)
+    parameters = double('AuthenticationParameters', request_body: expired_aws_headers)
     expect{subject.valid?(parameters)}.to(
         raise_error(Errors::Authentication::AuthnIam::InvalidAWSHeaders)
     )

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
   let(:input) do
     ::Authentication::AuthenticatorInput.new(
       authenticator_name: 'ldap',
-      service_id: 'test',
-      account: 'test',
-      username: username,
-      password: password,
-      origin: '127.0.0.1',
-      request: nil
+      service_id:         'test',
+      account:            'test',
+      username:           username,
+      request_body:       password,
+      origin:             '127.0.0.1',
+      request:            nil
     )
   end
 


### PR DESCRIPTION
We would like to make this field more generic so it will
make sense in all of its uses. For example, in the authn-iam
authenticator, we use the AuthenticatorInput's password field
to extract the AWS headers which are located in the request's
body. Calling that field `password` just because the body happens
to include the password in `authn` and `authn-ldap` is wrong.
This will also be the case in `authn-azure` where the body
will have the Azure access token and not a password.