### PR TITLE
Insert enabled_authenticators as input for ValidateStatus

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -22,7 +22,8 @@ class AuthenticateController < ApplicationController
 
   def status
     Authentication::ValidateStatus.new.(
-      authenticator_status_input: status_input
+      authenticator_status_input: status_input,
+      enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV)
     )
     render json: { status: "ok" }
   rescue => e

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -19,10 +19,9 @@ module Authentication
       validate_webservice_exists:      ::Authentication::Security::ValidateWebserviceExists.new,
       role_class:                      ::Role,
       implemented_authenticators:      Authentication::InstalledAuthenticators.authenticators(ENV),
-      enabled_authenticators:          Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV),
       audit_event:                     AuditEvent.new
     },
-    inputs:       %i(authenticator_status_input)
+    inputs:       %i(authenticator_status_input enabled_authenticators)
   ) do
 
     def call

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -112,10 +112,10 @@ RSpec.describe Authentication::ValidateStatus do
         validate_whitelisted_webservice: mock_validate_whitelisted_webservice(validation_succeeded: true),
         validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-        implemented_authenticators: mock_implemented_authenticators,
-        enabled_authenticators: mock_enabled_authenticators
+        implemented_authenticators: mock_implemented_authenticators
       ).call(
-        authenticator_status_input: mock_status_input("authn-status-pass")
+        authenticator_status_input: mock_status_input("authn-status-pass"),
+        enabled_authenticators: mock_enabled_authenticators
       )
     end
 
@@ -131,10 +131,10 @@ RSpec.describe Authentication::ValidateStatus do
         validate_whitelisted_webservice: mock_validate_whitelisted_webservice(validation_succeeded: true),
         validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-        implemented_authenticators: mock_implemented_authenticators,
-        enabled_authenticators: mock_enabled_authenticators
+        implemented_authenticators: mock_implemented_authenticators
       ).call(
-        authenticator_status_input: mock_status_input("authn-non-exist")
+        authenticator_status_input: mock_status_input("authn-non-exist"),
+        enabled_authenticators: mock_enabled_authenticators
       )
     end
 
@@ -153,10 +153,10 @@ RSpec.describe Authentication::ValidateStatus do
           validate_whitelisted_webservice: mock_validate_whitelisted_webservice(validation_succeeded: true),
           validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
           validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-          implemented_authenticators: mock_implemented_authenticators,
-          enabled_authenticators: mock_enabled_authenticators
+          implemented_authenticators: mock_implemented_authenticators
         ).call(
-          authenticator_status_input: mock_status_input("authn-status-not-implemented")
+          authenticator_status_input: mock_status_input("authn-status-not-implemented"),
+          enabled_authenticators: mock_enabled_authenticators
         )
       end
 
@@ -175,10 +175,10 @@ RSpec.describe Authentication::ValidateStatus do
             validate_whitelisted_webservice: mock_validate_webservice_exists(validation_succeeded: true),
             validate_webservice_access: mock_validate_webservice_access(validation_succeeded: false),
             validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-            implemented_authenticators: mock_implemented_authenticators,
-            enabled_authenticators: mock_enabled_authenticators
+            implemented_authenticators: mock_implemented_authenticators
           ).call(
-            authenticator_status_input: mock_status_input("authn-status-pass")
+            authenticator_status_input: mock_status_input("authn-status-pass"),
+            enabled_authenticators: mock_enabled_authenticators
           )
         end
 
@@ -198,10 +198,10 @@ RSpec.describe Authentication::ValidateStatus do
               validate_whitelisted_webservice: mock_validate_webservice_exists(validation_succeeded: true),
               validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
               validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: false),
-              implemented_authenticators: mock_implemented_authenticators,
-              enabled_authenticators: mock_enabled_authenticators
+              implemented_authenticators: mock_implemented_authenticators
             ).call(
-              authenticator_status_input: mock_status_input("authn-status-pass")
+              authenticator_status_input: mock_status_input("authn-status-pass"),
+              enabled_authenticators: mock_enabled_authenticators
             )
           end
 
@@ -221,10 +221,10 @@ RSpec.describe Authentication::ValidateStatus do
                 validate_whitelisted_webservice: mock_validate_whitelisted_webservice(validation_succeeded: false),
                 validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
                 validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-                implemented_authenticators: mock_implemented_authenticators,
-                enabled_authenticators: not_including_enabled_authenticators
+                implemented_authenticators: mock_implemented_authenticators
               ).call(
-                authenticator_status_input: mock_status_input("authn-status-pass")
+                authenticator_status_input: mock_status_input("authn-status-pass"),
+                enabled_authenticators: not_including_enabled_authenticators
               )
             end
 
@@ -242,10 +242,10 @@ RSpec.describe Authentication::ValidateStatus do
                   validate_whitelisted_webservice: mock_validate_webservice_exists(validation_succeeded: true),
                   validate_webservice_access: mock_validate_webservice_access(validation_succeeded: true),
                   validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-                  implemented_authenticators: mock_implemented_authenticators,
-                  enabled_authenticators: mock_enabled_authenticators
+                  implemented_authenticators: mock_implemented_authenticators
                 ).call(
-                  authenticator_status_input: mock_status_input("authn-status-fail")
+                  authenticator_status_input: mock_status_input("authn-status-fail"),
+                  enabled_authenticators: mock_enabled_authenticators
                 )
               end
 


### PR DESCRIPTION
The enabled_authenticators was inserted to ValidateStatus as a dependency
instead of as an input. This wasn't good as the enabled_authenticators can now
change in the DB so we need to load it each time the request is sent. Dependencies
are loaded when the server starts so if an authenticator is enabled in the DB so it
won't be reflected in the next time a request is sent. Moving to an input solves this as
the enabled_authenticators will be loaded for each request.