### PR TITLE
Add test script for authn-azure

### DIFF
--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -23,6 +23,9 @@ module Authentication
       inputs:       %i(authenticator_input)
     ) do
 
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :webservice
+
       def call
         validate_account_exists
         decode_and_verify_id_token
@@ -41,7 +44,7 @@ module Authentication
 
       def validate_account_exists
         @validate_account_exists.(
-          account: @authenticator_input.account
+          account: account
         )
       end
 
@@ -57,14 +60,14 @@ module Authentication
       end
 
       def request_body
-        @request_body ||= AuthnOidc::AuthenticateRequestBody.new(@authenticator_input.request)
+        @request_body ||= AuthnOidc::AuthenticateRequestBody.new(request)
       end
 
       def oidc_authenticator_secrets
         @oidc_authenticator_secrets ||= @fetch_authenticator_secrets.(
-          service_id: @authenticator_input.service_id,
-          conjur_account: @authenticator_input.account,
-          authenticator_name: @authenticator_input.authenticator_name,
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
           required_variable_names: required_variable_names
         )
       end
@@ -75,8 +78,8 @@ module Authentication
 
       def new_token
         @token_factory.signed_token(
-          account:  @authenticator_input.account,
-          username: @authenticator_input.username
+          account:  account,
+          username: username
         )
       end
 
@@ -96,9 +99,9 @@ module Authentication
 
       def validate_security
         @validate_security.(
-          webservice: @authenticator_input.webservice,
-            account: @authenticator_input.account,
-            user_id: @authenticator_input.username,
+          webservice: webservice,
+            account: account,
+            user_id: username,
             enabled_authenticators: @enabled_authenticators
         )
 

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# Get an authn-azure Conjur access token for host azure-apps/Ftest-app
+authn_azure_response=$(curl -k -X POST \
+  https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
+authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+
+# Retrieve a Conjur secret using the authn-azure Conjur access token
+curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+
+sudo docker load -i conjur-image.tar
+
+# Remove old containers if they are up
+if [[ -d "conjur-quickstart" ]]
+then
+  pushd conjur-quickstart
+  sudo docker-compose down -v
+  popd
+fi
+
+rm -rf conjur-quickstart
+git clone --single-branch --branch local-conjur-image https://github.com/cyberark/conjur-quickstart.git
+cd conjur-quickstart
+sudo docker-compose down -v
+
+sed "s#{{ CONJUR_IMAGE_VERSION }}#$CONJUR_IMAGE_VERSION#g" ./Dockerfile.template > ./Dockerfile
+sudo docker-compose pull
+sudo docker-compose build
+sudo docker-compose run --no-deps --rm conjur data-key generate > data_key
+
+export CONJUR_DATA_KEY="$(< data_key)"
+echo "Generated CONJUR_DATA_KEY $CONJUR_DATA_KEY"
+
+# TODO: Make it work without sed. docker-compose should take the host's env var if it is not set but it doesn't work
+sed "s#{{ CONJUR_DATA_KEY }}#${CONJUR_DATA_KEY}#" ./docker-compose.yml.template > ./docker-compose.yml
+
+sudo docker-compose up -d
+
+# Wait for all components to be up before we create the account
+sleep 5
+sudo docker-compose exec -T conjur conjurctl account create cucumber
+
+sudo docker-compose exec -T client conjur init -u conjur -a cucumber
+ADMIN_API_KEY=$(sudo docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+sudo docker-compose exec -T client conjur authn login -u admin -p $ADMIN_API_KEY
+
+# Copy the policy files into the directory that is volumed into the client
+cp ../policies/* conf/policy/
+
+sudo docker-compose exec -T client conjur policy load root policy/authn-azure.yml
+
+AZURE_PROVIDER_URI="https://some-provider.com"
+sudo docker-compose exec -T client conjur variable values add conjur/authn-azure/test/provider-uri $AZURE_PROVIDER_URI
+
+sudo docker-compose exec -T client conjur policy load root policy/azure-hosts.yml
+
+sudo docker-compose exec -T client conjur policy load root policy/test-secrets.yml
+sudo docker-compose exec -T client conjur variable values add secrets/test-variable test-secret

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"
+USERNAME="<username of AWS machine>"
+AWS_MACHINE="<AWS machine>"
+
+pushd ../..
+  . version_utils.sh
+  CONJUR_IMAGE_VERSION="$(version_tag)"
+  export CONJUR_IMAGE_VERSION
+
+  ./build.sh
+popd
+
+# copy docker image into AWS machine
+docker save -o ./conjur-image.tar conjur:$CONJUR_IMAGE_VERSION
+scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar $USERNAME@$AWS_MACHINE:~/.
+
+# copy authn-azure policies into AWS machine
+scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $USERNAME@$AWS_MACHINE:~/.
+
+scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $USERNAME@$AWS_MACHINE:~/.
+
+ssh -i "${AWS_PEM_FILE_LOCATION}" $USERNAME@$AWS_MACHINE CONJUR_IMAGE_VERSION="$CONJUR_IMAGE_VERSION" ./setup-conjur.sh

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,24 +1,30 @@
 #!/bin/bash -ex
 
+# TODO: get these dynamically
 AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"
-USERNAME="<username of AWS machine>"
-AWS_MACHINE="<AWS machine>"
+AWS_MACHINE_USERNAME="<username of AWS machine>"
+CONJUR_SERVER_DNS="<DNS of Conjur server machine>"
 
+AZURE_VM_USERNAME="<username of Azure VM>"
+AZURE_VM_IP="<IP address of Azure VM>"
+
+# Build Conjur image
 pushd ../..
   . version_utils.sh
-  CONJUR_IMAGE_VERSION="$(version_tag)"
-  export CONJUR_IMAGE_VERSION
+  export CONJUR_IMAGE_VERSION="$(version_tag)"
 
   ./build.sh
 popd
 
-# copy docker image into AWS machine
+# Copy docker image into AWS machine
 docker save -o ./conjur-image.tar conjur:$CONJUR_IMAGE_VERSION
-scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar $USERNAME@$AWS_MACHINE:~/.
+scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
 
-# copy authn-azure policies into AWS machine
-scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $USERNAME@$AWS_MACHINE:~/.
+# Copy authn-azure policies into AWS machine
+scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
 
-scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $USERNAME@$AWS_MACHINE:~/.
+scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+ssh -i "${AWS_PEM_FILE_LOCATION}" $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS CONJUR_IMAGE_VERSION="$CONJUR_IMAGE_VERSION" ./setup-conjur.sh
 
-ssh -i "${AWS_PEM_FILE_LOCATION}" $USERNAME@$AWS_MACHINE CONJUR_IMAGE_VERSION="$CONJUR_IMAGE_VERSION" ./setup-conjur.sh
+scp run-authn-azure.sh $AZURE_VM_USERNAME@$AZURE_VM_IP:~/.
+ssh $AZURE_VM_USERNAME@$AZURE_VM_IP CONJUR_SERVER_DNS="$CONJUR_SERVER_DNS" ./run-authn-azure.sh


### PR DESCRIPTION
This script will deploy Conjur in an AWS machine, load policies into
Conjur (authenticator policy, azure-app & a test var). It will then
send authn-azure requests from the Azure VM to Conjur to get an access token
and use it to retrieve a secret.

This commit adds the part for Conjur (deploy & load policies).
