### PR TITLE
Application identity validation implementation (P3)

### DIFF
--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,0 +1,131 @@
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
+
+    # This class defines an Azure application identity of a given Conjur resource.
+    # The constructor initializes an ApplicationIdentity object and validates that
+    # it is configured correctly.
+    # The difference between the validation in this constructor and
+    # the validation in ValidateApplicationIdentity is that here we validate that
+    # the application identity is configured correctly, and thus is a valid application
+    # identity. In ValidateApplicationIdentity we validate that the defined application
+    # identity is actually the one we expect from Azure. This validation is done through
+    # a combination of comparisons that are performed based on the type of assigned
+    # identity provided.
+    # For example, an application identity `authn-azure/some-value` is not
+    # valid and will fail the validation here. For example, application identity like
+    # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
+    # defined in the Conjur resource's annotations is a valid application identity
+    # because `subscription_id` is one of the defined, accepted constraints and will pass
+    # the validation here.
+    # If the Azure-related annotations in the resource defined in Conjur has Azure-specific
+    # annotations that do not match the supplied JWT token, then it will fail the
+    # validation of ValidateApplicationIdentity.
+    class ApplicationIdentity
+
+      def initialize(role_annotations:, service_id:)
+        @role_annotations = role_annotations
+        @service_id       = service_id
+
+        validate
+      end
+
+      def constraints
+        @constraints ||= {
+          subscription_id:          constraint_value("subscription-id"),
+          resource_group:           constraint_value("resource-group"),
+          user_assigned_identity:   constraint_value("user-assigned-identity"),
+          system_assigned_identity: constraint_value("system-assigned-identity"),
+        }.compact
+      end
+
+      private
+
+      # validate that the application identity is defined correctly
+      def validate
+        validate_azure_annotations_are_permitted
+        validate_required_constraints_exist
+        validate_constraint_combinations
+      end
+
+      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
+      def validate_azure_annotations_are_permitted
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with the given prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @role_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+            # verify we take only annotations from the same level
+            annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map {|k| "#{prefix}#{k}"}
+      end
+
+      def validate_required_constraints_exist
+        validate_constraint_exists :subscription_id
+        validate_constraint_exists :resource_group
+      end
+
+      def validate_constraint_exists constraint
+        raise Err::MissingConstraint.new(constraint) unless constraints[constraint]
+      end
+
+      # check the `service-id` specific constraint first to be more granular
+      def constraint_from_annotation constraint_name
+        annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
+          annotation_value("authn-azure/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @role_annotations.find {|a| a.values[:name] == name}
+
+        # return the value of the annotation if it exists, nil otherwise
+        if annotation
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          annotation[:value]
+        end
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
+
+      # validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      def validate_constraint_combinations
+        identifiers = %i(user_assigned_identity system_assigned_identity)
+
+        identifiers_constraints = constraints.keys & identifiers
+        raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
+      end
+
+      def constraint_value constraint_name
+        constraint_from_annotation(constraint_name)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -15,8 +15,8 @@ module Authentication
     # identity is actually the one we expect from Azure. This validation is done through
     # a combination of comparisons that are performed based on the type of assigned
     # identity provided.
-    # For example, an application identity `authn-azure/some-value` is not
-    # valid and will fail the validation here. For example, application identity like
+    # For example, an application identity annotation `authn-azure/some-value` is not
+    # valid and will fail the validation here. For example, application identity annotation like
     # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
     # defined in the Conjur resource's annotations is a valid application identity
     # because `subscription_id` is one of the defined, accepted constraints and will pass
@@ -80,7 +80,7 @@ module Authentication
 
       # add prefix to all permitted constraints
       def prefixed_permitted_constraints prefix
-        permitted_constraints.map {|k| "#{prefix}#{k}"}
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
       end
 
       def validate_required_constraints_exist
@@ -93,13 +93,13 @@ module Authentication
       end
 
       # check the `service-id` specific constraint first to be more granular
-      def constraint_from_annotation constraint_name
+      def constraint_value constraint_name
         annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
           annotation_value("authn-azure/#{constraint_name}")
       end
 
       def annotation_value name
-        annotation = @role_annotations.find {|a| a.values[:name] == name}
+        annotation = @role_annotations.find { |a| a.values[:name] == name }
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
@@ -121,10 +121,6 @@ module Authentication
 
         identifiers_constraints = constraints.keys & identifiers
         raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
-      end
-
-      def constraint_value constraint_name
-        constraint_from_annotation(constraint_name)
       end
     end
   end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -64,10 +64,10 @@ module Authentication
       def validate_application_identity
         @validate_application_identity.(
           service_id: service_id,
-            account: account,
-            username: username,
-            xms_mirid: xms_mirid,
-            oid: oid
+          account: account,
+          username: username,
+          xms_mirid_token_field: xms_mirid,
+          oid_token_field: oid
         )
       end
 
@@ -78,9 +78,9 @@ module Authentication
       def azure_authenticator_secrets
         @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
           service_id: service_id,
-            conjur_account: account,
-            authenticator_name: authenticator_name,
-            required_variable_names: required_variable_names
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
         )
       end
 

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -1,0 +1,105 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity
+
+    ValidateApplicationIdentity = CommandClass.new(
+      dependencies: {
+        role_class:                 ::Role,
+        resource_class:             ::Resource,
+        application_identity_class: ApplicationIdentity,
+        logger:                     Rails.logger
+      },
+      inputs:       %i(account service_id username xms_mirid oid)
+    ) do
+
+      def call
+        token_identity_from_claims
+        # compare xms_mirid with what is defined in annotations
+        validate_application_identity
+      end
+
+      private
+
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+          role_annotations: role.annotations,
+          service_id:       @service_id
+        )
+      end
+
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @username)
+      end
+
+      def role
+        @role ||= @resource_class[role_id].tap do |role|
+          raise SecurityErr::RoleNotFound(role_id) unless role
+        end
+      end
+
+      # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's
+      # among other details the subscription_id, resource group, and provider identity needed for authorization.
+      # xms_mirid is one of the fields in the JWT token. This function will extract the relevant information from
+      # xms_mirid claim and populate a representative hash with the appropriate fields.
+      def token_identity_from_claims
+
+        # validates format of claim
+        raise Err::ClaimInInvalidFormat unless validate_xms_mirid_format
+
+        @token_identity = {
+          subscription_id: xms_mirid_hash["subscriptions"],
+          resource_group:  xms_mirid_hash["resourcegroups"]
+        }
+
+        # determines which Azure assigned identity is provided in annotations
+        # user-assigned-identity:
+        #   - validates that the correct provider (Microsoft.ManagedIdentity) for a user identity is defined in the
+        #     claim. If so, the 'user_assigned_identity' attribute will be added to the hash with the corresponding
+        #     value from xms_mirid claim
+        # system-assigned-identity:
+        #   - validates that the correct provider (Microsoft.Compute) for a system identity is defined in the
+        #     claim and its resource is one that we support. At current, we only support a virtualMachines resource.
+        #     If these conditions are met, a 'system_assigned_identity' attribute will be added to the hash with its
+        #     value being the oid field in the JWT token.
+        @logger.debug(Log::ExtractingIdentityForAuthentication.new("#{xms_mirid_hash["providers"]}/#{xms_mirid_hash.keys[-1]}"))
+        if xms_mirid_hash["providers"] == "Microsoft.ManagedIdentity"
+          @token_identity[:user_assigned_identity] = xms_mirid_hash["userAssignedIdentities"]
+          @token_identity[:resource_name]          = xms_mirid_hash["userAssignedIdentities"]
+        else
+          @token_identity[:system_assigned_identity] = @oid
+          @token_identity[:resource_name]            = @oid
+        end
+      end
+
+      # xms_mirid claim starts with an extra '/' so we will be ignoring it for parsing purposes
+      # ex: /subscription/<subscription_id> -> subscription/<subscription_id>
+      def xms_mirid_hash
+        _, *field_split = @xms_mirid.split('/')
+        Hash[field_split.each_slice(2).to_a]
+      end
+
+      def validate_xms_mirid_format
+        xms_mirid_hash.length == 4 && xms_mirid_hash.key?("subscriptions" && "resourcegroups" && "providers")
+      end
+
+      # validate the integrity of annotations against the xms_mirid object representation
+      def validate_application_identity
+        @logger.debug(Log::ValidatingApplicationIdentity.new(@token_identity[:resource_name]))
+        application_identity.constraints.each do |constraint|
+          annotation_type  = constraint[0].to_s
+          annotation_value = constraint[1]
+          unless annotation_value == @token_identity[annotation_type.to_sym]
+            raise Err::InvalidApplicationIdentity.new(annotation_type)
+          end
+        end
+        @logger.debug(Log::ValidatedApplicationIdentity.new(@token_identity[:resource_name]))
+      end
+    end
+  end
+
+end

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -85,7 +85,7 @@ module Authentication
         controllers = %i(deployment deployment_config stateful_set)
 
         controller_constraints = constraints.keys & controllers
-        raise Err::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
+        raise Errors::Authentication::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
       end
 
       def constraint_value constraint_name
@@ -98,11 +98,11 @@ module Authentication
       end
 
       def annotation_value name
-        annotation = @host_annotations.find { |a| a.values[:name] == name }
+        annotation = @host_annotations.find {|a| a.values[:name] == name}
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
-          Rails.logger.debug(Log::RetrievedAnnotationValue.new(name))
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
           annotation[:value]
         end
       end
@@ -127,7 +127,7 @@ module Authentication
       end
 
       def validate_prefixed_permitted_annotations prefix
-        Rails.logger.debug(Log::ValidatingAnnotationsWithPrefix.new(prefix))
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
 
         prefixed_k8s_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]
@@ -141,13 +141,13 @@ module Authentication
           annotation_name = a.values[:name]
 
           annotation_name.start_with?(prefix) &&
-            # Verify we take only annotations from the same level
+            # verify we take only annotations from the same level
             annotation_name.split('/').length == prefix.split('/').length + 1
         end
       end
 
       def prefixed_permitted_annotations prefix
-        permitted_annotations.map { |k| "#{prefix}#{k}" }
+        permitted_annotations.map {|k| "#{prefix}#{k}"}
       end
 
       def validate_host_id
@@ -174,7 +174,7 @@ module Authentication
       end
 
       def annotation_type_constraints
-        @annotation_type_constraints ||= permitted_constraints.map { |constraint| annotation_type_constraint(constraint) }
+        @annotation_type_constraints ||= permitted_constraints.map {|constraint| annotation_type_constraint(constraint)}
       end
 
       def annotation_type_constraint constraint
@@ -182,7 +182,7 @@ module Authentication
       end
 
       def application_identity_in_annotations?
-        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
+        @application_identity_in_annotations ||= @host_annotations.select {|a| a.values[:name].start_with?("authn-k8s/")}.any?
       end
 
       def host_id_namespace_scoped?

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -98,7 +98,7 @@ module Authentication
       end
 
       def annotation_value name
-        annotation = @host_annotations.find {|a| a.values[:name] == name}
+        annotation = @host_annotations.find { |a| a.values[:name] == name }
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
@@ -147,7 +147,7 @@ module Authentication
       end
 
       def prefixed_permitted_annotations prefix
-        permitted_annotations.map {|k| "#{prefix}#{k}"}
+        permitted_annotations.map { |k| "#{prefix}#{k}" }
       end
 
       def validate_host_id
@@ -174,7 +174,7 @@ module Authentication
       end
 
       def annotation_type_constraints
-        @annotation_type_constraints ||= permitted_constraints.map {|constraint| annotation_type_constraint(constraint)}
+        @annotation_type_constraints ||= permitted_constraints.map { |constraint| annotation_type_constraint(constraint) }
       end
 
       def annotation_type_constraint constraint
@@ -182,7 +182,7 @@ module Authentication
       end
 
       def application_identity_in_annotations?
-        @application_identity_in_annotations ||= @host_annotations.select {|a| a.values[:name].start_with?("authn-k8s/")}.any?
+        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
       end
 
       def host_id_namespace_scoped?

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -10,7 +10,7 @@ module Authentication
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
-        resource_class:              Resource,
+        resource_class:             ::Resource,
         k8s_resolver:               K8sResolver,
         k8s_object_lookup_class:    K8sObjectLookup,
         application_identity_class: ApplicationIdentity

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -10,17 +10,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Conjur
 
       RequiredResourceMissing = Util::TrackableErrorClass.new(
-        msg: "Missing required resource: {0-resource-name}",
+        msg:  "Missing required resource: {0-resource-name}",
         code: "CONJ00036E"
       )
 
       RequiredSecretMissing = Util::TrackableErrorClass.new(
-        msg: "Missing value for resource: {0-resource-name}",
+        msg:  "Missing value for resource: {0-resource-name}",
         code: "CONJ00037E"
       )
 
       InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
-        msg: "The password you have chosen does not meet the complexity requirements. " \
+        msg:  "The password you have chosen does not meet the complexity requirements. " \
              "Choose a password that includes: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit, 1 special character",
         code: "CONJ00046E"
       )
@@ -30,41 +30,46 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Authentication
 
       AuthenticatorNotFound = ::Util::TrackableErrorClass.new(
-        msg: "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
+        msg:  "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
         code: "CONJ00001E"
       )
 
       InvalidCredentials = ::Util::TrackableErrorClass.new(
-        msg: "Invalid credentials",
+        msg:  "Invalid credentials",
         code: "CONJ00002E"
       )
 
       InvalidOrigin = ::Util::TrackableErrorClass.new(
-        msg: "Invalid origin",
+        msg:  "Invalid origin",
         code: "CONJ00003E"
       )
 
       StatusNotImplemented = ::Util::TrackableErrorClass.new(
-        msg: "Status check not implemented for authenticator '{0-authenticator-name}'",
+        msg:  "Status check not implemented for authenticator '{0-authenticator-name}'",
         code: "CONJ00045E"
+      )
+
+      IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
+        msg:  "Application identity includes an illegal resource constraint combination - '{0-constraints}'",
+        code: "CONJ00044E"
       )
 
       module AuthenticatorClass
 
         DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-parent-name}' is not a valid authenticator parent module because it does " \
+          msg:  "'{0-authenticator-parent-name}' is not a valid authenticator parent module because it does " \
             "not begin with 'Authn'",
           code: "CONJ00038E"
         )
 
         NotNamedAuthenticator = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not a valid authenticator name. " \
+          msg:  "'{0-authenticator-name}' is not a valid authenticator name. " \
             "The actual class implementing the authenticator must be named 'Authenticator'",
           code: "CONJ00039E"
         )
 
         MissingValidMethod = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not a valid authenticator because " \
+          msg:  "'{0-authenticator-name}' is not a valid authenticator because " \
             "it does not have a `:valid?(input)` method.",
           code: "CONJ00040E"
         )
@@ -74,27 +79,27 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module Security
 
         AuthenticatorNotWhitelisted = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not enabled",
+          msg:  "'{0-authenticator-name}' is not enabled",
           code: "CONJ00004E"
         )
 
         WebserviceNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Webservice '{0-webservice-name}' wasn't found",
+          msg:  "Webservice '{0-webservice-name}' wasn't found",
           code: "CONJ00005E"
         )
 
         RoleNotAuthorizedOnWebservice = ::Util::TrackableErrorClass.new(
-          msg: "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
+          msg:  "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
           code: "CONJ00006E"
         )
 
         RoleNotFound = ::Util::TrackableErrorClass.new(
-          msg: "'{0-role-name}' wasn't found",
+          msg:  "'{0-role-name}' wasn't found",
           code: "CONJ00007E"
         )
 
         AccountNotDefined = ::Util::TrackableErrorClass.new(
-          msg: "Account '{0-account-name}' is not defined in Conjur",
+          msg:  "Account '{0-account-name}' is not defined in Conjur",
           code: "CONJ00008E"
         )
 
@@ -103,7 +108,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module RequestBody
 
         MissingRequestParam = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' is missing or empty in request body",
+          msg:  "Field '{0-field-name}' is missing or empty in request body",
           code: "CONJ00009E"
         )
 
@@ -112,17 +117,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module OAuth
 
         ProviderDiscoveryTimeout = ::Util::TrackableErrorClass.new(
-          msg: "Identity Provider discovery failed with timeout error (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Identity Provider discovery failed with timeout error (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00010E"
         )
 
         ProviderDiscoveryFailed = ::Util::TrackableErrorClass.new(
-          msg: "Identity Provider discovery failed (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Identity Provider discovery failed (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00011E"
         )
 
         FetchProviderKeysFailed = ::Util::TrackableErrorClass.new(
-          msg: "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00012E"
         )
 
@@ -131,17 +136,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module Jwt
 
         TokenExpired = ::Util::TrackableErrorClass.new(
-          msg: "Token expired",
+          msg:  "Token expired",
           code: "CONJ00016E"
         )
 
         TokenDecodeFailed = ::Util::TrackableErrorClass.new(
-          msg: "Token decode failed (3rdPartyError ='{0}')",
+          msg:  "Token decode failed (3rdPartyError ='{0}')",
           code: "CONJ00035E"
         )
 
         TokenVerificationFailed = ::Util::TrackableErrorClass.new(
-          msg: "Token verification failed (3rdPartyError ='{0}')",
+          msg:  "Token verification failed (3rdPartyError ='{0}')",
           code: "CONJ00015E"
         )
 
@@ -150,12 +155,12 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnOidc
 
         IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
+          msg:  "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
           code: "CONJ00013E"
         )
 
         AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
-          msg: "admin user is not allowed to authenticate with OIDC",
+          msg:  "admin user is not allowed to authenticate with OIDC",
           code: "CONJ00017E"
         )
 
@@ -164,7 +169,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnIam
 
         InvalidAWSHeaders = ::Util::TrackableErrorClass.new(
-          msg: "'Invalid or expired AWS headers: {0}",
+          msg:  "'Invalid or expired AWS headers: {0}",
           code: "CONJ00018E"
         )
 
@@ -173,112 +178,127 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnK8s
 
         CSRIsMissingSpiffeId = ::Util::TrackableErrorClass.new(
-          msg: 'CSR must contain SPIFFE ID SAN',
+          msg:  'CSR must contain SPIFFE ID SAN',
           code: "CONJ00022E"
         )
 
         PodNotFound = ::Util::TrackableErrorClass.new(
-          msg: "No pod found for '{0-pod-name}' in namespace '{1}'",
+          msg:  "No pod found for '{0-pod-name}' in namespace '{1}'",
           code: "CONJ00024E"
         )
 
         ScopeNotSupported = ::Util::TrackableErrorClass.new(
-          msg: "Resource type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          msg:  "Resource type '{0}' is not a supported application identity. The supported resources are '{1}'",
           code: "CONJ00025E"
         )
 
         K8sResourceNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
+          msg:  "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
           code: "CONJ00026E"
         )
 
         CertInstallationError = ::Util::TrackableErrorClass.new(
-          msg: "Certificate could not be copied to pod: {0}",
+          msg:  "Certificate could not be copied to pod: {0}",
           code: "CONJ00027E"
         )
 
         ContainerNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Container {0} was not found in the pod. Host id: {1}",
+          msg:  "Container {0} was not found in the pod. Host id: {1}",
           code: "CONJ00028E"
         )
 
         MissingClientCertificate = ::Util::TrackableErrorClass.new(
-          msg: "Client SSL certificate is missing from the header",
+          msg:  "Client SSL certificate is missing from the header",
           code: "CONJ00029E"
         )
 
         UntrustedClientCertificate = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate cannot be verified by certification authority",
+          msg:  "Client certificate cannot be verified by certification authority",
           code: "CONJ00030E"
         )
 
         CommonNameDoesntMatchHost = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate CN must match host name. Cert CN: {0}. " \
+          msg:  "Client certificate CN must match host name. Cert CN: {0}. " \
             "Host name: {1}. ",
           code: "CONJ00031E"
         )
 
         ClientCertificateExpired = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate expired",
+          msg:  "Client certificate expired",
           code: "CONJ00032E"
         )
 
         CommandTimedOut = ::Util::TrackableErrorClass.new(
-          msg: "Command timed out in container '{0}' of pod '{1}'",
+          msg:  "Command timed out in container '{0}' of pod '{1}'",
           code: "CONJ00033E"
         )
 
         MissingServiceAccountDir = ::Util::TrackableErrorClass.new(
-          msg: "Kubernetes serviceaccount dir '{0}' does not exist",
+          msg:  "Kubernetes serviceaccount dir '{0}' does not exist",
           code: "CONJ00034E"
         )
 
         UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
-          msg: "Unknown Kubernetes resource type '{0}'",
+          msg:  "Unknown Kubernetes resource type '{0}'",
           code: "CONJ00041E"
         )
 
         InvalidApiUrl = ::Util::TrackableErrorClass.new(
-          msg: "Received invalid Kubernetes API url: '{0}'",
+          msg:  "Received invalid Kubernetes API url: '{0}'",
           code: "CONJ00042E"
         )
 
         MissingCertificate = ::Util::TrackableErrorClass.new(
-          msg: "No Kubernetes API certificate available",
+          msg:  "No Kubernetes API certificate available",
           code: "CONJ00043E"
         )
 
-        IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
-          msg: "Application identity includes an illegal Kubernetes resource constraint combination - '{0-controller-constraints}'",
-          code: "CONJ00044E"
-        )
-
         MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
-          msg: "Host does not have a namespace constraint",
+          msg:  "Host does not have a namespace constraint",
           code: "CONJ00045E"
         )
 
         NamespaceMismatch = ::Util::TrackableErrorClass.new(
-          msg: "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
+          msg:  "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
             "implied by application identity '{1-application-identity-namespace}'",
           code: "CONJ00023E"
         )
 
         ValidationError = ::Util::TrackableErrorClass.new(
-          msg: "{0-message}",
+          msg:  "{0-message}",
           code: "CONJ00047E"
         )
 
         InvalidHostId = ::Util::TrackableErrorClass.new(
-          msg: "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
+          msg:  "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
           code: "CONJ00048E"
         )
       end
 
       module AuthnAzure
 
+        MissingConstraint = ::Util::TrackableErrorClass.new(
+          msg:  "Role does not have the required constraint: {0-constraint}",
+          code: "CONJ00045E"
+        )
+
+        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+          msg:  "Application identity field '{0-field-name}' does not match what is provided in Azure token",
+          code: "CONJ00049E"
+        )
+
+        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+          msg:  "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          code: "CONJ00050E"
+        )
+
+        ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
+          msg:  "xms_mirid claim has been received in an invalid format",
+          code: "CONJ00051E"
+        )
+
         TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' not found or empty in token",
+          msg:  "Field '{0-field-name}' not found or empty in token",
           code: "CONJ00049E"
         )
 
@@ -288,7 +308,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Util
 
       ConcurrencyLimitReachedBeforeCacheInitialization = ::Util::TrackableErrorClass.new(
-        msg: "Concurrency limited cache reached before cache initialized",
+        msg:  "Concurrency limited cache reached before cache initialized",
         code: "CONJ00044E"
       )
     end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -146,13 +146,8 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00029D"
         )
 
-        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Validating application identity for {0-resource-name}",
-          code: "CONJ00030D"
-        )
-
         ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Application identity for {0-resource-name} validated",
+          msg:  "Application identity validated",
           code: "CONJ00030D"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -141,8 +141,8 @@ unless defined? LogMessages::Authentication::OriginValidated
 
       module AuthnAzure
 
-        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
-          msg:  "Extracting resource type {0-resource-type} for authentication",
+        ExtractedApplicationIdentityFromToken = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracted application identity from Token",
           code: "CONJ00029D"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -11,19 +11,29 @@ unless defined? LogMessages::Authentication::OriginValidated
     module Authentication
 
       OriginValidated = ::Util::TrackableLogMessageClass.new(
-        msg: "Origin validated",
+        msg:  "Origin validated",
         code: "CONJ00003D"
+      )
+
+      ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+        msg:  "Validating annotations with prefix {0-prefix}",
+        code: "CONJ00025D"
+      )
+
+      RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+        msg:  "Retrieved value of annotation {0-annotation-name}",
+        code: "CONJ00024D"
       )
 
       module Security
 
         SecurityValidated = ::Util::TrackableLogMessageClass.new(
-          msg: "Security validated",
+          msg:  "Security validated",
           code: "CONJ00001D"
         )
 
         UserNotAuthorized = ::Util::TrackableLogMessageClass.new(
-          msg: "User '{0}' is not authorized to authenticate with webservice '{1}'",
+          msg:  "User '{0}' is not authorized to authenticate with webservice '{1}'",
           code: "CONJ00002D"
         )
 
@@ -32,27 +42,27 @@ unless defined? LogMessages::Authentication::OriginValidated
       module OAuth
 
         IdentityProviderUri = ::Util::TrackableLogMessageClass.new(
-          msg: "Working with Identity Provider {0-provider-uri}",
+          msg:  "Working with Identity Provider {0-provider-uri}",
           code: "CONJ00007D"
         )
 
         IdentityProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider discovery succeeded",
+          msg:  "Identity Provider discovery succeeded",
           code: "CONJ00008D"
         )
 
         IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider keys fetched successfully from cache",
+          msg:  "Identity Provider keys fetched successfully from cache",
           code: "CONJ00017D"
         )
 
         FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Fetched Identity Provider keys successfully",
+          msg:  "Fetched Identity Provider keys successfully",
           code: "CONJ00009D"
         )
 
         ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating Identity Provider keys are up to date",
+          msg:  "Validating Identity Provider keys are up to date",
           code: "CONJ00019D"
         )
 
@@ -61,12 +71,12 @@ unless defined? LogMessages::Authentication::OriginValidated
       module Jwt
 
         TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Token decode succeeded",
+          msg:  "Token decode succeeded",
           code: "CONJ00005D"
         )
 
         TokenDecodeFailed = ::Util::TrackableLogMessageClass.new(
-          msg: "Failed to decode the token with the error '{0-exception}'",
+          msg:  "Failed to decode the token with the error '{0-exception}'",
           code: "CONJ00018D"
         )
 
@@ -75,7 +85,7 @@ unless defined? LogMessages::Authentication::OriginValidated
       module AuthnOidc
 
         ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
-          msg: "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
+          msg:  "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
           code: "CONJ00004D"
         )
 
@@ -84,71 +94,75 @@ unless defined? LogMessages::Authentication::OriginValidated
       module AuthnK8s
 
         PodChannelOpen = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' : channel open",
+          msg:  "Pod '{0-pod-name}' : channel open",
           code: "CONJ00010D"
         )
 
         PodChannelClosed = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' : channel closed",
+          msg:  "Pod '{0-pod-name}' : channel closed",
           code: "CONJ00011D"
         )
 
         PodChannelData = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
+          msg:  "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
           code: "CONJ00012D"
         )
 
         PodMessageData = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
+          msg:  "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
           code: "CONJ00013D"
         )
 
         PodError = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' error : '{1}'",
+          msg:  "Pod '{0-pod-name}' error : '{1}'",
           code: "CONJ00014D"
         )
 
         CopySSLToPod = ::Util::TrackableLogMessageClass.new(
-          msg: "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
+          msg:  "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
           code: "CONJ00015D"
         )
 
-        RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
-          msg: "Retrieved value of annotation {0-annotation-name}",
-          code: "CONJ00024D"
-        )
-
-        ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating annotations with prefix {0-prefix}",
-          code: "CONJ00025D"
-        )
-
         ValidatingHostId = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating host id {0}",
+          msg:  "Validating host id {0}",
           code: "CONJ00026D"
         )
 
         HostIdFromCommonName = ::Util::TrackableLogMessageClass.new(
-          msg: "Host id {0} extracted from CSR common name",
+          msg:  "Host id {0} extracted from CSR common name",
           code: "CONJ00027D"
         )
 
         SetCommonName = ::Util::TrackableLogMessageClass.new(
-          msg: "Setting common name to {0-full-host-name}",
+          msg:  "Setting common name to {0-full-host-name}",
           code: "CONJ00028D"
         )
       end
 
       module AuthnAzure
 
-        # TODO: get security approval for this message
+        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracting resource type {0-resource-type} for authentication",
+          code: "CONJ00029D"
+        )
+
+        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+          msg:  "Validating application identity for {0-resource-name}",
+          code: "CONJ00030D"
+        )
+
+        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+          msg:  "Application identity for {0-resource-name} validated",
+          code: "CONJ00030D"
+        )
+
         ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
-          msg: "Extracted field '{0-field-name}' with value {1-field-value} from token",
+          msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
           code: "CONJ00029D"
         )
 
         ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating that field '{0}' exists in token",
+          msg:  "Validating that field '{0}' exists in token",
           code: "CONJ00030D"
         )
 
@@ -158,27 +172,27 @@ unless defined? LogMessages::Authentication::OriginValidated
     module Util
 
       RateLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Rate limited cache updated successfully",
+        msg:  "Rate limited cache updated successfully",
         code: "CONJ00016D"
       )
 
       RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
-        msg: "Rate limited cache reached the '{0-limit}' limit and will not call target for the next '{1-seconds}' seconds",
+        msg:  "Rate limited cache reached the '{0-limit}' limit and will not call target for the next '{1-seconds}' seconds",
         code: "CONJ00020D"
       )
 
       ConcurrencyLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache updated successfully",
+        msg:  "Concurrency limited cache updated successfully",
         code: "CONJ00021D"
       )
 
       ConcurrencyLimitedCacheReached = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
+        msg:  "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
         code: "CONJ00022D"
       )
 
       ConcurrencyLimitedCacheConcurrentRequestsUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
+        msg:  "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
         code: "CONJ00023D"
       )
 

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
 
   include_context "fetch secrets", %w(provider-uri)
 
-  let(:account) {"my-acct"}
-  let(:authenticator_name) {"authn-azure"}
-  let(:service) {"my-service"}
+  let(:account) { "my-acct" }
+  let(:authenticator_name) { "authn-azure" }
+  let(:service) { "my-service" }
 
-  let(:mocked_verify_and_decode_token) {double("VerifyAndDecodeAzureToken")}
-  let(:mocked_validate_application_identity) {double("ValidateApplicationIdentity")}
+  let(:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+  let(:mocked_validate_application_identity) { double("ValidateApplicationIdentity") }
 
   before(:each) do
-    allow(mocked_verify_and_decode_token).to receive(:call) {|*args|
+    allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
       JSON.parse(args[0][:token_jwt]).to_hash
     }
 
@@ -88,7 +88,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "does not raise an error" do
-            expect {subject}.to_not raise_error
+            expect { subject }.to_not raise_error
             expect(subject).to eq(true)
           end
 
@@ -119,9 +119,9 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
             allow(mocked_validate_application_identity).to receive(:call)
                                                              .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
 
-            expect {subject}.to raise_error(
-                                  /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                                )
+            expect { subject }.to raise_error(
+                                    /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+                                  )
           end
         end
       end
@@ -151,9 +151,9 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
             allow(mocked_verify_and_decode_token).to receive(:call)
                                                        .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
 
-            expect {subject}.to raise_error(
-                                  /FAKE_VERIFY_AND_DECODE_ERROR/
-                                )
+            expect { subject }.to raise_error(
+                                    /FAKE_VERIFY_AND_DECODE_ERROR/
+                                  )
           end
         end
 
@@ -178,7 +178,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
           end
         end
 
@@ -203,7 +203,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
           end
         end
       end
@@ -229,7 +229,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
         end
 
         it "raises a MissingRequestParam error" do
-          expect {subject}.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
 
@@ -254,7 +254,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
         end
 
         it "raises a MissingRequestParam error" do
-          expect {subject}.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
     end

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -5,29 +5,29 @@ require 'spec_helper'
 RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
   include_context "running outside kubernetes"
 
-  let(:host_id_prefix) {"accountName:host:"}
+  let(:host_id_prefix) { "accountName:host:" }
 
-  let(:namespace) {"K8sNamespace"}
+  let(:namespace) { "K8sNamespace" }
 
-  let(:k8s_resource_name) {"K8sResourceName"}
-  let(:k8s_resource_value) {"K8sResourceValue"}
+  let(:k8s_resource_name) { "K8sResourceName" }
+  let(:k8s_resource_value) { "K8sResourceValue" }
 
-  let(:namespace_annotation) {double("NamespaceAnnotation")}
-  let(:namespace_annotation_service_id_scoped) {double("NamespaceServiceIdAnnotation")}
+  let(:namespace_annotation) { double("NamespaceAnnotation") }
+  let(:namespace_annotation_service_id_scoped) { double("NamespaceServiceIdAnnotation") }
 
-  let(:container_name_annotation) {double("ContainerNameAnnotation")}
-  let(:container_name_annotation_service_id_prefix) {double("ContainerNameAnnotation")}
-  let(:container_name_annotation_kubernetes_prefix) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_service_id_prefix) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_kubernetes_prefix) { double("ContainerNameAnnotation") }
 
-  let(:service_account_annotation) {double("ServiceAccountAnnotation")}
-  let(:pod_annotation) {double("PodAnnotation")}
-  let(:deployment_annotation) {double("DeploymentAnnotation")}
-  let(:stateful_set_annotation) {double("StatefulSetAnnotation")}
-  let(:deployment_config_annotation) {double("DeploymentConfigAnnotation")}
+  let(:service_account_annotation) { double("ServiceAccountAnnotation") }
+  let(:pod_annotation) { double("PodAnnotation") }
+  let(:deployment_annotation) { double("DeploymentAnnotation") }
+  let(:stateful_set_annotation) { double("StatefulSetAnnotation") }
+  let(:deployment_config_annotation) { double("DeploymentConfigAnnotation") }
 
-  let(:invalid_annotation) {double("InvalidAnnotation")}
+  let(:invalid_annotation) { double("InvalidAnnotation") }
 
-  let(:good_service_id) {"MockService"}
+  let(:good_service_id) { "MockService" }
 
   before(:each) do
     allow(namespace_annotation).to receive(:values)
@@ -137,24 +137,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     }
 
     context "Application identity in host id" do
-      let(:host_annotations) {[]}
-      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
+      let(:host_annotations) { [] }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
-          let(:k8s_resource_name) {"*"}
-          let(:k8s_resource_value) {"*"}
+          let(:k8s_resource_name) { "*" }
+          let(:k8s_resource_value) { "*" }
 
           it "does not raise an error" do
-            expect {subject}.not_to raise_error
+            expect { subject }.not_to raise_error
           end
         end
 
         context "when is not namespace scoped" do
-          let(:k8s_resource_name) {"service_account"}
+          let(:k8s_resource_name) { "service_account" }
 
           it "does not raise an error" do
-            expect {subject}.not_to raise_error
+            expect { subject }.not_to raise_error
           end
         end
 
@@ -163,49 +163,49 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
       context "with an invalid application identity" do
         context "where the id isn't a 3 part string" do
-          let(:host_id) {"#{host_id_prefix}HostId"}
+          let(:host_id) { "#{host_id_prefix}HostId" }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
           end
         end
 
         context "with a non existing resource" do
-          let(:k8s_resource_name) {"non_existing_resource"}
+          let(:k8s_resource_name) { "non_existing_resource" }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
           end
         end
       end
     end
 
     context "Application identity in annotations" do
-      let(:host_id) {"#{host_id_prefix}HostId"}
+      let(:host_id) { "#{host_id_prefix}HostId" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
           context "in a global constraint" do
-            let(:host_annotations) {[namespace_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) {[namespace_annotation_service_id_scoped, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation_service_id_scoped, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "in both global & service-id constraints" do
-            let(:host_annotations) {[namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the service-id constraint" do
@@ -223,67 +223,67 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "when is not namespace scoped" do
           context "has only a service account constraint" do
-            let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a pod constraint" do
-            let(:host_annotations) {[namespace_annotation, pod_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, pod_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a deployment constraint" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a stateful set constraint" do
-            let(:host_annotations) {[namespace_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a deployment config constraint" do
-            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has a valid constraint combination" do
             context "with a deployment constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
 
             context "with a deployment config constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
 
             context "with a stateful_set constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
           end
@@ -291,13 +291,13 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "with different annotations for container name" do
           context "all possible options exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_service_id_prefix,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -306,12 +306,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global and service-id exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_service_id_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -320,12 +320,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id & kubernetes exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_service_id_prefix,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -334,12 +334,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global & kubernetes exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -348,11 +348,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_service_id_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -361,11 +361,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -374,11 +374,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only kubernetes exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the kubernetes annotation" do
@@ -387,10 +387,10 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "no annotation exists for container name" do
-            let(:host_annotations) {[namespace_annotation]}
+            let(:host_annotations) { [namespace_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the default container name" do
@@ -403,24 +403,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       context "with an invalid application identity" do
 
         context "where namespace constraint doesn't exist" do
-          let(:host_annotations) {[service_account_annotation, container_name_annotation]}
+          let(:host_annotations) { [service_account_annotation, container_name_annotation] }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
 
         context "with a non existing resource" do
           context "in a global constraint" do
-            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
 
             before(:each) do
               allow(invalid_annotation).to receive(:[])
@@ -429,47 +429,47 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
             end
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
         end
 
         context "with an invalid constraint combination" do
           context "deployment and deployment_config" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment_config and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment, deployment_config and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
         end
 
         context "where a constraint is missing a slash after authn-k8s" do
-          let(:host_annotations) {[namespace_annotation, container_name_annotation]}
+          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
 
           before(:each) do
             allow(namespace_annotation).to receive(:[])
@@ -479,16 +479,16 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
           it "ignores the annotation" do
             # the namespace annotation is not present
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
       end
     end
 
     context "Application identity in host id and in annotations" do
-      let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
-      let(:k8s_resource_name) {"service_account"}
-      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
+      let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+      let(:k8s_resource_name) { "service_account" }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       before(:each) do
         allow(namespace_annotation).to receive(:[])
@@ -501,7 +501,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       end
 
       it "does not raise an error" do
-        expect {subject}.not_to raise_error
+        expect { subject }.not_to raise_error
       end
 
       it "takes the application identity from the annotations" do

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -5,29 +5,29 @@ require 'spec_helper'
 RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
   include_context "running outside kubernetes"
 
-  let(:host_id_prefix) { "accountName:host:" }
+  let(:host_id_prefix) {"accountName:host:"}
 
-  let(:namespace) { "K8sNamespace" }
+  let(:namespace) {"K8sNamespace"}
 
-  let(:k8s_resource_name) { "K8sResourceName" }
-  let(:k8s_resource_value) { "K8sResourceValue" }
+  let(:k8s_resource_name) {"K8sResourceName"}
+  let(:k8s_resource_value) {"K8sResourceValue"}
 
-  let(:namespace_annotation) { double("NamespaceAnnotation") }
-  let(:namespace_annotation_service_id_scoped) { double("NamespaceServiceIdAnnotation") }
+  let(:namespace_annotation) {double("NamespaceAnnotation")}
+  let(:namespace_annotation_service_id_scoped) {double("NamespaceServiceIdAnnotation")}
 
-  let(:container_name_annotation) { double("ContainerNameAnnotation") }
-  let(:container_name_annotation_service_id_prefix) { double("ContainerNameAnnotation") }
-  let(:container_name_annotation_kubernetes_prefix) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation_service_id_prefix) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation_kubernetes_prefix) {double("ContainerNameAnnotation")}
 
-  let(:service_account_annotation) { double("ServiceAccountAnnotation") }
-  let(:pod_annotation) { double("PodAnnotation") }
-  let(:deployment_annotation) { double("DeploymentAnnotation") }
-  let(:stateful_set_annotation) { double("StatefulSetAnnotation") }
-  let(:deployment_config_annotation) { double("DeploymentConfigAnnotation") }
+  let(:service_account_annotation) {double("ServiceAccountAnnotation")}
+  let(:pod_annotation) {double("PodAnnotation")}
+  let(:deployment_annotation) {double("DeploymentAnnotation")}
+  let(:stateful_set_annotation) {double("StatefulSetAnnotation")}
+  let(:deployment_config_annotation) {double("DeploymentConfigAnnotation")}
 
-  let(:invalid_annotation) { double("InvalidAnnotation") }
+  let(:invalid_annotation) {double("InvalidAnnotation")}
 
-  let(:good_service_id) { "MockService" }
+  let(:good_service_id) {"MockService"}
 
   before(:each) do
     allow(namespace_annotation).to receive(:values)
@@ -137,24 +137,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     }
 
     context "Application identity in host id" do
-      let(:host_annotations) { [] }
-      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_annotations) {[]}
+      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
-          let(:k8s_resource_name) { "*" }
-          let(:k8s_resource_value) { "*" }
+          let(:k8s_resource_name) {"*"}
+          let(:k8s_resource_value) {"*"}
 
           it "does not raise an error" do
-            expect { subject }.not_to raise_error
+            expect {subject}.not_to raise_error
           end
         end
 
         context "when is not namespace scoped" do
-          let(:k8s_resource_name) { "service_account" }
+          let(:k8s_resource_name) {"service_account"}
 
           it "does not raise an error" do
-            expect { subject }.not_to raise_error
+            expect {subject}.not_to raise_error
           end
         end
 
@@ -163,49 +163,49 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
       context "with an invalid application identity" do
         context "where the id isn't a 3 part string" do
-          let(:host_id) { "#{host_id_prefix}HostId" }
+          let(:host_id) {"#{host_id_prefix}HostId"}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
           end
         end
 
         context "with a non existing resource" do
-          let(:k8s_resource_name) { "non_existing_resource" }
+          let(:k8s_resource_name) {"non_existing_resource"}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
           end
         end
       end
     end
 
     context "Application identity in annotations" do
-      let(:host_id) { "#{host_id_prefix}HostId" }
+      let(:host_id) {"#{host_id_prefix}HostId"}
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
           context "in a global constraint" do
-            let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) { [namespace_annotation_service_id_scoped, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation_service_id_scoped, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "in both global & service-id constraints" do
-            let(:host_annotations) { [namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the service-id constraint" do
@@ -223,67 +223,67 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "when is not namespace scoped" do
           context "has only a service account constraint" do
-            let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a pod constraint" do
-            let(:host_annotations) { [namespace_annotation, pod_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, pod_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a deployment constraint" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a stateful set constraint" do
-            let(:host_annotations) { [namespace_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a deployment config constraint" do
-            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has a valid constraint combination" do
             context "with a deployment constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
 
             context "with a deployment config constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
 
             context "with a stateful_set constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
           end
@@ -291,13 +291,13 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "with different annotations for container name" do
           context "all possible options exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_service_id_prefix,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_service_id_prefix,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -306,12 +306,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global and service-id exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_service_id_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_service_id_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -320,12 +320,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id & kubernetes exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_service_id_prefix,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_service_id_prefix,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -334,12 +334,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global & kubernetes exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -348,11 +348,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_service_id_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_service_id_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -361,11 +361,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -374,11 +374,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only kubernetes exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the kubernetes annotation" do
@@ -387,10 +387,10 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "no annotation exists for container name" do
-            let(:host_annotations) { [namespace_annotation] }
+            let(:host_annotations) {[namespace_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the default container name" do
@@ -403,24 +403,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       context "with an invalid application identity" do
 
         context "where namespace constraint doesn't exist" do
-          let(:host_annotations) { [service_account_annotation, container_name_annotation] }
+          let(:host_annotations) {[service_account_annotation, container_name_annotation]}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
 
         context "with a non existing resource" do
           context "in a global constraint" do
-            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
 
             before(:each) do
               allow(invalid_annotation).to receive(:[])
@@ -429,47 +429,47 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
             end
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
         end
 
         context "with an invalid constraint combination" do
           context "deployment and deployment_config" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment_config and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment, deployment_config and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
         end
 
         context "where a constraint is missing a slash after authn-k8s" do
-          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+          let(:host_annotations) {[namespace_annotation, container_name_annotation]}
 
           before(:each) do
             allow(namespace_annotation).to receive(:[])
@@ -479,16 +479,16 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
           it "ignores the annotation" do
             # the namespace annotation is not present
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
       end
     end
 
     context "Application identity in host id and in annotations" do
-      let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
-      let(:k8s_resource_name) { "service_account" }
-      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
+      let(:k8s_resource_name) {"service_account"}
+      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
 
       before(:each) do
         allow(namespace_annotation).to receive(:[])
@@ -501,7 +501,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       end
 
       it "does not raise an error" do
-        expect { subject }.not_to raise_error
+        expect {subject}.not_to raise_error
       end
 
       it "takes the application identity from the annotations" do


### PR DESCRIPTION
#### What does this PR do?
This PR adds the second validation in for the Azure authenticator, validating the application identity of the resource sending the request

Object received: Hash object from decode/valid token

DOD
- [x] Check integrity of annotations relevant to authn-azure (prefixed correctly, in proper format, has the 2 required annotations, and that there is not a combo of user and system assigned identity
- [x] Validate xms_mirid/oid based on annotations
   - [x] Grab the `key -> value` list from output of previous check and perform validation check
   - [x] Ensure that there user/system assigned flows are accounted for

TODO:
- [x] validate xms_mirid format (length or # of slashes)
- [ ] UTs
- [ ] Look at PR: https://github.com/cyberark/conjur/pull/1346 to address Jonah comments
- [ ] Challenge xms_mirid format. Will it xms_mirid always have the same # of elements?