### PR TITLE
Log the initial line of authentication and login errors at `warn` level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Improved flows and rules around user creation
 - Kubernetes authenticator now returns 403 on unpermitted hosts instead of a 401
+- Authenticator will now log initial authentication failure reason at the `warn`
+  level rather than `debug`. Full stack trace is still available at `debug` level.
 
 ### Fixed
 - Updated broken links on server status page (#1341)

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -125,7 +125,7 @@ class AuthenticateController < ApplicationController
   private
 
   def handle_login_error(err)
-    logger.debug("Login Error: #{err.inspect}")
+    logger.warn("Login Error: #{err.inspect}")
     err.backtrace.each do |line|
       logger.debug(line)
     end
@@ -141,7 +141,7 @@ class AuthenticateController < ApplicationController
   end
 
   def handle_authentication_error(err)
-    logger.debug("Authentication Error: #{err.inspect}")
+    logger.warn("Authentication Error: #{err.inspect}")
     err.backtrace.each do |line|
       logger.debug(line)
     end


### PR DESCRIPTION
#### Pending

- [ ] Security Review Sign-off

#### What does this PR do?

The generic 401 error response from authenticators (specifically authn-k8s) can have a variety of root causes, some of them not directly related to the authentication credentials themselves, but rather issues with the authenticator configuration.

This change improves the ability for a Conjur operator to quickly pinpoint the cause for an authentication failure, without changing log levels and restarting the Conjur process/container.

#### Any background context you want to provide?

This is a follow-up issue to https://github.com/cyberark/conjur/pull/1219.

#### What ticket does this PR close?

Connected to #1377

#### Has the Version and Changelog been updated?

Yes

