### PR TITLE
Application identity validation implementation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,10 +77,15 @@ pipeline {
 
     stage('Submit Coverage Report'){
       steps{
-        archiveArtifacts artifacts: "coverage/.resultset.json", fingerprint: false
-        archiveArtifacts artifacts: "ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json", fingerprint: false
-        sh 'ci/submit-coverage'
-        publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
+        script {
+          try {
+            sh 'ci/submit-coverage'
+          } finally {
+            archiveArtifacts artifacts: "coverage/.resultset*.json", fingerprint: false
+            archiveArtifacts artifacts: "ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json", fingerprint: false
+            publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
+          }
+        }
       }
     }
 

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,0 +1,131 @@
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication
+    Err = Errors::Authentication
+    # Possible Errors Raised: ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
+
+    # This class defines an Azure application identity of a given Conjur resource.
+    # The constructor initializes an ApplicationIdentity object and validates that
+    # it is configured correctly.
+    # The difference between the validation in this constructor and
+    # the validation in ValidateApplicationIdentity is that here we validate that
+    # the application identity is configured correctly, and thus is a valid application
+    # identity. In ValidateApplicationIdentity we validate that the defined application
+    # identity is actually the one we expect from Azure. This validation is done through
+    # a combination of comparisons that are performed based on the type of assigned
+    # identity provided.
+    # For example, an application identity `authn-azure/some-value` is not
+    # valid and will fail the validation here. For example, application identity like
+    # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
+    # defined in the Conjur resource's annotations is a valid application identity
+    # because `subscription_id` is one of the defined, accepted constraints and will pass
+    # the validation here.
+    # If the Azure-related annotations in the resource defined in Conjur has Azure-specific
+    # annotations that do not match the supplied JWT token, then it will fail the
+    # validation of ValidateApplicationIdentity.
+    class ApplicationIdentity
+
+      def initialize(role_annotations:, service_id:)
+        @role_annotations = role_annotations
+        @service_id       = service_id
+
+        validate
+      end
+
+      def constraints
+        @constraints ||= {
+            subscription_id:          constraint_value("subscription-id"),
+            resource_group:           constraint_value("resource-group"),
+            user_assigned_identity:   constraint_value("user-assigned-identity"),
+            system_assigned_identity: constraint_value("system-assigned-identity"),
+        }.compact
+      end
+
+      private
+
+      # validate that the application identity is defined correctly
+      def validate
+        validate_azure_annotations_are_permitted
+        validate_required_constraints_exist
+        validate_constraint_combinations
+      end
+
+      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
+      def validate_azure_annotations_are_permitted
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with the given prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::AuthnAzure::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @role_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+              # verify we take only annotations from the same level
+              annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
+      end
+
+      def validate_required_constraints_exist
+        validate_constraint_exists :subscription_id
+        validate_constraint_exists :resource_group
+      end
+
+      def validate_constraint_exists constraint
+        raise Err::AuthnAzure::MissingConstraint.new(constraint) unless constraints[constraint]
+      end
+
+      # check the `service-id` specific constraint first to be more granular
+      def constraint_from_annotation constraint_name
+        annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
+            annotation_value("authn-azure/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @role_annotations.find { |a| a.values[:name] == name }
+
+        # return the value of the annotation if it exists, nil otherwise
+        if annotation
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          annotation[:value]
+        end
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
+
+      # validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      def validate_constraint_combinations
+        identifiers = %i(user_assigned_identity system_assigned_identity)
+
+        identifiers_constraints = constraints.keys & identifiers
+        raise Err::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
+      end
+
+      def constraint_value constraint_name
+        constraint_from_annotation(constraint_name)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -34,10 +34,9 @@ module Authentication
       private
 
       def validate_credentials_include_azure_token
-        # check that id token field exists and has some value
         unless decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
           !decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
-          raise Errors::Authentication::RequestBody::MissingRequestParam
+          raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME
         end
       end
 
@@ -89,14 +88,16 @@ module Authentication
       end
 
       def xms_mirid
-        decoded_token[XMS_MIRID_TOKEN_FIELD_NAME].tap do |token_field_value|
-          @logger.debug(Log::ExtractedFieldFromAzureToken.new(XMS_MIRID_TOKEN_FIELD_NAME, token_field_value))
-        end
+        token_field_value(XMS_MIRID_TOKEN_FIELD_NAME)
       end
 
       def oid
-        decoded_token[OID_TOKEN_FIELD_NAME].tap do |token_field_value|
-          @logger.debug(Log::ExtractedFieldFromAzureToken.new(OID_TOKEN_FIELD_NAME, token_field_value))
+        token_field_value(OID_TOKEN_FIELD_NAME)
+      end
+
+      def token_field_value field_name
+        decoded_token[field_name].tap do |token_field_value|
+          @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
         end
       end
     end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -4,6 +4,7 @@ module Authentication
   module AuthnAzure
 
     Err = Errors::Authentication::AuthnAzure
+    Log = LogMessages::Authentication::AuthnAzure
     # Possible Errors Raised:
     # TODO: Add errors
 
@@ -14,7 +15,7 @@ module Authentication
       inputs: [:authenticator_input]
     ) do
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
         validate_azure_token
@@ -28,14 +29,6 @@ module Authentication
       end
 
       def validate_application_identity
-
-      end
-
-      def host
-
-      end
-
-      def host_annotations
 
       end
     end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -10,10 +10,12 @@ module Authentication
 
     Authenticator = CommandClass.new(
       dependencies: {
-
+        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        logger:                      Rails.logger
       },
       inputs: [:authenticator_input]
     ) do
+
       extend Forwardable
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
@@ -30,6 +32,23 @@ module Authentication
 
       def validate_application_identity
 
+      end
+
+      def provider_uri
+        azure_authenticator_secrets["provider-uri"]
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
       end
     end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -6,48 +6,94 @@ module Authentication
     Err = Errors::Authentication::AuthnAzure
     Log = LogMessages::Authentication::AuthnAzure
     # Possible Errors Raised:
-    # TODO: Add errors
+    # TokenFieldNotFoundOrEmpty, MissingRequestParam
 
     Authenticator = CommandClass.new(
       dependencies: {
-        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        logger:                      Rails.logger
+        fetch_authenticator_secrets:   Authentication::Util::FetchAuthenticatorSecrets.new,
+        verify_and_decode_token:       Authentication::AuthnOidc::VerifyAndDecodeToken.new,
+        logger:                        Rails.logger
       },
-      inputs: [:authenticator_input]
+      inputs:       [:authenticator_input]
     ) do
 
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :credentials
+
+      JWT_REQUEST_BODY_FIELD_NAME = "jwt"
+      XMS_MIRID_TOKEN_FIELD_NAME = "xms_mirid"
+      OID_TOKEN_FIELD_NAME = "oid"
 
       def call
+        validate_credentials_include_azure_token
+        validate_azure_token
+        validate_required_token_fields_exist
         true
       end
 
       private
 
-      #def validate_azure_token
-      #
-      #end
-      #
-      #def validate_application_identity
-      #
-      #end
+      def validate_credentials_include_azure_token
+        # check that id token field exists and has some value
+        raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME unless decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
+          !decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
+      end
+
+      # The credentials are in a URL encoded form data in the request body
+      def decoded_credentials
+        @decoded_credentials ||= Hash[URI.decode_www_form(credentials)]
+      end
+
+      def validate_azure_token
+        decoded_token
+      end
+
+      def decoded_token
+        @decoded_token ||= @verify_and_decode_token.call(
+          provider_uri:     provider_uri,
+          token_jwt:        decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME],
+          claims_to_verify: {
+            verify_iss: true,
+            iss:        provider_uri
+          }
+        )
+      end
 
       def provider_uri
-        azure_authenticator_secrets["provider-uri"]
+        @provider_uri ||= azure_authenticator_secrets["provider-uri"]
       end
 
       def azure_authenticator_secrets
         @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
           service_id: service_id,
-          conjur_account: account,
-          authenticator_name: authenticator_name,
-          required_variable_names: required_variable_names
+            conjur_account: account,
+            authenticator_name: authenticator_name,
+            required_variable_names: required_variable_names
         )
       end
 
       def required_variable_names
         @required_variable_names ||= %w(provider-uri)
+      end
+
+      def validate_required_token_fields_exist
+        validate_token_field_exists(XMS_MIRID_TOKEN_FIELD_NAME)
+        validate_token_field_exists(OID_TOKEN_FIELD_NAME)
+      end
+
+      def validate_token_field_exists field_name
+        @logger.debug(Log::ValidatingTokenFieldExists.new(field_name))
+        raise Err::TokenFieldNotFoundOrEmpty, field_name if decoded_token[field_name].to_s.empty?
+      end
+
+      def xms_mirid
+        @logger.debug(Log::ExtractedFieldFromAzureToken.new(XMS_MIRID_TOKEN_FIELD_NAME, decoded_token[XMS_MIRID_TOKEN_FIELD_NAME]))
+        decoded_token[XMS_MIRID_TOKEN_FIELD_NAME]
+      end
+
+      def oid
+        @logger.debug(Log::ExtractedFieldFromAzureToken.new(OID_TOKEN_FIELD_NAME, decoded_token[OID_TOKEN_FIELD_NAME]))
+        decoded_token[OID_TOKEN_FIELD_NAME]
       end
     end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -20,19 +20,18 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
-        validate_azure_token
-        validate_application_identity
+        true
       end
 
       private
 
-      def validate_azure_token
-
-      end
-
-      def validate_application_identity
-
-      end
+      #def validate_azure_token
+      #
+      #end
+      #
+      #def validate_application_identity
+      #
+      #end
 
       def provider_uri
         azure_authenticator_secrets["provider-uri"]

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -1,0 +1,42 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    # TODO: Add errors
+
+    Authenticator = CommandClass.new(
+      dependencies: {
+
+      },
+      inputs: [:authenticator_input]
+    ) do
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+
+      def call
+
+      end
+
+      private
+
+    end
+
+    class Authenticator
+      # This delegates to all the work to the call method created automatically
+      # by CommandClass
+      #
+      # This is needed because we need `valid?` to exist on the Authenticator
+      # class, but that class contains only a metaprogramming generated
+      # `call(authenticator_input:)` method.  The methods we define in the
+      # block passed to `CommandClass` exist only on the private internal
+      # `Call` objects created each time `call` is run.
+      #
+      def valid?(input)
+        call(authenticator_input: input)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -17,11 +17,27 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
 
       def call
-
+        validate_azure_token
+        validate_application_identity
       end
 
       private
 
+      def validate_azure_token
+
+      end
+
+      def validate_application_identity
+
+      end
+
+      def host
+
+      end
+
+      def host_annotations
+
+      end
     end
 
     class Authenticator

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -18,7 +18,7 @@ module Authentication
     ) do
 
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :credentials
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :credentials, :username
 
       JWT_REQUEST_BODY_FIELD_NAME = "jwt"
       XMS_MIRID_TOKEN_FIELD_NAME  = "xms_mirid"
@@ -28,7 +28,7 @@ module Authentication
         validate_credentials_include_azure_token
         validate_azure_token
         validate_required_token_fields_exist
-        true
+        validate_application_identity
       end
 
       private
@@ -57,6 +57,17 @@ module Authentication
             verify_iss: true,
             iss:        provider_uri
           }
+        )
+      end
+
+      # expecting to receive xms_mirid and oid as inputs (either global instance or function). This will change to hash map.
+      def validate_application_identity
+        @validate_application_identity.(
+            service_id: service_id,
+                account: account,
+                username: username,
+                xms_mirid: xms_mirid,
+                oid: oid
         )
       end
 
@@ -111,7 +122,6 @@ module Authentication
       # `call(authenticator_input:)` method.  The methods we define in the
       # block passed to `CommandClass` exist only on the private internal
       # `Call` objects created each time `call` is run.
-      #
       def valid?(input)
         call(authenticator_input: input)
       end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -1,0 +1,105 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity
+
+    ValidateApplicationIdentity = CommandClass.new(
+        dependencies: {
+            role_class:                 ::Role,
+            resource_class:             ::Resource,
+            application_identity_class: ApplicationIdentity,
+            logger:                     Rails.logger
+        },
+        inputs: %i(account service_id username xms_mirid oid)
+    ) do
+
+      def call
+        token_identity_from_claims
+        # compare xms_mirid with what is defined in annotations
+        validate_application_identity
+      end
+
+      private
+
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+            role_annotations: role.annotations,
+            service_id: @service_id
+        )
+      end
+
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @username)
+      end
+
+      def role
+        @role ||= @resource_class[role_id].tap do |role|
+          raise SecurityErr::RoleNotFound(role_id) unless role
+        end
+      end
+
+      # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's
+      # among other details the subscription_id, resource group, and provider identity needed for authorization.
+      # xms_mirid is one of the fields in the JWT token. This function will extract the relevant information from
+      # xms_mirid claim and populate a representative hash with the appropriate fields.
+      def token_identity_from_claims
+
+        # validates format of claim
+        raise Err::ClaimInInvalidFormat unless validate_xms_mirid_format
+
+        @token_identity = {
+            subscription_id: xms_mirid_hash["subscriptions"],
+            resource_group: xms_mirid_hash["resourcegroups"]
+        }
+
+        # determines which Azure assigned identity is provided in annotations
+        # user-assigned-identity:
+        #   - validates that the correct provider (Microsoft.ManagedIdentity) for a user identity is defined in the
+        #     claim. If so, the 'user_assigned_identity' attribute will be added to the hash with the corresponding
+        #     value from xms_mirid claim
+        # system-assigned-identity:
+        #   - validates that the correct provider (Microsoft.Compute) for a system identity is defined in the
+        #     claim and its resource is one that we support. At current, we only support a virtualMachines resource.
+        #     If these conditions are met, a 'system_assigned_identity' attribute will be added to the hash with its
+        #     value being the oid field in the JWT token.
+        @logger.debug(Log::ExtractingIdentityForAuthentication.new("#{xms_mirid_hash["providers"]}/#{xms_mirid_hash.keys[-1]}"))
+        if xms_mirid_hash["providers"] == "Microsoft.ManagedIdentity"
+          @token_identity[:user_assigned_identity] = xms_mirid_hash["userAssignedIdentities"]
+          @token_identity[:resource_name] = xms_mirid_hash["userAssignedIdentities"]
+        else
+          @token_identity[:system_assigned_identity] = @oid
+          @token_identity[:resource_name] = @oid
+        end
+      end
+
+      # xms_mirid claim starts with an extra '/' so we will be ignoring it for parsing purposes
+      # ex: /subscription/<subscription_id> -> subscription/<subscription_id>
+      def xms_mirid_hash
+        _, *field_split = @xms_mirid.split('/')
+        Hash[field_split.each_slice(2).to_a]
+      end
+
+      def validate_xms_mirid_format
+        xms_mirid_hash.length == 4 && xms_mirid_hash.key?("subscriptions" && "resourcegroups" && "providers")
+      end
+
+      # validate the integrity of annotations against the xms_mirid object representation
+      def validate_application_identity
+        @logger.debug(Log::ValidatingApplicationIdentity.new(@token_identity[:resource_name]))
+        application_identity.constraints.each do |constraint|
+          annotation_type = constraint[0].to_s
+          annotation_value = constraint[1]
+          unless annotation_value == @token_identity[annotation_type.to_sym]
+            raise Err::InvalidApplicationIdentity.new(annotation_type)
+          end
+        end
+        @logger.debug(Log::ValidatedApplicationIdentity.new(@token_identity[:resource_name]))
+      end
+    end
+  end
+
+end

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -10,7 +10,7 @@ module Authentication
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
-        resource_class:              Resource,
+        resource_class:             ::Resource,
         k8s_resolver:               K8sResolver,
         k8s_object_lookup_class:    K8sObjectLookup,
         application_identity_class: ApplicationIdentity

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -69,12 +69,9 @@ module Authentication
         @authenticator_input = @authenticator_input.update(username: conjur_username)
       end
 
+      # The credentials are in a URL encoded form data in the request body
       def decoded_credentials
-        return @decoded_credentials unless @decoded_credentials.nil?
-
-        # The credentials are in a URL encoded form data in the request body
-        decoded_request_body = URI.decode_www_form(credentials)
-        @decoded_credentials = Hash[decoded_request_body]
+        @decoded_credentials ||= Hash[URI.decode_www_form(credentials)]
       end
 
       def oidc_authenticator_secrets

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -274,6 +274,10 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00048E"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -49,6 +49,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         code: "CONJ00045E"
       )
 
+      IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
+          msg: "Application identity includes an illegal resource constraint combination - '{0-constraints}'",
+          code: "CONJ00044E"
+      )
+
       module AuthenticatorClass
 
         DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
@@ -248,11 +253,6 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00043E"
         )
 
-        IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
-          msg: "Application identity includes an illegal Kubernetes resource constraint combination - '{0-controller-constraints}'",
-          code: "CONJ00044E"
-        )
-
         MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
           msg: "Host does not have a namespace constraint",
           code: "CONJ00045E"
@@ -276,6 +276,26 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       end
 
       module AuthnAzure
+
+        MissingConstraint = ::Util::TrackableErrorClass.new(
+            msg: "Role does not have the required constraint: {0-constraint}",
+            code: "CONJ00045E"
+        )
+
+        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+            msg: "Application identity field '{0-field-name}' does not match what is provided in Azure token",
+            code: "CONJ00049E"
+        )
+
+        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+            msg: "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+            code: "CONJ00050E"
+        )
+
+        ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
+            msg: "xms_mirid claim has been received in an invalid format",
+            code: "CONJ00051E"
+        )
 
         TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
           msg: "Field '{0-field-name}' not found or empty in token",

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -277,6 +277,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       module AuthnAzure
 
+        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg: "Field '{0-field-name}' not found or empty in token",
+          code: "CONJ00049E"
+        )
+
       end
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -141,6 +141,17 @@ unless defined? LogMessages::Authentication::OriginValidated
 
       module AuthnAzure
 
+        # TODO: get security approval for this message
+        ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
+          msg: "Extracted field '{0-field-name}' with value {1-field-value} from token",
+          code: "CONJ00029D"
+        )
+
+        ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating that field '{0}' exists in token",
+          code: "CONJ00030D"
+        )
+
       end
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -15,6 +15,16 @@ unless defined? LogMessages::Authentication::OriginValidated
         code: "CONJ00003D"
       )
 
+      ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating annotations with prefix {0-prefix}",
+          code: "CONJ00025D"
+      )
+
+      RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+          msg: "Retrieved value of annotation {0-annotation-name}",
+          code: "CONJ00024D"
+      )
+
       module Security
 
         SecurityValidated = ::Util::TrackableLogMessageClass.new(
@@ -113,16 +123,6 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00015D"
         )
 
-        RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
-          msg: "Retrieved value of annotation {0-annotation-name}",
-          code: "CONJ00024D"
-        )
-
-        ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating annotations with prefix {0-prefix}",
-          code: "CONJ00025D"
-        )
-
         ValidatingHostId = ::Util::TrackableLogMessageClass.new(
           msg: "Validating host id {0}",
           code: "CONJ00026D"
@@ -140,6 +140,20 @@ unless defined? LogMessages::Authentication::OriginValidated
       end
 
       module AuthnAzure
+        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
+            msg: "Extracting resource type {0-resource-type} for authentication",
+            code: "CONJ00029D"
+        )
+
+        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+            msg: "Validating application identity for {0-resource-name}",
+            code: "CONJ00030D"
+        )
+
+        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+            msg: "Application identity for {0-resource-name} validated",
+            code: "CONJ00030D"
+        )
 
         # TODO: get security approval for this message
         ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -138,6 +138,10 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00028D"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/ci/authn-azure/policies/authn-azure.yml
+++ b/ci/authn-azure/policies/authn-azure.yml
@@ -1,0 +1,16 @@
+# Azure authenticator
+- !policy
+  id: conjur/authn-azure/test
+  body:
+  - !webservice
+
+  - !variable
+    id: provider-uri
+
+  - !group
+    id: apps
+
+  - !permit
+    role: !group apps
+    privilege: [ read, authenticate ]
+    resource: !webservice

--- a/ci/authn-azure/policies/azure-hosts.yml
+++ b/ci/authn-azure/policies/azure-hosts.yml
@@ -1,0 +1,21 @@
+# Hosts that will authenticate with the Azure authenticator
+- !policy
+  id: azure-apps
+  body:
+    - !group
+
+    - &hosts
+      - !host
+        id: test-app
+        annotations:
+          authn-azure/subscription-id: test-subscription
+          authn-azure/resource-group: test-group
+          authn-azure/user-assigned-identity: test-app-pipeline
+
+    - !grant
+      role: !group
+      members: *hosts
+
+- !grant
+  role: !group conjur/authn-azure/test/apps
+  member: !group azure-apps

--- a/ci/authn-azure/policies/test-secrets.yml
+++ b/ci/authn-azure/policies/test-secrets.yml
@@ -1,0 +1,16 @@
+# Variable that will be consumed by azure-apps/test-app
+- !policy
+  id: secrets
+  body:
+    - !group consumers
+
+    - !variable test-variable
+
+    - !permit
+      role: !group consumers
+      privilege: [ read, execute ]
+      resource: !variable test-variable
+
+- !grant
+  role: !group secrets/consumers
+  member: !group azure-apps

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# Get an Azure access token
+azure_access_token=$(curl \
+  'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' \
+  -H Metadata:true -s | jq -r '.access_token')
+
+# Get an authn-azure Conjur access token for host azure-apps/test-app
+authn_azure_response=$(curl -k -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data "jwt=$azure_access_token" \
+  https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
+authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+
+# Retrieve a Conjur secret using the authn-azure Conjur access token
+curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -ex
 
+echo "Retieving Azure access token"
 # Get an Azure access token
 azure_access_token=$(curl \
   'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' \
   -H Metadata:true -s | jq -r '.access_token')
 
+echo "Get Conjur access token using an Azure access token"
 # Get an authn-azure Conjur access token for host azure-apps/test-app
 authn_azure_response=$(curl -k -X POST \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -12,6 +14,9 @@ authn_azure_response=$(curl -k -X POST \
   https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
 authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
 
+echo "Retrieve a secret using the Conjur access token"
 # Retrieve a Conjur secret using the authn-azure Conjur access token
-curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
-  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable
+secret=$(curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable)
+
+echo "Retrieved secret ${secret} from Conjur!!!"

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 echo "Retieving Azure access token"
 # Get an Azure access token

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 echo "Retieving Azure access token"
 # Get an Azure access token

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -ex
+
+tar xvzf conjur-image.tar.gz
+sudo docker load -i conjur-image.tar
+
+# Remove old containers if they are up
+if [[ -d "conjur-quickstart" ]]
+then
+  pushd conjur-quickstart
+  sudo docker-compose down -v
+  popd
+fi
+
+rm -rf conjur-quickstart
+git clone --single-branch --branch local-conjur-image https://github.com/cyberark/conjur-quickstart.git
+cd conjur-quickstart
+sudo docker-compose down -v
+
+sed "s#{{ CONJUR_IMAGE_VERSION }}#$CONJUR_IMAGE_VERSION#g" ./Dockerfile.template > ./Dockerfile
+sudo docker-compose pull
+sudo docker-compose build
+sudo docker-compose run --no-deps --rm conjur data-key generate > data_key
+
+conjur_data_key="$(< data_key)"
+echo "Generated CONJUR_DATA_KEY $conjur_data_key"
+
+# TODO: Make it work without sed. docker-compose should take the host's env var if it is not set but it doesn't work
+sed "s#{{ CONJUR_DATA_KEY }}#${conjur_data_key}#; s#postgres:9.4#postgres:9.3#" ./docker-compose.yml.template > ./docker-compose.yml
+
+sudo docker-compose up -d
+
+# Wait for all components to be up before we create the account
+sleep 5
+sudo docker-compose exec -T conjur conjurctl account create cucumber
+
+sudo docker-compose exec -T client conjur init -u conjur -a cucumber
+admin_api_key=$(sudo docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+sudo docker-compose exec -T client conjur authn login -u admin -p $admin_api_key
+
+# Copy the policy files into the directory that is volumed into the client
+cp ../policies/* conf/policy/
+
+sudo docker-compose exec -T client conjur policy load root policy/authn-azure.yml
+
+azure_provider_uri="https://sts.windows.net/df242c82-fe4a-47e0-b0f4-e3cb7f8104f1/"
+sudo docker-compose exec -T client conjur variable values add conjur/authn-azure/test/provider-uri $azure_provider_uri
+
+sudo docker-compose exec -T client conjur policy load root policy/azure-hosts.yml
+
+sudo docker-compose exec -T client conjur policy load root policy/test-secrets.yml
+sudo docker-compose exec -T client conjur variable values add secrets/test-variable test-secret
+
+# Get a Conjur access token for admin so we can enable the authn-azure authenticator in the DB
+authn_admin_response=$(curl -k -X POST --data "${admin_api_key}" \
+  https://0.0.0.0:8443/authn/cucumber/admin/authenticate)
+admin_conjur_access_token=$(echo -n "$authn_admin_response" | base64 | tr -d '\r\n')
+
+# Enable the authn-azure authenticator in the DB
+curl -k -X PATCH  -H "Authorization: Token token=\"$admin_conjur_access_token\"" \
+  --data "enabled=true" https://0.0.0.0:8443/authn-azure/test/cucumber

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 tar xvzf conjur-image.tar.gz
 sudo docker load -i conjur-image.tar

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 tar xvzf conjur-image.tar.gz
 sudo docker load -i conjur-image.tar

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -ex
+
+# TODO: get these dynamically
+AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"
+AWS_MACHINE_USERNAME="<username of AWS machine>"
+CONJUR_SERVER_DNS="<DNS of Conjur server machine>"
+
+AZURE_VM_USERNAME="<username of Azure VM>"
+AZURE_VM_IP="<IP address of Azure VM>"
+
+# Build Conjur image
+pushd ../..
+  . version_utils.sh
+  conjur_image_version="$(version_tag)"
+
+  ./build.sh
+popd
+
+# Copy docker image into AWS machine
+docker save -o ./conjur-image.tar conjur:$conjur_image_version
+tar -czvf conjur-image.tar.gz conjur-image.tar
+scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar.gz $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+
+# Copy authn-azure policies into AWS machine
+scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+
+scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+ssh -i "${AWS_PEM_FILE_LOCATION}" $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS CONJUR_IMAGE_VERSION="$conjur_image_version" ./setup-conjur.sh
+
+scp run-authn-azure.sh $AZURE_VM_USERNAME@$AZURE_VM_IP:~/.
+ssh $AZURE_VM_USERNAME@$AZURE_VM_IP CONJUR_SERVER_DNS="$CONJUR_SERVER_DNS" ./run-authn-azure.sh

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 # TODO: get these dynamically
 AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 # TODO: get these dynamically
 AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"

--- a/ci/submit-coverage
+++ b/ci/submit-coverage
@@ -22,6 +22,24 @@ if [[ ! -e ${REPORT} ]]; then
     exit 1
 fi
 
+if ! grep -q SimpleCov "${REPORT}"; then
+    echo "SimpleCov report (${REPORT}) does not contain any SimpleCov data: $(cat ${REPORT})"
+    exit 1
+fi
+
+if [[ ! -e "${GKE_REPORT}" ]]; then
+    echo "GKE SimpleCov report not found :("
+    ls -laR ci/authn-k8s/output
+    exit 1
+fi
+
+if ! grep -q SimpleCov "${GKE_REPORT}"; then
+    echo "SimpleCov report (${GKE_REPORT}) does not contain any SimpleCov data: $(cat ${GKE_REPORT})"
+    exit 1
+fi
+
+echo "SimpleCov Reports Found: ${REPORT}, ${GKE_REPORT}"
+
 if [[ ! -x ${BIN} ]]; then
     echo "cc-test-reporter binary not found, not reporting coverage data to code climate"
     ls -laR ${DIR}
@@ -29,12 +47,9 @@ if [[ ! -x ${BIN} ]]; then
     exit 1
 fi
 
-if [[ ! -e "${GKE_REPORT}" ]]; then
-    echo "GKE report not found :("
-    ls -laR ci/authn-k8s/output
-    exit 1
-fi
-echo "GKE report found"
+
+# Preserve a pre-merge version of the results from the non gke test branches.
+cp "${REPORT}" "${DIR}/.resultset-non-gke.json"
 
 # Merge GKE report with the already combined cucumber and rspec results.
 # -s loads input files into an array

--- a/design/authn_azure/authn_azure_solution_design.md
+++ b/design/authn_azure/authn_azure_solution_design.md
@@ -42,15 +42,13 @@
 
 ## Issue description
 
-Many of our customers are using Azure as their main cloud provider. Therefore we want to enable Azure resources to authenticate according to Azure 
+We want to enable Azure resources to authenticate according to Azure 
 properties and get back a Conjur access token in order to retrieve secrets from our providers. At current, customers can authenticate their Azure 
 VMs with Conjur by creating a Conjur host identity for their Azure resources. The Azure resource would then receive an API key as part of the 
 creation of a Conjur identity which they must use to connect to targets. This is not optimal nor convenient because we are not allowing the 
 resources to authenticate based on their Azure identity and demand that the resource hold an extra secret, the Conjur-given API key.
 
 ## Solution
-
-We expect the app to be on an Azure VM and we currently do not officially support having a Conjur instance in Azure.
 
 We will add a new authenticator to Conjur, which users can authenticate with from Azure VMs. As mentioned in the [feature doc](https://app.zenhub.com/workspaces/appliance-development-5c9cf04bfa1c204b63eddcc6/issues/cyberark/conjur/1266), before any authentication 
 request is sent to Conjur, the admin will load the authenticator policy: 

--- a/design/authn_azure/authn_azure_solution_design.md
+++ b/design/authn_azure/authn_azure_solution_design.md
@@ -466,7 +466,7 @@ Azure authenticator performance should conform with our other authenticators wit
 
 |    | Scenario                                                                | Log message                                                                            | Implemented            |
 |--- |-----------------------------------------------------------------------  |----------------------------------------------------------------------------------------|------------------------|
-| 1  | Authenticator is not enabled (in DB/ENV)                                | {0-authenticator-name}' is not enabled                                                 | <ul><li> [ ] </li></ul> |
+| 1  | Authenticator is not enabled (in DB/ENV)                                | Authenticator '{0-authenticator-name}' is not enabled                                                 | <ul><li> [ ] </li></ul> |
 | 2  | Webservice is not defined in a Conjur policy                            | Webservice '{0-webservice-name}' wasn't found                                          | <ul><li> [ ] </li></ul> |
 | 3  | Host is not permitted to authenticate with the webservice               | '{0-role-name}' does not have 'authenticate' privilege on {1-service-name}             | <ul><li> [ ] </li></ul> |
 | 4  | Host is not defined in Conjur                                           | '{0-role-name}' wasn't found                                                           | <ul><li> [ ] </li></ul> |

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -4,17 +4,13 @@ require 'spec_helper'
 
 RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
 
-  include_context "fetch secrets"
+  include_context "fetch secrets", %w(provider-uri)
 
-  let(:azure_authenticator_name) { "authn-azure-test" }
+  let(:account) { "my-acct" }
+  let(:authenticator_name) { "authn-azure" }
+  let(:service) { "my-service" }
 
-  let(:azure_authenticator_secrets) do
-    {
-      "provider-uri" => "test-uri"
-    }
-  end
-
-  let (:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+  let(:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
 
   before(:each) do
     allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
@@ -26,24 +22,38 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
   # request mock
   ####################################
 
-  let (:authenticate_azure_token_request) do
-    request_body = StringIO.new
-    request_body.puts "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
-    request_body.rewind
+  def mock_authenticate_azure_token_request(request_body_data:)
+    double('AuthnAzureRequest').tap do |request|
+      request_body = StringIO.new
+      request_body.puts request_body_data
+      request_body.rewind
 
-    double('Request').tap do |request|
       allow(request).to receive(:body).and_return(request_body)
     end
   end
 
-  let (:authenticate_azure_token_request_missing_azure_token_field) do
-    request_body = StringIO.new
-    request_body.puts "some_key=some_value"
-    request_body.rewind
+  def request_body(request)
+    request.body.read.chomp
+  end
 
-    double('Request').tap do |request|
-      allow(request).to receive(:body).and_return(request_body)
-    end
+  let(:authenticate_azure_token_request) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_xms_mirid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_oid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "some_key=some_value")
+  end
+
+  let(:authenticate_azure_token_request_empty_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt=")
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
@@ -56,22 +66,18 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
       context "with a valid azure token" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
-            authenticator_name: 'authn-azure',
-            service_id:         'my-service',
-            account:            'my-acct',
+            authenticator_name: authenticator_name,
+            service_id:         service,
+            account:            account,
             username:           'my-user',
-            credentials:        authenticate_azure_token_request.body.read,
+            credentials:        request_body(authenticate_azure_token_request),
             origin:             '127.0.0.1',
             request:            authenticate_azure_token_request
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: true,
-                                           fetched_secrets: azure_authenticator_secrets
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
@@ -80,27 +86,104 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           expect { subject }.to_not raise_error
           expect(subject).to eq(true)
         end
+
+        it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
       end
 
-      context "with no azure_token field in the request" do
+      context "with an invalid azure token" do
+        context "that fails token verification" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it 'raises the error raised by mocked_verify_and_decode_token' do
+            allow(mocked_verify_and_decode_token).to receive(:call)
+                                                  .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
+
+            expect { subject }.to raise_error(
+                                    /FAKE_VERIFY_AND_DECODE_ERROR/
+                                  )
+          end
+        end
+
+        context "that is missing the xms_mirid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_xms_mirid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_xms_mirid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+
+        context "that is missing the oid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_oid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_oid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+      end
+
+      context "with no jwt field in the request" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-azure',
             service_id:         'my-service',
             account:            'my-acct',
             username:           nil,
-            credentials:        authenticate_azure_token_request_missing_azure_token_field.body.read,
+            credentials:        request_body(authenticate_azure_token_request_missing_jwt_field),
             origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request_missing_azure_token_field
+            request:            authenticate_azure_token_request_missing_jwt_field
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: true,
-                                           fetched_secrets: azure_authenticator_secrets
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
@@ -109,32 +192,28 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
-
-      context "Required variables do not exist or does not have value" do
+      
+      context "with an empty jwt field in the request" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-azure',
             service_id:         'my-service',
             account:            'my-acct',
-            username:           'my-user',
-            credentials:        authenticate_azure_token_request.body.read,
+            username:           nil,
+            credentials:        request_body(authenticate_azure_token_request_empty_jwt_field),
             origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request
+            request:            authenticate_azure_token_request_empty_jwt_field
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: false,
-                                           fetched_secrets: nil
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
 
-        it "raises the error raised by fetch_authenticator_secrets" do
-          expect { subject }.to raise_error(test_fetch_secrets_error)
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
     end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
+
+  include_context "fetch secrets"
+
+  let(:azure_authenticator_name) { "authn-azure-test" }
+
+  let(:azure_authenticator_secrets) do
+    {
+      "provider-uri" => "test-uri"
+    }
+  end
+
+  let (:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+
+  before(:each) do
+    allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
+      JSON.parse(args[0][:token_jwt]).to_hash
+    }
+  end
+
+  ####################################
+  # request mock
+  ####################################
+
+  let (:authenticate_azure_token_request) do
+    request_body = StringIO.new
+    request_body.puts "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
+    request_body.rewind
+
+    double('Request').tap do |request|
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  let (:authenticate_azure_token_request_missing_azure_token_field) do
+    request_body = StringIO.new
+    request_body.puts "some_key=some_value"
+    request_body.rewind
+
+    double('Request').tap do |request|
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "An Azure authenticator" do
+    context "that receives an authenticate request" do
+      context "with a valid azure token" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           'my-user',
+            credentials:        authenticate_azure_token_request.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: true,
+                                           fetched_secrets: azure_authenticator_secrets
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "does not raise an error" do
+          expect { subject }.to_not raise_error
+          expect(subject).to eq(true)
+        end
+      end
+
+      context "with no azure_token field in the request" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            credentials:        authenticate_azure_token_request_missing_azure_token_field.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request_missing_azure_token_field
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: true,
+                                           fetched_secrets: azure_authenticator_secrets
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+
+      context "Required variables do not exist or does not have value" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           'my-user',
+            credentials:        authenticate_azure_token_request.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: false,
+                                           fetched_secrets: nil
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises the error raised by fetch_authenticator_secrets" do
+          expect { subject }.to raise_error(test_fetch_secrets_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 
 RSpec.describe 'Authentication::Oidc' do
 
-  include_context "fetch secrets"
+  include_context "fetch secrets", %w(provider-uri id-token-user-property)
   include_context "security mocks"
   include_context "oidc setup"
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds the second validation in for the Azure authenticator, validating the application identity of the resource sending the request

Object received: Hash object from decode/valid token

DOD
- [x] Check integrity of annotations relevant to authn-azure (prefixed correctly, in proper format, has the 2 required annotations, and that there is not a combo of user and system assigned identity
- [x] Validate xms_mirid/oid based on annotations
   - [x] Grab the `key -> value` list from output of previous check and perform validation check
   - [x] Ensure that there user/system assigned flows are accounted for

TODO:
- [ ] validate xms_mirid format (length or # of slashes)