### PR TITLE
Fix service-id scope

### DIFF
--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -110,7 +110,8 @@ module Authentication
 
       def validate_azure_annotations_are_permitted
         @validate_azure_annotations.call(
-          role_annotations: role.annotations
+          role_annotations: role.annotations,
+          service_id: @service_id
         )
       end
 

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -12,7 +12,7 @@ module Authentication
       dependencies: {
         logger: Rails.logger
       },
-      inputs:       %i(role_annotations)
+      inputs:       %i(role_annotations service_id)
     ) do
 
       def call


### PR DESCRIPTION
#### What does this PR do?
Previously, the code did not account for a service-id scoped application ids. 
Ex: `authn-azure/service-id/test` would not checked
