### PR TITLE
Adds failed build notification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ pipeline {
           }
       }
       always {
-        cleanupAndNotify(currentBuild.currentResult)
+        cleanupAndNotify(currentBuild.currentResult, '#conjur-core', '', true)
       }
   }
 }


### PR DESCRIPTION
This commit posts failed builds to the `#conjur-core` channel and creates a GH issue for failed builds.
