### PR TITLE
Extract security and secrets specs from oidc

### DIFF
--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'support/security_specs_helper'
+require 'support/fetch_secrets_helper'
 require 'json'
 
 RSpec.describe 'Authentication::Oidc' do
 
+  include_context "fetch secrets"
+  include_context "security mocks"
   include_context "oidc setup"
 
   let (:mocked_verify_and_decode_token) { double("MockIdTokenDecodeAndVerify") }
@@ -75,7 +79,7 @@ RSpec.describe 'Authentication::Oidc' do
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(
-            enabled_authenticators: oidc_authenticator_name,
+            enabled_authenticators: authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
             validate_account_exists: mocked_account_validator,
@@ -111,7 +115,7 @@ RSpec.describe 'Authentication::Oidc' do
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(
-            enabled_authenticators: oidc_authenticator_name,
+            enabled_authenticators: authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
             validate_account_exists: mocked_account_validator,
@@ -140,7 +144,7 @@ RSpec.describe 'Authentication::Oidc' do
           )
 
           ::Authentication::AuthnOidc::Authenticate.new(
-            enabled_authenticators: oidc_authenticator_name,
+            enabled_authenticators: authenticator_name,
             token_factory: token_factory,
             validate_security: mocked_security_validator,
             validate_account_exists: mocked_account_validator,

--- a/spec/support/fetch_secrets_helper.rb
+++ b/spec/support/fetch_secrets_helper.rb
@@ -2,7 +2,25 @@
 
 shared_context "fetch secrets" do
 
-  let (:test_fetch_secrets_error) { "test-fetch-secrets-error" }
+  let(:test_fetch_secrets_error) { "test-fetch-secrets-error" }
+
+  let(:mocked_secret) do
+    double('Secret').tap do |secret|
+      allow(secret).to receive(:value).and_return("mocked-secret")
+    end
+  end
+
+  let(:mocked_resource) do
+    double('Resource').tap do |resource|
+      allow(resource).to receive(:secret).and_return(mocked_secret)
+    end
+  end
+
+  let(:resource_without_value) do
+    double('Resource').tap do |resource|
+      allow(resource).to receive(:secret).and_return(nil)
+    end
+  end
 
   def mock_fetch_secrets(is_successful:, fetched_secrets:)
     double('fetch_secrets').tap do |fetch_secrets|
@@ -14,5 +32,23 @@ shared_context "fetch secrets" do
                                   .and_raise(test_fetch_secrets_error)
       end
     end
+  end
+end
+
+shared_examples_for "it fails when variable is missing or has no value" do |variable_name|
+  it "fails when variable is missing" do
+    allow(Resource).to receive(:[])
+                         .with(/#{account}:variable:conjur\/#{authenticator_name}\/#{service}\/#{variable_name}/)
+                         .and_return(nil)
+
+    expect { subject }.to raise_error(Errors::Conjur::RequiredResourceMissing)
+  end
+
+  it "fails when variable has no value" do
+    allow(Resource).to receive(:[])
+                         .with(/#{account}:variable:conjur\/#{authenticator_name}\/#{service}\/#{variable_name}/)
+                         .and_return(resource_without_value)
+
+    expect { subject }.to raise_error(Errors::Conjur::RequiredSecretMissing)
   end
 end

--- a/spec/support/oidc_spec_helper.rb
+++ b/spec/support/oidc_spec_helper.rb
@@ -2,7 +2,7 @@
 
 shared_context "oidc setup" do
 
-  let(:oidc_authenticator_name) { "authn-oidc-test" }
+  let(:authenticator_name) { "authn-oidc" }
   let(:account) { "my-acct" }
   let(:service) { "my-service" }
 
@@ -10,117 +10,31 @@ shared_context "oidc setup" do
   # TokenFactory double
   ####################################
 
-  let (:a_new_token) { 'A NICE NEW TOKEN' }
+  let(:a_new_token) { 'A NICE NEW TOKEN' }
 
-  let (:token_factory) do
+  let(:token_factory) do
     double('TokenFactory', signed_token: a_new_token)
   end
 
   ####################################
-  # secrets mocks
+  # oidc secrets mocks
   ####################################
 
-  let (:mocked_secret) do
-    double('Secret').tap do |secret|
-      allow(secret).to receive(:value).and_return("mocked-secret")
-    end
-  end
-
-  let (:mocked_resource) do
-    double('Resource').tap do |resource|
-      allow(resource).to receive(:secret).and_return(mocked_secret)
-    end
-  end
-
-  let (:resource_without_value) do
-    double('Resource').tap do |resource|
-      allow(resource).to receive(:secret).and_return(nil)
-    end
-  end
-
-  let (:mocked_id_token_secret) do
+  let(:mocked_id_token_secret) do
     double('Secret').tap do |secret|
       allow(secret).to receive(:value).and_return("id_token_username_field")
     end
   end
 
-  let (:mocked_id_token_resource) do
+  let(:mocked_id_token_resource) do
     double('Resource').tap do |resource|
       allow(resource).to receive(:secret).and_return(mocked_id_token_secret)
     end
   end
 
-  ####################################
-  # validator mocks
-  ####################################
-
-  let (:mocked_security_validator) { double("MockSecurityValidator") }
-  let (:mocked_origin_validator) { double("MockOriginValidator") }
-  let (:mocked_account_validator) { double("MockAccountValidator") }
-
   before(:each) do
     allow(Resource).to receive(:[])
                          .with(/#{account}:variable:conjur\/authn-oidc/)
                          .and_return(mocked_resource)
-
-    allow(mocked_security_validator).to receive(:call)
-                                          .and_return(true)
-
-    allow(mocked_origin_validator).to receive(:call)
-                                        .and_return(true)
-
-    allow(mocked_account_validator).to receive(:call)
-                                        .and_return(true)
-  end
-end
-
-shared_examples_for "it fails when variable is missing or has no value" do |variable|
-  it "fails when variable is missing" do
-    allow(Resource).to receive(:[])
-                         .with(/#{account}:variable:conjur\/authn-oidc\/#{service}\/#{variable}/)
-                         .and_return(nil)
-
-    expect { subject }.to raise_error(Errors::Conjur::RequiredResourceMissing)
-  end
-
-  it "fails when variable has no value" do
-    allow(Resource).to receive(:[])
-                         .with(/#{account}:variable:conjur\/authn-oidc\/#{service}\/#{variable}/)
-                         .and_return(resource_without_value)
-
-    expect { subject }.to raise_error(Errors::Conjur::RequiredSecretMissing)
-  end
-end
-
-shared_examples_for "raises an error when security validation fails" do
-  it 'raises an error when security validation fails' do
-    allow(mocked_security_validator).to receive(:call)
-                                          .and_raise('FAKE_SECURITY_ERROR')
-
-    expect { subject }.to raise_error(
-                            /FAKE_SECURITY_ERROR/
-                          )
-  end
-end
-
-shared_examples_for "raises an error when origin validation fails" do
-  it "raises an error when origin validation fails" do
-    allow(mocked_origin_validator).to receive(:call)
-                                        .and_raise('FAKE_ORIGIN_ERROR')
-
-    expect { subject }.to raise_error(
-                            /FAKE_ORIGIN_ERROR/
-                          )
-  end
-end
-
-shared_examples_for "raises an error when account validation fails" do
-  it 'raises an error when account validation fails' do
-    allow(mocked_account_validator).to receive(:call)
-                                          .and_raise('ACCOUNT_NOT_EXIST_ERROR')
-
-    expect { subject }.to raise_error(
-                            /ACCOUNT_NOT_EXIST_ERROR/
-                          )
   end
 end

--- a/spec/support/security_specs_helper.rb
+++ b/spec/support/security_specs_helper.rb
@@ -3,12 +3,21 @@
 require 'spec_helper'
 
 shared_context "security mocks" do
-  let (:test_account) { 'test-account' }
-  let (:non_existing_account) { 'non-existing' }
-  let (:fake_authenticator_name) { 'authn-x' }
-  let (:fake_service_id) { 'fake-service-id' }
-  let (:test_user_id) { 'some-user' }
-  let (:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
+  let(:test_account) { 'test-account' }
+  let(:non_existing_account) { 'non-existing' }
+  let(:fake_authenticator_name) { 'authn-x' }
+  let(:fake_service_id) { 'fake-service-id' }
+  let(:test_user_id) { 'some-user' }
+  let(:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
+  let(:mocked_security_validator) { double("ValidateSecurity") }
+  let(:mocked_origin_validator) { double("ValidateOrigin") }
+  let(:mocked_account_validator) { double("ValidateAccountExists") }
+
+  let(:validate_account_exists_error) { "validate account exists error" }
+  let(:validate_whitelisted_webservice_error) { "validate whitelisted webservice error" }
+  let(:validate_webservice_access_error) { "validate webservice access error" }
+  let(:validate_webservice_exists_error) { "validate webservice exists error" }
+  let(:validate_webservice_is_authenticator_error) { "validate webservice is authenticator error" }
 
   def mock_webservice(account, authenticator_name, service_id)
     double('webservice').tap do |webservice|
@@ -39,12 +48,6 @@ shared_context "security mocks" do
                              .and_return(nil)
     end
   end
-
-  let (:validate_account_exists_error) { "validate account exists error" }
-  let (:validate_whitelisted_webservice_error) { "validate whitelisted webservice error" }
-  let (:validate_webservice_access_error) { "validate webservice access error" }
-  let (:validate_webservice_exists_error) { "validate webservice exists error" }
-  let (:validate_webservice_is_authenticator_error) { "validate webservice is authenticator error" }
 
   def mock_validator(validation_succeeded:, validation_error:)
     double('validator').tap do |validator|
@@ -88,5 +91,49 @@ shared_context "security mocks" do
     double('user_role').tap do |role|
       allow(role).to receive(:role_id).and_return('some-role-id')
     end
+  end
+
+  before(:each) do
+    allow(mocked_security_validator).to receive(:call)
+                                          .and_return(true)
+
+    allow(mocked_origin_validator).to receive(:call)
+                                        .and_return(true)
+
+    allow(mocked_account_validator).to receive(:call)
+                                         .and_return(true)
+  end
+end
+
+shared_examples_for "raises an error when security validation fails" do
+  it 'raises an error when security validation fails' do
+    allow(mocked_security_validator).to receive(:call)
+                                          .and_raise('FAKE_SECURITY_ERROR')
+
+    expect { subject }.to raise_error(
+                            /FAKE_SECURITY_ERROR/
+                          )
+  end
+end
+
+shared_examples_for "raises an error when origin validation fails" do
+  it "raises an error when origin validation fails" do
+    allow(mocked_origin_validator).to receive(:call)
+                                        .and_raise('FAKE_ORIGIN_ERROR')
+
+    expect { subject }.to raise_error(
+                            /FAKE_ORIGIN_ERROR/
+                          )
+  end
+end
+
+shared_examples_for "raises an error when account validation fails" do
+  it 'raises an error when account validation fails' do
+    allow(mocked_account_validator).to receive(:call)
+                                         .and_raise('ACCOUNT_NOT_EXIST_ERROR')
+
+    expect { subject }.to raise_error(
+                            /ACCOUNT_NOT_EXIST_ERROR/
+                          )
   end
 end


### PR DESCRIPTION
We would like to use these helpers in other specs than oidc.
For this we need to extract them into their own helpers.
