### PR TITLE
Set `POSTGRES_HOST_AUTH_METHOD` to `trust` in pg containers

### DIFF
--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -49,6 +49,9 @@ spec:
       - image: postgres:9.4
         imagePullPolicy: Always
         name: postgres
+        env:
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,12 +2,18 @@ version: "3"
 services:
   pg:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   audit:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   testdb:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   conjur:
     image: "conjur:${TAG}"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -2,9 +2,13 @@ version: "3"
 services:
   pg:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   audit:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   testdb:
     image: postgres:9.4


### PR DESCRIPTION
postgres introduced a change that you can't start a `pg` container
without setting a password. They also introduced a new flag named
`POSTGRES_HOST_AUTH_METHOD` that you can set to `trust` in order to
let anyone connect with the db without a password (as we do today).
This is ok for our ci and dev envs so this commit adds this env var
to all `pg` containers that didn't have a password set for them.
