### PR TITLE
Fix landing page logo and add "Under Construction" banner

### DIFF
--- a/docs/_sass/_components/_hero.scss
+++ b/docs/_sass/_components/_hero.scss
@@ -3,7 +3,7 @@
 // ***********************
 
 #hero {
-  background: url("/img/conjur-hero-bg4.svg") no-repeat center center;
+  background: url($baseurl + "/img/conjur-hero-bg4.svg") no-repeat center center;
   background-size: cover;
   color: #ffffff;
   padding: 4.5em 0;

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -3,14 +3,14 @@
 // ***********************
 
 .icon-docker-hub {
-  background: url("/img/docker_icon.svg") no-repeat center center;
+  background: url($baseurl + "/img/docker_icon.svg") no-repeat center center;
   width: 16px;
   height: 16px;
   display: inline-block;
 }
 
 #footer .icon-docker-hub {
-  background: url("/img/docker-blue.svg") no-repeat center center;
+  background: url($baseurl + "/img/docker-blue.svg") no-repeat center center;
   width: 16px;
   height: 16px;
   display: inline-block;
@@ -78,7 +78,7 @@ a.doc-switch:after {
   position: absolute;
   width: 30px;
   height: 30px;
-  background: url("/img/copy-to-clipboard.svg");
+  background: url($baseurl + "/img/copy-to-clipboard.svg");
   background-repeat: no-repeat;
   background-position: center;
   border: none;
@@ -526,18 +526,18 @@ pre {
 	position: relative;
 	width: 1.5rem;
 	height: 2rem;
-	background: url("/img/clipboard.svg");
+	background: url($baseurl + "/img/clipboard.svg");
 	background-repeat: no-repeat;
 	background-position: center;
 	border: none;
 	cursor: pointer;
 	float: right;
 	&:hover {
-		background: url("/img/clipboard-hover.svg");
+		background: url($baseurl + "/img/clipboard-hover.svg");
 		background-repeat: no-repeat;
 	}
 	&:active {
-		background: url("/img/clipboard-focus.svg");
+		background: url($baseurl + "/img/clipboard-focus.svg");
 		background-repeat: no-repeat;
 	}
 }
@@ -545,7 +545,7 @@ pre {
   position: relative;
 	width: 1.5rem;
 	height: 2rem;
-  background: url("/img/clipboard-hover.svg");
+  background: url($baseurl + "/img/clipboard-hover.svg");
   background-repeat: no-repeat;
   background-position: center;
   border: none;

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -593,3 +593,18 @@ figure.highlight {
   border-width: 1rem;
   margin-left: -1rem;
 }
+
+// ***********************
+// Banner
+// ***********************
+.banner {
+  margin: 1em 0 1em 0;
+  padding: 1em;
+  background: $conjur-teal;
+  color: #FFFFFF;
+  border-radius: 3px;
+
+  a {
+    color: $cybr-dkblue;
+  }
+}

--- a/docs/_sass/_lp/_pages.scss
+++ b/docs/_sass/_lp/_pages.scss
@@ -28,7 +28,7 @@ body.lp
   }
   .lp-hero
   {
-    background: url(/img/lp/hero_banner.jpg);
+    background: url($baseurl + "/img/lp/hero_banner.jpg");
     height: calc(100vh - 127px);
     background-size: cover;
     h1,h2,h3,p
@@ -82,7 +82,7 @@ body.lp
   }
   .dark_bg
   {
-    background: url(/img/lp/Texture-01.png);
+    background: url($baseurl + "/img/lp/Texture-01.png");
     color: #fff;
     padding-bottom:60px;
 

--- a/docs/_sass/_navigation.scss
+++ b/docs/_sass/_navigation.scss
@@ -16,7 +16,7 @@
       margin-right: 35px;
       display: inline-block;
       width: 220px;
-      background: url("/img/Conjur_4C_KO.svg") no-repeat top left;
+      background: url($baseurl + "/img/Conjur_4C_KO.svg") no-repeat top left;
       padding: 0px;
     }
   }
@@ -167,7 +167,7 @@
         display: inline-block;
         width: 220px;
         margin-top: 1em;
-        background: url("/img/Conjur_4C_KO.svg") no-repeat top left;
+        background: url($baseurl + "/img/Conjur_4C_KO.svg") no-repeat top left;
         padding: 0px;
       }
     }

--- a/docs/css/conjur.scss
+++ b/docs/css/conjur.scss
@@ -12,6 +12,9 @@
 *
 */
 
+// Set the base URL
+$baseurl: "{{ site.baseurl }}";
+
 @import
   "bootstrap",
   "variables",

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,14 @@ id: index
 description: Conjur is a scalable, flexible, open source security service that stores secrets, provides machine identity based authorization, and more.
 ---
 
-
+<div class="container">
+  <div class="banner">
+    Work in progress - Please excuse our appearance while we collect feedback
+    for this page. If you have feedback or suggestions on how to improve this page,
+    we would love to hear from you
+    <a href="https://discuss.cyberarkcommons.org/t/new-github-landing-page-for-conjur-open-source-suite/661">in Discourse</a>.
+  </div>
+</div>
 
 <div class="container">
   <div class="landing-page-header">


### PR DESCRIPTION
#### What does this PR do?

Updates the landing page to fix a bug where the logo doesn't show in the top left
Also adds an "Under Construction" banner

#### Any background context you want to provide?

The page may move to conjur.org, so the banner is added to ensure people are aware this is a WIP and it may be relocated

#### Where should the reviewer start?

View the screenshot below. If you prefer to build locally yourself, you can clone this repo, run
```
cd docs/
bundle exec jekyll serve
```
and visit localhost:4000

#### Screenshots (if appropriate)
<img width="1212" alt="Screen Shot 2020-02-25 at 12 17 26 PM" src="https://user-images.githubusercontent.com/26872683/75271005-859e2b80-57c9-11ea-8fb5-6173154a6767.png">
