### PR TITLE
Add trailing slash to Azure Provider URI in case it's missing

### DIFF
--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -72,7 +72,9 @@ module Authentication
       end
 
       def provider_uri
-        @provider_uri ||= azure_authenticator_secrets["provider-uri"]
+        @provider_uri ||= azure_authenticator_secrets["provider-uri"].tap do |provider_uri_value|
+          provider_uri_value << "/" unless provider_uri_value.end_with?('/')
+        end
       end
 
       def azure_authenticator_secrets

--- a/spec/support/fetch_secrets_helper.rb
+++ b/spec/support/fetch_secrets_helper.rb
@@ -18,7 +18,7 @@ shared_context "fetch secrets" do |required_secrets|
 
   let(:mocked_secret) do
     double('Secret').tap do |secret|
-      allow(secret).to receive(:value).and_return("mocked-secret")
+      allow(secret).to receive(:value).and_return(+"mocked-secret") # unfreezing the secret for authn-azure tests
     end
   end
 


### PR DESCRIPTION
In case the user forgot to add a trailing slash to the provider-uri variable
(i.e `https://sts.windows.net/<tenant-id> instead of `https://sts.windows.net/<tenant-id>/`)
then they will get an error that is really hard to overcome. Instead, we can add the slash
for them in case they forgot it, without any harm.

This addition is not tested via UT as we mock the provider anyway. However, it does introduce a
new integration test that will be added once we have the infra for it (it is written and passes locally)
