### PR TITLE
Test `authentication-container-name` annotations is defaulted to `authenticator`

### DIFF
--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -189,6 +189,11 @@
         authn-k8s/service-account: other-service-account
         authn-k8s/authentication-container-name: authenticator
 
+    - !host
+      id: test-app-no-container-annotation
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+
   - !grant
     role: !layer
     members: *some-policy-hosts

--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -203,6 +203,29 @@
   role: !group conjur/authn-k8s/minikube/clients
   member: !layer some-policy
 
+# This policy is for testing that in case a host doesn't have any annotations defined
+# then the "authentication-container-name" annotation is defaulted to "authenticator"
+# and the host is authenticated.
+# We have a separate policy for this host so we can use the id '{{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*'
+# without duplication.
+- !policy
+  id: host-without-container-name
+  body:
+    - !layer
+
+    - &host-without-container-name-hosts
+      - !host
+        id: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+
+    - !grant
+      role: !layer
+      members: *host-without-container-name-hosts
+
+# Permit the host above to authenticate with authn-k8s
+- !grant
+  role: !group conjur/authn-k8s/minikube/clients
+  member: !layer host-without-container-name
+
 # Define hosts under root policy
 - &root-based-hosts
   # Application identity defined in the host id

--- a/cucumber/kubernetes/features/authenticate.feature
+++ b/cucumber/kubernetes/features/authenticate.feature
@@ -27,3 +27,7 @@ Feature: A permitted Conjur host can authenticate with a valid application ident
   Scenario: Authenticate as a host defined under the root policy
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "@namespace@/*/*" with prefix "host"
+
+  Scenario: Authenticate without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -29,3 +29,7 @@ Feature: A permitted Conjur host can login with a valid application identity
   Scenario: Authenticate as a host defined under the root policy
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "root-based-app" with prefix "host"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "root-based-app" with prefix "host"
+
+  Scenario: Authenticate without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
+    Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"

--- a/cucumber/kubernetes/features/login.feature
+++ b/cucumber/kubernetes/features/login.feature
@@ -25,3 +25,6 @@ Feature: A permitted Conjur host can login with a valid application identity
 
   Scenario: Login with a host defined in the root policy
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"
+
+  Scenario: Login without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"

--- a/cucumber/kubernetes/features/login_with_annotations.feature
+++ b/cucumber/kubernetes/features/login_with_annotations.feature
@@ -48,3 +48,6 @@ Feature: A permitted Conjur host can login with a valid application identity
   Scenario: it raises an error when logging in from a K8s resource which does not match the one configured in the host
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-resource" with prefix "host/some-policy"
     Then the HTTP status is "401"
+
+  Scenario: Login without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
+    Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"


### PR DESCRIPTION
#### What does this PR do?

Adds a test where we create a host that doesn't have the annotation `authentication-container-name` and send an authentication request from a container named `authenticator`. This test validates that in case the annotation is not present then the container name is defaulted to `authenticator`.