### PR TITLE
Generalize credentials field of AuthenticatorInput

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -79,7 +79,7 @@ class AuthenticateController < ApplicationController
       service_id:         params[:service_id],
       account:            params[:account],
       username:           params[:id],
-      request_body:       request.body.read,
+      credentials:       request.body.read,
       origin:             request.ip,
       request:            request
     )
@@ -100,7 +100,7 @@ class AuthenticateController < ApplicationController
       service_id:         params[:service_id],
       account:            params[:account],
       username:           nil,
-      request_body:       nil,
+      credentials:       nil,
       origin:             request.ip,
       request:            request
     )

--- a/app/controllers/concerns/basic_authenticator.rb
+++ b/app/controllers/concerns/basic_authenticator.rb
@@ -40,7 +40,7 @@ module BasicAuthenticator
       service_id:         params[:service_id],
       account:            params[:account],
       username:           username,
-      request_body:       password,
+      credentials:        password,
       origin:             request.ip,
       request:            request
     )

--- a/app/domain/authentication/authenticator_input.rb
+++ b/app/domain/authentication/authenticator_input.rb
@@ -9,7 +9,7 @@ module Authentication
     attribute :service_id, ::Types::NonEmptyString.optional
     attribute :account, ::Types::NonEmptyString
     attribute :username, ::Types::NonEmptyString.optional
-    attribute :request_body, ::Types::String.optional
+    attribute :credentials, ::Types::String.optional
     attribute :origin, ::Types::NonEmptyString
     attribute :request, ::Types::Any
 

--- a/app/domain/authentication/authn/authenticator.rb
+++ b/app/domain/authentication/authn/authenticator.rb
@@ -20,7 +20,7 @@ module Authentication
         creds = credentials(input)
         return nil unless creds
 
-        success = creds.authenticate(input.request_body)
+        success = creds.authenticate(input.credentials)
         success ? creds.api_key : nil
       end
 
@@ -29,7 +29,7 @@ module Authentication
         creds = credentials(input)
         return nil unless creds
         
-        creds.valid_api_key?(input.request_body)
+        creds.valid_api_key?(input.credentials)
       end
 
       def credentials(input)

--- a/app/domain/authentication/authn_iam/authenticator.rb
+++ b/app/domain/authentication/authn_iam/authenticator.rb
@@ -15,7 +15,7 @@ module Authentication
       end
 
       def valid?(input)
-        signed_aws_headers = JSON.parse input.request_body # input.request_body is JSON holding the AWS signed headers
+        signed_aws_headers = JSON.parse input.credentials # input.credentials is JSON holding the AWS signed headers
 
         response_hash = identity_hash(response_from_signed_request(signed_aws_headers))
         trusted = response_hash != false

--- a/app/domain/authentication/authn_ldap/authenticator.rb
+++ b/app/domain/authentication/authn_ldap/authenticator.rb
@@ -23,7 +23,7 @@ module Authentication
 
       # Login the role using LDAP credentials
       def login(input)
-        login, password = input.username, input.request_body
+        login, password = input.username, input.credentials
 
         # Prevent anonymous LDAP authentication with username only
         return nil if password.blank?

--- a/design/AUTHENTICATORS.md
+++ b/design/AUTHENTICATORS.md
@@ -141,7 +141,7 @@ module Authentication
         #     input.service_id
         #     input.account
         #     input.username
-        #     input.request_body
+        #     input.credentials
         #
         # return either
         #   - a `string` containing the authentication key if successful
@@ -155,7 +155,7 @@ module Authentication
         #     input.service_id
         #     input.account
         #     input.username
-        #     input.request_body
+        #     input.credentials
         #
         # return true for valid credentials, false otherwise
       end

--- a/spec/app/domain/authentication/authenticate_spec.rb
+++ b/spec/app/domain/authentication/authenticate_spec.rb
@@ -76,16 +76,16 @@ RSpec.describe 'Authentication::Authenticate' do
         service_id:         nil,
         account:            'my-acct',
         username:           'my-user',
-        request_body:       'my-pw',
+        credentials:        'my-pw',
         origin:             '127.0.0.1',
         request:            nil
       )
 
       Authentication::Authenticate.new(
-        token_factory:          token_factory
+        token_factory: token_factory
       ).call(
-        authenticator_input: input_,
-        authenticators: authenticators,
+        authenticator_input:    input_,
+        authenticators:         authenticators,
         enabled_authenticators: two_authenticator_env
       )
     end
@@ -105,16 +105,16 @@ RSpec.describe 'Authentication::Authenticate' do
           service_id:         nil,
           account:            'my-acct',
           username:           'my-user',
-          request_body:       'my-pw',
+          credentials:        'my-pw',
           origin:             '127.0.0.1',
           request:            nil
         )
 
         Authentication::Authenticate.new(
-          token_factory:          token_factory
+          token_factory: token_factory
         ).call(
-          authenticator_input: input_,
-          authenticators: authenticators,
+          authenticator_input:    input_,
+          authenticators:         authenticators,
           enabled_authenticators: two_authenticator_env
         )
       end
@@ -133,16 +133,16 @@ RSpec.describe 'Authentication::Authenticate' do
           service_id:         nil,
           account:            'my-acct',
           username:           'my-user',
-          request_body:       'my-pw',
+          credentials:        'my-pw',
           origin:             '127.0.0.1',
           request:            nil
         )
 
         Authentication::Authenticate.new(
-          token_factory:          token_factory
+          token_factory: token_factory
         ).call(
-          authenticator_input: input_,
-          authenticators: authenticators,
+          authenticator_input:    input_,
+          authenticators:         authenticators,
           enabled_authenticators: two_authenticator_env
         )
       end

--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Authentication::Oidc' do
             service_id:         'my-service',
             account:            'my-acct',
             username:           nil,
-            request_body:       nil,
+            credentials:       nil,
             origin:             '127.0.0.1',
             request:            oidc_authenticate_id_token_request
           )
@@ -105,7 +105,7 @@ RSpec.describe 'Authentication::Oidc' do
             service_id:         'my-service',
             account:            'my-acct',
             username:           nil,
-            request_body:       nil,
+            credentials:       nil,
             origin:             '127.0.0.1',
             request:            no_field_oidc_authenticate_id_token_request
           )
@@ -134,7 +134,7 @@ RSpec.describe 'Authentication::Oidc' do
             service_id:         'my-service',
             account:            'my-acct',
             username:           nil,
-            request_body:       nil,
+            credentials:       nil,
             origin:             '127.0.0.1',
             request:            no_value_oidc_authenticate_id_token_request
           )

--- a/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Authentication::AuthnIam::Authenticator do
 
   it "valid? with expired AWS headers" do
     subject = authenticator_instance
-    parameters = double('AuthenticationParameters', request_body: expired_aws_headers)
+    parameters = double('AuthenticationParameters', credentials: expired_aws_headers)
     expect{subject.valid?(parameters)}.to(
         raise_error(Errors::Authentication::AuthnIam::InvalidAWSHeaders)
     )

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
       service_id:         'test',
       account:            'test',
       username:           username,
-      request_body:       password,
+      credentials:       password,
       origin:             '127.0.0.1',
       request:            nil
     )


### PR DESCRIPTION
We would like to make this field more generic so it will make sense in all of its uses. For example, in the authn-iam
authenticator, we use the AuthenticatorInput's credentials field
to extract the AWS header which are located in the request's
body. Calling that field `password` just because the body happens
to include the password in `authn` and `authn-ldap` is wrong.
This will also be the case in `authn-azure` where the body
will have the Azure access token and not a password.
Also, calling it `request_body` is too generic so the field
is called `credentials`
