### PR TITLE
Improve shared_context for fetching secrets in rspec

### DIFF
--- a/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authn_oidc_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 
 RSpec.describe 'Authentication::Oidc' do
 
-  include_context "fetch secrets"
+  include_context "fetch secrets", %w(provider-uri id-token-user-property)
   include_context "security mocks"
   include_context "oidc setup"
 


### PR DESCRIPTION
#### What does this PR do?
Improves the shared_context for fetching secrets in rspec so it is easier to add
UTs for cases where the required variables are missing or they have no value.
