### PR TITLE
Reduce noise from building authn-k8s test image

### DIFF
--- a/ci/authn-k8s/dev/Dockerfile.test
+++ b/ci/authn-k8s/dev/Dockerfile.test
@@ -15,7 +15,7 @@ RUN apt-get update && \
 # Install OpenShift client
 ARG OPENSHIFT_CLI_URL
 RUN mkdir -p ocbin && \
-    wget -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
+    wget --no-verbose -O oc.tar.gz ${OPENSHIFT_CLI_URL:-https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz} && \
     tar xvf oc.tar.gz --strip-components=1 -C ocbin && \
     mv ocbin/oc /usr/local/bin/oc && \
     rm -rf ocbin oc.tar.gz


### PR DESCRIPTION
`wget` was flooding the output with progress update from the `oc` tool
download. We now squelch the output of it with `--no-verbose` flag.

#### Any background context you want to provide?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
