### PR TITLE
Downgrade pg version to fix the build

### DIFF
--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -46,7 +46,7 @@ spec:
         app: postgres
     spec:
       containers:
-      - image: postgres:9.4
+      - image: postgres:9.3
         imagePullPolicy: Always
         name: postgres
 ---

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3"
 services:
   pg:
-    image: postgres:9.4
+    image: postgres:9.3
 
   audit:
-    image: postgres:9.4
+    image: postgres:9.3
 
   testdb:
-    image: postgres:9.4
+    image: postgres:9.3
 
   conjur:
     image: "conjur:${TAG}"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3"
 services:
   pg:
-    image: postgres:9.4
+    image: postgres:9.3
 
   audit:
-    image: postgres:9.4
+    image: postgres:9.3
 
   testdb:
-    image: postgres:9.4
+    image: postgres:9.3
     environment:
       POSTGRES_PASSWORD: postgres_secret
 


### PR DESCRIPTION
#### What does this PR do?
Downgrades the version of postgres to 9.3 in our test env.

The build is failing with an issue of Conjur with postrges. The `pg` container is being shut down immediately after we run `docker-compose up -d`

Until this is properly fix, this PR downgrades the `postgres` version to 9.3. [This issue](https://github.com/cyberark/conjur/issues/1333) was created to properly fix this.