### PR TITLE
1341 - Update server status page links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improved flows and rules around user creation
 - Kubernetes authenticator now returns 403 on unpermitted hosts instead of a 401
 
+### Fixed
+- Updated broken links on server status page (#1341)
+
 ## [1.4.6] - 2020-01-21
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'uglifier'
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass', '~> 3.4.0'
 gem 'dry-struct'
-gem 'font-awesome-sass', '~> 4.7.0'
+gem 'font-awesome-sass', '~> 5.12.0'
 gem 'net-ldap'
 
 # for AWS rotator

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,8 +184,8 @@ GEM
     excon (0.71.0)
     execjs (2.7.0)
     ffi (1.9.25)
-    font-awesome-sass (4.7.0)
-      sass (>= 3.2)
+    font-awesome-sass (5.12.0)
+      sassc (>= 1.11)
     gherkin (4.1.1)
     gli (2.17.1)
     globalid (0.4.2)
@@ -473,7 +473,7 @@ DEPENDENCIES
   debase
   dry-struct
   ffi (>= 1.9.24)
-  font-awesome-sass (~> 4.7.0)
+  font-awesome-sass (~> 5.12.0)
   gli
   haikunator (~> 1)
   iso8601

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -47,7 +47,7 @@ SECTION 4: MIT License
 >>> https://rubygems.org/gems/autoprefixer-rails/versions/7.1.2.3
 >>> https://rubygems.org/gems/bootstrap-sass/versions/3.4.1
 >>> https://rubygems.org/gems/dry-struct/versions/0.4.0
->>> https://rubygems.org/gems/font-awesome-sass/versions/4.7.0
+>>> https://rubygems.org/gems/font-awesome-sass/versions/5.12.0
 >>> https://rubygems.org/gems/net-ldap/versions/0.16.1
 >>> https://rubygems.org/gems/rails_12factor/versions/0.0.3
 >>> https://rubygems.org/gems/jwt
@@ -802,7 +802,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> https://rubygems.org/gems/font-awesome-sass/versions/4.7.0
+>>> https://rubygems.org/gems/font-awesome-sass/versions/5.12.0
 
 Copyright (c) 2013 Travis Chase
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,7 +5,7 @@
         <a href="https://www.cyberark.com/" target="_blank"><%= image_tag "cyberark-white.png", alt: "CyberArk Logo", class: "cyberark-sidebar-logo" %></a>
       </div>
       <div class="col-md-6">
-        <span class="text-right">Conjur Community Edition copyright &copy; <%= Time.current.year %> CyberArk. All rights reserved.</span>
+        <span class="text-right">Conjur Open Source copyright &copy; <%= Time.current.year %> CyberArk. All rights reserved.</span>
       </div>
     </div>
   </div>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -13,8 +13,8 @@
       </div>
       <div class="collapse navbar-collapse" id="mobileNav">
         <ul class="nav navbar-nav navbar-right">
-          <li><a href="https://slackin-conjur.herokuapp.com/" target="_blank"><%= icon('slack', class: 'fa-2x') %></a></li>
-          <li><a href="https://github.com/conjurinc/possum" target="_blank"><%= icon('github', class: 'fa-2x') %></a></li>
+          <li><a href="https://discuss.cyberarkcommons.org" target="_blank"><%= icon('fab', 'discourse', class: 'fa-2x') %></a></li>
+          <li><a href="https://github.com/cyberark/conjur" target="_blank"><%= icon('fab', 'github', class: 'fa-2x') %></a></li>
         </ul>
       </div>
     </div>

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -29,7 +29,7 @@
                 Conjur+TLS guide
             </a>
           to learn how to deploy Conjur securely &amp;
-          <a href="https://conjur.org/support.html">contact CyberArk</a>
+          <a href="https://discuss.cyberarkcommons.org">contact CyberArk</a>
           with any questions.
         </dd>
       </dl>
@@ -41,8 +41,8 @@
 
     <strong>More Info:</strong>
     <ul class="note">
-      <li><a href="https://www.conjur.org/reference/" target="_blank">Documentation</a></li>
-      <li><a href="https://www.cyberark.com/products/privileged-account-security-solution/cyberark-conjur/" target="_blank">Conjur Enterprise</a></li>
+      <li><a href="https://docs.conjur.org/Latest/en/Content/Resources/_TopNav/cc_Home.htm" target="_blank">Documentation</a></li>
+      <li><a href="https://www.cyberark.com/products/privileged-account-security-solution/application-access-manager/" target="_blank">CyberArk Application Access Manager</a></li>
       <li><a href="https://www.conjur.org/" target="_blank">Conjur.org</a></li>
     </ul>
   </div>


### PR DESCRIPTION
#### What ticket does this PR close?
Connected to #1341 

#### Where should the reviewer start?
To verify the changes, you can run `./build.sh` and then update the [quick start repo](github.com/cyberark/conjur-quickstart/) to refer to your local build instead. Then you can run through the [quick start](https://www.conjur.org/get-started/quick-start/oss-environment/) commands to get the server up and running, and visit https://localhost:8443 to see the new server status page.

Or you can look at the attached screenshot.

#### Screenshots (if appropriate)
<img width="1178" alt="Screen Shot 2020-02-18 at 9 21 34 PM" src="https://user-images.githubusercontent.com/26872683/74795843-fe1a5f00-5294-11ea-8f9f-99774a90f4ac.png">


#### Has the Version and Changelog been updated?
Changelog - yes. Version - no.