### PR TITLE
Raise ClaimInInvalidFormat properly

### DIFF
--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -2,35 +2,12 @@ module Authentication
   module AuthnAzure
 
     Log = LogMessages::Authentication::AuthnAzure
-    Err = Errors::Authentication::AuthnAzure
-    # Possible Errors Raised: ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
 
-    # This class defines an Azure application identity of a given Conjur resource.
-    # The constructor initializes an ApplicationIdentity object and validates that
-    # it is configured correctly.
-    # The difference between the validation in this constructor and
-    # the validation in ValidateApplicationIdentity is that here we validate that
-    # the application identity is configured correctly, and thus is a valid application
-    # identity. In ValidateApplicationIdentity we validate that the defined application
-    # identity is actually the one we expect from Azure. This validation is done through
-    # a combination of comparisons that are performed based on the type of assigned
-    # identity provided.
-    # For example, an application identity annotation `authn-azure/some-value` is not
-    # valid and will fail the validation here. For example, application identity annotation like
-    # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
-    # defined in the Conjur resource's annotations is a valid application identity
-    # because `subscription_id` is one of the defined, accepted constraints and will pass
-    # the validation here.
-    # If the Azure-related annotations in the resource defined in Conjur has Azure-specific
-    # annotations that do not match the supplied JWT token, then it will fail the
-    # validation of ValidateApplicationIdentity.
     class ApplicationIdentity
 
       def initialize(role_annotations:, service_id:)
         @role_annotations = role_annotations
         @service_id       = service_id
-
-        validate
       end
 
       def constraints
@@ -43,54 +20,6 @@ module Authentication
       end
 
       private
-
-      # validate that the application identity is defined correctly
-      def validate
-        validate_azure_annotations_are_permitted
-        validate_required_constraints_exist
-        validate_constraint_combinations
-      end
-
-      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
-      def validate_azure_annotations_are_permitted
-        validate_prefixed_permitted_annotations("authn-azure/")
-        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
-      end
-
-      # check if annotations with the given prefix is part of the permitted list
-      def validate_prefixed_permitted_annotations prefix
-        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
-
-        prefixed_annotations(prefix).each do |annotation|
-          annotation_name = annotation[:name]
-          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
-          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
-        end
-      end
-
-      def prefixed_annotations prefix
-        @role_annotations.select do |a|
-          annotation_name = a.values[:name]
-
-          annotation_name.start_with?(prefix) &&
-            # verify we take only annotations from the same level
-            annotation_name.split('/').length == prefix.split('/').length + 1
-        end
-      end
-
-      # add prefix to all permitted constraints
-      def prefixed_permitted_constraints prefix
-        permitted_constraints.map { |k| "#{prefix}#{k}" }
-      end
-
-      def validate_required_constraints_exist
-        validate_constraint_exists :subscription_id
-        validate_constraint_exists :resource_group
-      end
-
-      def validate_constraint_exists constraint
-        raise Err::MissingConstraint.new(constraint) unless constraints[constraint]
-      end
 
       # check the `service-id` specific constraint first to be more granular
       def constraint_value constraint_name
@@ -106,21 +35,6 @@ module Authentication
           Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
           annotation[:value]
         end
-      end
-
-      def permitted_constraints
-        @permitted_constraints ||= %w(
-          subscription-id resource-group user-assigned-identity system-assigned-identity
-        )
-      end
-
-      # validates that the application identity doesn't include logical constraint
-      # combinations (e.g user_assigned_identity & system_assigned_identity)
-      def validate_constraint_combinations
-        identifiers = %i(user_assigned_identity system_assigned_identity)
-
-        identifiers_constraints = constraints.keys & identifiers
-        raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
       end
     end
   end

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,0 +1,131 @@
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
+
+    # This class defines an Azure application identity of a given Conjur resource.
+    # The constructor initializes an ApplicationIdentity object and validates that
+    # it is configured correctly.
+    # The difference between the validation in this constructor and
+    # the validation in ValidateApplicationIdentity is that here we validate that
+    # the application identity is configured correctly, and thus is a valid application
+    # identity. In ValidateApplicationIdentity we validate that the defined application
+    # identity is actually the one we expect from Azure. This validation is done through
+    # a combination of comparisons that are performed based on the type of assigned
+    # identity provided.
+    # For example, an application identity `authn-azure/some-value` is not
+    # valid and will fail the validation here. For example, application identity like
+    # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
+    # defined in the Conjur resource's annotations is a valid application identity
+    # because `subscription_id` is one of the defined, accepted constraints and will pass
+    # the validation here.
+    # If the Azure-related annotations in the resource defined in Conjur has Azure-specific
+    # annotations that do not match the supplied JWT token, then it will fail the
+    # validation of ValidateApplicationIdentity.
+    class ApplicationIdentity
+
+      def initialize(role_annotations:, service_id:)
+        @role_annotations = role_annotations
+        @service_id       = service_id
+
+        validate
+      end
+
+      def constraints
+        @constraints ||= {
+          subscription_id:          constraint_value("subscription-id"),
+          resource_group:           constraint_value("resource-group"),
+          user_assigned_identity:   constraint_value("user-assigned-identity"),
+          system_assigned_identity: constraint_value("system-assigned-identity"),
+        }.compact
+      end
+
+      private
+
+      # validate that the application identity is defined correctly
+      def validate
+        validate_azure_annotations_are_permitted
+        validate_required_constraints_exist
+        validate_constraint_combinations
+      end
+
+      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
+      def validate_azure_annotations_are_permitted
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with the given prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @role_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+            # verify we take only annotations from the same level
+            annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map {|k| "#{prefix}#{k}"}
+      end
+
+      def validate_required_constraints_exist
+        validate_constraint_exists :subscription_id
+        validate_constraint_exists :resource_group
+      end
+
+      def validate_constraint_exists constraint
+        raise Err::MissingConstraint.new(constraint) unless constraints[constraint]
+      end
+
+      # check the `service-id` specific constraint first to be more granular
+      def constraint_from_annotation constraint_name
+        annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
+          annotation_value("authn-azure/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @role_annotations.find {|a| a.values[:name] == name}
+
+        # return the value of the annotation if it exists, nil otherwise
+        if annotation
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          annotation[:value]
+        end
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
+
+      # validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      def validate_constraint_combinations
+        identifiers = %i(user_assigned_identity system_assigned_identity)
+
+        identifiers_constraints = constraints.keys & identifiers
+        raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
+      end
+
+      def constraint_value constraint_name
+        constraint_from_annotation(constraint_name)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -15,8 +15,8 @@ module Authentication
     # identity is actually the one we expect from Azure. This validation is done through
     # a combination of comparisons that are performed based on the type of assigned
     # identity provided.
-    # For example, an application identity `authn-azure/some-value` is not
-    # valid and will fail the validation here. For example, application identity like
+    # For example, an application identity annotation `authn-azure/some-value` is not
+    # valid and will fail the validation here. For example, application identity annotation like
     # `authn-azure/subscription-id` or `authn-azure/<service-id>/subscription-id`
     # defined in the Conjur resource's annotations is a valid application identity
     # because `subscription_id` is one of the defined, accepted constraints and will pass
@@ -80,7 +80,7 @@ module Authentication
 
       # add prefix to all permitted constraints
       def prefixed_permitted_constraints prefix
-        permitted_constraints.map {|k| "#{prefix}#{k}"}
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
       end
 
       def validate_required_constraints_exist
@@ -93,13 +93,13 @@ module Authentication
       end
 
       # check the `service-id` specific constraint first to be more granular
-      def constraint_from_annotation constraint_name
+      def constraint_value constraint_name
         annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
           annotation_value("authn-azure/#{constraint_name}")
       end
 
       def annotation_value name
-        annotation = @role_annotations.find {|a| a.values[:name] == name}
+        annotation = @role_annotations.find { |a| a.values[:name] == name }
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
@@ -121,10 +121,6 @@ module Authentication
 
         identifiers_constraints = constraints.keys & identifiers
         raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
-      end
-
-      def constraint_value constraint_name
-        constraint_from_annotation(constraint_name)
       end
     end
   end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -34,10 +34,9 @@ module Authentication
       private
 
       def validate_credentials_include_azure_token
-        # check that id token field exists and has some value
         unless decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
           !decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
-          raise Errors::Authentication::RequestBody::MissingRequestParam
+          raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME
         end
       end
 
@@ -89,14 +88,16 @@ module Authentication
       end
 
       def xms_mirid
-        decoded_token[XMS_MIRID_TOKEN_FIELD_NAME].tap do |token_field_value|
-          @logger.debug(Log::ExtractedFieldFromAzureToken.new(XMS_MIRID_TOKEN_FIELD_NAME, token_field_value))
-        end
+        token_field_value(XMS_MIRID_TOKEN_FIELD_NAME)
       end
 
       def oid
-        decoded_token[OID_TOKEN_FIELD_NAME].tap do |token_field_value|
-          @logger.debug(Log::ExtractedFieldFromAzureToken.new(OID_TOKEN_FIELD_NAME, token_field_value))
+        token_field_value(OID_TOKEN_FIELD_NAME)
+      end
+
+      def token_field_value field_name
+        decoded_token[field_name].tap do |token_field_value|
+          @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
         end
       end
     end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -4,6 +4,7 @@ module Authentication
   module AuthnAzure
 
     Err = Errors::Authentication::AuthnAzure
+    Log = LogMessages::Authentication::AuthnAzure
     # Possible Errors Raised:
     # TODO: Add errors
 
@@ -14,7 +15,7 @@ module Authentication
       inputs: [:authenticator_input]
     ) do
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
         validate_azure_token
@@ -28,14 +29,6 @@ module Authentication
       end
 
       def validate_application_identity
-
-      end
-
-      def host
-
-      end
-
-      def host_annotations
 
       end
     end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -10,10 +10,12 @@ module Authentication
 
     Authenticator = CommandClass.new(
       dependencies: {
-
+        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        logger:                      Rails.logger
       },
       inputs: [:authenticator_input]
     ) do
+
       extend Forwardable
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
@@ -30,6 +32,23 @@ module Authentication
 
       def validate_application_identity
 
+      end
+
+      def provider_uri
+        azure_authenticator_secrets["provider-uri"]
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
       end
     end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -64,10 +64,10 @@ module Authentication
       def validate_application_identity
         @validate_application_identity.(
           service_id: service_id,
-            account: account,
-            username: username,
-            xms_mirid: xms_mirid,
-            oid: oid
+          account: account,
+          username: username,
+          xms_mirid_token_field: xms_mirid,
+          oid_token_field: oid
         )
       end
 
@@ -78,9 +78,9 @@ module Authentication
       def azure_authenticator_secrets
         @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
           service_id: service_id,
-            conjur_account: account,
-            authenticator_name: authenticator_name,
-            required_variable_names: required_variable_names
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
         )
       end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -6,48 +6,94 @@ module Authentication
     Err = Errors::Authentication::AuthnAzure
     Log = LogMessages::Authentication::AuthnAzure
     # Possible Errors Raised:
-    # TODO: Add errors
+    # TokenFieldNotFoundOrEmpty, MissingRequestParam
 
     Authenticator = CommandClass.new(
       dependencies: {
-        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        logger:                      Rails.logger
+        fetch_authenticator_secrets:   Authentication::Util::FetchAuthenticatorSecrets.new,
+        verify_and_decode_token:       Authentication::AuthnOidc::VerifyAndDecodeToken.new,
+        logger:                        Rails.logger
       },
-      inputs: [:authenticator_input]
+      inputs:       [:authenticator_input]
     ) do
 
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :credentials
+
+      JWT_REQUEST_BODY_FIELD_NAME = "jwt"
+      XMS_MIRID_TOKEN_FIELD_NAME = "xms_mirid"
+      OID_TOKEN_FIELD_NAME = "oid"
 
       def call
+        validate_credentials_include_azure_token
+        validate_azure_token
+        validate_required_token_fields_exist
         true
       end
 
       private
 
-      #def validate_azure_token
-      #
-      #end
-      #
-      #def validate_application_identity
-      #
-      #end
+      def validate_credentials_include_azure_token
+        # check that id token field exists and has some value
+        raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME unless decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
+          !decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
+      end
+
+      # The credentials are in a URL encoded form data in the request body
+      def decoded_credentials
+        @decoded_credentials ||= Hash[URI.decode_www_form(credentials)]
+      end
+
+      def validate_azure_token
+        decoded_token
+      end
+
+      def decoded_token
+        @decoded_token ||= @verify_and_decode_token.call(
+          provider_uri:     provider_uri,
+          token_jwt:        decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME],
+          claims_to_verify: {
+            verify_iss: true,
+            iss:        provider_uri
+          }
+        )
+      end
 
       def provider_uri
-        azure_authenticator_secrets["provider-uri"]
+        @provider_uri ||= azure_authenticator_secrets["provider-uri"]
       end
 
       def azure_authenticator_secrets
         @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
           service_id: service_id,
-          conjur_account: account,
-          authenticator_name: authenticator_name,
-          required_variable_names: required_variable_names
+            conjur_account: account,
+            authenticator_name: authenticator_name,
+            required_variable_names: required_variable_names
         )
       end
 
       def required_variable_names
         @required_variable_names ||= %w(provider-uri)
+      end
+
+      def validate_required_token_fields_exist
+        validate_token_field_exists(XMS_MIRID_TOKEN_FIELD_NAME)
+        validate_token_field_exists(OID_TOKEN_FIELD_NAME)
+      end
+
+      def validate_token_field_exists field_name
+        @logger.debug(Log::ValidatingTokenFieldExists.new(field_name))
+        raise Err::TokenFieldNotFoundOrEmpty, field_name if decoded_token[field_name].to_s.empty?
+      end
+
+      def xms_mirid
+        @logger.debug(Log::ExtractedFieldFromAzureToken.new(XMS_MIRID_TOKEN_FIELD_NAME, decoded_token[XMS_MIRID_TOKEN_FIELD_NAME]))
+        decoded_token[XMS_MIRID_TOKEN_FIELD_NAME]
+      end
+
+      def oid
+        @logger.debug(Log::ExtractedFieldFromAzureToken.new(OID_TOKEN_FIELD_NAME, decoded_token[OID_TOKEN_FIELD_NAME]))
+        decoded_token[OID_TOKEN_FIELD_NAME]
       end
     end
 

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -20,19 +20,18 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :credentials
 
       def call
-        validate_azure_token
-        validate_application_identity
+        true
       end
 
       private
 
-      def validate_azure_token
-
-      end
-
-      def validate_application_identity
-
-      end
+      #def validate_azure_token
+      #
+      #end
+      #
+      #def validate_application_identity
+      #
+      #end
 
       def provider_uri
         azure_authenticator_secrets["provider-uri"]

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -1,0 +1,42 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    # TODO: Add errors
+
+    Authenticator = CommandClass.new(
+      dependencies: {
+
+      },
+      inputs: [:authenticator_input]
+    ) do
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
+
+      def call
+
+      end
+
+      private
+
+    end
+
+    class Authenticator
+      # This delegates to all the work to the call method created automatically
+      # by CommandClass
+      #
+      # This is needed because we need `valid?` to exist on the Authenticator
+      # class, but that class contains only a metaprogramming generated
+      # `call(authenticator_input:)` method.  The methods we define in the
+      # block passed to `CommandClass` exist only on the private internal
+      # `Call` objects created each time `call` is run.
+      #
+      def valid?(input)
+        call(authenticator_input: input)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -17,11 +17,27 @@ module Authentication
       def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :request, :request_body
 
       def call
-
+        validate_azure_token
+        validate_application_identity
       end
 
       private
 
+      def validate_azure_token
+
+      end
+
+      def validate_application_identity
+
+      end
+
+      def host
+
+      end
+
+      def host_annotations
+
+      end
     end
 
     class Authenticator

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -125,6 +125,13 @@ module Authentication
       def valid?(input)
         call(authenticator_input: input)
       end
+
+      def status(authenticator_status_input:)
+        Authentication::AuthnAzure::ValidateStatus.new.(
+          account: authenticator_status_input.account,
+          service_id: authenticator_status_input.service_id
+        )
+      end
     end
   end
 end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -34,7 +34,7 @@ module Authentication
         begin
           required_keys = %w(subscriptions resourcegroups providers)
           missing_keys = required_keys - xms_mirid_hash.keys
-          raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" if missing_keys.empty?
+          raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" unless missing_keys.empty?
         rescue => e
           raise Err::ClaimInInvalidFormat, e.inspect
         end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -19,6 +19,7 @@ module Authentication
     ) do
 
       def call
+        parse_xms_mirid
         validate_xms_mirid_format
         token_identity_from_claims
         validate_azure_annotations_are_permitted
@@ -30,11 +31,9 @@ module Authentication
 
       private
 
-      def validate_xms_mirid_format
+      def parse_xms_mirid
         begin
-          required_keys = %w(subscriptions resourcegroups providers)
-          missing_keys = required_keys - xms_mirid_hash.keys
-          raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" unless missing_keys.empty?
+          xms_mirid_hash
         rescue => e
           raise Err::ClaimInInvalidFormat, e.inspect
         end
@@ -67,6 +66,12 @@ module Authentication
           end
           index += 1
         end
+      end
+
+      def validate_xms_mirid_format
+        required_keys = %w(subscriptions resourcegroups providers)
+        missing_keys = required_keys - xms_mirid_hash.keys
+        raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" unless missing_keys.empty?
       end
 
       # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -132,12 +132,6 @@ module Authentication
         raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints unless identifiers_constraints.length <= 1
       end
 
-      def permitted_constraints
-        @permitted_constraints ||= %w(
-          subscription-id resource-group user-assigned-identity system-assigned-identity
-        )
-      end
-
       def validate_token_identity_matches_annotations
         application_identity.constraints.each do |constraint|
           annotation_type  = constraint[0].to_s

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -33,10 +33,10 @@ module Authentication
       def validate_xms_mirid_format
         begin
           required_keys = %w(subscriptions resourcegroups providers)
-          required_keys_exist = required_keys.all? { |s| xms_mirid_hash.key? s }
-          raise Err::ClaimInInvalidFormat unless required_keys_exist
-        rescue
-          raise Err::ClaimInInvalidFormat
+          missing_keys = required_keys - xms_mirid_hash.keys
+          raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" if missing_keys.empty?
+        rescue => e
+          raise Err::ClaimInInvalidFormat, e.inspect
         end
       end
 

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -59,7 +59,7 @@ module Authentication
             when "resourcegroups"
               xms_mirid_hash["resourcegroups"] = split_xms_mirid[index + 1]
             when "providers"
-              xms_mirid_hash["providers"] = split_xms_mirid[index + 1, index + 3]
+              xms_mirid_hash["providers"] = split_xms_mirid[index + 1, 3]
             end
             index += 1
           end
@@ -72,7 +72,11 @@ module Authentication
         required_keys = %w(subscriptions resourcegroups providers)
         missing_keys = required_keys - xms_mirid_hash.keys
         unless missing_keys.empty?
-          raise Err::MissingRequiredKeysInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+        end
+
+        unless xms_mirid_hash["providers"].length == 3
+          raise Err::MissingProviderFieldsInXmsMirid.new(@xms_mirid_token_field)
         end
       end
 

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -1,0 +1,105 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity
+
+    ValidateApplicationIdentity = CommandClass.new(
+      dependencies: {
+        role_class:                 ::Role,
+        resource_class:             ::Resource,
+        application_identity_class: ApplicationIdentity,
+        logger:                     Rails.logger
+      },
+      inputs:       %i(account service_id username xms_mirid oid)
+    ) do
+
+      def call
+        token_identity_from_claims
+        # compare xms_mirid with what is defined in annotations
+        validate_application_identity
+      end
+
+      private
+
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+          role_annotations: role.annotations,
+          service_id:       @service_id
+        )
+      end
+
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @username)
+      end
+
+      def role
+        @role ||= @resource_class[role_id].tap do |role|
+          raise SecurityErr::RoleNotFound(role_id) unless role
+        end
+      end
+
+      # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's
+      # among other details the subscription_id, resource group, and provider identity needed for authorization.
+      # xms_mirid is one of the fields in the JWT token. This function will extract the relevant information from
+      # xms_mirid claim and populate a representative hash with the appropriate fields.
+      def token_identity_from_claims
+
+        # validates format of claim
+        raise Err::ClaimInInvalidFormat unless validate_xms_mirid_format
+
+        @token_identity = {
+          subscription_id: xms_mirid_hash["subscriptions"],
+          resource_group:  xms_mirid_hash["resourcegroups"]
+        }
+
+        # determines which Azure assigned identity is provided in annotations
+        # user-assigned-identity:
+        #   - validates that the correct provider (Microsoft.ManagedIdentity) for a user identity is defined in the
+        #     claim. If so, the 'user_assigned_identity' attribute will be added to the hash with the corresponding
+        #     value from xms_mirid claim
+        # system-assigned-identity:
+        #   - validates that the correct provider (Microsoft.Compute) for a system identity is defined in the
+        #     claim and its resource is one that we support. At current, we only support a virtualMachines resource.
+        #     If these conditions are met, a 'system_assigned_identity' attribute will be added to the hash with its
+        #     value being the oid field in the JWT token.
+        @logger.debug(Log::ExtractingIdentityForAuthentication.new("#{xms_mirid_hash["providers"]}/#{xms_mirid_hash.keys[-1]}"))
+        if xms_mirid_hash["providers"] == "Microsoft.ManagedIdentity"
+          @token_identity[:user_assigned_identity] = xms_mirid_hash["userAssignedIdentities"]
+          @token_identity[:resource_name]          = xms_mirid_hash["userAssignedIdentities"]
+        else
+          @token_identity[:system_assigned_identity] = @oid
+          @token_identity[:resource_name]            = @oid
+        end
+      end
+
+      # xms_mirid claim starts with an extra '/' so we will be ignoring it for parsing purposes
+      # ex: /subscription/<subscription_id> -> subscription/<subscription_id>
+      def xms_mirid_hash
+        _, *field_split = @xms_mirid.split('/')
+        Hash[field_split.each_slice(2).to_a]
+      end
+
+      def validate_xms_mirid_format
+        xms_mirid_hash.length == 4 && xms_mirid_hash.key?("subscriptions" && "resourcegroups" && "providers")
+      end
+
+      # validate the integrity of annotations against the xms_mirid object representation
+      def validate_application_identity
+        @logger.debug(Log::ValidatingApplicationIdentity.new(@token_identity[:resource_name]))
+        application_identity.constraints.each do |constraint|
+          annotation_type  = constraint[0].to_s
+          annotation_value = constraint[1]
+          unless annotation_value == @token_identity[annotation_type.to_sym]
+            raise Err::InvalidApplicationIdentity.new(annotation_type)
+          end
+        end
+        @logger.debug(Log::ValidatedApplicationIdentity.new(@token_identity[:resource_name]))
+      end
+    end
+  end
+
+end

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -1,0 +1,64 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity,
+    # ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
+
+    ValidateAzureAnnotations = CommandClass.new(
+      dependencies: {
+        logger: Rails.logger
+      },
+      inputs:       %i(role_annotations)
+    ) do
+
+      def call
+        validate_azure_annotations_are_permitted
+      end
+
+      private
+
+      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
+      def validate_azure_annotations_are_permitted
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with the given prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @role_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+            # verify we take only annotations from the same level
+            annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
+    end
+  end
+
+end

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -1,0 +1,52 @@
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    #   ProviderDiscoveryTimeout, ProviderDiscoveryFailed
+    #   RequiredResourceMissing, RequiredSecretMissing
+
+    ValidateStatus = CommandClass.new(
+      dependencies: {
+        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+      },
+      inputs: %i(account service_id)
+    ) do
+
+      def call
+        validate_secrets
+        validate_provider_is_responsive
+      end
+
+      private
+
+      def validate_secrets
+        azure_authenticator_secrets
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: @service_id,
+          conjur_account: @account,
+          authenticator_name: "authn-azure",
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
+      end
+
+      def validate_provider_is_responsive
+        @discover_identity_provider.(
+          provider_uri: provider_uri
+        )
+      end
+
+      def provider_uri
+        @azure_authenticator_secrets["provider-uri"]
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -85,7 +85,7 @@ module Authentication
         controllers = %i(deployment deployment_config stateful_set)
 
         controller_constraints = constraints.keys & controllers
-        raise Err::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
+        raise Errors::Authentication::IllegalConstraintCombinations, controller_constraints unless controller_constraints.length <= 1
       end
 
       def constraint_value constraint_name
@@ -98,11 +98,11 @@ module Authentication
       end
 
       def annotation_value name
-        annotation = @host_annotations.find { |a| a.values[:name] == name }
+        annotation = @host_annotations.find {|a| a.values[:name] == name}
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
-          Rails.logger.debug(Log::RetrievedAnnotationValue.new(name))
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
           annotation[:value]
         end
       end
@@ -127,7 +127,7 @@ module Authentication
       end
 
       def validate_prefixed_permitted_annotations prefix
-        Rails.logger.debug(Log::ValidatingAnnotationsWithPrefix.new(prefix))
+        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
 
         prefixed_k8s_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]
@@ -141,13 +141,13 @@ module Authentication
           annotation_name = a.values[:name]
 
           annotation_name.start_with?(prefix) &&
-            # Verify we take only annotations from the same level
+            # verify we take only annotations from the same level
             annotation_name.split('/').length == prefix.split('/').length + 1
         end
       end
 
       def prefixed_permitted_annotations prefix
-        permitted_annotations.map { |k| "#{prefix}#{k}" }
+        permitted_annotations.map {|k| "#{prefix}#{k}"}
       end
 
       def validate_host_id
@@ -174,7 +174,7 @@ module Authentication
       end
 
       def annotation_type_constraints
-        @annotation_type_constraints ||= permitted_constraints.map { |constraint| annotation_type_constraint(constraint) }
+        @annotation_type_constraints ||= permitted_constraints.map {|constraint| annotation_type_constraint(constraint)}
       end
 
       def annotation_type_constraint constraint
@@ -182,7 +182,7 @@ module Authentication
       end
 
       def application_identity_in_annotations?
-        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
+        @application_identity_in_annotations ||= @host_annotations.select {|a| a.values[:name].start_with?("authn-k8s/")}.any?
       end
 
       def host_id_namespace_scoped?

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -98,7 +98,7 @@ module Authentication
       end
 
       def annotation_value name
-        annotation = @host_annotations.find {|a| a.values[:name] == name}
+        annotation = @host_annotations.find { |a| a.values[:name] == name }
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
@@ -147,7 +147,7 @@ module Authentication
       end
 
       def prefixed_permitted_annotations prefix
-        permitted_annotations.map {|k| "#{prefix}#{k}"}
+        permitted_annotations.map { |k| "#{prefix}#{k}" }
       end
 
       def validate_host_id
@@ -174,7 +174,7 @@ module Authentication
       end
 
       def annotation_type_constraints
-        @annotation_type_constraints ||= permitted_constraints.map {|constraint| annotation_type_constraint(constraint)}
+        @annotation_type_constraints ||= permitted_constraints.map { |constraint| annotation_type_constraint(constraint) }
       end
 
       def annotation_type_constraint constraint
@@ -182,7 +182,7 @@ module Authentication
       end
 
       def application_identity_in_annotations?
-        @application_identity_in_annotations ||= @host_annotations.select {|a| a.values[:name].start_with?("authn-k8s/")}.any?
+        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
       end
 
       def host_id_namespace_scoped?

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -10,7 +10,7 @@ module Authentication
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
-        resource_class:              Resource,
+        resource_class:             ::Resource,
         k8s_resolver:               K8sResolver,
         k8s_object_lookup_class:    K8sObjectLookup,
         application_identity_class: ApplicationIdentity

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -69,12 +69,9 @@ module Authentication
         @authenticator_input = @authenticator_input.update(username: conjur_username)
       end
 
+      # The credentials are in a URL encoded form data in the request body
       def decoded_credentials
-        return @decoded_credentials unless @decoded_credentials.nil?
-
-        # The credentials are in a URL encoded form data in the request body
-        decoded_request_body = URI.decode_www_form(credentials)
-        @decoded_credentials = Hash[decoded_request_body]
+        @decoded_credentials ||= Hash[URI.decode_www_form(credentials)]
       end
 
       def oidc_authenticator_secrets

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -292,14 +292,19 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00050E"
         )
 
-        ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
-          msg:  "xms_mirid claim has been received in an invalid format. Reason: {0}",
+        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg:  "Field '{0-field-name}' not found or empty in token",
           code: "CONJ00051E"
         )
 
-        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' not found or empty in token",
+        XmsMiridParseError = ::Util::TrackableErrorClass.new(
+          msg:  "Failed to parse xms_mirid {0}. Reason: {1}",
           code: "CONJ00052E"
+        )
+
+        MissingRequiredKeysInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Required keys {0} are missing in xms_mirid {1}",
+          code: "CONJ00053E"
         )
 
       end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -274,6 +274,10 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00048E"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -160,7 +160,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
-          msg:  "admin user is not allowed to authenticate with OIDC",
+          msg:  "Admin user is not allowed to authenticate with OIDC",
           code: "CONJ00017E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -277,6 +277,11 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       module AuthnAzure
 
+        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg: "Field '{0-field-name}' not found or empty in token",
+          code: "CONJ00049E"
+        )
+
       end
     end
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -302,9 +302,14 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00052E"
         )
 
-        MissingRequiredKeysInXmsMirid = ::Util::TrackableErrorClass.new(
-          msg:  "Required keys {0} are missing in xms_mirid {1}",
+        MissingRequiredFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Required fields {0} are missing in xms_mirid {1}",
           code: "CONJ00053E"
+        )
+
+        MissingProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Provider fields are missing in xms_mirid {1}",
+          code: "CONJ00054E"
         )
 
       end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -293,7 +293,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
-          msg:  "xms_mirid claim has been received in an invalid format",
+          msg:  "xms_mirid claim has been received in an invalid format. Reason: {0}",
           code: "CONJ00051E"
         )
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -299,7 +299,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
         TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
           msg:  "Field '{0-field-name}' not found or empty in token",
-          code: "CONJ00049E"
+          code: "CONJ00052E"
         )
 
       end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -10,17 +10,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Conjur
 
       RequiredResourceMissing = Util::TrackableErrorClass.new(
-        msg: "Missing required resource: {0-resource-name}",
+        msg:  "Missing required resource: {0-resource-name}",
         code: "CONJ00036E"
       )
 
       RequiredSecretMissing = Util::TrackableErrorClass.new(
-        msg: "Missing value for resource: {0-resource-name}",
+        msg:  "Missing value for resource: {0-resource-name}",
         code: "CONJ00037E"
       )
 
       InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
-        msg: "The password you have chosen does not meet the complexity requirements. " \
+        msg:  "The password you have chosen does not meet the complexity requirements. " \
              "Choose a password that includes: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit, 1 special character",
         code: "CONJ00046E"
       )
@@ -30,41 +30,46 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Authentication
 
       AuthenticatorNotFound = ::Util::TrackableErrorClass.new(
-        msg: "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
+        msg:  "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
         code: "CONJ00001E"
       )
 
       InvalidCredentials = ::Util::TrackableErrorClass.new(
-        msg: "Invalid credentials",
+        msg:  "Invalid credentials",
         code: "CONJ00002E"
       )
 
       InvalidOrigin = ::Util::TrackableErrorClass.new(
-        msg: "Invalid origin",
+        msg:  "Invalid origin",
         code: "CONJ00003E"
       )
 
       StatusNotImplemented = ::Util::TrackableErrorClass.new(
-        msg: "Status check not implemented for authenticator '{0-authenticator-name}'",
+        msg:  "Status check not implemented for authenticator '{0-authenticator-name}'",
         code: "CONJ00045E"
+      )
+
+      IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
+        msg:  "Application identity includes an illegal resource constraint combination - '{0-constraints}'",
+        code: "CONJ00044E"
       )
 
       module AuthenticatorClass
 
         DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-parent-name}' is not a valid authenticator parent module because it does " \
+          msg:  "'{0-authenticator-parent-name}' is not a valid authenticator parent module because it does " \
             "not begin with 'Authn'",
           code: "CONJ00038E"
         )
 
         NotNamedAuthenticator = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not a valid authenticator name. " \
+          msg:  "'{0-authenticator-name}' is not a valid authenticator name. " \
             "The actual class implementing the authenticator must be named 'Authenticator'",
           code: "CONJ00039E"
         )
 
         MissingValidMethod = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not a valid authenticator because " \
+          msg:  "'{0-authenticator-name}' is not a valid authenticator because " \
             "it does not have a `:valid?(input)` method.",
           code: "CONJ00040E"
         )
@@ -74,27 +79,27 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module Security
 
         AuthenticatorNotWhitelisted = ::Util::TrackableErrorClass.new(
-          msg: "'{0-authenticator-name}' is not enabled",
+          msg:  "'{0-authenticator-name}' is not enabled",
           code: "CONJ00004E"
         )
 
         WebserviceNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Webservice '{0-webservice-name}' wasn't found",
+          msg:  "Webservice '{0-webservice-name}' wasn't found",
           code: "CONJ00005E"
         )
 
         RoleNotAuthorizedOnWebservice = ::Util::TrackableErrorClass.new(
-          msg: "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
+          msg:  "'{0-role-name}' does not have 'authenticate' privilege on {1-service-name}",
           code: "CONJ00006E"
         )
 
         RoleNotFound = ::Util::TrackableErrorClass.new(
-          msg: "'{0-role-name}' wasn't found",
+          msg:  "'{0-role-name}' wasn't found",
           code: "CONJ00007E"
         )
 
         AccountNotDefined = ::Util::TrackableErrorClass.new(
-          msg: "Account '{0-account-name}' is not defined in Conjur",
+          msg:  "Account '{0-account-name}' is not defined in Conjur",
           code: "CONJ00008E"
         )
 
@@ -103,7 +108,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module RequestBody
 
         MissingRequestParam = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' is missing or empty in request body",
+          msg:  "Field '{0-field-name}' is missing or empty in request body",
           code: "CONJ00009E"
         )
 
@@ -112,17 +117,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module OAuth
 
         ProviderDiscoveryTimeout = ::Util::TrackableErrorClass.new(
-          msg: "Identity Provider discovery failed with timeout error (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Identity Provider discovery failed with timeout error (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00010E"
         )
 
         ProviderDiscoveryFailed = ::Util::TrackableErrorClass.new(
-          msg: "Identity Provider discovery failed (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Identity Provider discovery failed (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00011E"
         )
 
         FetchProviderKeysFailed = ::Util::TrackableErrorClass.new(
-          msg: "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
+          msg:  "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
           code: "CONJ00012E"
         )
 
@@ -131,17 +136,17 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module Jwt
 
         TokenExpired = ::Util::TrackableErrorClass.new(
-          msg: "Token expired",
+          msg:  "Token expired",
           code: "CONJ00016E"
         )
 
         TokenDecodeFailed = ::Util::TrackableErrorClass.new(
-          msg: "Token decode failed (3rdPartyError ='{0}')",
+          msg:  "Token decode failed (3rdPartyError ='{0}')",
           code: "CONJ00035E"
         )
 
         TokenVerificationFailed = ::Util::TrackableErrorClass.new(
-          msg: "Token verification failed (3rdPartyError ='{0}')",
+          msg:  "Token verification failed (3rdPartyError ='{0}')",
           code: "CONJ00015E"
         )
 
@@ -150,12 +155,12 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnOidc
 
         IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
+          msg:  "Field '{0-field-name}' not found or empty in ID Token. This field is defined in the id-token-user-property variable.",
           code: "CONJ00013E"
         )
 
         AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
-          msg: "admin user is not allowed to authenticate with OIDC",
+          msg:  "admin user is not allowed to authenticate with OIDC",
           code: "CONJ00017E"
         )
 
@@ -164,7 +169,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnIam
 
         InvalidAWSHeaders = ::Util::TrackableErrorClass.new(
-          msg: "'Invalid or expired AWS headers: {0}",
+          msg:  "'Invalid or expired AWS headers: {0}",
           code: "CONJ00018E"
         )
 
@@ -173,112 +178,127 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnK8s
 
         CSRIsMissingSpiffeId = ::Util::TrackableErrorClass.new(
-          msg: 'CSR must contain SPIFFE ID SAN',
+          msg:  'CSR must contain SPIFFE ID SAN',
           code: "CONJ00022E"
         )
 
         PodNotFound = ::Util::TrackableErrorClass.new(
-          msg: "No pod found for '{0-pod-name}' in namespace '{1}'",
+          msg:  "No pod found for '{0-pod-name}' in namespace '{1}'",
           code: "CONJ00024E"
         )
 
         ScopeNotSupported = ::Util::TrackableErrorClass.new(
-          msg: "Resource type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          msg:  "Resource type '{0}' is not a supported application identity. The supported resources are '{1}'",
           code: "CONJ00025E"
         )
 
         K8sResourceNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
+          msg:  "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
           code: "CONJ00026E"
         )
 
         CertInstallationError = ::Util::TrackableErrorClass.new(
-          msg: "Certificate could not be copied to pod: {0}",
+          msg:  "Certificate could not be copied to pod: {0}",
           code: "CONJ00027E"
         )
 
         ContainerNotFound = ::Util::TrackableErrorClass.new(
-          msg: "Container {0} was not found in the pod. Host id: {1}",
+          msg:  "Container {0} was not found in the pod. Host id: {1}",
           code: "CONJ00028E"
         )
 
         MissingClientCertificate = ::Util::TrackableErrorClass.new(
-          msg: "Client SSL certificate is missing from the header",
+          msg:  "Client SSL certificate is missing from the header",
           code: "CONJ00029E"
         )
 
         UntrustedClientCertificate = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate cannot be verified by certification authority",
+          msg:  "Client certificate cannot be verified by certification authority",
           code: "CONJ00030E"
         )
 
         CommonNameDoesntMatchHost = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate CN must match host name. Cert CN: {0}. " \
+          msg:  "Client certificate CN must match host name. Cert CN: {0}. " \
             "Host name: {1}. ",
           code: "CONJ00031E"
         )
 
         ClientCertificateExpired = ::Util::TrackableErrorClass.new(
-          msg: "Client certificate expired",
+          msg:  "Client certificate expired",
           code: "CONJ00032E"
         )
 
         CommandTimedOut = ::Util::TrackableErrorClass.new(
-          msg: "Command timed out in container '{0}' of pod '{1}'",
+          msg:  "Command timed out in container '{0}' of pod '{1}'",
           code: "CONJ00033E"
         )
 
         MissingServiceAccountDir = ::Util::TrackableErrorClass.new(
-          msg: "Kubernetes serviceaccount dir '{0}' does not exist",
+          msg:  "Kubernetes serviceaccount dir '{0}' does not exist",
           code: "CONJ00034E"
         )
 
         UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
-          msg: "Unknown Kubernetes resource type '{0}'",
+          msg:  "Unknown Kubernetes resource type '{0}'",
           code: "CONJ00041E"
         )
 
         InvalidApiUrl = ::Util::TrackableErrorClass.new(
-          msg: "Received invalid Kubernetes API url: '{0}'",
+          msg:  "Received invalid Kubernetes API url: '{0}'",
           code: "CONJ00042E"
         )
 
         MissingCertificate = ::Util::TrackableErrorClass.new(
-          msg: "No Kubernetes API certificate available",
+          msg:  "No Kubernetes API certificate available",
           code: "CONJ00043E"
         )
 
-        IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
-          msg: "Application identity includes an illegal Kubernetes resource constraint combination - '{0-controller-constraints}'",
-          code: "CONJ00044E"
-        )
-
         MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
-          msg: "Host does not have a namespace constraint",
+          msg:  "Host does not have a namespace constraint",
           code: "CONJ00045E"
         )
 
         NamespaceMismatch = ::Util::TrackableErrorClass.new(
-          msg: "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
+          msg:  "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
             "implied by application identity '{1-application-identity-namespace}'",
           code: "CONJ00023E"
         )
 
         ValidationError = ::Util::TrackableErrorClass.new(
-          msg: "{0-message}",
+          msg:  "{0-message}",
           code: "CONJ00047E"
         )
 
         InvalidHostId = ::Util::TrackableErrorClass.new(
-          msg: "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
+          msg:  "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
           code: "CONJ00048E"
         )
       end
 
       module AuthnAzure
 
+        MissingConstraint = ::Util::TrackableErrorClass.new(
+          msg:  "Role does not have the required constraint: {0-constraint}",
+          code: "CONJ00045E"
+        )
+
+        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+          msg:  "Application identity field '{0-field-name}' does not match what is provided in Azure token",
+          code: "CONJ00049E"
+        )
+
+        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+          msg:  "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          code: "CONJ00050E"
+        )
+
+        ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
+          msg:  "xms_mirid claim has been received in an invalid format",
+          code: "CONJ00051E"
+        )
+
         TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg: "Field '{0-field-name}' not found or empty in token",
+          msg:  "Field '{0-field-name}' not found or empty in token",
           code: "CONJ00049E"
         )
 
@@ -288,7 +308,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
     module Util
 
       ConcurrencyLimitReachedBeforeCacheInitialization = ::Util::TrackableErrorClass.new(
-        msg: "Concurrency limited cache reached before cache initialized",
+        msg:  "Concurrency limited cache reached before cache initialized",
         code: "CONJ00044E"
       )
     end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -153,12 +153,12 @@ unless defined? LogMessages::Authentication::OriginValidated
 
         ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
           msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
-          code: "CONJ00029D"
+          code: "CONJ00031D"
         )
 
         ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
           msg:  "Validating that field '{0}' exists in token",
-          code: "CONJ00030D"
+          code: "CONJ00032D"
         )
 
       end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -146,13 +146,8 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00029D"
         )
 
-        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Validating application identity for {0-resource-name}",
-          code: "CONJ00030D"
-        )
-
         ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Application identity for {0-resource-name} validated",
+          msg:  "Application identity validated",
           code: "CONJ00030D"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -141,6 +141,17 @@ unless defined? LogMessages::Authentication::OriginValidated
 
       module AuthnAzure
 
+        # TODO: get security approval for this message
+        ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
+          msg: "Extracted field '{0-field-name}' with value {1-field-value} from token",
+          code: "CONJ00029D"
+        )
+
+        ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
+          msg: "Validating that field '{0}' exists in token",
+          code: "CONJ00030D"
+        )
+
       end
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -141,8 +141,8 @@ unless defined? LogMessages::Authentication::OriginValidated
 
       module AuthnAzure
 
-        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
-          msg:  "Extracting resource type {0-resource-type} for authentication",
+        ExtractedApplicationIdentityFromToken = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracted application identity from Token",
           code: "CONJ00029D"
         )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -11,19 +11,29 @@ unless defined? LogMessages::Authentication::OriginValidated
     module Authentication
 
       OriginValidated = ::Util::TrackableLogMessageClass.new(
-        msg: "Origin validated",
+        msg:  "Origin validated",
         code: "CONJ00003D"
+      )
+
+      ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+        msg:  "Validating annotations with prefix {0-prefix}",
+        code: "CONJ00025D"
+      )
+
+      RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+        msg:  "Retrieved value of annotation {0-annotation-name}",
+        code: "CONJ00024D"
       )
 
       module Security
 
         SecurityValidated = ::Util::TrackableLogMessageClass.new(
-          msg: "Security validated",
+          msg:  "Security validated",
           code: "CONJ00001D"
         )
 
         UserNotAuthorized = ::Util::TrackableLogMessageClass.new(
-          msg: "User '{0}' is not authorized to authenticate with webservice '{1}'",
+          msg:  "User '{0}' is not authorized to authenticate with webservice '{1}'",
           code: "CONJ00002D"
         )
 
@@ -32,27 +42,27 @@ unless defined? LogMessages::Authentication::OriginValidated
       module OAuth
 
         IdentityProviderUri = ::Util::TrackableLogMessageClass.new(
-          msg: "Working with Identity Provider {0-provider-uri}",
+          msg:  "Working with Identity Provider {0-provider-uri}",
           code: "CONJ00007D"
         )
 
         IdentityProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider discovery succeeded",
+          msg:  "Identity Provider discovery succeeded",
           code: "CONJ00008D"
         )
 
         IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
-          msg: "Identity Provider keys fetched successfully from cache",
+          msg:  "Identity Provider keys fetched successfully from cache",
           code: "CONJ00017D"
         )
 
         FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Fetched Identity Provider keys successfully",
+          msg:  "Fetched Identity Provider keys successfully",
           code: "CONJ00009D"
         )
 
         ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating Identity Provider keys are up to date",
+          msg:  "Validating Identity Provider keys are up to date",
           code: "CONJ00019D"
         )
 
@@ -61,12 +71,12 @@ unless defined? LogMessages::Authentication::OriginValidated
       module Jwt
 
         TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
-          msg: "Token decode succeeded",
+          msg:  "Token decode succeeded",
           code: "CONJ00005D"
         )
 
         TokenDecodeFailed = ::Util::TrackableLogMessageClass.new(
-          msg: "Failed to decode the token with the error '{0-exception}'",
+          msg:  "Failed to decode the token with the error '{0-exception}'",
           code: "CONJ00018D"
         )
 
@@ -75,7 +85,7 @@ unless defined? LogMessages::Authentication::OriginValidated
       module AuthnOidc
 
         ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
-          msg: "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
+          msg:  "Extracted username '{0}' from ID Token field '{1-id-token-username-field}'",
           code: "CONJ00004D"
         )
 
@@ -84,71 +94,75 @@ unless defined? LogMessages::Authentication::OriginValidated
       module AuthnK8s
 
         PodChannelOpen = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' : channel open",
+          msg:  "Pod '{0-pod-name}' : channel open",
           code: "CONJ00010D"
         )
 
         PodChannelClosed = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' : channel closed",
+          msg:  "Pod '{0-pod-name}' : channel closed",
           code: "CONJ00011D"
         )
 
         PodChannelData = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
+          msg:  "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
           code: "CONJ00012D"
         )
 
         PodMessageData = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
+          msg:  "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
           code: "CONJ00013D"
         )
 
         PodError = ::Util::TrackableLogMessageClass.new(
-          msg: "Pod '{0-pod-name}' error : '{1}'",
+          msg:  "Pod '{0-pod-name}' error : '{1}'",
           code: "CONJ00014D"
         )
 
         CopySSLToPod = ::Util::TrackableLogMessageClass.new(
-          msg: "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
+          msg:  "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
           code: "CONJ00015D"
         )
 
-        RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
-          msg: "Retrieved value of annotation {0-annotation-name}",
-          code: "CONJ00024D"
-        )
-
-        ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating annotations with prefix {0-prefix}",
-          code: "CONJ00025D"
-        )
-
         ValidatingHostId = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating host id {0}",
+          msg:  "Validating host id {0}",
           code: "CONJ00026D"
         )
 
         HostIdFromCommonName = ::Util::TrackableLogMessageClass.new(
-          msg: "Host id {0} extracted from CSR common name",
+          msg:  "Host id {0} extracted from CSR common name",
           code: "CONJ00027D"
         )
 
         SetCommonName = ::Util::TrackableLogMessageClass.new(
-          msg: "Setting common name to {0-full-host-name}",
+          msg:  "Setting common name to {0-full-host-name}",
           code: "CONJ00028D"
         )
       end
 
       module AuthnAzure
 
-        # TODO: get security approval for this message
+        ExtractingIdentityForAuthentication = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracting resource type {0-resource-type} for authentication",
+          code: "CONJ00029D"
+        )
+
+        ValidatingApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+          msg:  "Validating application identity for {0-resource-name}",
+          code: "CONJ00030D"
+        )
+
+        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+          msg:  "Application identity for {0-resource-name} validated",
+          code: "CONJ00030D"
+        )
+
         ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
-          msg: "Extracted field '{0-field-name}' with value {1-field-value} from token",
+          msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
           code: "CONJ00029D"
         )
 
         ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
-          msg: "Validating that field '{0}' exists in token",
+          msg:  "Validating that field '{0}' exists in token",
           code: "CONJ00030D"
         )
 
@@ -158,27 +172,27 @@ unless defined? LogMessages::Authentication::OriginValidated
     module Util
 
       RateLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Rate limited cache updated successfully",
+        msg:  "Rate limited cache updated successfully",
         code: "CONJ00016D"
       )
 
       RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
-        msg: "Rate limited cache reached the '{0-limit}' limit and will not call target for the next '{1-seconds}' seconds",
+        msg:  "Rate limited cache reached the '{0-limit}' limit and will not call target for the next '{1-seconds}' seconds",
         code: "CONJ00020D"
       )
 
       ConcurrencyLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache updated successfully",
+        msg:  "Concurrency limited cache updated successfully",
         code: "CONJ00021D"
       )
 
       ConcurrencyLimitedCacheReached = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
+        msg:  "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
         code: "CONJ00022D"
       )
 
       ConcurrencyLimitedCacheConcurrentRequestsUpdated = ::Util::TrackableLogMessageClass.new(
-        msg: "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
+        msg:  "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
         code: "CONJ00023D"
       )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -138,6 +138,10 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00028D"
         )
       end
+
+      module AuthnAzure
+
+      end
     end
 
     module Util

--- a/ci/authn-azure/policies/authn-azure.yml
+++ b/ci/authn-azure/policies/authn-azure.yml
@@ -1,0 +1,16 @@
+# Azure authenticator
+- !policy
+  id: conjur/authn-azure/test
+  body:
+  - !webservice
+
+  - !variable
+    id: provider-uri
+
+  - !group
+    id: apps
+
+  - !permit
+    role: !group apps
+    privilege: [ read, authenticate ]
+    resource: !webservice

--- a/ci/authn-azure/policies/authn-azure.yml
+++ b/ci/authn-azure/policies/authn-azure.yml
@@ -4,13 +4,28 @@
   body:
   - !webservice
 
+  - !webservice
+    id: status
+    annotations:
+      description: Status service to verify the authenticator is configured correctly
+
   - !variable
     id: provider-uri
 
   - !group
     id: apps
 
+  - !group
+    id: operators
+    annotations:
+      description: Group of users who can check the status of the authn-azure/test authenticator
+
   - !permit
     role: !group apps
     privilege: [ read, authenticate ]
     resource: !webservice
+
+  - !permit
+    role: !group operators
+    privilege: [ read ]
+    resource: !webservice status

--- a/ci/authn-azure/policies/azure-hosts.yml
+++ b/ci/authn-azure/policies/azure-hosts.yml
@@ -10,6 +10,13 @@
         annotations:
           authn-azure/subscription-id: test-subscription
           authn-azure/resource-group: test-group
+          authn-azure/system-assigned-identity: test-app-pipeline
+
+      - !host
+        id: user-app
+        annotations:
+          authn-azure/subscription-id: test-subscription
+          authn-azure/resource-group: test-group
           authn-azure/user-assigned-identity: test-app-pipeline
 
     - !grant

--- a/ci/authn-azure/policies/azure-hosts.yml
+++ b/ci/authn-azure/policies/azure-hosts.yml
@@ -6,18 +6,18 @@
 
     - &hosts
       - !host
-        id: test-app
+        id: system-assigned-identity-app
         annotations:
-          authn-azure/subscription-id: test-subscription
-          authn-azure/resource-group: test-group
-          authn-azure/system-assigned-identity: test-app-pipeline
+          authn-azure/subscription-id: <subscription_id>
+          authn-azure/resource-group: <resource_group>
+          authn-azure/system-assigned-identity: <oid>
 
       - !host
-        id: user-app
+        id: user-assigned-identity-app
         annotations:
-          authn-azure/subscription-id: test-subscription
-          authn-azure/resource-group: test-group
-          authn-azure/user-assigned-identity: test-app-pipeline
+          authn-azure/subscription-id: <subscription_id>
+          authn-azure/resource-group: <resource_group>
+          authn-azure/user-assigned-identity: <user-assigned-identity>
 
     - !grant
       role: !group

--- a/ci/authn-azure/policies/azure-hosts.yml
+++ b/ci/authn-azure/policies/azure-hosts.yml
@@ -1,0 +1,21 @@
+# Hosts that will authenticate with the Azure authenticator
+- !policy
+  id: azure-apps
+  body:
+    - !group
+
+    - &hosts
+      - !host
+        id: test-app
+        annotations:
+          authn-azure/subscription-id: test-subscription
+          authn-azure/resource-group: test-group
+          authn-azure/user-assigned-identity: test-app-pipeline
+
+    - !grant
+      role: !group
+      members: *hosts
+
+- !grant
+  role: !group conjur/authn-azure/test/apps
+  member: !group azure-apps

--- a/ci/authn-azure/policies/azure-operators.yml
+++ b/ci/authn-azure/policies/azure-operators.yml
@@ -1,0 +1,7 @@
+# Users who can check the status of the authn-azure/test authenticator
+- !user
+  id: authn-azure-test-operator
+
+- !grant
+  role: !group conjur/authn-azure/test/operators
+  member: !user authn-azure-test-operator

--- a/ci/authn-azure/policies/test-secrets.yml
+++ b/ci/authn-azure/policies/test-secrets.yml
@@ -1,4 +1,4 @@
-# Variable that will be consumed by azure-apps/test-app
+# Variable that will be consumed by azure-apps/system-assigned-identity-app or user-assigned-identity-app
 - !policy
   id: secrets
   body:

--- a/ci/authn-azure/policies/test-secrets.yml
+++ b/ci/authn-azure/policies/test-secrets.yml
@@ -1,0 +1,16 @@
+# Variable that will be consumed by azure-apps/test-app
+- !policy
+  id: secrets
+  body:
+    - !group consumers
+
+    - !variable test-variable
+
+    - !permit
+      role: !group consumers
+      privilege: [ read, execute ]
+      resource: !variable test-variable
+
+- !grant
+  role: !group secrets/consumers
+  member: !group azure-apps

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# Get an Azure access token
+azure_access_token=$(curl \
+  'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' \
+  -H Metadata:true -s | jq -r '.access_token')
+
+# Get an authn-azure Conjur access token for host azure-apps/test-app
+authn_azure_response=$(curl -k -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data "jwt=$azure_access_token" \
+  https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
+authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+
+# Retrieve a Conjur secret using the authn-azure Conjur access token
+curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -5,40 +5,60 @@ function main() {
     # configure client_id of user identity for Azure instance
     client_id=""
 
-    user_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&client_id=$client_id&resource=https%3A%2F%2Fmanagement.azure.com%2F"
-    conjur_host_user_identity="user-app"
+    user_assigned_identity_token_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&client_id=$client_id&resource=https%3A%2F%2Fmanagement.azure.com%2F"
+    user_assigned_identity_host_name="user-assigned-identity-app"
 
-    system_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F"
-    conjur_host_system_identity="test-app"
+    # use Azure user-assigned-identity to get Conjur access token
+    getConjurTokenWithAzureIdentity $user_assigned_identity_token_endpoint $user_assigned_identity_host_name
 
-    getConjurSecret $user_endpoint $conjur_host_user_identity
-    getConjurSecret $system_endpoint $conjur_host_system_identity
+    echo "Getting Conjur secret"
+    getConjurSecret $conjur_access_token
+
+    system_assigned_identity_token_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F"
+    system_assigned_identity_host_name="system-assigned-identity-app"
+
+    # use Azure system-assigned-identity to get Conjur access token
+    getConjurTokenWithAzureIdentity $system_assigned_identity_token_endpoint $system_assigned_identity_host_name
+
+    echo "Getting Conjur secret"
+    getConjurSecret $conjur_access_token
 }
 
-function getConjurSecret() {
+function getConjurTokenWithAzureIdentity() {
     azure_token_endpoint="$1"
     conjur_role="$2"
-    echo $azure_token_endpoint
-    echo "Retrieving Azure access token"
+
+    getAzureAccessToken $azure_token_endpoint $conjur_role
+
+    getConjurToken $azure_access_token
+}
+
+function getAzureAccessToken(){
+    echo "Retrieving Azure access token from $azure_token_endpoint"
     # Get an Azure access token
     azure_access_token=$(curl \
       "$azure_token_endpoint" \
       -H Metadata:true -s | jq -r '.access_token')
+}
 
-    echo "Get Conjur access token using an Azure access token"
-    # Get an authn-azure Conjur access token for host azure-apps/test-app and user-app
+function getConjurToken() {
+    # Get a Conjur access token for host azure-apps/system-assigned-identity-app or user-assigned-identity-app using the Azure token details
+    echo "Get Conjur access token for $conjur_role using its Azure access token"
     authn_azure_response=$(curl -k -X POST \
       -H "Content-Type: application/x-www-form-urlencoded" \
       --data "jwt=$azure_access_token" \
       https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2F"$conjur_role"/authenticate)
-    authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
 
+    conjur_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+}
+
+function getConjurSecret(){
     echo "Retrieve a secret using the Conjur access token"
     # Retrieve a Conjur secret using the authn-azure Conjur access token
-    secret=$(curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+    secret=$(curl -k -H "Authorization: Token token=\"$conjur_access_token\"" \
       https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable)
 
-    echo "Retrieved secret ${secret} from Conjur!!!"
+    echo "Retrieved secret ${secret} from Conjur!"
 }
 
 main

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,23 +1,44 @@
 #!/bin/bash
 set -exuo pipefail
 
-echo "Retieving Azure access token"
-# Get an Azure access token
-azure_access_token=$(curl \
-  'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' \
-  -H Metadata:true -s | jq -r '.access_token')
+function main() {
+    # configure client_id of user identity for Azure instance
+    client_id=""
 
-echo "Get Conjur access token using an Azure access token"
-# Get an authn-azure Conjur access token for host azure-apps/test-app
-authn_azure_response=$(curl -k -X POST \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  --data "jwt=$azure_access_token" \
-  https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
-authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+    user_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&client_id=$client_id&resource=https%3A%2F%2Fmanagement.azure.com%2F"
+    conjur_host_user_identity="user-app"
 
-echo "Retrieve a secret using the Conjur access token"
-# Retrieve a Conjur secret using the authn-azure Conjur access token
-secret=$(curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
-  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable)
+    system_endpoint="http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F"
+    conjur_host_system_identity="test-app"
 
-echo "Retrieved secret ${secret} from Conjur!!!"
+    getConjurSecret $user_endpoint $conjur_host_user_identity
+    getConjurSecret $system_endpoint $conjur_host_system_identity
+}
+
+function getConjurSecret() {
+    azure_token_endpoint="$1"
+    conjur_role="$2"
+    echo $azure_token_endpoint
+    echo "Retrieving Azure access token"
+    # Get an Azure access token
+    azure_access_token=$(curl \
+      "$azure_token_endpoint" \
+      -H Metadata:true -s | jq -r '.access_token')
+
+    echo "Get Conjur access token using an Azure access token"
+    # Get an authn-azure Conjur access token for host azure-apps/test-app and user-app
+    authn_azure_response=$(curl -k -X POST \
+      -H "Content-Type: application/x-www-form-urlencoded" \
+      --data "jwt=$azure_access_token" \
+      https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2F"$conjur_role"/authenticate)
+    authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
+
+    echo "Retrieve a secret using the Conjur access token"
+    # Retrieve a Conjur secret using the authn-azure Conjur access token
+    secret=$(curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+      https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable)
+
+    echo "Retrieved secret ${secret} from Conjur!!!"
+}
+
+main

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -ex
 
+echo "Retieving Azure access token"
 # Get an Azure access token
 azure_access_token=$(curl \
   'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' \
   -H Metadata:true -s | jq -r '.access_token')
 
+echo "Get Conjur access token using an Azure access token"
 # Get an authn-azure Conjur access token for host azure-apps/test-app
 authn_azure_response=$(curl -k -X POST \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -12,6 +14,9 @@ authn_azure_response=$(curl -k -X POST \
   https://"$CONJUR_SERVER_DNS":8443/authn-azure/test/cucumber/host%2Fazure-apps%2Ftest-app/authenticate)
 authn_azure_access_token=$(echo -n "$authn_azure_response" | base64 | tr -d '\r\n')
 
+echo "Retrieve a secret using the Conjur access token"
 # Retrieve a Conjur secret using the authn-azure Conjur access token
-curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
-  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable
+secret=$(curl -k -H "Authorization: Token token=\"$authn_azure_access_token\"" \
+  https://"$CONJUR_SERVER_DNS":8443/secrets/cucumber/variable/secrets/test-variable)
+
+echo "Retrieved secret ${secret} from Conjur!!!"

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 echo "Retieving Azure access token"
 # Get an Azure access token

--- a/ci/authn-azure/run-authn-azure.sh
+++ b/ci/authn-azure/run-authn-azure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 echo "Retieving Azure access token"
 # Get an Azure access token

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -ex
+
+tar xvzf conjur-image.tar.gz
+sudo docker load -i conjur-image.tar
+
+# Remove old containers if they are up
+if [[ -d "conjur-quickstart" ]]
+then
+  pushd conjur-quickstart
+  sudo docker-compose down -v
+  popd
+fi
+
+rm -rf conjur-quickstart
+git clone --single-branch --branch local-conjur-image https://github.com/cyberark/conjur-quickstart.git
+cd conjur-quickstart
+sudo docker-compose down -v
+
+sed "s#{{ CONJUR_IMAGE_VERSION }}#$CONJUR_IMAGE_VERSION#g" ./Dockerfile.template > ./Dockerfile
+sudo docker-compose pull
+sudo docker-compose build
+sudo docker-compose run --no-deps --rm conjur data-key generate > data_key
+
+conjur_data_key="$(< data_key)"
+echo "Generated CONJUR_DATA_KEY $conjur_data_key"
+
+# TODO: Make it work without sed. docker-compose should take the host's env var if it is not set but it doesn't work
+sed "s#{{ CONJUR_DATA_KEY }}#${conjur_data_key}#; s#postgres:9.4#postgres:9.3#" ./docker-compose.yml.template > ./docker-compose.yml
+
+sudo docker-compose up -d
+
+# Wait for all components to be up before we create the account
+sleep 5
+sudo docker-compose exec -T conjur conjurctl account create cucumber
+
+sudo docker-compose exec -T client conjur init -u conjur -a cucumber
+admin_api_key=$(sudo docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+sudo docker-compose exec -T client conjur authn login -u admin -p $admin_api_key
+
+# Copy the policy files into the directory that is volumed into the client
+cp ../policies/* conf/policy/
+
+sudo docker-compose exec -T client conjur policy load root policy/authn-azure.yml
+
+azure_provider_uri="https://sts.windows.net/df242c82-fe4a-47e0-b0f4-e3cb7f8104f1/"
+sudo docker-compose exec -T client conjur variable values add conjur/authn-azure/test/provider-uri $azure_provider_uri
+
+sudo docker-compose exec -T client conjur policy load root policy/azure-hosts.yml
+
+sudo docker-compose exec -T client conjur policy load root policy/test-secrets.yml
+sudo docker-compose exec -T client conjur variable values add secrets/test-variable test-secret
+
+# Get a Conjur access token for admin so we can enable the authn-azure authenticator in the DB
+authn_admin_response=$(curl -k -X POST --data "${admin_api_key}" \
+  https://0.0.0.0:8443/authn/cucumber/admin/authenticate)
+admin_conjur_access_token=$(echo -n "$authn_admin_response" | base64 | tr -d '\r\n')
+
+# Enable the authn-azure authenticator in the DB
+curl -k -X PATCH  -H "Authorization: Token token=\"$admin_conjur_access_token\"" \
+  --data "enabled=true" https://0.0.0.0:8443/authn-azure/test/cucumber

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 tar xvzf conjur-image.tar.gz
 sudo docker load -i conjur-image.tar

--- a/ci/authn-azure/setup-conjur.sh
+++ b/ci/authn-azure/setup-conjur.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 tar xvzf conjur-image.tar.gz
 sudo docker load -i conjur-image.tar

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -ex
+
+# TODO: get these dynamically
+AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"
+AWS_MACHINE_USERNAME="<username of AWS machine>"
+CONJUR_SERVER_DNS="<DNS of Conjur server machine>"
+
+AZURE_VM_USERNAME="<username of Azure VM>"
+AZURE_VM_IP="<IP address of Azure VM>"
+
+# Build Conjur image
+pushd ../..
+  . version_utils.sh
+  conjur_image_version="$(version_tag)"
+
+  ./build.sh
+popd
+
+# Copy docker image into AWS machine
+docker save -o ./conjur-image.tar conjur:$conjur_image_version
+tar -czvf conjur-image.tar.gz conjur-image.tar
+scp -i "${AWS_PEM_FILE_LOCATION}" conjur-image.tar.gz $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+
+# Copy authn-azure policies into AWS machine
+scp -i "${AWS_PEM_FILE_LOCATION}" -r policies $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+
+scp -i "${AWS_PEM_FILE_LOCATION}" setup-conjur.sh $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS:~/.
+ssh -i "${AWS_PEM_FILE_LOCATION}" $AWS_MACHINE_USERNAME@$CONJUR_SERVER_DNS CONJUR_IMAGE_VERSION="$conjur_image_version" ./setup-conjur.sh
+
+scp run-authn-azure.sh $AZURE_VM_USERNAME@$AZURE_VM_IP:~/.
+ssh $AZURE_VM_USERNAME@$AZURE_VM_IP CONJUR_SERVER_DNS="$CONJUR_SERVER_DNS" ./run-authn-azure.sh

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -euo pipefail
 
 # TODO: get these dynamically
 AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"

--- a/ci/authn-azure/test.sh
+++ b/ci/authn-azure/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 # TODO: get these dynamically
 AWS_PEM_FILE_LOCATION="<location of pem file to login to machine>"

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -4,17 +4,13 @@ require 'spec_helper'
 
 RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
 
-  include_context "fetch secrets"
+  include_context "fetch secrets", %w(provider-uri)
 
-  let(:azure_authenticator_name) { "authn-azure-test" }
+  let(:account) { "my-acct" }
+  let(:authenticator_name) { "authn-azure" }
+  let(:service) { "my-service" }
 
-  let(:azure_authenticator_secrets) do
-    {
-      "provider-uri" => "test-uri"
-    }
-  end
-
-  let (:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+  let(:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
 
   before(:each) do
     allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
@@ -26,24 +22,38 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
   # request mock
   ####################################
 
-  let (:authenticate_azure_token_request) do
-    request_body = StringIO.new
-    request_body.puts "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
-    request_body.rewind
+  def mock_authenticate_azure_token_request(request_body_data:)
+    double('AuthnAzureRequest').tap do |request|
+      request_body = StringIO.new
+      request_body.puts request_body_data
+      request_body.rewind
 
-    double('Request').tap do |request|
       allow(request).to receive(:body).and_return(request_body)
     end
   end
 
-  let (:authenticate_azure_token_request_missing_azure_token_field) do
-    request_body = StringIO.new
-    request_body.puts "some_key=some_value"
-    request_body.rewind
+  def request_body(request)
+    request.body.read.chomp
+  end
 
-    double('Request').tap do |request|
-      allow(request).to receive(:body).and_return(request_body)
-    end
+  let(:authenticate_azure_token_request) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_xms_mirid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_oid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "some_key=some_value")
+  end
+
+  let(:authenticate_azure_token_request_empty_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt=")
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
@@ -56,22 +66,18 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
       context "with a valid azure token" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
-            authenticator_name: 'authn-azure',
-            service_id:         'my-service',
-            account:            'my-acct',
+            authenticator_name: authenticator_name,
+            service_id:         service,
+            account:            account,
             username:           'my-user',
-            credentials:        authenticate_azure_token_request.body.read,
+            credentials:        request_body(authenticate_azure_token_request),
             origin:             '127.0.0.1',
             request:            authenticate_azure_token_request
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: true,
-                                           fetched_secrets: azure_authenticator_secrets
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
@@ -80,27 +86,104 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           expect { subject }.to_not raise_error
           expect(subject).to eq(true)
         end
+
+        it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
       end
 
-      context "with no azure_token field in the request" do
+      context "with an invalid azure token" do
+        context "that fails token verification" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it 'raises the error raised by mocked_verify_and_decode_token' do
+            allow(mocked_verify_and_decode_token).to receive(:call)
+                                                  .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
+
+            expect { subject }.to raise_error(
+                                    /FAKE_VERIFY_AND_DECODE_ERROR/
+                                  )
+          end
+        end
+
+        context "that is missing the xms_mirid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_xms_mirid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_xms_mirid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+
+        context "that is missing the oid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_oid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_oid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token: mocked_verify_and_decode_token,
+              ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+      end
+
+      context "with no jwt field in the request" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-azure',
             service_id:         'my-service',
             account:            'my-acct',
             username:           nil,
-            credentials:        authenticate_azure_token_request_missing_azure_token_field.body.read,
+            credentials:        request_body(authenticate_azure_token_request_missing_jwt_field),
             origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request_missing_azure_token_field
+            request:            authenticate_azure_token_request_missing_jwt_field
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: true,
-                                           fetched_secrets: azure_authenticator_secrets
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
@@ -109,32 +192,28 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
-
-      context "Required variables do not exist or does not have value" do
+      
+      context "with an empty jwt field in the request" do
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-azure',
             service_id:         'my-service',
             account:            'my-acct',
-            username:           'my-user',
-            credentials:        authenticate_azure_token_request.body.read,
+            username:           nil,
+            credentials:        request_body(authenticate_azure_token_request_empty_jwt_field),
             origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request
+            request:            authenticate_azure_token_request_empty_jwt_field
           )
 
           ::Authentication::AuthnAzure::Authenticator.new(
-            fetch_authenticator_secrets: mock_fetch_secrets(
-                                           is_successful: false,
-                                           fetched_secrets: nil
-                                         ),
             verify_and_decode_token: mocked_verify_and_decode_token,
-            ).call(
+          ).call(
             authenticator_input: input_
           )
         end
 
-        it "raises the error raised by fetch_authenticator_secrets" do
-          expect { subject }.to raise_error(test_fetch_secrets_error)
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
     end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
+
+  include_context "fetch secrets"
+
+  let(:azure_authenticator_name) { "authn-azure-test" }
+
+  let(:azure_authenticator_secrets) do
+    {
+      "provider-uri" => "test-uri"
+    }
+  end
+
+  let (:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+
+  before(:each) do
+    allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
+      JSON.parse(args[0][:token_jwt]).to_hash
+    }
+  end
+
+  ####################################
+  # request mock
+  ####################################
+
+  let (:authenticate_azure_token_request) do
+    request_body = StringIO.new
+    request_body.puts "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
+    request_body.rewind
+
+    double('Request').tap do |request|
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  let (:authenticate_azure_token_request_missing_azure_token_field) do
+    request_body = StringIO.new
+    request_body.puts "some_key=some_value"
+    request_body.rewind
+
+    double('Request').tap do |request|
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "An Azure authenticator" do
+    context "that receives an authenticate request" do
+      context "with a valid azure token" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           'my-user',
+            credentials:        authenticate_azure_token_request.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: true,
+                                           fetched_secrets: azure_authenticator_secrets
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "does not raise an error" do
+          expect { subject }.to_not raise_error
+          expect(subject).to eq(true)
+        end
+      end
+
+      context "with no azure_token field in the request" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            credentials:        authenticate_azure_token_request_missing_azure_token_field.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request_missing_azure_token_field
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: true,
+                                           fetched_secrets: azure_authenticator_secrets
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+
+      context "Required variables do not exist or does not have value" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           'my-user',
+            credentials:        authenticate_azure_token_request.body.read,
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            fetch_authenticator_secrets: mock_fetch_secrets(
+                                           is_successful: false,
+                                           fetched_secrets: nil
+                                         ),
+            verify_and_decode_token: mocked_verify_and_decode_token,
+            ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises the error raised by fetch_authenticator_secrets" do
+          expect { subject }.to raise_error(test_fetch_secrets_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
 
   include_context "fetch secrets", %w(provider-uri)
 
-  let(:account) {"my-acct"}
-  let(:authenticator_name) {"authn-azure"}
-  let(:service) {"my-service"}
+  let(:account) { "my-acct" }
+  let(:authenticator_name) { "authn-azure" }
+  let(:service) { "my-service" }
 
-  let(:mocked_verify_and_decode_token) {double("VerifyAndDecodeAzureToken")}
-  let(:mocked_validate_application_identity) {double("ValidateApplicationIdentity")}
+  let(:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+  let(:mocked_validate_application_identity) { double("ValidateApplicationIdentity") }
 
   before(:each) do
-    allow(mocked_verify_and_decode_token).to receive(:call) {|*args|
+    allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
       JSON.parse(args[0][:token_jwt]).to_hash
     }
 
@@ -88,7 +88,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "does not raise an error" do
-            expect {subject}.to_not raise_error
+            expect { subject }.to_not raise_error
             expect(subject).to eq(true)
           end
 
@@ -119,9 +119,9 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
             allow(mocked_validate_application_identity).to receive(:call)
                                                              .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
 
-            expect {subject}.to raise_error(
-                                  /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                                )
+            expect { subject }.to raise_error(
+                                    /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+                                  )
           end
         end
       end
@@ -151,9 +151,9 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
             allow(mocked_verify_and_decode_token).to receive(:call)
                                                        .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
 
-            expect {subject}.to raise_error(
-                                  /FAKE_VERIFY_AND_DECODE_ERROR/
-                                )
+            expect { subject }.to raise_error(
+                                    /FAKE_VERIFY_AND_DECODE_ERROR/
+                                  )
           end
         end
 
@@ -178,7 +178,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
           end
         end
 
@@ -203,7 +203,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           end
 
           it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
           end
         end
       end
@@ -229,7 +229,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
         end
 
         it "raises a MissingRequestParam error" do
-          expect {subject}.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
 
@@ -254,7 +254,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
         end
 
         it "raises a MissingRequestParam error" do
-          expect {subject}.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
     end

--- a/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Authentication::AuthnAzure::ValidateStatus do
+
+  let(:authenticator_name) { "authn-azure" }
+  let(:account) { "my-acct" }
+  let(:service) { "my-service" }
+
+  include_context "fetch secrets", %w(provider-uri)
+
+  let(:test_azure_discovery_error) { "test-azure-discovery-error" }
+
+  def mock_discover_identity_provider(is_successful:)
+    double('discovery-provider').tap do |discover_provider|
+      if is_successful
+        allow(discover_provider).to receive(:call)
+      else
+        allow(discover_provider).to receive(:call)
+                                      .and_raise(test_azure_discovery_error)
+      end
+    end
+  end
+
+  context "Required variables exist and have values" do
+    context "and Azure provider is responsive" do
+      subject do
+        Authentication::AuthnAzure::ValidateStatus.new(
+          discover_identity_provider: mock_discover_identity_provider(is_successful: true)
+        ).call(
+          account: account,
+          service_id: service
+        )
+      end
+
+      it "validates without errors" do
+        expect { subject }.to_not raise_error
+      end
+
+      it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
+    end
+
+    context "and Azure provider is not responsive" do
+      subject do
+        Authentication::AuthnAzure::ValidateStatus.new(
+          discover_identity_provider: mock_discover_identity_provider(is_successful: false)
+        ).call(
+          account: account,
+          service_id: service
+        )
+      end
+
+      it "raises the error raised by discover_identity_provider" do
+        expect { subject }.to raise_error(test_azure_discovery_error)
+      end
+
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -5,29 +5,29 @@ require 'spec_helper'
 RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
   include_context "running outside kubernetes"
 
-  let(:host_id_prefix) {"accountName:host:"}
+  let(:host_id_prefix) { "accountName:host:" }
 
-  let(:namespace) {"K8sNamespace"}
+  let(:namespace) { "K8sNamespace" }
 
-  let(:k8s_resource_name) {"K8sResourceName"}
-  let(:k8s_resource_value) {"K8sResourceValue"}
+  let(:k8s_resource_name) { "K8sResourceName" }
+  let(:k8s_resource_value) { "K8sResourceValue" }
 
-  let(:namespace_annotation) {double("NamespaceAnnotation")}
-  let(:namespace_annotation_service_id_scoped) {double("NamespaceServiceIdAnnotation")}
+  let(:namespace_annotation) { double("NamespaceAnnotation") }
+  let(:namespace_annotation_service_id_scoped) { double("NamespaceServiceIdAnnotation") }
 
-  let(:container_name_annotation) {double("ContainerNameAnnotation")}
-  let(:container_name_annotation_service_id_prefix) {double("ContainerNameAnnotation")}
-  let(:container_name_annotation_kubernetes_prefix) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_service_id_prefix) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation_kubernetes_prefix) { double("ContainerNameAnnotation") }
 
-  let(:service_account_annotation) {double("ServiceAccountAnnotation")}
-  let(:pod_annotation) {double("PodAnnotation")}
-  let(:deployment_annotation) {double("DeploymentAnnotation")}
-  let(:stateful_set_annotation) {double("StatefulSetAnnotation")}
-  let(:deployment_config_annotation) {double("DeploymentConfigAnnotation")}
+  let(:service_account_annotation) { double("ServiceAccountAnnotation") }
+  let(:pod_annotation) { double("PodAnnotation") }
+  let(:deployment_annotation) { double("DeploymentAnnotation") }
+  let(:stateful_set_annotation) { double("StatefulSetAnnotation") }
+  let(:deployment_config_annotation) { double("DeploymentConfigAnnotation") }
 
-  let(:invalid_annotation) {double("InvalidAnnotation")}
+  let(:invalid_annotation) { double("InvalidAnnotation") }
 
-  let(:good_service_id) {"MockService"}
+  let(:good_service_id) { "MockService" }
 
   before(:each) do
     allow(namespace_annotation).to receive(:values)
@@ -137,24 +137,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     }
 
     context "Application identity in host id" do
-      let(:host_annotations) {[]}
-      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
+      let(:host_annotations) { [] }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
-          let(:k8s_resource_name) {"*"}
-          let(:k8s_resource_value) {"*"}
+          let(:k8s_resource_name) { "*" }
+          let(:k8s_resource_value) { "*" }
 
           it "does not raise an error" do
-            expect {subject}.not_to raise_error
+            expect { subject }.not_to raise_error
           end
         end
 
         context "when is not namespace scoped" do
-          let(:k8s_resource_name) {"service_account"}
+          let(:k8s_resource_name) { "service_account" }
 
           it "does not raise an error" do
-            expect {subject}.not_to raise_error
+            expect { subject }.not_to raise_error
           end
         end
 
@@ -163,49 +163,49 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
       context "with an invalid application identity" do
         context "where the id isn't a 3 part string" do
-          let(:host_id) {"#{host_id_prefix}HostId"}
+          let(:host_id) { "#{host_id_prefix}HostId" }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
           end
         end
 
         context "with a non existing resource" do
-          let(:k8s_resource_name) {"non_existing_resource"}
+          let(:k8s_resource_name) { "non_existing_resource" }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
           end
         end
       end
     end
 
     context "Application identity in annotations" do
-      let(:host_id) {"#{host_id_prefix}HostId"}
+      let(:host_id) { "#{host_id_prefix}HostId" }
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
           context "in a global constraint" do
-            let(:host_annotations) {[namespace_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) {[namespace_annotation_service_id_scoped, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation_service_id_scoped, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "in both global & service-id constraints" do
-            let(:host_annotations) {[namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the service-id constraint" do
@@ -223,67 +223,67 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "when is not namespace scoped" do
           context "has only a service account constraint" do
-            let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a pod constraint" do
-            let(:host_annotations) {[namespace_annotation, pod_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, pod_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a deployment constraint" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a stateful set constraint" do
-            let(:host_annotations) {[namespace_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has only a deployment config constraint" do
-            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
           end
 
           context "has a valid constraint combination" do
             context "with a deployment constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
 
             context "with a deployment config constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
 
             context "with a stateful_set constraint" do
-              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation]}
+              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation] }
 
               it "does not raise an error" do
-                expect {subject}.not_to raise_error
+                expect { subject }.not_to raise_error
               end
             end
           end
@@ -291,13 +291,13 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "with different annotations for container name" do
           context "all possible options exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_service_id_prefix,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -306,12 +306,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global and service-id exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_service_id_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_service_id_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -320,12 +320,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id & kubernetes exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_service_id_prefix,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -334,12 +334,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global & kubernetes exist" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -348,11 +348,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_service_id_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_service_id_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -361,11 +361,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -374,11 +374,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only kubernetes exists" do
-            let(:host_annotations) {[namespace_annotation,
-                                     container_name_annotation_kubernetes_prefix]}
+            let(:host_annotations) { [namespace_annotation,
+                                      container_name_annotation_kubernetes_prefix] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the container name from the kubernetes annotation" do
@@ -387,10 +387,10 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "no annotation exists for container name" do
-            let(:host_annotations) {[namespace_annotation]}
+            let(:host_annotations) { [namespace_annotation] }
 
             it "does not raise an error" do
-              expect {subject}.not_to raise_error
+              expect { subject }.not_to raise_error
             end
 
             it "chooses the default container name" do
@@ -403,24 +403,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       context "with an invalid application identity" do
 
         context "where namespace constraint doesn't exist" do
-          let(:host_annotations) {[service_account_annotation, container_name_annotation]}
+          let(:host_annotations) { [service_account_annotation, container_name_annotation] }
 
           it "raises an error" do
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
 
         context "with a non existing resource" do
           context "in a global constraint" do
-            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
 
             before(:each) do
               allow(invalid_annotation).to receive(:[])
@@ -429,47 +429,47 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
             end
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
         end
 
         context "with an invalid constraint combination" do
           context "deployment and deployment_config" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment_config and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment, deployment_config and stateful_set" do
-            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
+            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
 
             it "raises an error" do
-              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+              expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
         end
 
         context "where a constraint is missing a slash after authn-k8s" do
-          let(:host_annotations) {[namespace_annotation, container_name_annotation]}
+          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
 
           before(:each) do
             allow(namespace_annotation).to receive(:[])
@@ -479,16 +479,16 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
           it "ignores the annotation" do
             # the namespace annotation is not present
-            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
       end
     end
 
     context "Application identity in host id and in annotations" do
-      let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
-      let(:k8s_resource_name) {"service_account"}
-      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
+      let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+      let(:k8s_resource_name) { "service_account" }
+      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
 
       before(:each) do
         allow(namespace_annotation).to receive(:[])
@@ -501,7 +501,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       end
 
       it "does not raise an error" do
-        expect {subject}.not_to raise_error
+        expect { subject }.not_to raise_error
       end
 
       it "takes the application identity from the annotations" do

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -5,29 +5,29 @@ require 'spec_helper'
 RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
   include_context "running outside kubernetes"
 
-  let(:host_id_prefix) { "accountName:host:" }
+  let(:host_id_prefix) {"accountName:host:"}
 
-  let(:namespace) { "K8sNamespace" }
+  let(:namespace) {"K8sNamespace"}
 
-  let(:k8s_resource_name) { "K8sResourceName" }
-  let(:k8s_resource_value) { "K8sResourceValue" }
+  let(:k8s_resource_name) {"K8sResourceName"}
+  let(:k8s_resource_value) {"K8sResourceValue"}
 
-  let(:namespace_annotation) { double("NamespaceAnnotation") }
-  let(:namespace_annotation_service_id_scoped) { double("NamespaceServiceIdAnnotation") }
+  let(:namespace_annotation) {double("NamespaceAnnotation")}
+  let(:namespace_annotation_service_id_scoped) {double("NamespaceServiceIdAnnotation")}
 
-  let(:container_name_annotation) { double("ContainerNameAnnotation") }
-  let(:container_name_annotation_service_id_prefix) { double("ContainerNameAnnotation") }
-  let(:container_name_annotation_kubernetes_prefix) { double("ContainerNameAnnotation") }
+  let(:container_name_annotation) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation_service_id_prefix) {double("ContainerNameAnnotation")}
+  let(:container_name_annotation_kubernetes_prefix) {double("ContainerNameAnnotation")}
 
-  let(:service_account_annotation) { double("ServiceAccountAnnotation") }
-  let(:pod_annotation) { double("PodAnnotation") }
-  let(:deployment_annotation) { double("DeploymentAnnotation") }
-  let(:stateful_set_annotation) { double("StatefulSetAnnotation") }
-  let(:deployment_config_annotation) { double("DeploymentConfigAnnotation") }
+  let(:service_account_annotation) {double("ServiceAccountAnnotation")}
+  let(:pod_annotation) {double("PodAnnotation")}
+  let(:deployment_annotation) {double("DeploymentAnnotation")}
+  let(:stateful_set_annotation) {double("StatefulSetAnnotation")}
+  let(:deployment_config_annotation) {double("DeploymentConfigAnnotation")}
 
-  let(:invalid_annotation) { double("InvalidAnnotation") }
+  let(:invalid_annotation) {double("InvalidAnnotation")}
 
-  let(:good_service_id) { "MockService" }
+  let(:good_service_id) {"MockService"}
 
   before(:each) do
     allow(namespace_annotation).to receive(:values)
@@ -137,24 +137,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
     }
 
     context "Application identity in host id" do
-      let(:host_annotations) { [] }
-      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_annotations) {[]}
+      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
-          let(:k8s_resource_name) { "*" }
-          let(:k8s_resource_value) { "*" }
+          let(:k8s_resource_name) {"*"}
+          let(:k8s_resource_value) {"*"}
 
           it "does not raise an error" do
-            expect { subject }.not_to raise_error
+            expect {subject}.not_to raise_error
           end
         end
 
         context "when is not namespace scoped" do
-          let(:k8s_resource_name) { "service_account" }
+          let(:k8s_resource_name) {"service_account"}
 
           it "does not raise an error" do
-            expect { subject }.not_to raise_error
+            expect {subject}.not_to raise_error
           end
         end
 
@@ -163,49 +163,49 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
       context "with an invalid application identity" do
         context "where the id isn't a 3 part string" do
-          let(:host_id) { "#{host_id_prefix}HostId" }
+          let(:host_id) {"#{host_id_prefix}HostId"}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::InvalidHostId)
           end
         end
 
         context "with a non existing resource" do
-          let(:k8s_resource_name) { "non_existing_resource" }
+          let(:k8s_resource_name) {"non_existing_resource"}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
           end
         end
       end
     end
 
     context "Application identity in annotations" do
-      let(:host_id) { "#{host_id_prefix}HostId" }
+      let(:host_id) {"#{host_id_prefix}HostId"}
 
       context "with a valid application identity" do
         context "when is namespace scoped" do
           context "in a global constraint" do
-            let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) { [namespace_annotation_service_id_scoped, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation_service_id_scoped, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "in both global & service-id constraints" do
-            let(:host_annotations) { [namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, namespace_annotation_service_id_scoped, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the service-id constraint" do
@@ -223,67 +223,67 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "when is not namespace scoped" do
           context "has only a service account constraint" do
-            let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a pod constraint" do
-            let(:host_annotations) { [namespace_annotation, pod_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, pod_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a deployment constraint" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a stateful set constraint" do
-            let(:host_annotations) { [namespace_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has only a deployment config constraint" do
-            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
           end
 
           context "has a valid constraint combination" do
             context "with a deployment constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
 
             context "with a deployment config constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, deployment_config_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
 
             context "with a stateful_set constraint" do
-              let(:host_annotations) { [namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation] }
+              let(:host_annotations) {[namespace_annotation, service_account_annotation, pod_annotation, stateful_set_annotation, container_name_annotation]}
 
               it "does not raise an error" do
-                expect { subject }.not_to raise_error
+                expect {subject}.not_to raise_error
               end
             end
           end
@@ -291,13 +291,13 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
         context "with different annotations for container name" do
           context "all possible options exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_service_id_prefix,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_service_id_prefix,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -306,12 +306,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global and service-id exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_service_id_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_service_id_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -320,12 +320,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id & kubernetes exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_service_id_prefix,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_service_id_prefix,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -334,12 +334,12 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global & kubernetes exist" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -348,11 +348,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only service-id exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_service_id_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_service_id_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the service-id annotation" do
@@ -361,11 +361,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only global exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the global annotation" do
@@ -374,11 +374,11 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "only kubernetes exists" do
-            let(:host_annotations) { [namespace_annotation,
-                                      container_name_annotation_kubernetes_prefix] }
+            let(:host_annotations) {[namespace_annotation,
+                                     container_name_annotation_kubernetes_prefix]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the container name from the kubernetes annotation" do
@@ -387,10 +387,10 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           end
 
           context "no annotation exists for container name" do
-            let(:host_annotations) { [namespace_annotation] }
+            let(:host_annotations) {[namespace_annotation]}
 
             it "does not raise an error" do
-              expect { subject }.not_to raise_error
+              expect {subject}.not_to raise_error
             end
 
             it "chooses the default container name" do
@@ -403,24 +403,24 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       context "with an invalid application identity" do
 
         context "where namespace constraint doesn't exist" do
-          let(:host_annotations) { [service_account_annotation, container_name_annotation] }
+          let(:host_annotations) {[service_account_annotation, container_name_annotation]}
 
           it "raises an error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
 
         context "with a non existing resource" do
           context "in a global constraint" do
-            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
 
           context "in service-id constraint" do
-            let(:host_annotations) { [namespace_annotation, invalid_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, invalid_annotation, container_name_annotation]}
 
             before(:each) do
               allow(invalid_annotation).to receive(:[])
@@ -429,47 +429,47 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
             end
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
+              expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::ScopeNotSupported)
             end
           end
         end
 
         context "with an invalid constraint combination" do
           context "deployment and deployment_config" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment_config and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
 
           context "deployment, deployment_config and stateful_set" do
-            let(:host_annotations) { [namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation] }
+            let(:host_annotations) {[namespace_annotation, deployment_annotation, deployment_config_annotation, stateful_set_annotation, container_name_annotation]}
 
             it "raises an error" do
-              expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::IllegalConstraintCombinations)
+              expect {subject}.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
             end
           end
         end
 
         context "where a constraint is missing a slash after authn-k8s" do
-          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+          let(:host_annotations) {[namespace_annotation, container_name_annotation]}
 
           before(:each) do
             allow(namespace_annotation).to receive(:[])
@@ -479,16 +479,16 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
 
           it "ignores the annotation" do
             # the namespace annotation is not present
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
+            expect {subject}.to raise_error(::Errors::Authentication::AuthnK8s::MissingNamespaceConstraint)
           end
         end
       end
     end
 
     context "Application identity in host id and in annotations" do
-      let(:host_annotations) { [namespace_annotation, service_account_annotation, container_name_annotation] }
-      let(:k8s_resource_name) { "service_account" }
-      let(:host_id) { "#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}" }
+      let(:host_annotations) {[namespace_annotation, service_account_annotation, container_name_annotation]}
+      let(:k8s_resource_name) {"service_account"}
+      let(:host_id) {"#{host_id_prefix}#{namespace}/#{k8s_resource_name}/#{k8s_resource_value}"}
 
       before(:each) do
         allow(namespace_annotation).to receive(:[])
@@ -501,7 +501,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
       end
 
       it "does not raise an error" do
-        expect { subject }.not_to raise_error
+        expect {subject}.not_to raise_error
       end
 
       it "takes the application identity from the annotations" do


### PR DESCRIPTION
#### What does this PR do?
1. Raises a ClaimInInvalidFormat when the claim is actually invalid instead of only when the claim was valid. 
2. Parse the xms_mirid separately so it's clearer where the error came from.
