### PR TITLE
Generalize fetch_secrets mock for use in other specs

### DIFF
--- a/spec/support/fetch_secrets_helper.rb
+++ b/spec/support/fetch_secrets_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+shared_context "fetch secrets" do
+
+  let (:test_fetch_secrets_error) { "test-fetch-secrets-error" }
+
+  def mock_fetch_secrets(is_successful:, fetched_secrets:)
+    double('fetch_secrets').tap do |fetch_secrets|
+      if is_successful
+        allow(fetch_secrets).to receive(:call)
+                                  .and_return(fetched_secrets)
+      else
+        allow(fetch_secrets).to receive(:call)
+                                  .and_raise(test_fetch_secrets_error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `validate_status_spec` implemented a `mock_fetch_secrets` to
mock the way that we fetch secrets from Conjur in run-time. This commit
moves this logic outside of this class so it can be consumed in other
specs.
