### PR TITLE
Re-Fix RoleNotFound initialized constant SecurityErr 

### DIFF
--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -5,7 +5,9 @@ module Authentication
 
     Log = LogMessages::Authentication::AuthnAzure
     Err = Errors::Authentication::AuthnAzure
-    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity, XmsMiridParseError,
+    # MissingRequiredFieldsInXmsMirid, MissingProviderFieldsInXmsMirid, MissingConstraint,
+    # IllegalConstraintCombinations
 
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
@@ -157,7 +159,7 @@ module Authentication
 
       def role
         @role ||= @resource_class[role_id].tap do |role|
-          raise SecurityErr::RoleNotFound(role_id) unless role
+          raise Errors::Authentication::Security::RoleNotFound, role_id unless role
         end
       end
 


### PR DESCRIPTION
#### What does this PR do?
**Repushing these changes b/c they were overriden
In the code we have
```
@role ||= @resource_class[role_id].tap do |role|
  raise SecurityErr::RoleNotFound(role_id) unless role
end
```
but we don’t ever have the following:
```
SecurityErr = Errors::Authentication::Security
```
so we get an error: `initialized constant SecurityErr`

This PR fixes this bug
