### PR TITLE
Refactor xms_mirid logic

### DIFF
--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -160,7 +160,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
-          msg:  "admin user is not allowed to authenticate with OIDC",
+          msg:  "Admin user is not allowed to authenticate with OIDC",
           code: "CONJ00017E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -299,7 +299,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
         TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
           msg:  "Field '{0-field-name}' not found or empty in token",
-          code: "CONJ00049E"
+          code: "CONJ00052E"
         )
 
       end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -153,12 +153,12 @@ unless defined? LogMessages::Authentication::OriginValidated
 
         ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
           msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
-          code: "CONJ00029D"
+          code: "CONJ00031D"
         )
 
         ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
           msg:  "Validating that field '{0}' exists in token",
-          code: "CONJ00030D"
+          code: "CONJ00032D"
         )
 
       end


### PR DESCRIPTION
#### What does this PR do?
Refactors the way we parse xms_mirid field so that the length of the xms_mirid claim is not a factor in validating the integrity of the token