### PR TITLE
Decode JWT token fixes

### DIFF
--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -47,7 +47,7 @@ module Authentication
         end
       rescue JWT::ExpiredSignature
         raise Err::TokenExpired
-      rescue JWT::DecodeError
+      rescue JWT::DecodeError => e
         @logger.debug(Log::TokenDecodeFailed.new(e.inspect))
         raise Err::TokenDecodeFailed, e.inspect
       rescue => e

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -34,7 +34,7 @@ module Authentication
         @discovered_provider = @open_id_discovery_service.discover!(@provider_uri).tap do
           @logger.debug(Log::IdentityProviderDiscoverySuccess.new)
         end
-      rescue HTTPClient::ConnectTimeoutError => e
+      rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
         raise_error(Err::ProviderDiscoveryTimeout, e)
       rescue => e
         raise_error(Err::ProviderDiscoveryFailed, e)


### PR DESCRIPTION
This PR fixes 2 issues we had when decoding JWT tokens:
1. When we rescue a `JWT::DecodeError` we inspect the error to log it and to re-raise it but we forgot to mark the error in a variable.
2. We didn't rescue `Errno::ETIMEDOUT` when trying to discover the Oauth provider so we didn't raise a 504 Gateway Timeout error properly.