### PR TITLE
Generalize errors so they are consumed in all authenticators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Improved flows and rules around user creation
+- Kubernetes authenticator now returns 403 on unpermitted hosts instead of a 401
 
 ## [1.4.6] - 2020-01-21
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -130,8 +130,8 @@ class AuthenticateController < ApplicationController
     end
 
     case err
-    when Errors::Authentication::Security::NotWhitelisted,
-      Errors::Authentication::Security::ServiceNotDefined,
+    when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
+      Errors::Authentication::Security::WebserviceNotFound,
       Errors::Authentication::Security::AccountNotDefined
       raise Unauthorized
     else
@@ -146,9 +146,9 @@ class AuthenticateController < ApplicationController
     end
 
     case err
-    when Errors::Authentication::Security::NotWhitelisted,
-      Errors::Authentication::Security::ServiceNotDefined,
-      Errors::Authentication::Security::UserNotDefinedInConjur,
+    when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
+      Errors::Authentication::Security::WebserviceNotFound,
+      Errors::Authentication::Security::RoleNotFound,
       Errors::Authentication::Security::AccountNotDefined,
       Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty,
       Errors::Authentication::AuthnOidc::IdTokenVerifyFailed,
@@ -157,7 +157,7 @@ class AuthenticateController < ApplicationController
       Errors::Conjur::RequiredResourceMissing
       raise Unauthorized
 
-    when Errors::Authentication::Security::UserNotAuthorizedInConjur
+    when Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
       raise Forbidden
 
     when Errors::Authentication::RequestBody::MissingRequestParam
@@ -188,7 +188,7 @@ class AuthenticateController < ApplicationController
     }
 
     status_code = case error
-                  when Errors::Authentication::Security::UserNotAuthorizedInConjur
+                  when Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
                     :forbidden
                   when Errors::Authentication::StatusNotImplemented
                     :not_implemented

--- a/app/controllers/concerns/basic_authenticator.rb
+++ b/app/controllers/concerns/basic_authenticator.rb
@@ -19,7 +19,7 @@ module BasicAuthenticator
       raise ApplicationController::Unauthorized, "Invalid username or password"
     rescue Errors::Authentication::InvalidOrigin
       raise ApplicationController::Forbidden, "User is not authorized to login from the current origin"
-    rescue Errors::Authentication::Security::UserNotAuthorizedInConjur
+    rescue Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
       raise ApplicationController::Forbidden, "User is not authorized to login to Conjur"
     end
   end

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -6,8 +6,9 @@ module Authentication
   module AuthnK8s
 
     Err = Errors::Authentication::AuthnK8s
+    SecurityErr = Errors::Authentication::Security
     # Possible Errors Raised:
-    # WebserviceNotFound, HostNotAuthorized, PodNotFound
+    # WebserviceNotFound, RoleNotAuthorizedOnWebservice, PodNotFound
     # ContainerNotFound, ScopeNotSupported, K8sResourceNotFound
 
     ValidatePodRequest = CommandClass.new(
@@ -32,12 +33,12 @@ module Authentication
       private
 
       def validate_webservice_exists
-        raise Err::WebserviceNotFound, service_id unless webservice.resource
+        raise SecurityErr::WebserviceNotFound, service_id unless webservice.resource
       end
 
       def validate_host_can_access_service
         return if host_can_access_service?
-        raise Err::HostNotAuthorized.new(host.role.id, service_id)
+        raise SecurityErr::RoleNotAuthorizedOnWebservice.new(host.role.id, service_id)
       end
 
       def validate_pod_exists
@@ -73,7 +74,7 @@ module Authentication
 
       def host
         @host ||= @resource_class[k8s_host.conjur_host_id]
-        raise Err::HostNotFound(k8s_host.conjur_host_id) if @host.nil?
+        raise SecurityErr::RoleNotFound(k8s_host.conjur_host_id) if @host.nil?
         @host
       end
 

--- a/app/domain/authentication/validate_security.rb
+++ b/app/domain/authentication/validate_security.rb
@@ -9,8 +9,8 @@ module Authentication
   module Security
 
     # Possible Errors Raised:
-    # AccountNotDefined, ServiceNotDefined, NotWhitelisted,
-    # UserNotDefinedInConjur, UserNotAuthorizedInConjur
+    # AccountNotDefined, WebserviceNotFound, AuthenticatorNotWhitelisted,
+    # RoleNotFound, RoleNotAuthorizedOnWebservice
 
     ValidateSecurity = CommandClass.new(
       dependencies: {

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -9,8 +9,8 @@ module Authentication
 
   # Possible Errors Raised:
   # AuthenticatorNotFound, StatusNotImplemented, AccountNotDefined
-  # ServiceNotDefined, UserNotDefinedInConjur, UserNotAuthorizedInConjur,
-  # NotWhitelisted
+  # WebserviceNotFound, RoleNotFound, RoleNotAuthorizedOnWebservice,
+  # AuthenticatorNotWhitelisted
 
   ValidateStatus = CommandClass.new(
     dependencies: {

--- a/app/domain/authentication/validate_webservice_access.rb
+++ b/app/domain/authentication/validate_webservice_access.rb
@@ -11,8 +11,8 @@ module Authentication
     Log = LogMessages::Authentication::Security
     Err = Errors::Authentication::Security
     # Possible Errors Raised:
-    # AccountNotDefined, ServiceNotDefined,
-    # UserNotDefinedInConjur, UserNotAuthorizedInConjur
+    # AccountNotDefined, WebserviceNotFound,
+    # RoleNotFound, RoleNotAuthorizedOnWebservice
 
     ValidateWebserviceAccess = CommandClass.new(
       dependencies: {
@@ -56,7 +56,7 @@ module Authentication
       end
 
       def validate_user_is_defined
-        raise Err::UserNotDefinedInConjur, @user_id unless user_role
+        raise Err::RoleNotFound, @user_id unless user_role
       end
 
       def validate_user_has_access
@@ -65,7 +65,7 @@ module Authentication
         unless has_access
           @logger.debug(Log::UserNotAuthorized
                           .new(@user_id, webservice_resource_id))
-          raise Err::UserNotAuthorizedInConjur, @user_id
+          raise Err::RoleNotAuthorizedOnWebservice.new(@user_id, webservice_resource_id)
         end
       end
 

--- a/app/domain/authentication/validate_webservice_exists.rb
+++ b/app/domain/authentication/validate_webservice_exists.rb
@@ -8,7 +8,7 @@ module Authentication
 
     Err = Errors::Authentication::Security
     # Possible Errors Raised:
-    # AccountNotDefined, ServiceNotDefined
+    # AccountNotDefined, WebserviceNotFound
 
     ValidateWebserviceExists = CommandClass.new(
       dependencies: {
@@ -41,7 +41,7 @@ module Authentication
       end
 
       def validate_webservice_exists
-        raise Err::ServiceNotDefined, @webservice.name unless webservice_resource
+        raise Err::WebserviceNotFound, @webservice.name unless webservice_resource
       end
 
       def webservice_resource

--- a/app/domain/authentication/validate_whitelisted_webservice.rb
+++ b/app/domain/authentication/validate_whitelisted_webservice.rb
@@ -9,7 +9,7 @@ module Authentication
 
     Err = Errors::Authentication::Security
     # Possible Errors Raised:
-    # AccountNotDefined, NotWhitelisted
+    # AccountNotDefined, AuthenticatorNotWhitelisted
 
     ValidateWhitelistedWebservice = CommandClass.new(
       dependencies: {
@@ -43,7 +43,7 @@ module Authentication
 
       def validate_webservice_is_whitelisted
         is_whitelisted = whitelisted_webservices.include?(@webservice)
-        raise Err::NotWhitelisted, @webservice.name unless is_whitelisted
+        raise Err::AuthenticatorNotWhitelisted, @webservice.name unless is_whitelisted
       end
 
       def whitelisted_webservices

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -240,11 +240,6 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00034E"
         )
 
-        MissingEnvVar = ::Util::TrackableErrorClass.new(
-          msg: "Expected ENV variable '{0}' is not set",
-          code: "CONJ00035E"
-        )
-
         UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
           msg: "Unknown Kubernetes resource type '{0}'",
           code: "CONJ00041E"

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -73,23 +73,23 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       module Security
 
-        NotWhitelisted = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not whitelisted in CONJUR_AUTHENTICATORS",
+        AuthenticatorNotWhitelisted = ::Util::TrackableErrorClass.new(
+          msg: "'{0-authenticator-name}' is not enabled",
           code: "CONJ00004E"
         )
 
-        ServiceNotDefined = ::Util::TrackableErrorClass.new(
-          msg: "Webservice '{0-webservice-name}' is not defined in the Conjur policy",
+        WebserviceNotFound = ::Util::TrackableErrorClass.new(
+          msg: "Webservice '{0-webservice-name}' wasn't found",
           code: "CONJ00005E"
         )
 
-        UserNotAuthorizedInConjur = ::Util::TrackableErrorClass.new(
-          msg: "User '{0-user-name}' is not authorized in the Conjur policy",
+        RoleNotAuthorizedOnWebservice = ::Util::TrackableErrorClass.new(
+          msg: "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
           code: "CONJ00006E"
         )
 
-        UserNotDefinedInConjur = ::Util::TrackableErrorClass.new(
-          msg: "User '{0-user-name}' is not defined in Conjur",
+        RoleNotFound = ::Util::TrackableErrorClass.new(
+          msg: "'{0-role-name}' wasn't found",
           code: "CONJ00007E"
         )
 
@@ -163,21 +163,6 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       end
 
       module AuthnK8s
-
-        WebserviceNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Webservice '{0-webservice-name}' wasn't found",
-          code: "CONJ00019E"
-        )
-
-        HostNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Host '{0-host-name}' wasn't found",
-          code: "CONJ00020E"
-        )
-
-        HostNotAuthorized = ::Util::TrackableErrorClass.new(
-          msg: "'{0-hostname}' does not have 'authenticate' privilege on {1-service-name}",
-          code: "CONJ00021E"
-        )
 
         CSRIsMissingSpiffeId = ::Util::TrackableErrorClass.new(
           msg: 'CSR must contain SPIFFE ID SAN',

--- a/cucumber/authenticators/features/authn_config.feature
+++ b/cucumber/authenticators/features/authn_config.feature
@@ -96,7 +96,7 @@ Feature: Authenticator configuration
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::ServiceNotDefined
+    Errors::Authentication::Security::WebserviceNotFound
     """
 
   Scenario: Authenticated user can not update authenticator
@@ -110,7 +110,7 @@ Feature: Authenticator configuration
     And authenticator "cucumber:webservice:conjur/authn-config/db" is disabled
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::UserNotAuthorizedInConjur
+    Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
     """
 
   Scenario: Nested webservice can not be configured

--- a/cucumber/authenticators/features/authn_oidc.feature
+++ b/cucumber/authenticators/features/authn_oidc.feature
@@ -82,7 +82,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::UserNotDefinedInConjur
+    Errors::Authentication::Security::RoleNotFound
     """
 
   Scenario: User that is not permitted to webservice in ID token is denied
@@ -96,7 +96,7 @@ Feature: Users can authneticate with OIDC authenticator
     Then it is forbidden
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::UserNotAuthorizedInConjur
+    Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
     """
 
   Scenario: ID token without value of variable id-token-user-property is denied

--- a/cucumber/authenticators/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators/features/authn_oidc_bad_policy.feature
@@ -103,7 +103,7 @@ Feature: Users can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::ServiceNotDefined
+    Errors::Authentication::Security::WebserviceNotFound
     """
 
   Scenario: webservice with read and no authenticate permission in policy is denied
@@ -143,5 +143,5 @@ Feature: Users can authenticate with OIDC authenticator
     Then it is forbidden
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::UserNotAuthorizedInConjur
+    Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
     """

--- a/cucumber/authenticators/features/authn_status.feature
+++ b/cucumber/authenticators/features/authn_status.feature
@@ -104,7 +104,7 @@ Feature: Authenticator status check
     And I login as "alice"
     When I GET "/authn-oidc/keycloak/cucumber/status"
     Then the HTTP response status code is 403
-    And the authenticator status check fails with error "UserNotAuthorizedInConjur: CONJ00006E"
+    And the authenticator status check fails with error "RoleNotAuthorizedOnWebservice: CONJ00006E"
 
   Scenario: An authenticator without an implemented status check returns 503
     Given I login as "alice"
@@ -155,7 +155,7 @@ Feature: Authenticator status check
     And I login as "alice"
     When I GET "/authn-oidc/keycloak/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "ServiceNotDefined: CONJ00005E"
+    And the authenticator status check fails with error "WebserviceNotFound: CONJ00005E"
 
   Scenario: A non-existing account name in the status request returns 500
     Given a policy:
@@ -251,7 +251,7 @@ Feature: Authenticator status check
     And I login as "alice"
     When I GET "/authn-oidc/keycloak/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "ServiceNotDefined: CONJ00005E"
+    And the authenticator status check fails with error "WebserviceNotFound: CONJ00005E"
 
     # TODO: Implement this test when we have the ability to start a Conjur server from Cucumber
 #    Scenario: The authenticator is not whitelisted in environment variables

--- a/cucumber/authenticators/features/support/authenticator_helpers.rb
+++ b/cucumber/authenticators/features/support/authenticator_helpers.rb
@@ -6,12 +6,12 @@ require 'util/error_class'
 #
 module AuthenticatorHelpers
 
-  MissingEnvVarirable = ::Util::ErrorClass.new(
+  MissingEnvVariable = ::Util::ErrorClass.new(
     'Environment variable [{0}] is not defined'
   )
 
   def validated_env_var(var)
-    raise MissingEnvVarirable, var if ENV[var].blank?
+    raise MissingEnvVariable, var if ENV[var].blank?
     ENV[var]
   end
 

--- a/cucumber/kubernetes/features/login_errors.feature
+++ b/cucumber/kubernetes/features/login_errors.feature
@@ -15,12 +15,12 @@ Feature: Errors emitted by the login method.
   Scenario: it raises an error when logging in as a host which does not hold "authenticate" privilege
     on the webservice.
     When I login to authn-k8s as "pod/inventory-unauthorized"
-    Then the HTTP status is "401"
+    Then the HTTP status is "403"
 
   Scenario: it raises an error when logging in with a custom prefix as a host which does not
     hold "authenticate" privilege on the webservice.
     When I login to authn-k8s as "@namespace@/pod/inventory-unauthorized" with prefix "host/conjur/authn-k8s/minikube/apps"
-    Then the HTTP status is "401"
+    Then the HTTP status is "403"
 
   Scenario: it raises an error when logging in with a service account which does not match the calling pod.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "service_account/inventory-pod-only"

--- a/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/validate_pod_request_spec.rb
@@ -92,10 +92,10 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
 
       expected_message = /Webservice '#{bad_service_name}' wasn't found/
       expect { validator.(pod_request: pod_request) }
-        .to raise_error(Errors::Authentication::AuthnK8s::WebserviceNotFound, expected_message)
+        .to raise_error(Errors::Authentication::Security::WebserviceNotFound, expected_message)
     end
 
-    it 'raises HostNotAuthorized when host is not allowed to authenticate to service' do
+    it 'raises RoleNotAuthorizedOnWebservice when host is not allowed to authenticate to service' do
       allow(pod_request).to receive(:service_id).and_return(good_service_id)
       allow(host_role).to receive(:allowed_to?)
                             .with("authenticate", good_webservice)
@@ -104,7 +104,7 @@ RSpec.describe Authentication::AuthnK8s::ValidatePodRequest do
       expected_message = /'#{host_id}' does not have 'authenticate' privilege on #{good_service_id}/
 
       expect { validator.(pod_request: pod_request) }
-        .to raise_error(Errors::Authentication::AuthnK8s::HostNotAuthorized, expected_message)
+        .to raise_error(Errors::Authentication::Security::RoleNotAuthorizedOnWebservice, expected_message)
     end
 
     it 'raises PodNotFound when pod is not known' do

--- a/spec/app/domain/authentication/validate_webservice_access_spec.rb
+++ b/spec/app/domain/authentication/validate_webservice_access_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Authentication::Security::ValidateWebserviceAccess do
         privilege: 'test-privilege'
       )
     end
-    it "raises a NotDefinedInConjur error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
+    it "raises a RoleNotFound error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::RoleNotFound)
     end
   end
 
@@ -111,8 +111,8 @@ RSpec.describe Authentication::Security::ValidateWebserviceAccess do
       )
     end
 
-    it "raises a NotAuthorizedInConjur error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::UserNotAuthorizedInConjur
+    it "raises a RoleNotAuthorizedOnWebservice error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
       )
     end
   end
@@ -178,7 +178,7 @@ RSpec.describe Authentication::Security::ValidateWebserviceAccess do
         user_id: user_id,
         privilege: 'test-privilege'
       )
-      }.to raise_error(Errors::Authentication::Security::UserNotDefinedInConjur)
+      }.to raise_error(Errors::Authentication::Security::RoleNotFound)
 
       # For the second, the role should be found, and validation
       # should succeed.

--- a/spec/app/domain/authentication/validate_webservice_exists_spec.rb
+++ b/spec/app/domain/authentication/validate_webservice_exists_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Authentication::Security::ValidateWebserviceExists do
       )
     end
 
-    it "raises a ServiceNotDefined error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::ServiceNotDefined)
+    it "raises a WebserviceNotFound error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::WebserviceNotFound)
     end
   end
 

--- a/spec/app/domain/authentication/validate_whitelisted_webservice_spec.rb
+++ b/spec/app/domain/authentication/validate_whitelisted_webservice_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Authentication::Security::ValidateWhitelistedWebservice do
       )
     end
 
-    it "raises a NotWhitelisted error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::NotWhitelisted)
+    it "raises a AuthenticatorNotWhitelisted error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::AuthenticatorNotWhitelisted)
     end
   end
 


### PR DESCRIPTION
This PR re-arranges some errors so they can be consumed easily in all authenticators.

This PR also changes the behaviour of the Kubernetes authenticator so it now returns 403 on unpermitted hosts instead of a 401. This was done to align it with the other authenticators.