### PR TITLE
Add image scanning to the Jenkins build pipeline

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,7 @@
 SimpleCov.start 'rails' do
   command_name "SimpleCov #{rand(1000000)}"
   coverage_dir File.join(ENV['REPORT_ROOT'] || __dir__, 'coverage')
+  merge_timeout 1800 # Set largest gap between resultsets of 30 minutes
   # any custom configs like groups and filters can be here at a central place
 end
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# Rake vulnerability for versions < 12.3.3. The version of Rake used by Conjur
+# has been updated to 13.0.1. Some of the Conjur dependencies still declare a
+# vulnerable version of Rake in their development dependencies, but do not pose 
+# a risk to Conjur.
+CVE-2020-8130

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,18 @@ pipeline {
       }
     }
 
-    stage('Build Docker image') {
+    stage('Build Docker Image') {
       steps {
         sh './build.sh -j'
       }
+    }
+
+    stage('Scan Docker Image') {
+      steps { 
+        script {
+          TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short HEAD)')
+        }
+        scanAndReport("conjur:${TAG}", "CRITICAL") }
     }
 
     stage('Prepare For CodeClimate Coverage Report Submission'){

--- a/ci/coverage-report-generator/generate_report.rb
+++ b/ci/coverage-report-generator/generate_report.rb
@@ -28,6 +28,10 @@ end
 # Use the first argument so the user can specify the approprite dir
 SimpleCov.root ARGV[0]
 
+# Set the merge timeout so that older reports in the same file don't get
+# dropped when merging.
+SimpleCov.merge_timeout 1800
+
 # Read the result file, path passed in as second arg.
 jsonraw = File.open(ARGV[1]).read
 

--- a/engines/conjur_audit/spec/spec_helper.rb
+++ b/engines/conjur_audit/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 SimpleCov.command_name "SimpleCov #{rand(1000000)}"
+SimpleCov.merge_timeout 1800
 SimpleCov.start
 
 require 'db_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 SimpleCov.command_name "SimpleCov #{rand(1000000)}"
+SimpleCov.merge_timeout 1800
 SimpleCov.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'


### PR DESCRIPTION
#### What does this PR do?

This PR adds Trivy image scanning to the Conjur Docker image.

#### Any background context you want to provide?

We have downstream projects that use the Conjur image and add scanning to it. Those typically need to be fixed in the source repo here, and should be caught in the build here before we catch it downstream.

#### What ticket does this PR close?

TBD
