### PR TITLE
Fix bootstrap sass gem installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,6 @@ group :development, :test do
   gem 'parallel'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'ruby-debug-ide'
   gem 'debase'
   gem 'rails_layout'
   gem 'rake_shared_context'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,8 +363,6 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-checkstyle_formatter (0.4.0)
       rubocop (>= 0.35.1)
-    ruby-debug-ide (0.6.1)
-      rake (>= 0.8.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
@@ -506,7 +504,6 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.58.0)
   rubocop-checkstyle_formatter
-  ruby-debug-ide
   ruby_dep (= 1.3.1)
   sass-rails
   sequel-postgres-schemata

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,9 +379,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
+    sassc (2.2.1)
       ffi (~> 1.9)
-      rake
     sequel (4.46.0)
     sequel-postgres-schemata (0.1.1)
       sequel (~> 4.3)


### PR DESCRIPTION
#### What does this PR do?
It fixes the Docker image build step so the build is green. This PR includes 2 fixes:
1. Upgrade gem `sassc` to version `2.2.1` so `bootstrap-sass` can be installed.
2. Remove the `ruby-debug-ide` as it fails the build. This gem is not required by the app or by the tests so we can live without it until it is fixed. [This issue](https://github.com/cyberark/conjur/issues/1331) was created for fixing this.