### PR TITLE
Improve xms_mirid parse and validation

### DIFF
--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -19,6 +19,7 @@ module Authentication
     ) do
 
       def call
+        parse_xms_mirid
         validate_xms_mirid_format
         token_identity_from_claims
         validate_azure_annotations_are_permitted
@@ -30,14 +31,8 @@ module Authentication
 
       private
 
-      def validate_xms_mirid_format
-        begin
-          required_keys = %w(subscriptions resourcegroups providers)
-          missing_keys = required_keys - xms_mirid_hash.keys
-          raise Err::ClaimInInvalidFormat, "Required keys #{missing_keys} are missing" if missing_keys.empty?
-        rescue => e
-          raise Err::ClaimInInvalidFormat, e.inspect
-        end
+      def parse_xms_mirid
+        xms_mirid_hash
       end
 
       def xms_mirid_hash
@@ -49,23 +44,39 @@ module Authentication
       # according to fields we need to retrieve from the claim.
       # ultimately, transforming "/key1/value1/key2/value2" to {"key1" => "value1", "key2" => "value2"}
       def parsed_xms_mirid
-        split_xms_mirid = @xms_mirid_token_field.split('/')
+        begin
+          split_xms_mirid = @xms_mirid_token_field.split('/')
 
-        if split_xms_mirid.first == ''
-          split_xms_mirid = split_xms_mirid.drop(1)
+          if split_xms_mirid.first == ''
+            split_xms_mirid = split_xms_mirid.drop(1)
+          end
+
+          index = 0
+          split_xms_mirid.each_with_object({}) do |property, xms_mirid_hash|
+            case property
+            when "subscriptions"
+              xms_mirid_hash["subscriptions"] = split_xms_mirid[index + 1]
+            when "resourcegroups"
+              xms_mirid_hash["resourcegroups"] = split_xms_mirid[index + 1]
+            when "providers"
+              xms_mirid_hash["providers"] = split_xms_mirid[index + 1, 3]
+            end
+            index += 1
+          end
+        rescue => e
+          raise Err::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+        end
+      end
+
+      def validate_xms_mirid_format
+        required_keys = %w(subscriptions resourcegroups providers)
+        missing_keys  = required_keys - xms_mirid_hash.keys
+        unless missing_keys.empty?
+          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
         end
 
-        index = 0
-        split_xms_mirid.each_with_object({}) do |property, xms_mirid_hash|
-          case property
-          when "subscriptions"
-            xms_mirid_hash["subscriptions"] = split_xms_mirid[index + 1]
-          when "resourcegroups"
-            xms_mirid_hash["resourcegroups"] = split_xms_mirid[index + 1]
-          when "providers"
-            xms_mirid_hash["providers"] = split_xms_mirid[index + 1, index + 3]
-          end
-          index += 1
+        unless xms_mirid_hash["providers"].length == 3
+          raise Err::MissingProviderFieldsInXmsMirid.new(@xms_mirid_token_field)
         end
       end
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -89,7 +89,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         RoleNotAuthorizedOnWebservice = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-role-name}' does not have '{1-privilege}' privilege on {1-service-name}",
+          msg:  "'{0-role-name}' does not have '{1-privilege}' privilege on {2-service-name}",
           code: "CONJ00006E"
         )
 
@@ -292,16 +292,25 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00050E"
         )
 
-        ClaimInInvalidFormat = ::Util::TrackableErrorClass.new(
-          msg:  "xms_mirid claim has been received in an invalid format. Reason: {0}",
+        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg:  "Field '{0-field-name}' not found or empty in token",
           code: "CONJ00051E"
         )
 
-        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' not found or empty in token",
+        XmsMiridParseError = ::Util::TrackableErrorClass.new(
+          msg:  "Failed to parse xms_mirid {0}. Reason: {1}",
           code: "CONJ00052E"
         )
 
+        MissingRequiredFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Required fields {0} are missing in xms_mirid {1}",
+          code: "CONJ00053E"
+        )
+
+        MissingProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Provider fields are missing in xms_mirid {1}",
+          code: "CONJ00054E"
+        )
       end
     end
 


### PR DESCRIPTION
This PR has some improvements:
1. Parse the xms_mirid separately than using it so it's clearer where
the error was raised from if it does.
2. Validate that the "providers" section has 3 parts
3. Split the general error message to separate ones to enhance supportability
