### PR TITLE
trigger cyberark--secrets-provider-for-k8s build on success

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,8 +115,15 @@ pipeline {
   }
 
   post {
-    always {
-      cleanupAndNotify(currentBuild.currentResult)
-    }
+      success {
+          script {
+               if (env.BRANCH_NAME == 'master') {
+                      build (job:'../cyberark--secrets-provider-for-k8s/master', wait: false)
+               }
+          }
+      }
+      always {
+        cleanupAndNotify(currentBuild.currentResult)
+      }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
If build success it will trigger cyberark--secrets-provider-for-k8s and will not wait for the result.

#### What ticket does this PR close?
#1319 

Verified on Master as well.