### PR TITLE
Extract to oauth module

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -151,7 +151,7 @@ class AuthenticateController < ApplicationController
       Errors::Authentication::Security::RoleNotFound,
       Errors::Authentication::Security::AccountNotDefined,
       Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty,
-      Errors::Authentication::Jwt::TokenVerifyFailed,
+      Errors::Authentication::Jwt::TokenVerificationFailed,
       Errors::Authentication::Jwt::TokenDecodeFailed,
       Errors::Conjur::RequiredSecretMissing,
       Errors::Conjur::RequiredResourceMissing

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -151,8 +151,8 @@ class AuthenticateController < ApplicationController
       Errors::Authentication::Security::RoleNotFound,
       Errors::Authentication::Security::AccountNotDefined,
       Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty,
-      Errors::Authentication::OAuth::TokenVerifyFailed,
-      Errors::Authentication::OAuth::TokenDecodeFailed,
+      Errors::Authentication::Jwt::TokenVerifyFailed,
+      Errors::Authentication::Jwt::TokenDecodeFailed,
       Errors::Conjur::RequiredSecretMissing,
       Errors::Conjur::RequiredResourceMissing
       raise Unauthorized
@@ -163,7 +163,7 @@ class AuthenticateController < ApplicationController
     when Errors::Authentication::RequestBody::MissingRequestParam
       raise BadRequest
 
-    when Errors::Authentication::OAuth::TokenExpired
+    when Errors::Authentication::Jwt::TokenExpired
       raise Unauthorized.new(err.message, true)
 
     when Errors::Authentication::OAuth::ProviderDiscoveryTimeout

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -173,7 +173,7 @@ class AuthenticateController < ApplicationController
       raise ServiceUnavailable
 
     when Errors::Authentication::OAuth::ProviderDiscoveryFailed,
-      Errors::Authentication::OAuth::ProviderFetchCertificateFailed
+      Errors::Authentication::OAuth::FetchProviderKeysFailed
       raise BadGateway
 
     else

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -151,8 +151,8 @@ class AuthenticateController < ApplicationController
       Errors::Authentication::Security::RoleNotFound,
       Errors::Authentication::Security::AccountNotDefined,
       Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty,
-      Errors::Authentication::AuthnOidc::TokenVerifyFailed,
-      Errors::Authentication::AuthnOidc::TokenDecodeFailed,
+      Errors::Authentication::OAuth::TokenVerifyFailed,
+      Errors::Authentication::OAuth::TokenDecodeFailed,
       Errors::Conjur::RequiredSecretMissing,
       Errors::Conjur::RequiredResourceMissing
       raise Unauthorized
@@ -163,17 +163,17 @@ class AuthenticateController < ApplicationController
     when Errors::Authentication::RequestBody::MissingRequestParam
       raise BadRequest
 
-    when Errors::Authentication::AuthnOidc::IdTokenExpired
+    when Errors::Authentication::OAuth::TokenExpired
       raise Unauthorized.new(err.message, true)
 
-    when Errors::Authentication::AuthnOidc::ProviderDiscoveryTimeout
+    when Errors::Authentication::OAuth::ProviderDiscoveryTimeout
       raise GatewayTimeout
 
     when Errors::Util::ConcurrencyLimitReachedBeforeCacheInitialization
       raise ServiceUnavailable
 
-    when Errors::Authentication::AuthnOidc::ProviderDiscoveryFailed,
-      Errors::Authentication::AuthnOidc::ProviderFetchCertificateFailed
+    when Errors::Authentication::OAuth::ProviderDiscoveryFailed,
+      Errors::Authentication::OAuth::ProviderFetchCertificateFailed
       raise BadGateway
 
     else

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -17,7 +17,7 @@ module Authentication
         validate_security:           ::Authentication::Security::ValidateSecurity.new,
         validate_origin:             ValidateOrigin.new,
         audit_event:                 AuditEvent.new,
-        verify_and_decode_token:     VerifyAndDecodeToken.new,
+        verify_and_decode_token:     ::Authentication::OAuth::VerifyAndDecodeToken.new,
         logger:                      Rails.logger
       },
       inputs:       %i(authenticator_input)

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -9,7 +9,7 @@ module Authentication
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        discover_oidc_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
       },
       inputs: %i(account service_id)
     ) do
@@ -39,7 +39,7 @@ module Authentication
       end
 
       def validate_provider_is_responsive
-        @discover_oidc_provider.(
+        @discover_identity_provider.(
           provider_uri: provider_uri
         )
       end

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -9,7 +9,7 @@ module Authentication
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        discover_oidc_provider: Authentication::AuthnOidc::DiscoverOIDCProvider.new
+        discover_oidc_provider: Authentication::OAuth::DiscoverIdentityProvider.new
       },
       inputs: %i(account service_id)
     ) do

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -1,0 +1,49 @@
+require 'jwt'
+
+module Authentication
+  module Jwt
+
+    Err = Errors::Authentication::Jwt
+    Log = LogMessages::Authentication::Jwt
+    # Possible Errors Raised:
+    # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
+
+    VerifyAndDecodeToken = CommandClass.new(
+      dependencies: {
+        jwt_decoder: JWT,
+        logger:      Rails.logger
+      },
+      inputs:       %i(token_jwt verification_options)
+    ) do
+
+      def call
+        verified_and_decoded_token
+      end
+
+      private
+
+      def verified_and_decoded_token
+        # @jwt_decoder.decode returns an array with one decoded token so we take the first object
+        @decoded_token = @jwt_decoder.decode(
+          @token_jwt,
+          nil, # the key will be taken from options[:jwks] if present
+          should_verify,
+          @verification_options
+        ).first.tap do
+          @logger.debug(Log::TokenDecodeSuccess.new)
+        end
+      rescue JWT::ExpiredSignature
+        raise Err::TokenExpired
+      rescue JWT::DecodeError
+        @logger.debug(Log::TokenDecodeFailed.new(e.inspect))
+        raise Err::TokenDecodeFailed, e.inspect
+      rescue => e
+        raise Err::TokenVerifyFailed, e.inspect
+      end
+
+      def should_verify
+        @should_verify ||= @verification_options && !@verification_options.empty?
+      end
+    end
+  end
+end

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -6,9 +6,9 @@ module Authentication
     Err = Errors::Authentication::Jwt
     Log = LogMessages::Authentication::Jwt
     # Possible Errors Raised:
-    # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
+    # TokenExpired, TokenDecodeFailed, TokenVerificationFailed
 
-    # This class Verifies and decodes a JWT token. It doesn't connect with the issuer
+    # This class verifies and decodes a JWT token. It doesn't connect with the issuer
     # of the token for verification. If a token verification is needed, a verification_options
     # object should be provided with the JWKs & algorithms required for the verification.
     # In addition, if token claims need to be verified they should be specified in the verification_options.
@@ -51,7 +51,7 @@ module Authentication
         @logger.debug(Log::TokenDecodeFailed.new(e.inspect))
         raise Err::TokenDecodeFailed, e.inspect
       rescue => e
-        raise Err::TokenVerifyFailed, e.inspect
+        raise Err::TokenVerificationFailed, e.inspect
       end
 
       def should_verify

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -8,6 +8,19 @@ module Authentication
     # Possible Errors Raised:
     # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
 
+    # This class Verifies and decodes a JWT token. It doesn't connect with the issuer
+    # of the token for verification. If a token verification is needed, a verification_options
+    # object should be provided with the JWKs & algorithms required for the verification.
+    # In addition, if token claims need to be verified they should be specified in the verification_options.
+    # For example:
+    #     @verification_options = {
+    #       algorithms: @algs,
+    #       jwks: @jwks,
+    #       verify_iss: true
+    #       iss: https://token-issuer.com/
+    #     }
+    #
+    # For more information on the verification and decode process: https://github.com/jwt/ruby-jwt
     VerifyAndDecodeToken = CommandClass.new(
       dependencies: {
         jwt_decoder: JWT,

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -37,7 +37,7 @@ module Authentication
 
       def verified_and_decoded_token
         # @jwt_decoder.decode returns an array with one decoded token so we take the first object
-        @decoded_token = @jwt_decoder.decode(
+        @verified_and_decoded_token ||= @jwt_decoder.decode(
           @token_jwt,
           nil, # the key will be taken from options[:jwks] if present
           should_verify,

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -1,13 +1,13 @@
 module Authentication
-  module AuthnOidc
+  module OAuth
 
-    Log = LogMessages::Authentication::AuthnOidc
-    Err = Errors::Authentication::AuthnOidc
+    Log = LogMessages::Authentication::OAuth
+    Err = Errors::Authentication::OAuth
     # Possible Errors Raised:
     #   ProviderDiscoveryTimeout
     #   ProviderDiscoveryFailed
 
-    DiscoverOIDCProvider = CommandClass.new(
+    DiscoverIdentityProvider = CommandClass.new(
       dependencies: {
         logger:                    Rails.logger,
         open_id_discovery_service: OpenIDConnect::Discovery::Provider::Config
@@ -23,7 +23,7 @@ module Authentication
       private
 
       def log_provider_uri
-        @logger.debug(Log::OIDCProviderUri.new(@provider_uri))
+        @logger.debug(Log::IdentityProviderUri.new(@provider_uri))
       end
 
       # returns an OpenIDConnect::Discovery::Provider::Config::Resource instance.
@@ -32,7 +32,7 @@ module Authentication
       # unlikely to be a problem
       def discover_provider
         @discovered_provider = @open_id_discovery_service.discover!(@provider_uri).tap do
-          @logger.debug(Log::OIDCProviderDiscoverySuccess.new)
+          @logger.debug(Log::IdentityProviderDiscoverySuccess.new)
         end
       rescue HTTPClient::ConnectTimeoutError => e
         raise_error(Err::ProviderDiscoveryTimeout, e)

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -28,7 +28,7 @@ module Authentication
 
       # returns an OpenIDConnect::Discovery::Provider::Config::Resource instance.
       # While this leaks 3rd party code into ours, the only time this Resource
-      # is used is inside of FetchProviderCertificate.  This is unlikely change, and hence
+      # is used is inside of FetchProviderKeys.  This is unlikely change, and hence
       # unlikely to be a problem
       def discover_provider
         @discovered_provider = @open_id_discovery_service.discover!(@provider_uri).tap do

--- a/app/domain/authentication/o_auth/fetch_provider_certificates.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_certificates.rb
@@ -13,7 +13,7 @@ module Authentication
     FetchProviderCertificates = CommandClass.new(
       dependencies: {
         logger:                 Rails.logger,
-        discover_oidc_provider: ::Authentication::OAuth::DiscoverIdentityProvider.new
+        discover_identity_provider: DiscoverIdentityProvider.new
       },
       inputs:       %i(provider_uri)
     ) do
@@ -30,7 +30,7 @@ module Authentication
       end
 
       def discovered_provider
-        @discovered_provider ||= @discover_oidc_provider.(
+        @discovered_provider ||= @discover_identity_provider.(
           provider_uri: @provider_uri
         )
       end

--- a/app/domain/authentication/o_auth/fetch_provider_certificates.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_certificates.rb
@@ -1,10 +1,10 @@
 require 'json'
 
 module Authentication
-  module AuthnOidc
+  module OAuth
 
-    Log = LogMessages::Authentication::AuthnOidc
-    Err = Errors::Authentication::AuthnOidc
+    Log = LogMessages::Authentication::OAuth
+    Err = Errors::Authentication::OAuth
     # Possible Errors Raised:
     #   ProviderDiscoveryTimeout
     #   ProviderDiscoveryFailed
@@ -13,7 +13,7 @@ module Authentication
     FetchProviderCertificates = CommandClass.new(
       dependencies: {
         logger:                 Rails.logger,
-        discover_oidc_provider: Authentication::AuthnOidc::DiscoverOIDCProvider.new
+        discover_oidc_provider: ::Authentication::OAuth::DiscoverIdentityProvider.new
       },
       inputs:       %i(provider_uri)
     ) do
@@ -40,6 +40,7 @@ module Authentication
           keys: @discovered_provider.jwks
         }
         algs = @discovered_provider.id_token_signing_alg_values_supported
+        @logger.debug(Log::FetchProviderCertsSuccess.new)
         ProviderCertificates.new(jwks, algs)
       rescue => e
         raise Err::ProviderFetchCertificateFailed.new(@provider_uri, e.inspect)

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -8,9 +8,9 @@ module Authentication
     # Possible Errors Raised:
     #   ProviderDiscoveryTimeout
     #   ProviderDiscoveryFailed
-    #   ProviderFetchCertificateFailed
+    #   FetchProviderKeysFailed
 
-    FetchProviderCertificates = CommandClass.new(
+    FetchProviderKeys = CommandClass.new(
       dependencies: {
         logger:                 Rails.logger,
         discover_identity_provider: DiscoverIdentityProvider.new
@@ -20,7 +20,7 @@ module Authentication
 
       def call
         discover_provider
-        fetch_certs
+        fetch_provider_keys
       end
 
       private
@@ -35,15 +35,15 @@ module Authentication
         )
       end
 
-      def fetch_certs
+      def fetch_provider_keys
         jwks = {
           keys: @discovered_provider.jwks
         }
         algs = @discovered_provider.id_token_signing_alg_values_supported
-        @logger.debug(Log::FetchProviderCertsSuccess.new)
-        ProviderCertificates.new(jwks, algs)
+        @logger.debug(Log::FetchProviderKeysSuccess.new)
+        ProviderKeys.new(jwks, algs)
       rescue => e
-        raise Err::ProviderFetchCertificateFailed.new(@provider_uri, e.inspect)
+        raise Err::FetchProviderKeysFailed.new(@provider_uri, e.inspect)
       end
     end
   end

--- a/app/domain/authentication/o_auth/provider_certificates.rb
+++ b/app/domain/authentication/o_auth/provider_certificates.rb
@@ -1,8 +1,7 @@
-require 'uri'
 require 'json'
 
 module Authentication
-  module AuthnOidc
+  module OAuth
     class ProviderCertificates
       attr_reader :jwks
       attr_reader :algorithms

--- a/app/domain/authentication/o_auth/provider_certificates.rb
+++ b/app/domain/authentication/o_auth/provider_certificates.rb
@@ -2,6 +2,9 @@ require 'json'
 
 module Authentication
   module OAuth
+
+    # This class represents a set of OAuth 2.0 Identity Provider certificates
+    # Each object stores the retrieved JWKs and the algorithms that signed them
     class ProviderCertificates
       attr_reader :jwks
       attr_reader :algorithms

--- a/app/domain/authentication/o_auth/provider_keys.rb
+++ b/app/domain/authentication/o_auth/provider_keys.rb
@@ -3,9 +3,9 @@ require 'json'
 module Authentication
   module OAuth
 
-    # This class represents a set of OAuth 2.0 Identity Provider certificates
+    # This class represents a set of OAuth 2.0 Identity Provider keys
     # Each object stores the retrieved JWKs and the algorithms that signed them
-    class ProviderCertificates
+    class ProviderKeys
       attr_reader :jwks
       attr_reader :algorithms
 

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -6,7 +6,7 @@ module Authentication
     Err = Errors::Authentication::OAuth
     Log = LogMessages::Authentication::OAuth
     # Possible Errors Raised:
-    # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
+    # TokenExpired, TokenDecodeFailed, TokenVerificationFailed
 
     # This class decodes and verifies JWT tokens, issued by an OAuthn 2.0 Identity Provider.
     # It first retrieves the JWKs from the identity provider and sets them as verification options

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -8,6 +8,10 @@ module Authentication
     # Possible Errors Raised:
     # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
 
+    # This class decodes and verifies JWT tokens, issued by an OAuthn 2.0 Identity Provider.
+    # It first retrieves the JWKs from the identity provider and sets them as verification options
+    # for Authentication::Jwt::VerifyAndDecodeToken. That class does the offline verification and decode,
+    # using the JWKs retrieved from the OAuthn 2.0 Identity Provider.
     VerifyAndDecodeToken = CommandClass.new(
       dependencies: {
         # We have a ConcurrencyLimitedCache which wraps a RateLimitedCache which wraps a FetchProviderCertificate class

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -1,10 +1,10 @@
 require 'jwt'
 
 module Authentication
-  module AuthnOidc
+  module OAuth
 
-    Err = Errors::Authentication::AuthnOidc
-    Log = LogMessages::Authentication::AuthnOidc
+    Err = Errors::Authentication::OAuth
+    Log = LogMessages::Authentication::OAuth
     # Possible Errors Raised:
     # TokenExpired, TokenDecodeFailed, TokenVerifyFailed
 
@@ -13,7 +13,7 @@ module Authentication
         # We have a ConcurrencyLimitedCache which wraps a RateLimitedCache which wraps a FetchProviderCertificate class
         fetch_provider_certificate: ::Util::ConcurrencyLimitedCache.new(
           ::Util::RateLimitedCache.new(
-            ::Authentication::AuthnOidc::FetchProviderCertificates.new,
+            ::Authentication::OAuth::FetchProviderCertificates.new,
             refreshes_per_interval: 10,
             rate_limit_interval:    300, # 300 seconds (every 5 mins)
             logger: Rails.logger
@@ -41,7 +41,7 @@ module Authentication
 
         @jwks = provider_certificates.jwks
         @algs = provider_certificates.algorithms
-        @logger.debug(Log::OIDCProviderCertificateFetchedFromCache.new)
+        @logger.debug(Log::IdentityProviderCertificateFetchedFromCache.new)
       end
 
       def verify_and_decode_token
@@ -75,7 +75,7 @@ module Authentication
           @logger.debug(Log::TokenDecodeSuccess.new)
         end
       rescue JWT::ExpiredSignature
-        raise Err::IdTokenExpired
+        raise Err::TokenExpired
       rescue JWT::DecodeError
         @logger.debug(Log::TokenDecodeFailed.new(e.inspect))
         raise Err::TokenDecodeFailed, e.inspect

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -49,6 +49,11 @@ module Authentication
         @logger.debug(Log::IdentityProviderKeysFetchedFromCache.new)
       end
 
+      # ensure_keys_are_fresh will try to verify and decode the token and if it
+      # fails we fetch the provider keys again. We then verify and decode again
+      # so we definitely don't fail because the keys are too old. If ensure_keys_are_fresh
+      # will succeed to decode the token then the call to verified_and_decoded_token
+      # will not do a thing because the object is memoized
       def verify_and_decode_token
         ensure_keys_are_fresh
         verified_and_decoded_token

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -17,7 +17,7 @@ module Authentication
         # We have a ConcurrencyLimitedCache which wraps a RateLimitedCache which wraps a FetchProviderCertificate class
         fetch_provider_certificate: ::Util::ConcurrencyLimitedCache.new(
           ::Util::RateLimitedCache.new(
-            ::Authentication::OAuth::FetchProviderCertificates.new,
+            FetchProviderCertificates.new,
             refreshes_per_interval: 10,
             rate_limit_interval:    300, # 300 seconds (every 5 mins)
             logger: Rails.logger

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -109,7 +109,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       end
 
-      module AuthnOidc
+      module OAuth
 
         ProviderDiscoveryTimeout = ::Util::TrackableErrorClass.new(
           msg: "Identity Provider discovery failed with timeout error (Provider URI: '{0}'). Reason: '{1}'",
@@ -126,14 +126,9 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00012E"
         )
 
-        IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
-          code: "CONJ00013E"
-        )
-
-        TokenVerifyFailed = ::Util::TrackableErrorClass.new(
-          msg: "Token verification failed (3rdPartyError ='{0}')",
-          code: "CONJ00015E"
+        TokenExpired = ::Util::TrackableErrorClass.new(
+          msg: "Token expired",
+          code: "CONJ00016E"
         )
 
         TokenDecodeFailed = ::Util::TrackableErrorClass.new(
@@ -141,9 +136,18 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00035E"
         )
 
-        IdTokenExpired = ::Util::TrackableErrorClass.new(
-          msg: "Token expired",
-          code: "CONJ00016E"
+        TokenVerifyFailed = ::Util::TrackableErrorClass.new(
+          msg: "Token verification failed (3rdPartyError ='{0}')",
+          code: "CONJ00015E"
+        )
+
+      end
+
+      module AuthnOidc
+
+        IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg: "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
+          code: "CONJ00013E"
         )
 
         AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -126,6 +126,10 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00012E"
         )
 
+      end
+
+      module Jwt
+
         TokenExpired = ::Util::TrackableErrorClass.new(
           msg: "Token expired",
           code: "CONJ00016E"

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -121,8 +121,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00011E"
         )
 
-        ProviderFetchCertificateFailed = ::Util::TrackableErrorClass.new(
-          msg: "Failed to fetch certificate from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
+        FetchProviderKeysFailed = ::Util::TrackableErrorClass.new(
+          msg: "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00012E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -140,7 +140,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00035E"
         )
 
-        TokenVerifyFailed = ::Util::TrackableErrorClass.new(
+        TokenVerificationFailed = ::Util::TrackableErrorClass.new(
           msg: "Token verification failed (3rdPartyError ='{0}')",
           code: "CONJ00015E"
         )

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -29,11 +29,31 @@ unless defined? LogMessages::Authentication::OriginValidated
 
       end
 
-      module AuthnOidc
+      module OAuth
 
-        ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
-          msg: "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
-          code: "CONJ00004D"
+        IdentityProviderUri = ::Util::TrackableLogMessageClass.new(
+          msg: "Working with Identity Provider {0-provider-uri}",
+          code: "CONJ00007D"
+        )
+
+        IdentityProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
+          msg: "Identity Provider discovery succeeded",
+          code: "CONJ00008D"
+        )
+
+        IdentityProviderCertificateFetchedFromCache = ::Util::TrackableLogMessageClass.new(
+          msg: "Identity Provider certificates fetched successfully from cache",
+          code: "CONJ00017D"
+        )
+
+        FetchProviderCertsSuccess = ::Util::TrackableLogMessageClass.new(
+          msg: "Fetched Identity Provider certificates successfully",
+          code: "CONJ00009D"
+        )
+
+        ValidateProviderCertificateIsUpdated = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating Identity Provider certificates are up to date",
+          code: "CONJ00019D"
         )
 
         TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
@@ -46,29 +66,13 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00018D"
         )
 
-        OIDCProviderUri = ::Util::TrackableLogMessageClass.new(
-          msg: "Working with Identity Provider {0-provider-uri}",
-          code: "CONJ00007D"
-        )
+      end
 
-        OIDCProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider discovery succeeded",
-          code: "CONJ00008D"
-        )
+      module AuthnOidc
 
-        FetchProviderCertsSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Fetched Identity Provider certificates successfully",
-          code: "CONJ00009D"
-        )
-
-        OIDCProviderCertificateFetchedFromCache = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider certificates fetched successfully from cache",
-          code: "CONJ00017D"
-        )
-
-        ValidateProviderCertificateIsUpdated = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating Identity Provider certificates are up to date",
-          code: "CONJ00019D"
+        ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
+          msg: "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
+          code: "CONJ00004D"
         )
 
       end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -41,18 +41,18 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00008D"
         )
 
-        IdentityProviderCertificateFetchedFromCache = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider certificates fetched successfully from cache",
+        IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
+          msg: "Identity Provider keys fetched successfully from cache",
           code: "CONJ00017D"
         )
 
-        FetchProviderCertsSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Fetched Identity Provider certificates successfully",
+        FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
+          msg: "Fetched Identity Provider keys successfully",
           code: "CONJ00009D"
         )
 
-        ValidateProviderCertificateIsUpdated = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating Identity Provider certificates are up to date",
+        ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating Identity Provider keys are up to date",
           code: "CONJ00019D"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -56,6 +56,10 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00019D"
         )
 
+      end
+
+      module Jwt
+
         TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
           msg: "Token decode succeeded",
           code: "CONJ00005D"

--- a/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Authentication::AuthnOidc::ValidateStatus do
     }
   end
 
-  def mock_discover_oidc_provider(is_successful:)
+  def mock_discover_identity_provider(is_successful:)
     double('discovery-provider').tap do |discover_provider|
       if is_successful
         allow(discover_provider).to receive(:call)
@@ -36,7 +36,7 @@ RSpec.describe Authentication::AuthnOidc::ValidateStatus do
                                          is_successful: true,
                                          fetched_secrets: oidc_authenticator_secrets
                                        ),
-          discover_oidc_provider: mock_discover_oidc_provider(is_successful: true)
+          discover_identity_provider: mock_discover_identity_provider(is_successful: true)
         ).call(
           account: test_account,
             service_id: test_service_id
@@ -56,14 +56,14 @@ RSpec.describe Authentication::AuthnOidc::ValidateStatus do
                                          is_successful: true,
                                          fetched_secrets: oidc_authenticator_secrets
                                        ),
-          discover_oidc_provider: mock_discover_oidc_provider(is_successful: false)
+          discover_identity_provider: mock_discover_identity_provider(is_successful: false)
         ).call(
           account: test_account,
             service_id: test_service_id
         )
       end
 
-      it "raises the error raised by discover_oidc_provider" do
+      it "raises the error raised by discover_identity_provider" do
         expect { subject }.to raise_error(test_oidc_discovery_error)
       end
 
@@ -77,7 +77,7 @@ RSpec.describe Authentication::AuthnOidc::ValidateStatus do
                                        is_successful: false,
                                        fetched_secrets: oidc_authenticator_secrets
                                      ),
-        discover_oidc_provider: mock_discover_oidc_provider(is_successful: true)
+        discover_identity_provider: mock_discover_identity_provider(is_successful: true)
       ).call(
         account: test_account,
           service_id: test_service_id

--- a/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Authentication::AuthnOidc::DiscoverOIDCProvider do
+RSpec.describe Authentication::OAuth::DiscoverIdentityProvider do
 
   let (:test_provider_uri) { "test-provider-uri" }
   let (:test_error) { "test-error" }
@@ -18,9 +18,9 @@ RSpec.describe Authentication::AuthnOidc::DiscoverOIDCProvider do
     end
   end
 
-  context "A discoverable Oidc provider" do
+  context "A discoverable identity provider" do
     subject do
-      Authentication::AuthnOidc::DiscoverOIDCProvider.new(
+      Authentication::OAuth::DiscoverIdentityProvider.new(
         open_id_discovery_service: mock_discovery_provider(error: nil)
       ).call(
         provider_uri: test_provider_uri
@@ -36,10 +36,10 @@ RSpec.describe Authentication::AuthnOidc::DiscoverOIDCProvider do
     end
   end
 
-  context "A non-discoverable Oidc provider" do
+  context "A non-discoverable identity provider" do
     context "fails on timeout error" do
       subject do
-        Authentication::AuthnOidc::DiscoverOIDCProvider.new(
+        Authentication::OAuth::DiscoverIdentityProvider.new(
           open_id_discovery_service: mock_discovery_provider(error: HTTPClient::ConnectTimeoutError)
         ).call(
           provider_uri: test_provider_uri
@@ -47,12 +47,12 @@ RSpec.describe Authentication::AuthnOidc::DiscoverOIDCProvider do
       end
 
       it "returns a ProviderDiscoveryTimeout error" do
-        expect { subject }.to raise_error(Errors::Authentication::AuthnOidc::ProviderDiscoveryTimeout)
+        expect { subject }.to raise_error(Errors::Authentication::OAuth::ProviderDiscoveryTimeout)
       end
 
       context "fails on general error" do
         subject do
-          Authentication::AuthnOidc::DiscoverOIDCProvider.new(
+          Authentication::OAuth::DiscoverIdentityProvider.new(
             open_id_discovery_service: mock_discovery_provider(error: test_error)
           ).call(
             provider_uri: test_provider_uri
@@ -60,7 +60,7 @@ RSpec.describe Authentication::AuthnOidc::DiscoverOIDCProvider do
         end
 
         it "returns a ProviderDiscoveryFailed error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnOidc::ProviderDiscoveryFailed)
+          expect { subject }.to raise_error(Errors::Authentication::OAuth::ProviderDiscoveryFailed)
         end
       end
     end


### PR DESCRIPTION
#### What does this PR do?

Extracts OAuthn related code into its own module and JWT related code into its own module.
This is done so other authenticators can use these parts of code independently from the OIDC authenticator, as it can be confusing to the reader which parts are OIDC related, which are OAuth related and which are JWT related.
