### PR TITLE
Fix link to landing page home

### DIFF
--- a/docs/_includes/page-layout/top_nav.html
+++ b/docs/_includes/page-layout/top_nav.html
@@ -6,7 +6,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/" title="CyberArk Logo"></a>
+      <a class="navbar-brand" href="{{ site.baseurl }}" title="CyberArk Logo"></a>
     </div>
     <div class="collapse navbar-collapse" id="mobileNav">
       <ul class="nav navbar-nav">


### PR DESCRIPTION
The landing page home link was set to "/", but when published to gh pages,
it was hitting cyberark.github.io instead of cyberark.github.io/conjur

This commit sets the home link to the site's baseurl instead

#### What does this PR do?

Fixes a bad link on the github landing page.