### PR TITLE
Fix RoleNotAuthorizedOnWebservice message

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -182,6 +182,11 @@ class AuthenticateController < ApplicationController
   end
 
   def status_failure_response(error)
+    logger.debug("Status check failed with error: #{error.inspect}")
+    error.backtrace.each do |line|
+      logger.debug(line)
+    end
+
     payload = {
       status: "error",
       error: error.inspect

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -38,7 +38,7 @@ module Authentication
 
       def validate_host_can_access_service
         return if host_can_access_service?
-        raise SecurityErr::RoleNotAuthorizedOnWebservice.new(host.role.id, service_id)
+        raise SecurityErr::RoleNotAuthorizedOnWebservice.new(host.role.id, "authenticate", service_id)
       end
 
       def validate_pod_exists

--- a/app/domain/authentication/validate_webservice_access.rb
+++ b/app/domain/authentication/validate_webservice_access.rb
@@ -60,11 +60,8 @@ module Authentication
       end
 
       def validate_user_has_access
-        # Ensure user has access to the service
         has_access = user_role.allowed_to?(@privilege, webservice_resource)
         unless has_access
-          @logger.debug(Log::UserNotAuthorized
-                          .new(@user_id, webservice_resource_id))
           raise Err::RoleNotAuthorizedOnWebservice.new(@user_id, @privilege, webservice_resource_id)
         end
       end

--- a/app/domain/authentication/validate_webservice_access.rb
+++ b/app/domain/authentication/validate_webservice_access.rb
@@ -65,7 +65,7 @@ module Authentication
         unless has_access
           @logger.debug(Log::UserNotAuthorized
                           .new(@user_id, webservice_resource_id))
-          raise Err::RoleNotAuthorizedOnWebservice.new(@user_id, webservice_resource_id)
+          raise Err::RoleNotAuthorizedOnWebservice.new(@user_id, @privilege, webservice_resource_id)
         end
       end
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -84,7 +84,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         RoleNotAuthorizedOnWebservice = ::Util::TrackableErrorClass.new(
-          msg: "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
+          msg: "'{0-role-name}' does not have '{1-privilege}' privilege on {2-webservice-name}",
           code: "CONJ00006E"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -22,11 +22,6 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00001D"
         )
 
-        UserNotAuthorized = ::Util::TrackableLogMessageClass.new(
-          msg: "User '{0}' is not authorized to authenticate with webservice '{1}'",
-          code: "CONJ00002D"
-        )
-
       end
 
       module OAuth


### PR DESCRIPTION
The error message said that the role doesn't have `authenticate` privilege
even though sometimes we check for other privileges (e.g `update`). This PR
receives the privilege as input for the error message.