### PR TITLE
WIP Add application identity validation

### DIFF
--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,0 +1,119 @@
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
+    # ScopeNotSupported, InvalidHostId
+
+    # This class defines an application identity of a given conjur host.
+    # The constructor initializes an ApplicationIdentity object and validates that
+    # it is configured correctly.
+    # The difference between the validation in this constructor and
+    # the validation in ValidateApplicationIdentity is that here we validate that
+    # the application identity is configured correctly, and thus is a valid application
+    # identity. In ValidateApplicationIdentity we validate that the defined application
+    # identity is actually the correct one in kubernetes.
+    # For example, an application identity `some-namepsace/blah/some-value` is not
+    # valid and will fail the validation here. However, an application identity
+    # `some-namespace/service-account/some-value` is a valid application identity
+    # and will pass the validation here. If the host is actually running from
+    # a pod with service account `some-other-value` then it will fail the
+    # validation of ValidateApplicationIdentity
+    class ApplicationIdentity
+
+      def initialize(host_id:, host_annotations:)
+        @host_id          = host_id
+        @host_annotations = host_annotations
+        @service_id       = service_id
+
+        validate
+      end
+
+      # add validator to check resource group and subscription id are present
+      def constraints
+        @constraints ||= {
+            subscription_id:          constraint_value("subscription-id"),
+            resource_group:           constraint_value("resource-group"),
+            user_assigned_identity:   constraint_value("user-assigned-identity"),
+            system_assigned_identity: constraint_value("system-assigned-identity"),
+        }.compact
+      end
+
+      private
+
+      # Validates that the application identity is defined correctly
+      def validate
+        # Check if annotations present are part of the permitted annotations for authn-azure
+        validate_permitted_annotations
+
+        # validate that a constraint exists on the required annotations
+        raise Err::MissingAnnotationConstraint.new(constraints.subscription_id) unless constraint_from_annotation constraints.has_key? "subscription_id"
+        raise Err::MissingAnnotationConstraint.new(constraints.resource_group) unless constraint_from_annotation constraints.has_key? "resource_group"
+
+        validate_constraint_combinations
+      end
+
+      # Validates that the required annotations (subscription_id and resource_group) exist in annotations
+      def constraint_from_annotation constraint_name
+        annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
+            annotation_value("authn-azure/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @host_annotations.find { |a| a.values[:name] == name }
+
+        # return the value of the annotation if it exists, nil otherwise
+        if annotation
+          Rails.logger.debug(Log::RetrievedAnnotationValue.new(name))
+          annotation[:value]
+        end
+      end
+
+      # Validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      # & TODO: .key & = union
+      def validate_constraint_combinations
+        controllers = %i(user_assigned_identity system_assigned_identity)
+
+        controller_constraints = constraints.keys & controllers
+        raise Err::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
+      end
+
+      def constraint_value constraint_name
+        constraint_from_annotation(constraint_name)
+      end
+
+      def validate_permitted_annotations
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      def prefixed_k8s_annotations prefix
+        @host_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+              # Verify we take only annotations from the same level
+              annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # adds 'authn-azure prefix' to all permitted constraints
+      def prefixed_permitted_annotations prefix
+        permitted_annotations.map { |k| "#{prefix}#{k}" }
+      end
+
+      # takes all annotations with authn-azure and checks if annotations is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(Log::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_k8s_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_annotations(prefix).include?(annotation_name)
+          raise Err::ScopeNotSupported.new(annotation_name.gsub(prefix, ""), annotation_type_constraints)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -3,34 +3,34 @@ module Authentication
 
     Log = LogMessages::Authentication
     Err = Errors::Authentication::AuthnAzure
-    # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
-    # ScopeNotSupported, InvalidHostId
+    # Possible Errors Raised: ConstraintNotSupported, MissingAnnotationConstraint, IllegalConstraintCombinations
 
-    # This class defines an application identity of a given conjur host.
+    # This class defines an application identity of a given Conjur host.
     # The constructor initializes an ApplicationIdentity object and validates that
     # it is configured correctly.
     # The difference between the validation in this constructor and
     # the validation in ValidateApplicationIdentity is that here we validate that
     # the application identity is configured correctly, and thus is a valid application
     # identity. In ValidateApplicationIdentity we validate that the defined application
-    # identity is actually the correct one in kubernetes.
-    # For example, an application identity `some-namepsace/blah/some-value` is not
+    # identity is actually the one we expect from Azure. This validation is done through
+    # a combination of comparisons that are performed based on the type of assigned
+    # identity provided.
+    # For example, an application identity `some-namespace/blah/some-value` is not
     # valid and will fail the validation here. However, an application identity
     # `some-namespace/service-account/some-value` is a valid application identity
-    # and will pass the validation here. If the host is actually running from
-    # a pod with service account `some-other-value` then it will fail the
-    # validation of ValidateApplicationIdentity
+    # and will pass the validation here.
+    # If the Azure-related annotations in the host defined in Conjur has Azure-specific
+    # annotations that do not match the supplied JWT token, then it will fail the
+    # validation of ValidateApplicationIdentity.
     class ApplicationIdentity
 
-      def initialize(host_id:, host_annotations:)
-        @host_id          = host_id
+      def initialize(host_annotations:, service_id:)
         @host_annotations = host_annotations
         @service_id       = service_id
 
         validate
       end
 
-      # add validator to check resource group and subscription id are present
       def constraints
         @constraints ||= {
             subscription_id:          constraint_value("subscription-id"),
@@ -42,19 +42,57 @@ module Authentication
 
       private
 
-      # Validates that the application identity is defined correctly
+      # validate that the application identity is defined correctly
       def validate
-        # Check if annotations present are part of the permitted annotations for authn-azure
+        # check if annotations present are part of the permitted annotations for authn-azure
         validate_permitted_annotations
 
         # validate that a constraint exists on the required annotations
-        raise Err::MissingAnnotationConstraint.new(constraints.subscription_id) unless constraint_from_annotation constraints.has_key? "subscription_id"
-        raise Err::MissingAnnotationConstraint.new(constraints.resource_group) unless constraint_from_annotation constraints.has_key? "resource_group"
-
+        validate_required_annotations_exist
         validate_constraint_combinations
       end
 
-      # Validates that the required annotations (subscription_id and resource_group) exist in annotations
+      def validate_permitted_annotations
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(Log::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @host_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+              # verify we take only annotations from the same level
+              annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
+      end
+
+      def validate_required_annotation_exists
+        validate_annotations_exist "subscription-id"
+        validate_annotations_exist "resource-group"
+      end
+
+      def validate_annotations_exist constraint
+        raise Err::MissingAnnotationConstraint.new(constraint) unless constraint_from_annotation(constraint)
+      end
+
+      # validates that the required annotations (subscription_id and resource_group) exist in annotations
       def constraint_from_annotation constraint_name
         annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
             annotation_value("authn-azure/#{constraint_name}")
@@ -70,49 +108,23 @@ module Authentication
         end
       end
 
-      # Validates that the application identity doesn't include logical constraint
-      # combinations (e.g user_assigned_identity & system_assigned_identity)
-      # & TODO: .key & = union
-      def validate_constraint_combinations
-        controllers = %i(user_assigned_identity system_assigned_identity)
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
 
-        controller_constraints = constraints.keys & controllers
-        raise Err::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
+      # validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      def validate_constraint_combinations
+        identifiers = %i(user_assigned_identity system_assigned_identity)
+
+        identifiers_constraints = constraints.keys & identifiers
+        raise Err::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
       end
 
       def constraint_value constraint_name
         constraint_from_annotation(constraint_name)
-      end
-
-      def validate_permitted_annotations
-        validate_prefixed_permitted_annotations("authn-azure/")
-        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
-      end
-
-      def prefixed_k8s_annotations prefix
-        @host_annotations.select do |a|
-          annotation_name = a.values[:name]
-
-          annotation_name.start_with?(prefix) &&
-              # Verify we take only annotations from the same level
-              annotation_name.split('/').length == prefix.split('/').length + 1
-        end
-      end
-
-      # adds 'authn-azure prefix' to all permitted constraints
-      def prefixed_permitted_annotations prefix
-        permitted_annotations.map { |k| "#{prefix}#{k}" }
-      end
-
-      # takes all annotations with authn-azure and checks if annotations is part of the permitted list
-      def validate_prefixed_permitted_annotations prefix
-        Rails.logger.debug(Log::ValidatingAnnotationsWithPrefix.new(prefix))
-
-        prefixed_k8s_annotations(prefix).each do |annotation|
-          annotation_name = annotation[:name]
-          next if prefixed_permitted_annotations(prefix).include?(annotation_name)
-          raise Err::ScopeNotSupported.new(annotation_name.gsub(prefix, ""), annotation_type_constraints)
-        end
       end
     end
   end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -4,6 +4,7 @@ module Authentication
   module AuthnAzure
 
     Err = Errors::Authentication::AuthnAzure
+    Log = LogMessages::Authentication::AuthnAzure
     # Possible Errors Raised:
     # TODO: Add errors
 
@@ -14,7 +15,7 @@ module Authentication
       inputs: [:authenticator_input]
     ) do
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
         validate_azure_token
@@ -28,14 +29,6 @@ module Authentication
       end
 
       def validate_application_identity
-
-      end
-
-      def host
-
-      end
-
-      def host_annotations
 
       end
     end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -10,10 +10,12 @@ module Authentication
 
     Authenticator = CommandClass.new(
       dependencies: {
-
+        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        logger:                      Rails.logger
       },
       inputs: [:authenticator_input]
     ) do
+
       extend Forwardable
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
@@ -30,6 +32,23 @@ module Authentication
 
       def validate_application_identity
 
+      end
+
+      def provider_uri
+        azure_authenticator_secrets["provider-uri"]
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
       end
     end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -20,19 +20,18 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
-        validate_azure_token
-        validate_application_identity
+        true
       end
 
       private
 
-      def validate_azure_token
-
-      end
-
-      def validate_application_identity
-
-      end
+      #def validate_azure_token
+      #
+      #end
+      #
+      #def validate_application_identity
+      #
+      #end
 
       def provider_uri
         azure_authenticator_secrets["provider-uri"]

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -4,13 +4,14 @@ module Authentication
   module AuthnAzure
 
     Err = Errors::Authentication::AuthnAzure
-    Log = LogMessages::Authentication::AuthnAzure
+    Log = LogMessages::Authentication
     # Possible Errors Raised:
     # TODO: Add errors
 
     Authenticator = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        validate_application_identity: ValidateApplicationIdentity.new,
         logger:                      Rails.logger
       },
       inputs: [:authenticator_input]

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -1,0 +1,42 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    # TODO: Add errors
+
+    Authenticator = CommandClass.new(
+      dependencies: {
+
+      },
+      inputs: [:authenticator_input]
+    ) do
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+
+      def call
+
+      end
+
+      private
+
+    end
+
+    class Authenticator
+      # This delegates to all the work to the call method created automatically
+      # by CommandClass
+      #
+      # This is needed because we need `valid?` to exist on the Authenticator
+      # class, but that class contains only a metaprogramming generated
+      # `call(authenticator_input:)` method.  The methods we define in the
+      # block passed to `CommandClass` exist only on the private internal
+      # `Call` objects created each time `call` is run.
+      #
+      def valid?(input)
+        call(authenticator_input: input)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -3,16 +3,14 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    Err = Errors::Authentication::AuthnAzure
     Log = LogMessages::Authentication
-    # Possible Errors Raised:
-    # TODO: Add errors
+    Err = Errors::Authentication::AuthnAzure
 
     Authenticator = CommandClass.new(
       dependencies: {
-        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        validate_application_identity: ValidateApplicationIdentity.new,
-        logger:                      Rails.logger
+        fetch_authenticator_secrets:    Authentication::Util::FetchAuthenticatorSecrets.new,
+        validate_application_identity:  ValidateApplicationIdentity.new,
+        logger:                         Rails.logger
       },
       inputs: [:authenticator_input]
     ) do
@@ -21,18 +19,21 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
-        true
+        validate_application_identity
       end
 
       private
 
-      #def validate_azure_token
-      #
-      #end
-      #
-      #def validate_application_identity
-      #
-      #end
+      # expecting to receive xms_mirid and oid as inputs (either global instance or function). This will change to hash map.
+      def validate_application_identity
+        @validate_application_identity.(
+            service_id: service_id,
+            account: account,
+            username: username,
+            xms_mirid: decoded_token["xms_mirid"],
+            oid: decoded_token["oid"]
+        )
+      end
 
       def provider_uri
         azure_authenticator_secrets["provider-uri"]

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -17,11 +17,27 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
 
       def call
-
+        validate_azure_token
+        validate_application_identity
       end
 
       private
 
+      def validate_azure_token
+
+      end
+
+      def validate_application_identity
+
+      end
+
+      def host
+
+      end
+
+      def host_annotations
+
+      end
     end
 
     class Authenticator

--- a/app/domain/authentication/authn_azure/token_identity.rb
+++ b/app/domain/authentication/authn_azure/token_identity.rb
@@ -1,0 +1,13 @@
+module Authentication
+  module AuthnOidc
+    class TokenIdentity
+      attr_reader :subscription_id, :resource_group
+      attr_accessor :system_assigned_identity, :user_assigned_identity
+
+      def initialize(subscription_id:, resource_group:)
+        @subscription_id = subscription_id
+        @resource_group = resource_group
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -1,0 +1,95 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity
+
+    ValidateApplicationIdentity = CommandClass.new(
+        dependencies: {
+            role_class:                 Role,
+            resource_class:             Resource,
+            application_identity_class: ApplicationIdentity,
+            logger:                     Rails.logger
+        },
+        inputs: %i(account, service_id, username, xms_mirid, oid)
+    ) do
+
+      def call
+        parse_xms_mirid
+        # compare xms_mirid with what is defined in annotations
+        validate_application_identity
+      end
+
+      private
+
+      # validate integrity of annotations
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+            role_annotations: role.host_annotations,
+            service_id: @service_id
+        )
+      end
+
+      # convert host ID to full host ID, cucumber:host:somepolicy
+      # TODO For a Conjur user, an incorrect full id will be returned
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @username)
+      end
+
+      def role
+        @role ||= @resource_class[role_id]
+        raise SecurityErr::RoleNotFound(role_id) if @username.nil?
+        @role
+      end
+
+      # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's
+      # subscription, resource group, and provider identity needed for authorization. xms_mirid is one of the fields in
+      # the JWT token. This function will extract the relevant information from xms_mirid claim and populate a representative
+      # hash with the appropriate fields.
+      def parse_xms_mirid
+        field_split = @xms_mirid.split('/')
+        xms_mirid_hash = Hash[field_split.each_slice(2).to_a]
+
+        @token_identity = TokenIdentity.new(
+            subscription_id: @xms_mirid_hash["subscriptions"],
+            resource_group: @xms_mirid_hash["resourcegroups"]
+        )
+
+        # determines which Azure assigned identity is provided in annotations
+        # user-assigned-identity:
+        #   - validates that the correct provider (Microsoft.ManagedIdentity) for a user identity is defined in the
+        #     claim. If so, the 'user_assigned_identity' attribute will be added to the hash with the corresponding
+        #     value from xms_mirid claim
+        # system-assigned-identity:
+        #   - validates that the correct provider (Microsoft.Compute) for a system identity is defined in the
+        #     claim and its resource is one that we support. At current, we only support a virtualMachines resource.
+        #     If these conditions are met, a 'system_assigned_identity' attribute will be added to the hash with its
+        #     value being the oid field in the JWT token.
+        if xms_mirid_hash["providers"] == "Microsoft.ManagedIdentity"
+          logger.debug(Log::ExtractingIdentityForAuthentication.new(xms_mirid_hash["providers"] << "/" << xms_mirid_hash.keys[-1]))
+          @token_identity.user_assigned_identity = xms_mirid_hash["userAssignedIdentities"]
+        else
+          logger.debug(Log::ExtractingIdentityForAuthentication.new(xms_mirid_hash["providers"] << "/" << xms_mirid_hash.keys[-1]))
+          @token_identity.system_assigned_identity = @oid
+        end
+      end
+
+      # validate the integrity of host annotations against the xms_mirid object representation
+      def validate_application_identity
+        logger.debug(Log::ValidatingApplicationIdentity.new(@xms_mirid_hash[@xms_mirid_hash.key[-1]]))
+        application_identity.constraints.each do |constraint|
+          annotation_type = constraint[0].to_s
+          annotation_value = constraint[1]
+          unless annotation_value == @token_identity[annotation_type]
+            raise Err::InvalidApplicationIdentity.new(annotation_type)
+          end
+        end
+        logger.debug(ValidatedApplicationIdentity.new(@xms_mirid_hash[@xms_mirid_hash.key[-1]]))
+      end
+    end
+  end
+
+end

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -1,7 +1,7 @@
 module Authentication
   module AuthnK8s
 
-    Log = LogMessages::Authentication::AuthnK8s
+    Log = LogMessages::Authentication
     Err = Errors::Authentication::AuthnK8s
     # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
     # ScopeNotSupported, InvalidHostId
@@ -97,6 +97,7 @@ module Authentication
           annotation_value("authn-k8s/#{constraint_name}")
       end
 
+      # gets value for annotations for name inputed as key
       def annotation_value name
         annotation = @host_annotations.find { |a| a.values[:name] == name }
 
@@ -141,7 +142,7 @@ module Authentication
           annotation_name = a.values[:name]
 
           annotation_name.start_with?(prefix) &&
-            # Verify we take only annotations from the same level
+            # verify we take only annotations from the same level
             annotation_name.split('/').length == prefix.split('/').length + 1
         end
       end

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -10,7 +10,7 @@ module Authentication
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
-        resource_class:              Resource,
+        resource_class:             Resource,
         k8s_resolver:               K8sResolver,
         k8s_object_lookup_class:    K8sObjectLookup,
         application_identity_class: ApplicationIdentity

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -23,6 +23,9 @@ module Authentication
       inputs:       %i(authenticator_input)
     ) do
 
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :webservice
+
       def call
         validate_account_exists
         decode_and_verify_id_token
@@ -41,7 +44,7 @@ module Authentication
 
       def validate_account_exists
         @validate_account_exists.(
-          account: @authenticator_input.account
+          account: account
         )
       end
 
@@ -57,14 +60,14 @@ module Authentication
       end
 
       def request_body
-        @request_body ||= AuthnOidc::AuthenticateRequestBody.new(@authenticator_input.request)
+        @request_body ||= AuthnOidc::AuthenticateRequestBody.new(request)
       end
 
       def oidc_authenticator_secrets
         @oidc_authenticator_secrets ||= @fetch_authenticator_secrets.(
-          service_id: @authenticator_input.service_id,
-          conjur_account: @authenticator_input.account,
-          authenticator_name: @authenticator_input.authenticator_name,
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
           required_variable_names: required_variable_names
         )
       end
@@ -75,8 +78,8 @@ module Authentication
 
       def new_token
         @token_factory.signed_token(
-          account:  @authenticator_input.account,
-          username: @authenticator_input.username
+          account:  account,
+          username: username
         )
       end
 
@@ -96,9 +99,9 @@ module Authentication
 
       def validate_security
         @validate_security.(
-          webservice: @authenticator_input.webservice,
-            account: @authenticator_input.account,
-            user_id: @authenticator_input.username,
+          webservice: webservice,
+            account: account,
+            user_id: username,
             enabled_authenticators: @enabled_authenticators
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -270,8 +270,18 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnAzure
 
         MissingAnnotationConstraint = ::Util::TrackableErrorClass.new(
-            msg: "Host does not have a {0} constraint",
+            msg: "Host does not have a {0} constraint defined in its annotations",
             code: "CONJ00045E"
+        )
+
+        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+            msg: "Application identity field '{0-field-name}' does not match what is provided in Azure token",
+            code: "CONJ00049E"
+        )
+
+        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+            msg: "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+            code: "CONJ00025E"
         )
 
       end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -266,6 +266,10 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00048E"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -269,6 +269,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       module AuthnAzure
 
+        MissingAnnotationConstraint = ::Util::TrackableErrorClass.new(
+            msg: "Host does not have a {0} constraint",
+            code: "CONJ00045E"
+        )
+
       end
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -15,6 +15,16 @@ unless defined? LogMessages::Authentication::OriginValidated
         code: "CONJ00003D"
       )
 
+      ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating annotations with prefix {0-prefix}",
+          code: "CONJ00025D"
+      )
+
+      RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+          msg: "Retrieved value of annotation {0-annotation-name}",
+          code: "CONJ00024D"
+      )
+
       module Security
 
         SecurityValidated = ::Util::TrackableLogMessageClass.new(
@@ -108,16 +118,6 @@ unless defined? LogMessages::Authentication::OriginValidated
         CopySSLToPod = ::Util::TrackableLogMessageClass.new(
           msg: "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
           code: "CONJ00015D"
-        )
-
-        RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
-          msg: "Retrieved value of annotation {0-annotation-name}",
-          code: "CONJ00024D"
-        )
-
-        ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating annotations with prefix {0-prefix}",
-          code: "CONJ00025D"
         )
 
         ValidatingHostId = ::Util::TrackableLogMessageClass.new(

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -137,6 +137,20 @@ unless defined? LogMessages::Authentication::OriginValidated
       end
 
       module AuthnAzure
+        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
+            msg: "Extracting resource type {0-resource-type} for authentication",
+            code: "CONJ00029D"
+        )
+
+        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+            msg: "Validating application identity for {0-resource-name}",
+            code: "CONJ00030D"
+        )
+
+        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+            msg: "Application identity for {0-resource-name} validated",
+            code: "CONJ00030D"
+        )
 
       end
     end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -135,6 +135,10 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00028D"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/ci/authn-azure/policies/authn-azure.yml
+++ b/ci/authn-azure/policies/authn-azure.yml
@@ -1,0 +1,16 @@
+# Azure authenticator
+- !policy
+  id: conjur/authn-azure/test
+  body:
+  - !webservice
+
+  - !variable
+    id: provider-uri
+
+  - !group
+    id: apps
+
+  - !permit
+    role: !group apps
+    privilege: [ read, authenticate ]
+    resource: !webservice

--- a/ci/authn-azure/policies/azure-hosts.yml
+++ b/ci/authn-azure/policies/azure-hosts.yml
@@ -1,0 +1,21 @@
+# Hosts that will authenticate with the Azure authenticator
+- !policy
+  id: azure-apps
+  body:
+    - !group
+
+    - &hosts
+      - !host
+        id: test-app
+        annotations:
+          authn-azure/subscription-id: test-subscription
+          authn-azure/resource-group: test-group
+          authn-azure/user-assigned-identity: test-app-pipeline
+
+    - !grant
+      role: !group
+      members: *hosts
+
+- !grant
+  role: !group conjur/authn-azure/test/apps
+  member: !group azure-apps

--- a/ci/authn-azure/policies/test-secrets.yml
+++ b/ci/authn-azure/policies/test-secrets.yml
@@ -1,0 +1,16 @@
+# Variable that will be consumed by azure-apps/test-app
+- !policy
+  id: secrets
+  body:
+    - !group consumers
+
+    - !variable test-variable
+
+    - !permit
+      role: !group consumers
+      privilege: [ read, execute ]
+      resource: !variable test-variable
+
+- !grant
+  role: !group secrets/consumers
+  member: !group azure-apps

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+
+sudo docker load -i conjur-image.tar
+
+# Remove old containers if they are up
+if [[ -d "conjur-quickstart" ]]
+then
+  pushd conjur-quickstart
+  sudo docker-compose down -v
+  popd
+fi
+
+rm -rf conjur-quickstart
+git clone --single-branch --branch local-conjur-image https://github.com/cyberark/conjur-quickstart.git
+cd conjur-quickstart
+sudo docker-compose down -v
+
+sed "s#{{ CONJUR_IMAGE_VERSION }}#$CONJUR_IMAGE_VERSION#g" ./Dockerfile.template > ./Dockerfile
+sudo docker-compose pull
+sudo docker-compose build
+sudo docker-compose run --no-deps --rm conjur data-key generate > data_key
+
+export CONJUR_DATA_KEY="$(< data_key)"
+echo "Generated CONJUR_DATA_KEY $CONJUR_DATA_KEY"
+
+# TODO: Make it work without sed. docker-compose should take the host's env var if it is not set but it doesn't work
+sed "s#{{ CONJUR_DATA_KEY }}#${CONJUR_DATA_KEY}#" ./docker-compose.yml.template > ./docker-compose.yml
+
+sudo docker-compose up -d
+
+# Wait for all components to be up before we create the account
+sleep 5
+sudo docker-compose exec -T conjur conjurctl account create cucumber
+
+sudo docker-compose exec -T client conjur init -u conjur -a cucumber
+ADMIN_API_KEY=$(sudo docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+sudo docker-compose exec -T client conjur authn login -u admin -p $ADMIN_API_KEY
+
+# Copy the policy files into the directory that is volumed into the client
+cp ../policies/* conf/policy/
+
+sudo docker-compose exec -T client conjur policy load root policy/authn-azure.yml
+
+AZURE_PROVIDER_URI="https://some-provider.com"
+sudo docker-compose exec -T client conjur variable values add conjur/authn-azure/test/provider-uri $AZURE_PROVIDER_URI
+
+sudo docker-compose exec -T client conjur policy load root policy/azure-hosts.yml
+
+sudo docker-compose exec -T client conjur policy load root policy/test-secrets.yml
+sudo docker-compose exec -T client conjur variable values add secrets/test-variable test-secret

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"
+USERNAME="<username of AWS machine>"
+AWS_MACHINE="<AWS machine>"
+
+pushd ../..
+  . version_utils.sh
+  CONJUR_IMAGE_VERSION="$(version_tag)"
+  export CONJUR_IMAGE_VERSION
+
+  ./build.sh
+popd
+
+# copy docker image into AWS machine
+docker save -o ./conjur-image.tar conjur:$CONJUR_IMAGE_VERSION
+scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar $USERNAME@$AWS_MACHINE:~/.
+
+# copy authn-azure policies into AWS machine
+scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $USERNAME@$AWS_MACHINE:~/.
+
+scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $USERNAME@$AWS_MACHINE:~/.
+
+ssh -i "${AWS_PEM_FILE_LOCATION}" $USERNAME@$AWS_MACHINE CONJUR_IMAGE_VERSION="$CONJUR_IMAGE_VERSION" ./setup-conjur.sh


### PR DESCRIPTION
#### What does this PR do?
This PR adds the second validation in for the Azure authenticator, validating the application identity of the resource sending the request

DOD
- [x] Check integrity of annotations relevant to authn-azure (prefixed correctly, in proper format, has the 2 required annotations, and that there is not a combo of user and system assigned identity
- [x] Validate xms_mirid/oid based on annotations
   - [ ] Grab the `key -> value` list from output of previous check and perform validation check
   - [ ] Ensure that there user/system assigned flows are accounted for