### PR TITLE
Hosts can authenticate with Azure Authenticator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,44 @@ pipeline {
         stage('OIDC Authenticator') {
           steps { sh 'ci/test cucumber_authenticators_oidc' }
         }
+        // We have 2 stages for the Azure Authenticator tests. One is
+        // responsible for allocating an Azure VM, from which we will get an
+        // Azure access token for Conjur authentication. It sets the Azure VM IP
+        // in the env and waits until the authn-azure tests are finished. We use
+        // this mechanism as we need a live Azure VM for getting the Azure token
+        // and we don't want to have a long running-machine deployed in Azure.
+        stage('Azure Authenticator preparation - Allocate Azure Authenticator Instance') {
+          steps {
+            script {
+              node('azure-authn') {
+                env.AZURE_AUTHN_INSTANCE_IP = sh(script: 'curl icanhazip.com', returnStdout: true)
+                env.KEEP_AZURE_AUTHN_INSTANCE = "true"
+                while(env.KEEP_AZURE_AUTHN_INSTANCE == "true") {
+                  sleep(time: 15, unit: "SECONDS")
+                }
+              }
+            }
+          }
+        }
+        stage('Azure Authenticator') {
+          steps {
+            script {
+              while (!env.AZURE_AUTHN_INSTANCE_IP?.trim()) {
+                sleep(time: 15, unit: "SECONDS")
+              }
+              sh(
+                script: 'summon -f ci/authn-azure/secrets.yml ci/test cucumber_authenticators_azure',
+              )
+            }
+          }
+          post {
+            always {
+              script {
+                env.KEEP_AZURE_AUTHN_INSTANCE = "false"
+              }
+            }
+          }
+        }
         stage('Policy') {
           steps { sh 'ci/test cucumber_policy' }
         }

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,0 +1,41 @@
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+
+    class ApplicationIdentity
+
+      def initialize(role_annotations:, service_id:)
+        @role_annotations = role_annotations
+        @service_id       = service_id
+      end
+
+      def constraints
+        @constraints ||= {
+          subscription_id:          constraint_value("subscription-id"),
+          resource_group:           constraint_value("resource-group"),
+          user_assigned_identity:   constraint_value("user-assigned-identity"),
+          system_assigned_identity: constraint_value("system-assigned-identity")
+        }.compact
+      end
+
+      private
+
+      # check the `service-id` specific constraint first to be more granular
+      def constraint_value constraint_name
+        annotation_value("authn-azure/#{@service_id}/#{constraint_name}") ||
+          annotation_value("authn-azure/#{constraint_name}")
+      end
+
+      def annotation_value name
+        annotation = @role_annotations.find { |a| a.values[:name] == name }
+
+        # return the value of the annotation if it exists, nil otherwise
+        if annotation
+          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          annotation[:value]
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -5,9 +5,10 @@ module Authentication
 
     class ApplicationIdentity
 
-      def initialize(role_annotations:, service_id:)
+      def initialize(role_annotations:, service_id:, logger:)
         @role_annotations = role_annotations
         @service_id       = service_id
+        @logger           = logger
       end
 
       def constraints
@@ -32,7 +33,7 @@ module Authentication
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
-          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          @logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
           annotation[:value]
         end
       end

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -1,0 +1,139 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    Log = LogMessages::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    # TokenFieldNotFoundOrEmpty, MissingRequestParam
+
+    Authenticator = CommandClass.new(
+      dependencies: {
+        fetch_authenticator_secrets:   Authentication::Util::FetchAuthenticatorSecrets.new,
+        verify_and_decode_token:       Authentication::OAuth::VerifyAndDecodeToken.new,
+        validate_application_identity: ValidateApplicationIdentity.new,
+        logger:                        Rails.logger
+      },
+      inputs:       [:authenticator_input]
+    ) do
+
+      extend Forwardable
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :credentials, :username
+
+      JWT_REQUEST_BODY_FIELD_NAME = "jwt".freeze
+      XMS_MIRID_TOKEN_FIELD_NAME  = "xms_mirid".freeze
+      OID_TOKEN_FIELD_NAME        = "oid".freeze
+
+      def call
+        validate_credentials_include_azure_token
+        validate_azure_token
+        validate_required_token_fields_exist
+        validate_application_identity
+      end
+
+      private
+
+      def validate_credentials_include_azure_token
+        unless decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
+            !decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
+          raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME
+        end
+      end
+
+      # The credentials are in a URL encoded form data in the request body
+      def decoded_credentials
+        @decoded_credentials ||= Hash[URI.decode_www_form(credentials)]
+      end
+
+      def validate_azure_token
+        decoded_token
+      end
+
+      def decoded_token
+        @decoded_token ||= @verify_and_decode_token.call(
+          provider_uri:     provider_uri,
+          token_jwt:        decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME],
+          claims_to_verify: {
+            verify_iss: true,
+            iss:        provider_uri
+          }
+        )
+      end
+
+      def validate_application_identity
+        @validate_application_identity.(
+          service_id: service_id,
+          account: account,
+          username: username,
+          xms_mirid_token_field: xms_mirid,
+          oid_token_field: oid
+        )
+      end
+
+      def provider_uri
+        @provider_uri ||= azure_authenticator_secrets["provider-uri"].tap do |provider_uri_value|
+          provider_uri_value << "/" unless provider_uri_value.end_with?('/')
+        end
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: service_id,
+          conjur_account: account,
+          authenticator_name: authenticator_name,
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
+      end
+
+      def validate_required_token_fields_exist
+        validate_token_field_exists(XMS_MIRID_TOKEN_FIELD_NAME)
+        validate_token_field_exists(OID_TOKEN_FIELD_NAME)
+      end
+
+      def validate_token_field_exists field_name
+        @logger.debug(Log::ValidatingTokenFieldExists.new(field_name))
+        raise Err::TokenFieldNotFoundOrEmpty, field_name if decoded_token[field_name].to_s.empty?
+      end
+
+      def xms_mirid
+        token_field_value(XMS_MIRID_TOKEN_FIELD_NAME)
+      end
+
+      def oid
+        token_field_value(OID_TOKEN_FIELD_NAME)
+      end
+
+      def token_field_value field_name
+        decoded_token[field_name].tap do |token_field_value|
+          @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
+        end
+      end
+    end
+
+    class Authenticator
+      # This delegates to all the work to the call method created automatically
+      # by CommandClass
+      #
+      # This is needed because we need `valid?` to exist on the Authenticator
+      # class, but that class contains only a metaprogramming generated
+      # `call(authenticator_input:)` method.  The methods we define in the
+      # block passed to `CommandClass` exist only on the private internal
+      # `Call` objects created each time `call` is run.
+      def valid?(input)
+        call(authenticator_input: input)
+      end
+
+      def status(authenticator_status_input:)
+        Authentication::AuthnAzure::ValidateStatus.new.(
+          account: authenticator_status_input.account,
+          service_id: authenticator_status_input.service_id
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/decoded_credentials.rb
+++ b/app/domain/authentication/authn_azure/decoded_credentials.rb
@@ -1,0 +1,27 @@
+module Authentication
+  module AuthnAzure
+
+    class DecodedCredentials
+
+      JWT_REQUEST_BODY_FIELD_NAME = "jwt".freeze
+
+      def initialize(credentials)
+        @decoded_credentials = Hash[URI.decode_www_form(credentials)]
+        validate
+      end
+
+      def jwt
+        @decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME]
+      end
+
+      private
+
+      def validate
+        unless @decoded_credentials.include?(JWT_REQUEST_BODY_FIELD_NAME) &&
+            !@decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].empty?
+          raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/decoded_token.rb
+++ b/app/domain/authentication/authn_azure/decoded_token.rb
@@ -1,0 +1,44 @@
+module Authentication
+  module AuthnAzure
+
+    class DecodedToken
+
+      XMS_MIRID_TOKEN_FIELD_NAME = "xms_mirid".freeze
+      OID_TOKEN_FIELD_NAME       = "oid".freeze
+
+      def initialize(decoded_token_hash:, logger:)
+        @decoded_token_hash = decoded_token_hash
+        @logger = logger
+        validate
+      end
+
+      def xms_mirid
+        @xms_mirid ||= token_field_value(XMS_MIRID_TOKEN_FIELD_NAME)
+      end
+
+      def oid
+        @oid ||= token_field_value(OID_TOKEN_FIELD_NAME)
+      end
+
+      private
+
+      def validate
+        validate_token_field_exists(XMS_MIRID_TOKEN_FIELD_NAME)
+        validate_token_field_exists(OID_TOKEN_FIELD_NAME)
+      end
+
+      def validate_token_field_exists(field_name)
+        @logger.debug(Log::ValidatingTokenFieldExists.new(field_name))
+        if @decoded_token_hash[field_name].to_s.empty?
+          raise Err::TokenFieldNotFoundOrEmpty, field_name
+        end
+      end
+
+      def token_field_value(field_name)
+        @decoded_token_hash[field_name].tap do |token_field_value|
+          @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -124,7 +124,8 @@ module Authentication
       def application_identity
         @application_identity ||= @application_identity_class.new(
           role_annotations: role.annotations,
-          service_id:       @service_id
+          service_id:       @service_id,
+          logger:           @logger
         )
       end
 

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -1,0 +1,185 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity, XmsMiridParseError,
+    # MissingRequiredFieldsInXmsMirid, MissingProviderFieldsInXmsMirid, MissingConstraint,
+    # IllegalConstraintCombinations
+
+    ValidateApplicationIdentity = CommandClass.new(
+      dependencies: {
+        role_class:                 ::Role,
+        resource_class:             ::Resource,
+        validate_azure_annotations: ValidateAzureAnnotations.new,
+        application_identity_class: ApplicationIdentity,
+        logger:                     Rails.logger
+      },
+      inputs:       %i(account service_id username xms_mirid_token_field oid_token_field)
+    ) do
+
+      def call
+        parse_xms_mirid
+        validate_xms_mirid_format
+        token_identity_from_claims
+        validate_azure_annotations_are_permitted
+        extract_application_identity_from_role
+        validate_required_constraints_exist
+        validate_constraint_combinations
+        validate_token_identity_matches_annotations
+      end
+
+      private
+
+      def parse_xms_mirid
+        xms_mirid_hash
+      end
+
+      def xms_mirid_hash
+        @xms_mirid_hash ||= parsed_xms_mirid
+      end
+
+      # we expect the xms_mirid claim to be in the format of /subscriptions/<subscription-id>/...
+      # therefore, we ignore the first slash of the xms_mirid claim and group the entries in key-value pairs
+      # according to fields we need to retrieve from the claim.
+      # ultimately, transforming "/key1/value1/key2/value2" to {"key1" => "value1", "key2" => "value2"}
+      def parsed_xms_mirid
+        split_xms_mirid = @xms_mirid_token_field.split('/')
+
+        if split_xms_mirid.first == ''
+          split_xms_mirid = split_xms_mirid.drop(1)
+        end
+
+        index = 0
+        split_xms_mirid.each_with_object({}) do |property_name, xms_mirid_hash|
+          property_value_index = index + 1
+
+          case property_name
+          when "subscriptions"
+            xms_mirid_hash["subscriptions"] = split_xms_mirid[property_value_index]
+          when "resourcegroups"
+            xms_mirid_hash["resourcegroups"] = split_xms_mirid[property_value_index]
+          when "providers"
+            xms_mirid_hash["providers"] = split_xms_mirid[property_value_index, 3]
+          end
+          index += 1
+        end
+      rescue => e
+        raise Err::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+      end
+
+      def validate_xms_mirid_format
+        required_keys = %w(subscriptions resourcegroups providers)
+        missing_keys  = required_keys - xms_mirid_hash.keys
+        unless missing_keys.empty?
+          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+        end
+
+        unless xms_mirid_hash["providers"].length == 3
+          raise Err::MissingProviderFieldsInXmsMirid, @xms_mirid_token_field
+        end
+      end
+
+      # xms_mirid is a term in Azure to define a claim that describes the resource that holds the encoding of the instance's
+      # among other details the subscription_id, resource group, and provider identity needed for authorization.
+      # xms_mirid is one of the fields in the JWT token. This function will extract the relevant information from
+      # xms_mirid claim and populate a representative hash with the appropriate fields.
+      def token_identity_from_claims
+        @token_identity = {
+          subscription_id: xms_mirid_hash["subscriptions"],
+          resource_group:  xms_mirid_hash["resourcegroups"]
+        }
+
+        # determines which Azure assigned identity is provided in annotations
+        # user-assigned-identity:
+        #   - validates that the correct provider (Microsoft.ManagedIdentity) for a user identity is defined in the
+        #     claim. If so, the 'user_assigned_identity' attribute will be added to the hash with the corresponding
+        #     value from xms_mirid claim
+        # system-assigned-identity:
+        #   - validates that the correct provider (Microsoft.Compute) for a system identity is defined in the
+        #     claim and its resource is one that we support. At current, we only support a virtualMachines resource.
+        #     If these conditions are met, a 'system_assigned_identity' attribute will be added to the hash with its
+        #     value being the oid field in the JWT token.
+        if xms_mirid_hash["providers"].include? "Microsoft.ManagedIdentity"
+          @token_identity[:user_assigned_identity] = xms_mirid_hash["providers"].last
+        else
+          @token_identity[:system_assigned_identity] = @oid_token_field
+        end
+        @logger.debug(Log::ExtractedApplicationIdentityFromToken.new)
+      end
+
+      def validate_azure_annotations_are_permitted
+        @validate_azure_annotations.call(
+          role_annotations: role.annotations,
+          service_id:       @service_id
+        )
+      end
+
+      def extract_application_identity_from_role
+        application_identity
+      end
+
+      def application_identity
+        @application_identity ||= @application_identity_class.new(
+          role_annotations: role.annotations,
+          service_id:       @service_id
+        )
+      end
+
+      def validate_required_constraints_exist
+        validate_constraint_exists :subscription_id
+        validate_constraint_exists :resource_group
+      end
+
+      def validate_constraint_exists constraint
+        unless application_identity.constraints[constraint]
+          raise Err::RoleMissingConstraint, annotation_type_constraint(constraint)
+        end
+      end
+
+      # validates that the application identity doesn't include logical constraint
+      # combinations (e.g user_assigned_identity & system_assigned_identity)
+      def validate_constraint_combinations
+        identifiers = %i(user_assigned_identity system_assigned_identity)
+
+        identifiers_constraints = application_identity.constraints.keys & identifiers
+        unless identifiers_constraints.length <= 1
+          raise Errors::Authentication::IllegalConstraintCombinations, annotation_type_constraints(identifiers_constraints)
+        end
+      end
+
+      def validate_token_identity_matches_annotations
+        application_identity.constraints.each do |constraint|
+          annotation_type  = constraint[0].to_s
+          annotation_value = constraint[1]
+          unless annotation_value == @token_identity[annotation_type.to_sym]
+            raise Err::InvalidApplicationIdentity, annotation_type_constraint(annotation_type)
+          end
+        end
+        @logger.debug(Log::ValidatedApplicationIdentity.new)
+      end
+
+      def annotation_type_constraints constraints
+        constraints.map { |constraint| annotation_type_constraint(constraint) }
+      end
+
+      # converts the constraint to be in annotation style (e.g resource-group
+      # instead of resource_group) to enhance supportability
+      def annotation_type_constraint constraint
+        constraint.to_s.tr('_', '-')
+      end
+
+      def role
+        @role ||= @resource_class[role_id].tap do |role|
+          raise Errors::Authentication::Security::RoleNotFound, role_id unless role
+        end
+      end
+
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @username)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -1,0 +1,63 @@
+require 'command_class'
+
+module Authentication
+  module AuthnAzure
+
+    Log = LogMessages::Authentication::AuthnAzure
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity,
+    # ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
+
+    ValidateAzureAnnotations = CommandClass.new(
+      dependencies: {
+        logger: Rails.logger
+      },
+      inputs:       %i(role_annotations service_id)
+    ) do
+
+      def call
+        validate_azure_annotations_are_permitted
+      end
+
+      private
+
+      # validating that the annotations listed for the Conjur resource align with the permitted Azure constraints
+      def validate_azure_annotations_are_permitted
+        validate_prefixed_permitted_annotations("authn-azure/")
+        validate_prefixed_permitted_annotations("authn-azure/#{@service_id}/")
+      end
+
+      # check if annotations with the given prefix is part of the permitted list
+      def validate_prefixed_permitted_annotations prefix
+        @logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+
+        prefixed_annotations(prefix).each do |annotation|
+          annotation_name = annotation[:name]
+          next if prefixed_permitted_constraints(prefix).include?(annotation_name)
+          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+        end
+      end
+
+      def prefixed_annotations prefix
+        @role_annotations.select do |a|
+          annotation_name = a.values[:name]
+
+          annotation_name.start_with?(prefix) &&
+            # verify we take only annotations from the same level
+            annotation_name.split('/').length == prefix.split('/').length + 1
+        end
+      end
+
+      # add prefix to all permitted constraints
+      def prefixed_permitted_constraints prefix
+        permitted_constraints.map { |k| "#{prefix}#{k}" }
+      end
+
+      def permitted_constraints
+        @permitted_constraints ||= %w(
+          subscription-id resource-group user-assigned-identity system-assigned-identity
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -1,0 +1,52 @@
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+    # Possible Errors Raised:
+    #   ProviderDiscoveryTimeout, ProviderDiscoveryFailed
+    #   RequiredResourceMissing, RequiredSecretMissing
+
+    ValidateStatus = CommandClass.new(
+      dependencies: {
+        fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
+        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+      },
+      inputs: %i(account service_id)
+    ) do
+
+      def call
+        validate_secrets
+        validate_provider_is_responsive
+      end
+
+      private
+
+      def validate_secrets
+        azure_authenticator_secrets
+      end
+
+      def azure_authenticator_secrets
+        @azure_authenticator_secrets ||= @fetch_authenticator_secrets.(
+          service_id: @service_id,
+          conjur_account: @account,
+          authenticator_name: "authn-azure",
+          required_variable_names: required_variable_names
+        )
+      end
+
+      def required_variable_names
+        @required_variable_names ||= %w(provider-uri)
+      end
+
+      def validate_provider_is_responsive
+        @discover_identity_provider.(
+          provider_uri: provider_uri
+        )
+      end
+
+      def provider_uri
+        @azure_authenticator_secrets["provider-uri"]
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -9,9 +9,9 @@ module Authentication
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+        discover_identity_provider:  Authentication::OAuth::DiscoverIdentityProvider.new
       },
-      inputs: %i(account service_id)
+      inputs:       %i(account service_id)
     ) do
 
       def call

--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -1,0 +1,66 @@
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+
+    class XmsMirid
+
+      REQUIRED_KEYS = %w(subscriptions resourcegroups providers).freeze
+
+      def initialize(xms_mirid_token_field)
+        @xms_mirid_token_field = xms_mirid_token_field
+
+        @mirid_parts_hash = mirid_parts_hash
+        validate
+      end
+
+      def subscriptions
+        @mirid_parts_hash["subscriptions"].first
+      end
+
+      def resource_groups
+        @mirid_parts_hash["resourcegroups"].first
+      end
+
+      def providers
+        @mirid_parts_hash["providers"]
+      end
+
+      private
+
+      # we expect the xms_mirid claim to be in the format of /subscriptions/<subscription-id>/...
+      # therefore, we ignore the first slash of the xms_mirid claim and group the entries in key-value pairs
+      # according to fields we need to retrieve from the claim.
+      # ultimately, transforming "/key1/value1/key2/value2" to {"key1" => "value1", "key2" => "value2"}
+      def mirid_parts_hash
+        raw_mirid_parts = @xms_mirid_token_field.split('/')
+
+        # accept also an xms_mirid field that doesn't start with a slash
+        if raw_mirid_parts.first == ''
+          mirid_parts = raw_mirid_parts.drop(1)
+        else
+          mirid_parts = raw_mirid_parts
+        end
+
+        # transform ["subscriptions", "a", "resourcegroups", "b", "providers", "c", "d", "e"]
+        # to {"subscriptions"=>["a"], "resourcegroups"=>["b"], "providers"=>["c", "d", "e"]}
+        mirid_parts.slice_before(Regexp.new(REQUIRED_KEYS.join('|')))
+          .map { |x| [x.first, x.drop(1)] }.to_h
+      rescue => e
+        # this should never occur, it's here to enhance supportability in case it does
+        raise Err::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+      end
+
+      def validate
+        missing_keys = REQUIRED_KEYS - @mirid_parts_hash.keys
+        unless missing_keys.empty?
+          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+        end
+
+        unless @mirid_parts_hash["providers"].length == 3
+          raise Err::MissingProviderFieldsInXmsMirid, @xms_mirid_token_field
+        end
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -274,6 +274,44 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00048E"
         )
       end
+
+      module AuthnAzure
+
+        RoleMissingConstraint = ::Util::TrackableErrorClass.new(
+          msg:  "Role does not have the required constraint: {0-constraint}",
+          code: "CONJ00057E"
+        )
+
+        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+          msg:  "Application identity field '{0-field-name}' does not match application identity in Azure token",
+          code: "CONJ00049E"
+        )
+
+        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+          msg:  "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          code: "CONJ00050E"
+        )
+
+        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+          msg:  "Field '{0-field-name}' not found or empty in token",
+          code: "CONJ00051E"
+        )
+
+        XmsMiridParseError = ::Util::TrackableErrorClass.new(
+          msg:  "Failed to parse xms_mirid {0}. Reason: {1}",
+          code: "CONJ00052E"
+        )
+
+        MissingRequiredFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Required fields {0} are missing in xms_mirid {1}",
+          code: "CONJ00053E"
+        )
+
+        MissingProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Provider fields are missing in xms_mirid {1}",
+          code: "CONJ00054E"
+        )
+      end
     end
 
     module Util

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -128,6 +128,30 @@ unless defined? LogMessages::Authentication::OriginValidated
           code: "CONJ00028D"
         )
       end
+
+      module AuthnAzure
+
+        ExtractedApplicationIdentityFromToken = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracted application identity from token",
+          code: "CONJ00029D"
+        )
+
+        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+          msg:  "Application identity validated",
+          code: "CONJ00030D"
+        )
+
+        ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
+          msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
+          code: "CONJ00031D"
+        )
+
+        ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
+          msg:  "Validating that field '{0}' exists in token",
+          code: "CONJ00032D"
+        )
+
+      end
     end
 
     module Util

--- a/ci/authn-azure/check_dependencies.sh
+++ b/ci/authn-azure/check_dependencies.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eo pipefail
+
+check_env_var() {
+  if [[ -z "${!1+x}" ]]; then
+    # where ${var+x} is a parameter expansion which evaluates to nothing if var is unset, and substitutes the string x otherwise.
+    # https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash/13864829#13864829
+    echo "You must set $1 before running these scripts."
+    exit 1
+  fi
+}
+
+echo "Checking required environment variables for authn-azure tests"
+
+# These variables should come from Conjur via summon
+check_env_var "AZURE_TENANT_ID"
+check_env_var "AZURE_SUBSCRIPTION_ID"
+check_env_var "AZURE_RESOURCE_GROUP"
+check_env_var "AZURE_AUTHN_INSTANCE_USERNAME"
+check_env_var "AZURE_AUTHN_INSTANCE_PASSWORD"
+check_env_var "USER_ASSIGNED_IDENTITY"
+check_env_var "USER_ASSIGNED_IDENTITY_CLIENT_ID"
+
+# These variables should come from Jenkins
+check_env_var "AZURE_AUTHN_INSTANCE_IP"
+#check_env_var "SYSTEM_ASSIGNED_IDENTITY" # TODO: add this once available
+
+echo "Required environment variables for authn-azure tests exist"
+

--- a/ci/authn-azure/policies/azure-hosts.template.yml
+++ b/ci/authn-azure/policies/azure-hosts.template.yml
@@ -1,0 +1,20 @@
+# Hosts that will authenticate with the Azure authenticator
+- !policy
+  id: azure-apps
+  body:
+    - !group
+
+    - &hosts
+      - !host
+        id: no-assigned-identity-app
+        annotations:
+          authn-azure/subscription-id: {{ AZURE_SUBSCRIPTION_ID }}
+          authn-azure/resource-group: {{ AZURE_RESOURCE_GROUP }}
+
+    - !grant
+      role: !group
+      members: *hosts
+
+- !grant
+  role: !group conjur/authn-azure/prod/apps
+  member: !group azure-apps

--- a/ci/authn-azure/policies/azure-operators.yml
+++ b/ci/authn-azure/policies/azure-operators.yml
@@ -1,0 +1,7 @@
+# Users who can check the status of the authn-azure/prod authenticator
+- !user
+  id: authn-azure-test-operator
+
+- !grant
+  role: !group conjur/authn-azure/prod/operators
+  member: !user authn-azure-test-operator

--- a/ci/authn-azure/policies/policy.yml
+++ b/ci/authn-azure/policies/policy.yml
@@ -1,0 +1,31 @@
+# Azure authenticator
+- !policy
+  id: conjur/authn-azure/prod
+  body:
+  - !webservice
+
+  - !webservice
+    id: status
+    annotations:
+      description: Status service to verify the authenticator is configured correctly
+
+  - !variable
+    id: provider-uri
+
+  - !group
+    id: apps
+
+  - !group
+    id: operators
+    annotations:
+      description: Group of users who can check the status of the authn-azure/prod authenticator
+
+  - !permit
+    role: !group apps
+    privilege: [ read, authenticate ]
+    resource: !webservice
+
+  - !permit
+    role: !group operators
+    privilege: [ read ]
+    resource: !webservice status

--- a/ci/authn-azure/policies/test-secrets.yml
+++ b/ci/authn-azure/policies/test-secrets.yml
@@ -1,0 +1,16 @@
+# Variable that will be consumed by azure-apps/system-assigned-identity-app or user-assigned-identity-app
+- !policy
+  id: secrets
+  body:
+    - !group consumers
+
+    - !variable test-variable
+
+    - !permit
+      role: !group consumers
+      privilege: [ read, execute ]
+      resource: !variable test-variable
+
+- !grant
+  role: !group secrets/consumers
+  member: !group azure-apps

--- a/ci/authn-azure/secrets.yml
+++ b/ci/authn-azure/secrets.yml
@@ -1,0 +1,9 @@
+AZURE_TENANT_ID: !var ci/azure/tenant-id
+AZURE_SUBSCRIPTION_ID: !var ci/azure/subscription-id
+AZURE_RESOURCE_GROUP: !var ci/azure/authn-test/resource-group
+USER_ASSIGNED_IDENTITY: !var ci/azure/authn-test/user-assigned-id
+USER_ASSIGNED_IDENTITY_CLIENT_ID: !var ci/azure/authn-test/user-assigned-id-client-id
+AZURE_AUTHN_INSTANCE_USERNAME: !var ci/azure/authn-test/instance-user
+AZURE_AUTHN_INSTANCE_PASSWORD: !var ci/azure/authn-test/instance-password
+
+# TODO: add system-assigned identity

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       RAILS_ENV:
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-config/env
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-config/env,authn-azure/prod
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'

--- a/ci/test
+++ b/ci/test
@@ -49,6 +49,14 @@ cucumber_authenticators_ldap() {
   _run_cucumber_tests authenticators_ldap 'ldap-server'
 }
 
+cucumber_authenticators_azure() {
+  : DOC - Runs Cucumber Azure Authenticator features
+
+  ./authn-azure/check_dependencies.sh
+
+  _run_cucumber_tests authenticators_azure "" "$(_get_azure_env_args)"
+}
+
 cucumber_authenticators_oidc() {
   : DOC - Runs Cucumber OIDC Authenticator features
 
@@ -187,6 +195,21 @@ _get_oidc_env_args() {
   echo "${oidc_env_args}"
 }
 
+_get_azure_env_args() {
+  local azure_env_args="-e AZURE_TENANT_ID=$AZURE_TENANT_ID"
+  azure_env_args="$azure_env_args -e AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID"
+  azure_env_args="$azure_env_args -e AZURE_RESOURCE_GROUP=$AZURE_RESOURCE_GROUP"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_IP=$AZURE_AUTHN_INSTANCE_IP"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_USERNAME=$AZURE_AUTHN_INSTANCE_USERNAME"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_PASSWORD=$AZURE_AUTHN_INSTANCE_PASSWORD"
+  azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY=$USER_ASSIGNED_IDENTITY"
+  azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY_CLIENT_ID=$USER_ASSIGNED_IDENTITY_CLIENT_ID"
+
+# TODO: add this once available
+#  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
+  echo "${azure_env_args}"
+}
+
 _wait_for_keycloak() {
   for i in {1..20}
   do
@@ -290,7 +313,7 @@ _run_cucumber() {
   # If there's no tty (e.g. we're running as a Jenkins job, pass -T to
   # docker-compose)
   local notty=$(tty -s || echo '-T' && true)
-  
+
   docker-compose run --no-deps $notty --rm $cucumber_env_args \
      -e CONJUR_AUTHN_API_KEY=$api_key \
      -e CUCUMBER_NETWORK=$(_find_cucumber_network) \
@@ -305,12 +328,12 @@ _run_cucumber_tests() {
   if [[ ! -z "$3" ]]; then
     local cucumber_env_args="$3"
   fi
-  
+
   _setup_for_cucumber "$services"
   
   # Grab the admin user API key
   local api_key=$(_get_api_key)
-  
+
   # Run the tests
   _run_cucumber "$cucumber_env_args" \
      "bundle exec cucumber -p $profile --format json --out cucumber/$profile/cucumber_results.json --format junit --out cucumber/$profile/features/reports"

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -73,6 +73,23 @@ authenticators_oidc: >
   -r cucumber/authenticators_oidc
   cucumber/authenticators_oidc
 
+authenticators_azure: >
+  --format pretty
+  -r cucumber/api/features/support/rest_helpers.rb
+  -r cucumber/api/features/step_definitions/request_steps.rb
+  -r cucumber/api/features/step_definitions/user_steps.rb
+  -r cucumber/api/features/support/ssh_helpers.rb
+  -r cucumber/api/features/support/logs_helpers.rb
+  -r cucumber/api/features/step_definitions/logs_steps.rb
+  -r cucumber/api/features/support/authz_helpers.rb
+  -r cucumber/api/features/step_definitions/authz_steps.rb
+  -r cucumber/policy/features/support/policy_helpers.rb
+  -r cucumber/policy/features/step_definitions/policy_steps.rb
+  -r cucumber/_authenticators_common
+  -r cucumber/authenticators_status/features/step_definitions/authn_status_steps.rb
+  -r cucumber/authenticators_azure
+  cucumber/authenticators_azure
+
 # NOTE: We have to require the needed files from "api" individually, because
 #       if you mass require the folder it includes "api"s env.rb, which screws
 #       things up because (I think) it sets ENV['CONJUR_ACCOUNT'].  Cucumber

--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -1,0 +1,157 @@
+Feature: Azure Authenticator - Bad authenticator configuration leads to an error
+
+  In this feature we define an Azure Authenticator with a configuration
+  mistake. Each test will verify that we fail the authentication in such a case
+  and log the relevant error for the user to re-configure the authenticator
+  properly
+
+  Scenario: provider-uri variable missing in policy is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "test-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Conjur::RequiredResourceMissing
+    """
+
+  # TODO: add this test when issue #1085 is done
+  @skip
+  Scenario: provider-uri variable without value is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "test-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Conjur::RequiredSecretMissing
+    """
+
+  Scenario: webservice missing in policy is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+    And I successfully set Azure variables with the correct values
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "test-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::WebserviceNotFound
+    """
+
+  Scenario: Webservice with read and no authenticate permission in policy is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+        - !webservice
+
+        - !variable
+          id: provider-uri
+
+        - !group apps
+
+        - !permit
+          role: !group apps
+          privilege: [ read ]
+          resource: !webservice
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+    And I successfully set Azure variables with the correct values
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "test-app"
+    Then it is forbidden
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
+    """
+
+  Scenario: Bad Gateway is raised in case of an invalid ID Provider hostname
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I add the secret value "http://127.0.0.1.com/" to the resource "cucumber:variable:conjur/authn-azure/prod/provider-uri"
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "test-app"
+    Then it is bad gateway
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::OAuth::ProviderDiscoveryFailed
+    """

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -1,0 +1,88 @@
+Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
+
+  In this feature we define an Azure authenticator in policy and perform authentication
+  with Conjur, using a host with subscription-id & resource-group annotations.
+  In successful scenarios we will also define a variable and permit the host to
+  execute it, to verify not only that the host can authenticate with the Azure
+  Authenticator, but that it can retrieve a secret using the Conjur access token.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I successfully set Azure variables with the correct values
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+
+  Scenario: Hosts can authenticate with Azure authenticator and fetch secret
+    Given I have a "variable" resource called "test-variable"
+    And I permit host "test-app" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I fetch an Azure access token from inside machine
+    When I authenticate via Azure with token as host "test-app"
+    Then host "test-app" has been authorized by Conjur
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+
+  Scenario: A valid provider-uri without trailing slash works
+    Given I have a "variable" resource called "test-variable"
+    And I permit host "test-app" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I fetch an Azure access token from inside machine
+    When I successfully set Azure provider-uri variable without trailing slash
+    And I authenticate via Azure with token as host "test-app"
+    Then host "test-app" has been authorized by Conjur
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+
+  Scenario: Changing provider-uri dynamically reflects on the ID Provider endpoint
+    Given I fetch an Azure access token from inside machine
+    And I authenticate via Azure with token as host "test-app"
+    And host "test-app" has been authorized by Conjur
+    # Update provider uri to a different hostname and verify `provider-uri` has changed
+    When I add the secret value "https://different-provider:8443" to the resource "cucumber:variable:conjur/authn-azure/prod/provider-uri"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    And I authenticate via Azure with token as host "test-app"
+    Then it is bad gateway
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00007D Working with Identity Provider https://different-provider:8443
+    """
+    # Check recovery to a valid provider uri
+    When I successfully set Azure variables with the correct values
+    And I fetch an Azure access token from inside machine
+    And I authenticate via Azure with token as host "test-app"
+    And host "test-app" has been authorized by Conjur
+
+  Scenario: Missing Azure access token is a bad request
+    Given I save my place in the log file
+    When I authenticate via Azure with no token as host "test-app"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+
+  Scenario: Empty Azure access token is a bad request
+    Given I save my place in the log file
+    When I authenticate via Azure with empty token as host "test-app"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -1,0 +1,140 @@
+Feature: Azure Authenticator - Different Hosts can authenticate with Azure authenticator
+
+  In this feature we define an Azure authenticator in policy, define different
+  hosts and perform authentication with Conjur.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I successfully set Azure variables with the correct values
+
+  Scenario: Host with user-assigned-identity annotation is authorized
+    And I have host "user-assigned-identity-app"
+    And I set subscription-id annotation to host "user-assigned-identity-app"
+    And I set resource-group annotation to host "user-assigned-identity-app"
+    And I set user-assigned-identity annotation to host "user-assigned-identity-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "user-assigned-identity-app"
+    And I fetch a user-assigned Azure access token from inside machine
+    When I authenticate via Azure with token as host "user-assigned-identity-app"
+    Then host "user-assigned-identity-app" has been authorized by Conjur
+
+  Scenario: Host without resource-group annotation is denied
+    And I have host "no-resource-group-app"
+    And I set subscription-id annotation to host "no-resource-group-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "no-resource-group-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "no-resource-group-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::RoleMissingConstraint: CONJ00057E Role does not have the required constraint: resource-group
+    """
+
+  Scenario: Host without subscription-id annotation is denied
+    And I have host "no-subscription-id-app"
+    And I set resource-group annotation to host "no-subscription-id-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "no-subscription-id-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "no-subscription-id-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::RoleMissingConstraint: CONJ00057E Role does not have the required constraint: subscription-id
+    """
+
+  Scenario: Host without any Azure annotation is denied
+    And I have host "no-azure-annotations-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "no-azure-annotations-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::RoleMissingConstraint
+    """
+
+  # TODO: add test for IllegalConstraintCombinations once we can test system-assigned id
+
+  Scenario: Host with incorrect subscription-id Azure annotation is denied
+    And I have host "incorrect-subscription-id-app"
+    And I set resource-group annotation to host "incorrect-subscription-id-app"
+    And I set subscription-id annotation with incorrect value to host "incorrect-subscription-id-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-subscription-id-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "incorrect-subscription-id-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+    """
+
+  Scenario: Host with incorrect resource-group Azure annotation is denied
+    And I have host "incorrect-resource-group-app"
+    And I set subscription-id annotation to host "incorrect-resource-group-app"
+    And I set resource-group annotation with incorrect value to host "incorrect-resource-group-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-resource-group-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "incorrect-resource-group-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+    """
+
+  Scenario: Host with incorrect user-assigned-identity annotation is authorized
+    And I have host "incorrect-user-assigned-identity-app"
+    And I set subscription-id annotation to host "incorrect-user-assigned-identity-app"
+    And I set resource-group annotation to host "incorrect-user-assigned-identity-app"
+    And I set user-assigned-identity annotation with incorrect value to host "incorrect-user-assigned-identity-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-user-assigned-identity-app"
+    And I fetch a user-assigned Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "incorrect-user-assigned-identity-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+    """
+
+  Scenario: Non-existing host is denied
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "non-existing-app"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotFound
+    """
+
+  Scenario: Host that is not in the permitted group is denied
+    And I have host "non-permitted-app"
+    And I set Azure annotations to host "non-permitted-app"
+    And I fetch an Azure access token from inside machine
+    And I save my place in the log file
+    When I authenticate via Azure with token as host "non-permitted-app"
+    Then it is forbidden
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
+    """

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -1,0 +1,47 @@
+Feature: Azure Authenticator - Performance tests
+
+  In this feature we test that Azure Authenticator performance is meeting
+  the SLA. We run multiple authn-azure requests in multiple threads and verify
+  that the average time of a request is no more that the agreed time.
+  We test both successful requests and unsuccessful requests.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I successfully set Azure variables with the correct values
+    And I have host "test-app"
+    And I set Azure annotations to host "test-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
+
+  Scenario: successful requests
+    And I fetch an Azure access token from inside machine
+    When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
+    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+
+  Scenario: Unsuccessful requests with an invalid token
+    And I fetch an Azure access token from inside machine
+    When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"
+    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+
+  Scenario: Unsuccessful requests with invalid application identity
+    Given I have host "no-azure-annotations-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
+    And I fetch an Azure access token from inside machine
+    When I authenticate 1000 times in 10 threads via Azure with token as host "no-azure-annotations-app"
+    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds

--- a/cucumber/authenticators_azure/features/authn_status_azure.feature
+++ b/cucumber/authenticators_azure/features/authn_status_azure.feature
@@ -1,0 +1,151 @@
+Feature: Azure Authenticator - Status Check
+
+  Scenario: A properly configured Azure authenticator returns a successful response
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !webservice
+        id: status
+        annotations:
+          description: Status service to verify the authenticator is configured correctly
+
+      - !variable
+        id: provider-uri
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+      - !group
+        id: operators
+        annotations:
+          description: Group of users who can check the status of the authn-azure/prod authenticator
+
+      - !permit
+        role: !group operators
+        privilege: [ read ]
+        resource: !webservice status
+
+    - !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/users
+      member: !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/operators
+      member: !user alice
+    """
+    And I am the super-user
+    And I successfully set Azure variables with the correct values
+    And I login as "alice"
+    When I GET "/authn-azure/prod/cucumber/status"
+    Then the HTTP response status code is 200
+    And the authenticator status check succeeds
+
+  Scenario: A non-responsive Azure AD provider returns a 500 response
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !webservice
+        id: status
+        annotations:
+          description: Status service to verify the authenticator is configured correctly
+
+      - !variable
+        id: provider-uri
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+      - !group
+        id: operators
+        annotations:
+          description: Group of users who can check the status of the authn-azure/prod authenticator
+
+      - !permit
+        role: !group operators
+        privilege: [ read ]
+        resource: !webservice status
+
+    - !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/users
+      member: !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/operators
+      member: !user alice
+    """
+    And I am the super-user
+    And I successfully set Azure provider-uri variable to value "https://not-responsive.com"
+    And I login as "alice"
+    When I GET "/authn-azure/prod/cucumber/status"
+    Then the HTTP response status code is 500
+    And the authenticator status check fails with error "ProviderDiscoveryFailed: CONJ00011E"
+
+  Scenario: provider-uri variable is missing and a 500 error response is returned
+    Given a policy:
+     """
+    - !policy
+      id: conjur/authn-azure/prod
+      body:
+      - !webservice
+
+      - !webservice
+        id: status
+        annotations:
+          description: Status service to verify the authenticator is configured correctly
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+      - !group
+        id: operators
+        annotations:
+          description: Group of users who can check the status of the authn-azure/prod authenticator
+
+      - !permit
+        role: !group operators
+        privilege: [ read ]
+        resource: !webservice status
+
+    - !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/users
+      member: !user alice
+
+    - !grant
+      role: !group conjur/authn-azure/prod/operators
+      member: !user alice
+    """
+    And I am the super-user
+    And I login as "alice"
+    When I GET "/authn-azure/prod/cucumber/status"
+    Then the HTTP response status code is 500
+    And the authenticator status check fails with error "RequiredResourceMissing: CONJ00036E"
+
+  # TODO: add this tes when issue #1085 is done
+#  Scenario: provider-uri value has not been set and a 500 error response is returned
+

--- a/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
+++ b/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
@@ -1,0 +1,93 @@
+Given(/^I successfully set Azure variables with the correct values$/) do
+  create_and_set_azure_provider_uri_variable
+end
+
+Given(/^I successfully set Azure provider-uri variable to value "([^"]*)"$/) do |provider_uri|
+  create_and_set_azure_provider_uri_variable(provider_uri)
+end
+
+Given(/^I successfully set Azure provider-uri variable without trailing slash$/) do
+  create_and_set_azure_provider_uri_variable(azure_provider_uri.chop)
+end
+
+Given(/I fetch an Azure access token from inside machine/) do
+  retrieve_system_assigned_azure_access_token
+end
+
+Given(/I fetch a user-assigned Azure access token from inside machine/) do
+  retrieve_user_assigned_azure_access_token
+end
+
+Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |empty |invalid )?token as (user|host) "([^"]*)"/) do |num_requests, num_threads, token_state, role_type, username|
+  username = role_type == "user" ? username : "host/#{username}"
+
+  token = case token_state
+          when "no "
+            nil
+          when "empty "
+            ""
+          when "invalid "
+            invalid_token
+          else
+            @azure_token
+          end
+
+  num_requests ||= 1
+  num_threads  ||= 1
+
+  queue   = (1..num_requests.to_i).inject(Queue.new, :push)
+  results = []
+
+  all_threads = Array.new(num_threads.to_i) do
+    Thread.new do
+      until queue.empty?
+        queue.shift
+        results.push(
+          Benchmark.measure do
+            authenticate_azure_token(
+              service_id:  'prod',
+              account:     'cucumber',
+              username:    username,
+              azure_token: token
+            )
+          end
+        )
+      end
+    end
+  end
+
+  all_threads.each(&:join)
+  @azure_perf_results = results.map(&:real)
+end
+
+Then(/^The "([^"]*)" Azure Authentication request response time should be less than "([^"]*)" seconds?$/) do |type, threshold|
+  type = type.downcase.to_sym
+  raise "Unexpected Type" unless %i(max avg).include?(type)
+  results     = @azure_perf_results
+  actual_time = type == :avg ? results.sum.fdiv(results.size) : results.max
+  expect(actual_time).to be < threshold.to_f
+end
+
+Given(/^I set Azure annotations to host "([^"]*)"$/) do |hostname|
+  i_have_a_resource "host", hostname
+  set_annotation_to_resource("authn-azure/subscription-id", azure_subscription_id)
+  set_annotation_to_resource("authn-azure/resource-group", azure_resource_group)
+end
+
+Given(/^I set (subscription-id|resource-group|user-assigned-identity) annotation (with incorrect value )?to host "([^"]*)"$/) do |annotation_name, incorrect_value, hostname|
+  i_have_a_resource "host", hostname
+
+  case annotation_name
+  when "subscription-id"
+    annotation_correct_value = azure_subscription_id
+  when "resource-group"
+    annotation_correct_value = azure_resource_group
+  when "user-assigned-identity"
+    annotation_correct_value = user_assigned_identity
+  else
+    raise "incorrect annotation name #{annotation_name}"
+  end
+
+  annotation_value = incorrect_value ? "some-incorrect-value" : annotation_correct_value
+  set_annotation_to_resource("authn-azure/#{annotation_name}", annotation_value)
+end

--- a/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
+++ b/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Utility methods for Azure authenticator
+
+module AuthnAzureHelper
+  include AuthenticatorHelpers
+
+  def create_and_set_azure_provider_uri_variable(value = azure_provider_uri)
+    create_and_set_azure_variable("provider-uri", value)
+  end
+
+  def retrieve_user_assigned_azure_access_token
+    retrieve_azure_access_token(retrieve_azure_token_command(is_user_assigned: true))
+  end
+
+  def retrieve_system_assigned_azure_access_token
+    retrieve_azure_access_token(retrieve_azure_token_command(is_user_assigned: false))
+  end
+
+  def retrieve_azure_token_command is_user_assigned:
+    base_command = "curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01" \
+      "&resource=https%3A%2F%2Fmanagement.azure.com%2F"
+
+    base_command = "#{base_command}&client_id=#{user_assigned_identity_client_id}" if is_user_assigned
+
+    "#{base_command}' -H Metadata:true -s | jq -r '.access_token'"
+  end
+
+  def retrieve_azure_access_token retrieve_access_token_command
+    @azure_token = run_command_in_machine(azure_machine_ip, azure_machine_username, azure_machine_password, retrieve_access_token_command)
+  rescue => err
+    raise "Failed to fetch azure token with reason: #{err}"
+  end
+
+  def authenticate_azure_token(service_id:, account:, username:, azure_token:)
+    username = username.gsub("/", "%2F")
+    path = "#{conjur_hostname}/authn-azure/#{service_id}/#{account}/#{username}/authenticate"
+
+    payload = {}
+    payload["jwt"] = azure_token
+
+    post(path, payload)
+  end
+
+  private
+
+  def create_and_set_azure_variable(variable_name, value)
+    path = "cucumber:variable:conjur/authn-azure/prod"
+    Secret.create(resource_id: "#{path}/#{variable_name}", value: value)
+  end
+
+  def azure_provider_uri
+    @azure_provider_uri ||= "https://sts.windows.net/#{validated_env_var('AZURE_TENANT_ID')}/"
+  end
+
+  def azure_machine_ip
+    @azure_machine_ip ||= validated_env_var('AZURE_AUTHN_INSTANCE_IP')
+  end
+
+  def azure_machine_username
+    @azure_machine_username ||= validated_env_var('AZURE_AUTHN_INSTANCE_USERNAME')
+  end
+
+  def azure_machine_password
+    @azure_machine_password ||= validated_env_var('AZURE_AUTHN_INSTANCE_PASSWORD')
+  end
+
+  def azure_subscription_id
+    @azure_subscription_id ||= validated_env_var('AZURE_SUBSCRIPTION_ID')
+  end
+
+  def azure_resource_group
+    @azure_resource_group ||= validated_env_var('AZURE_RESOURCE_GROUP')
+  end
+
+  # TODO: add this once available
+  # def system_assigned_identity
+  #   @system_assigned_identity ||= validated_env_var('SYSTEM_ASSIGNED_IDENTITY')
+  # end
+
+  def user_assigned_identity
+    @user_assigned_identity ||= validated_env_var('USER_ASSIGNED_IDENTITY')
+  end
+
+  def user_assigned_identity_client_id
+    @user_assigned_identity_client_id ||= validated_env_var('USER_ASSIGNED_IDENTITY_CLIENT_ID')
+  end
+
+  def invalid_token
+    "invalidAzureToken"
+  end
+end
+
+World(AuthnAzureHelper)

--- a/dev/cli
+++ b/dev/cli
@@ -30,6 +30,7 @@ GLOBAL OPTIONS
     --help                                    - Show this message
 COMMANDS
     --authn-oidc    Enables OIDC features
+    --authn-azure   Enables Azure features
 EOF
 exit
 }
@@ -46,6 +47,28 @@ function enable_oidc() {
   env_args="$env_args $keycloak_env_args"
 }
 
+function enable_azure() {
+
+  ../ci/authn-azure/check_dependencies.sh
+
+  echo "Setting Azure details as env variables"
+
+  local azure_env_args=''
+  azure_env_args="$azure_env_args -e AZURE_TENANT_ID=$AZURE_TENANT_ID"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_IP=$AZURE_AUTHN_INSTANCE_IP"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_USERNAME=$AZURE_AUTHN_INSTANCE_USERNAME"
+  azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_PASSWORD=$AZURE_AUTHN_INSTANCE_PASSWORD"
+  azure_env_args="$azure_env_args -e AZURE_SUBSCRIPTION_ID=$AZURE_SUBSCRIPTION_ID"
+  azure_env_args="$azure_env_args -e AZURE_RESOURCE_GROUP=$AZURE_RESOURCE_GROUP"
+  azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY=$USER_ASSIGNED_IDENTITY"
+  azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY_CLIENT_ID=$USER_ASSIGNED_IDENTITY_CLIENT_ID"
+
+ # TODO: add this once available
+#  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
+
+  env_args="$env_args $azure_env_args"
+}
+
 unset COMPOSE_PROJECT_NAME
 
 while true ; do
@@ -58,6 +81,7 @@ while true ; do
       case "$2" in
         -h | --help ) print_exec_help ; shift ;;
         --authn-oidc ) enable_oidc ; shift ;;
+        --authn-azure ) enable_azure ; shift ;;
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 

--- a/dev/start
+++ b/dev/start
@@ -15,6 +15,8 @@ Usage: start [options]
 
     --authn-iam     Starts with authn-iam/prod as authenticator
 
+    --authn-azure   Starts with authn-azure/prod as authenticator
+
     --authn-oidc    Starts with authn-oidc/keycloak as authenticator
 
     --oidc-adfs     Adds to authn-oidc adfs static env configuration
@@ -73,6 +75,7 @@ unset COMPOSE_PROJECT_NAME
 # Determine which extra services should be loaded when working with authenticators
 ENABLE_AUTHN_LDAP=false
 ENABLE_AUTHN_IAM=false
+ENABLE_AUTHN_AZURE=false
 ENABLE_AUTHN_OIDC=false
 ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
@@ -81,6 +84,7 @@ ENABLE_AUDIT=false
 while true ; do
   case "$1" in
     --authn-iam ) ENABLE_AUTHN_IAM=true ; shift ;;
+    --authn-azure ) ENABLE_AUTHN_AZURE=true ; shift ;;
     --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
     --authn-oidc ) ENABLE_AUTHN_OIDC=true ; shift ;;
     --oidc-adfs ) ENABLE_OIDC_ADFS=true ; shift ;;
@@ -127,6 +131,21 @@ if [[ $ENABLE_AUTHN_LDAP = true ]]; then
   enabled_authenticators="$enabled_authenticators,authn-ldap/test,authn-ldap/secure"
 
   docker-compose exec conjur conjurctl policy load cucumber /src/conjur-server/dev/files/authn-ldap/policy.yml
+fi
+
+if [[ $ENABLE_AUTHN_AZURE = true ]]; then
+  enabled_authenticators="$enabled_authenticators,authn-azure/prod"
+
+  ../ci/authn-azure/check_dependencies.sh
+
+  docker-compose exec client conjur policy load root /src/conjur-server/ci/authn-azure/policies/policy.yml
+  docker-compose exec client conjur variable values add conjur/authn-azure/prod/provider-uri "https://sts.windows.net/$AZURE_TENANT_ID/"
+
+  sed "s#{{ AZURE_SUBSCRIPTION_ID }}#$AZURE_SUBSCRIPTION_ID#g" ../ci/authn-azure/policies/azure-hosts.template.yml |
+    sed "s#{{ AZURE_RESOURCE_GROUP }}#$AZURE_RESOURCE_GROUP#g" > ../ci/authn-azure/policies/azure-hosts.yml
+  docker-compose exec client conjur policy load root /src/conjur-server/ci/authn-azure/policies/azure-hosts.yml
+
+  docker-compose exec client conjur policy load root /src/conjur-server/ci/authn-azure/policies/azure-operators.yml
 fi
 
 if [[ $ENABLE_AUTHN_OIDC = false && ($ENABLE_OIDC_ADFS = true || $ENABLE_OIDC_OKTA = true) ]]; then

--- a/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
     subject do
       Authentication::AuthnAzure::ApplicationIdentity.new(
         role_annotations: role_annotations,
-        service_id:       test_service_id
+        service_id:       test_service_id,
+        logger:           Rails.logger
       )
     end
     context("with a global scoped constraint") do

--- a/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
 
       it "has a constraints hash with its value" do
         expect(subject.constraints).to eq(
-                                         {
-                                           subscription_id:          "some-subscription-id-value",
-                                           resource_group:           "some-resource-group-value",
-                                           user_assigned_identity:   "some-user-assigned-identity-value",
-                                           system_assigned_identity: "some-system-assigned-identity-value"
-                                         }
-                                       )
+          {
+            subscription_id:          "some-subscription-id-value",
+            resource_group:           "some-resource-group-value",
+            user_assigned_identity:   "some-user-assigned-identity-value",
+            system_assigned_identity: "some-system-assigned-identity-value"
+          }
+        )
       end
     end
 
@@ -54,13 +54,13 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
 
       it "has a constraints hash with its value" do
         expect(subject.constraints).to eq(
-                                         {
-                                           subscription_id:          "some-subscription-id-service-id-scoped-value",
-                                           resource_group:           "some-resource-group-service-id-scoped-value",
-                                           user_assigned_identity:   "some-user-assigned-service-id-scoped-value",
-                                           system_assigned_identity: "some-system-assigned-service-id-scoped-value"
-                                         }
-                                       )
+          {
+            subscription_id:          "some-subscription-id-service-id-scoped-value",
+            resource_group:           "some-resource-group-service-id-scoped-value",
+            user_assigned_identity:   "some-user-assigned-service-id-scoped-value",
+            system_assigned_identity: "some-system-assigned-service-id-scoped-value"
+          }
+        )
       end
     end
 

--- a/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
+  include_context "azure setup"
+
+  let(:user_assigned_identity_service_id_scoped_annotation) { double("UserAssignedIdentityAnnotation") }
+  let(:system_assigned_identity_service_id_scoped_annotation) { double("UserAssignedIdentityServiceIdScopeAnnotation") }
+
+  before(:each) do
+    define_host_annotation(
+      host_annotation_type:  user_assigned_identity_service_id_scoped_annotation,
+      host_annotation_key:   "#{granular_annotation_type}/user-assigned-identity",
+      host_annotation_value: "some-user-assigned-service-id-scoped-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  system_assigned_identity_service_id_scoped_annotation,
+      host_annotation_key:   "#{granular_annotation_type}/system-assigned-identity",
+      host_annotation_value: "some-system-assigned-service-id-scoped-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  non_azure_annotation,
+      host_annotation_key:   "#{global_annotation_type}/non-azure-annotation",
+      host_annotation_value: "some-non-azure-value"
+    )
+  end
+
+  context "An application identity in annotations" do
+    subject do
+      Authentication::AuthnAzure::ApplicationIdentity.new(
+        role_annotations: role_annotations,
+        service_id:       test_service_id
+      )
+    end
+    context("with a global scoped constraint") do
+      let(:role_annotations) { [subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation, system_assigned_identity_annotation] }
+
+      it "has a constraints hash with its value" do
+        expect(subject.constraints).to eq(
+                                         {
+                                           subscription_id:          "some-subscription-id-value",
+                                           resource_group:           "some-resource-group-value",
+                                           user_assigned_identity:   "some-user-assigned-identity-value",
+                                           system_assigned_identity: "some-system-assigned-identity-value"
+                                         }
+                                       )
+      end
+    end
+
+    context("with a service-id scoped constraint") do
+      let(:role_annotations) { [subscription_id_service_id_scoped_annotation, resource_group_service_id_scoped_annotation, user_assigned_identity_service_id_scoped_annotation, system_assigned_identity_service_id_scoped_annotation] }
+
+      it "has a constraints hash with its value" do
+        expect(subject.constraints).to eq(
+                                         {
+                                           subscription_id:          "some-subscription-id-service-id-scoped-value",
+                                           resource_group:           "some-resource-group-service-id-scoped-value",
+                                           user_assigned_identity:   "some-user-assigned-service-id-scoped-value",
+                                           system_assigned_identity: "some-system-assigned-service-id-scoped-value"
+                                         }
+                                       )
+      end
+    end
+
+    # Here we are only testing the scope of the subscription-id application identity because
+    # we want to test that we grab the more granular application identity and the behaviour
+    # is the same regardless of the annotation name
+    context("with both global & service-id scoped constraints") do
+      let(:role_annotations) { [subscription_id_annotation, subscription_id_service_id_scoped_annotation] }
+
+      it ("chooses the service-id scoped constraint") do
+        expect(subject.constraints).to eq({ subscription_id: "some-subscription-id-service-id-scoped-value" })
+      end
+    end
+
+    context("without annotations") do
+      let(:role_annotations) { [] }
+
+      it "has an empty constraints hash" do
+        expect(subject.constraints).to eq({})
+      end
+    end
+
+    context("with annotations that are not Azure-specific") do
+      let(:role_annotations) { [non_azure_annotation] }
+
+      it "has an empty constraints hash" do
+        expect(subject.constraints).to eq({})
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
+
+  include_context "fetch secrets", %w(provider-uri)
+
+  let(:account) { "my-acct" }
+  let(:authenticator_name) { "authn-azure" }
+  let(:service) { "my-service" }
+
+  let(:mocked_verify_and_decode_token) { double("VerifyAndDecodeAzureToken") }
+  let(:mocked_validate_application_identity) { double("ValidateApplicationIdentity") }
+
+  before(:each) do
+    allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
+      JSON.parse(args[0][:token_jwt]).to_hash
+    }
+
+    allow(mocked_validate_application_identity).to receive(:call).and_return(true)
+  end
+
+  ####################################
+  # request mock
+  ####################################
+
+  def mock_authenticate_azure_token_request(request_body_data:)
+    double('AuthnAzureRequest').tap do |request|
+      request_body = StringIO.new
+      request_body.puts request_body_data
+      request_body.rewind
+
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  def request_body(request)
+    request.body.read.chomp
+  end
+
+  let(:authenticate_azure_token_request) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_xms_mirid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"oid\": \"some_oid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_oid_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\"}")
+  end
+
+  let(:authenticate_azure_token_request_missing_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "some_key=some_value")
+  end
+
+  let(:authenticate_azure_token_request_empty_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt=")
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "An Azure authenticator" do
+    context "that receives an authenticate request" do
+      context "with a valid azure token" do
+        context "with a valid application identity" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: authenticator_name,
+              service_id:         service,
+              account:            account,
+              username:           'my-user',
+              credentials:        request_body(authenticate_azure_token_request),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token:       mocked_verify_and_decode_token,
+              validate_application_identity: mocked_validate_application_identity
+            ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "does not raise an error" do
+            expect { subject }.to_not raise_error
+            expect(subject).to eq(true)
+          end
+
+          it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
+        end
+
+        context "with an invalid application identity" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token:       mocked_verify_and_decode_token,
+              validate_application_identity: mocked_validate_application_identity
+            ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it 'raises the error raised by mocked_validate_application_identity' do
+            allow(mocked_validate_application_identity).to receive(:call)
+                                                             .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
+
+            expect { subject }.to raise_error(
+                                    /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+                                  )
+          end
+        end
+      end
+
+      context "with an invalid azure token" do
+        context "that fails token verification" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token:       mocked_verify_and_decode_token,
+              validate_application_identity: mocked_validate_application_identity
+            ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it 'raises the error raised by mocked_verify_and_decode_token' do
+            allow(mocked_verify_and_decode_token).to receive(:call)
+                                                       .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
+
+            expect { subject }.to raise_error(
+                                    /FAKE_VERIFY_AND_DECODE_ERROR/
+                                  )
+          end
+        end
+
+        context "that is missing the xms_mirid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_xms_mirid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_xms_mirid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token:       mocked_verify_and_decode_token,
+              validate_application_identity: mocked_validate_application_identity
+            ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+
+        context "that is missing the oid field" do
+          subject do
+            input_ = Authentication::AuthenticatorInput.new(
+              authenticator_name: 'authn-azure',
+              service_id:         'my-service',
+              account:            'my-acct',
+              username:           nil,
+              credentials:        request_body(authenticate_azure_token_request_missing_oid_field),
+              origin:             '127.0.0.1',
+              request:            authenticate_azure_token_request_missing_oid_field
+            )
+
+            ::Authentication::AuthnAzure::Authenticator.new(
+              verify_and_decode_token:       mocked_verify_and_decode_token,
+              validate_application_identity: mocked_validate_application_identity
+            ).call(
+              authenticator_input: input_
+            )
+          end
+
+          it "raises a TokenFieldNotFoundOrEmpty error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
+          end
+        end
+      end
+
+      context "with no jwt field in the request" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            credentials:        request_body(authenticate_azure_token_request_missing_jwt_field),
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request_missing_jwt_field
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            verify_and_decode_token:       mocked_verify_and_decode_token,
+            validate_application_identity: mocked_validate_application_identity
+          ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+
+      context "with an empty jwt field in the request" do
+        subject do
+          input_ = Authentication::AuthenticatorInput.new(
+            authenticator_name: 'authn-azure',
+            service_id:         'my-service',
+            account:            'my-acct',
+            username:           nil,
+            credentials:        request_body(authenticate_azure_token_request_empty_jwt_field),
+            origin:             '127.0.0.1',
+            request:            authenticate_azure_token_request_empty_jwt_field
+          )
+
+          ::Authentication::AuthnAzure::Authenticator.new(
+            verify_and_decode_token:       mocked_verify_and_decode_token,
+            validate_application_identity: mocked_validate_application_identity
+          ).call(
+            authenticator_input: input_
+          )
+        end
+
+        it "raises a MissingRequestParam error" do
+          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -148,56 +148,6 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
             )
           end
         end
-
-        context "that is missing the xms_mirid field" do
-          subject do
-            input_ = Authentication::AuthenticatorInput.new(
-              authenticator_name: 'authn-azure',
-              service_id:         'my-service',
-              account:            'my-acct',
-              username:           nil,
-              credentials:        request_body(authenticate_azure_token_request_missing_xms_mirid_field),
-              origin:             '127.0.0.1',
-              request:            authenticate_azure_token_request_missing_xms_mirid_field
-            )
-
-            ::Authentication::AuthnAzure::Authenticator.new(
-              verify_and_decode_token:       mocked_verify_and_decode_token,
-              validate_application_identity: mocked_validate_application_identity
-            ).call(
-              authenticator_input: input_
-            )
-          end
-
-          it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
-          end
-        end
-
-        context "that is missing the oid field" do
-          subject do
-            input_ = Authentication::AuthenticatorInput.new(
-              authenticator_name: 'authn-azure',
-              service_id:         'my-service',
-              account:            'my-acct',
-              username:           nil,
-              credentials:        request_body(authenticate_azure_token_request_missing_oid_field),
-              origin:             '127.0.0.1',
-              request:            authenticate_azure_token_request_missing_oid_field
-            )
-
-            ::Authentication::AuthnAzure::Authenticator.new(
-              verify_and_decode_token:       mocked_verify_and_decode_token,
-              validate_application_identity: mocked_validate_application_identity
-            ).call(
-              authenticator_input: input_
-            )
-          end
-
-          it "raises a TokenFieldNotFoundOrEmpty error" do
-            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
-          end
-        end
       end
     end
   end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -51,14 +51,6 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
     mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\"}")
   end
 
-  let(:authenticate_azure_token_request_missing_jwt_field) do
-    mock_authenticate_azure_token_request(request_body_data: "some_key=some_value")
-  end
-
-  let(:authenticate_azure_token_request_empty_jwt_field) do
-    mock_authenticate_azure_token_request(request_body_data: "jwt=")
-  end
-
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
@@ -205,56 +197,6 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
           it "raises a TokenFieldNotFoundOrEmpty error" do
             expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty)
           end
-        end
-      end
-
-      context "with no jwt field in the request" do
-        subject do
-          input_ = Authentication::AuthenticatorInput.new(
-            authenticator_name: 'authn-azure',
-            service_id:         'my-service',
-            account:            'my-acct',
-            username:           nil,
-            credentials:        request_body(authenticate_azure_token_request_missing_jwt_field),
-            origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request_missing_jwt_field
-          )
-
-          ::Authentication::AuthnAzure::Authenticator.new(
-            verify_and_decode_token:       mocked_verify_and_decode_token,
-            validate_application_identity: mocked_validate_application_identity
-          ).call(
-            authenticator_input: input_
-          )
-        end
-
-        it "raises a MissingRequestParam error" do
-          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
-        end
-      end
-
-      context "with an empty jwt field in the request" do
-        subject do
-          input_ = Authentication::AuthenticatorInput.new(
-            authenticator_name: 'authn-azure',
-            service_id:         'my-service',
-            account:            'my-acct',
-            username:           nil,
-            credentials:        request_body(authenticate_azure_token_request_empty_jwt_field),
-            origin:             '127.0.0.1',
-            request:            authenticate_azure_token_request_empty_jwt_field
-          )
-
-          ::Authentication::AuthnAzure::Authenticator.new(
-            verify_and_decode_token:       mocked_verify_and_decode_token,
-            validate_application_identity: mocked_validate_application_identity
-          ).call(
-            authenticator_input: input_
-          )
-        end
-
-        it "raises a MissingRequestParam error" do
-          expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
         end
       end
     end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
                                                              .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
 
             expect { subject }.to raise_error(
-                                    /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                                  )
+              /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+            )
           end
         end
       end
@@ -152,8 +152,8 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
                                                        .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
 
             expect { subject }.to raise_error(
-                                    /FAKE_VERIFY_AND_DECODE_ERROR/
-                                  )
+              /FAKE_VERIFY_AND_DECODE_ERROR/
+            )
           end
         end
 

--- a/spec/app/domain/authentication/authn-azure/decoded_credentials_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/decoded_credentials_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::DecodedCredentials' do
+
+  ####################################
+  # request mock
+  ####################################
+
+  def mock_authenticate_azure_token_request(request_body_data:)
+    double('AuthnAzureRequest').tap do |request|
+      request_body = StringIO.new
+      request_body.puts request_body_data
+      request_body.rewind
+
+      allow(request).to receive(:body).and_return(request_body)
+    end
+  end
+
+  def request_body(request)
+    request.body.read.chomp
+  end
+
+  let(:valid_jwt_field_value) do
+    "{\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
+  end
+
+  let(:authenticate_azure_token_request) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt=#{valid_jwt_field_value}")
+  end
+
+  let(:authenticate_azure_token_request_missing_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "some_key=some_value")
+  end
+
+  let(:authenticate_azure_token_request_empty_jwt_field) do
+    mock_authenticate_azure_token_request(request_body_data: "jwt=")
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+
+  context "Credentials" do
+    context "with a jwt field" do
+      subject(:decoded_credentials) do
+        ::Authentication::AuthnAzure::DecodedCredentials.new(
+          request_body(authenticate_azure_token_request)
+        )
+      end
+
+      it "does not raise an error" do
+        expect { decoded_credentials }.to_not raise_error
+      end
+
+      it "parses the jwt field expectedly" do
+        expect(decoded_credentials.jwt).to eq(valid_jwt_field_value)
+      end
+    end
+
+    context "with no jwt field in the request" do
+      subject do
+        ::Authentication::AuthnAzure::DecodedCredentials.new(
+          request_body(authenticate_azure_token_request_missing_jwt_field)
+        )
+      end
+
+      it "raises a MissingRequestParam error" do
+        expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+      end
+    end
+
+    context "with an empty jwt field in the request" do
+      subject do
+        ::Authentication::AuthnAzure::DecodedCredentials.new(
+          request_body(authenticate_azure_token_request_empty_jwt_field)
+        )
+      end
+
+      it "raises a MissingRequestParam error" do
+        expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/decoded_token_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/decoded_token_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::DecodedToken' do
+
+  def decoded_token_hash(token_str)
+    JSON.parse(token_str).to_hash
+  end
+
+  let(:decoded_token_hash_valid) do
+    decoded_token_hash(
+      "{\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}"
+    )
+  end
+
+  let(:decoded_token_hash_missing_xms_mirid) do
+    decoded_token_hash(
+      "{\"oid\": \"some_oid_value\"}"
+    )
+  end
+
+  let(:decoded_token_hash_missing_oid) do
+    decoded_token_hash(
+      "{\"xms_mirid\": \"some_xms_mirid_value\"}"
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "A decoded token" do
+    context "with required fields" do
+      subject(:decoded_token) do
+        ::Authentication::AuthnAzure::DecodedToken.new(
+          decoded_token_hash: decoded_token_hash_valid,
+          logger:             Rails.logger
+        )
+      end
+
+      it "does not raise an error" do
+        expect { decoded_token }.to_not raise_error
+      end
+
+      it "parses the token expectedly" do
+        expect(decoded_token.xms_mirid).to eq("some_xms_mirid_value")
+        expect(decoded_token.oid).to eq("some_oid_value")
+      end
+    end
+
+    context "that is missing the xms_mirid field" do
+      subject do
+        ::Authentication::AuthnAzure::DecodedToken.new(
+          decoded_token_hash: decoded_token_hash_missing_xms_mirid,
+          logger:             Rails.logger
+        )
+      end
+
+      it "raises a TokenFieldNotFoundOrEmpty error" do
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty
+        )
+      end
+    end
+
+    context "that is missing the oid field" do
+      subject do
+        ::Authentication::AuthnAzure::DecodedToken.new(
+          decoded_token_hash: decoded_token_hash_missing_oid,
+          logger:             Rails.logger
+        )
+      end
+
+      it "raises a TokenFieldNotFoundOrEmpty error" do
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty
+        )
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -93,13 +93,19 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       context "with a user assigned Azure identity in application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               resource_group_annotation,
+                               user_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -118,7 +124,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -137,13 +143,18 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       context "where the subscription id does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([mismatched_subscription_id_annotation, resource_group_annotation])
+                           .and_return(
+                             [
+                               mismatched_subscription_id_annotation,
+                               resource_group_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -153,20 +164,27 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the resource group does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, mismatched_resource_group_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               mismatched_resource_group_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -176,20 +194,28 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the user assigned identity does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, mismatched_user_assigned_identity_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               resource_group_annotation,
+                               mismatched_user_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -199,20 +225,27 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the system assigned identity does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, mismatched_system_assigned_identity_annotation])
+                           .and_return(
+                             [subscription_id_annotation,
+                               resource_group_annotation,
+                               mismatched_system_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -222,7 +255,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
     end
@@ -238,7 +273,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -247,20 +282,29 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::RoleMissingConstraint)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::RoleMissingConstraint
+        )
       end
     end
 
     context "that has invalid constraint combination in annotations" do
       before(:each) do
         allow(host).to receive(:annotations)
-                         .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation, system_assigned_identity_annotation])
+                         .and_return(
+                           [
+                             subscription_id_annotation,
+                             resource_group_annotation,
+                             user_assigned_identity_annotation,
+                             system_assigned_identity_annotation
+                           ]
+                         )
       end
       subject do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -270,23 +314,33 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       end
 
       it "raise an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::IllegalConstraintCombinations
+        )
       end
     end
 
     context "that has invalid Azure annotations" do
       before(:each) do
         allow(host).to receive(:annotations)
-                         .and_return([subscription_id_annotation, resource_group_annotation, system_assigned_identity_annotation])
+                         .and_return(
+                           [
+                             subscription_id_annotation,
+                             resource_group_annotation,
+                             system_assigned_identity_annotation
+                           ]
+                         )
 
         allow(validate_azure_annotations).to receive(:call)
-                                               .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
+                                               .and_raise(
+                                                 'FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR'
+                                               )
       end
       subject do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -297,8 +351,8 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
 
       it "raises an error" do
         expect { subject }.to raise_error(
-                                /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                              )
+          /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+        )
       end
     end
   end
@@ -322,7 +376,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
     end
 
     it "raises an error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::RoleNotFound)
+      expect { subject }.to raise_error(
+        Errors::Authentication::Security::RoleNotFound
+      )
     end
   end
 end

--- a/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
+  include_context "azure setup"
+
+  let(:account) { "account" }
+
+  let(:hostname) { "azureTestVM" }
+  let(:username) { "host/#{hostname}" }
+
+  let(:resource_class) { double("Resource") }
+  let(:host) { double("some-host") }
+
+  let(:non_existent_host_id) { double ("some-non-existent-host-id") }
+  let(:xms_mirid_token_field_user_assigned_identity) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_field_system_assigned_identity) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.Compute/virtualMachines/some-system-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_subscription_id_field) { "/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+  let(:xms_mirid_token_missing_resource_groups_field) { "/subscriptions/some-subscription-id-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_missing_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/" }
+  let(:xms_mirid_token_missing_initial_slash) { "subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+
+  let(:invalid_xms_mirid_token_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+
+  let(:oid_token_field) { "test-oid" }
+
+  let(:mismatched_subscription_id_annotation) { double("MismatchedSubscriptionIdAnnotation") }
+  let(:mismatched_resource_group_annotation) { double("MismatchedResourceGroupAnnotation") }
+  let(:mismatched_system_assigned_identity_annotation) { double("MismatchedSystemAssignedAnnotation") }
+  let(:mismatched_user_assigned_identity_annotation) { double("MismatchedUserAssignedAnnotation") }
+
+  let(:validate_azure_annotations) { double("ValidateAzureAnnotations") }
+
+  before(:each) do
+    allow(host).to receive(:annotations)
+                     .and_return([subscription_id_annotation, resource_group_annotation])
+
+    allow(validate_azure_annotations).to receive(:call)
+                                           .and_return(true)
+
+    allow(resource_class).to receive(:[])
+                               .with("#{account}:host:#{hostname}")
+                               .and_return(host)
+
+    define_host_annotation(
+      host_annotation_type:  system_assigned_identity_annotation,
+      host_annotation_key:   "#{global_annotation_type}/system-assigned-identity",
+      host_annotation_value: oid_token_field
+    )
+    define_host_annotation(
+      host_annotation_type:  mismatched_subscription_id_annotation,
+      host_annotation_key:   "#{global_annotation_type}/subscription-id",
+      host_annotation_value: "mismatched-subscription-id"
+    )
+    define_host_annotation(
+      host_annotation_type:  mismatched_resource_group_annotation,
+      host_annotation_key:   "#{global_annotation_type}/resource-group",
+      host_annotation_value: "mismatched-resource-group"
+    )
+    define_host_annotation(
+      host_annotation_type:  mismatched_user_assigned_identity_annotation,
+      host_annotation_key:   "#{global_annotation_type}/user-assigned-identity",
+      host_annotation_value: "mismatched-user-assigned-identity"
+    )
+    define_host_annotation(
+      host_annotation_type:  mismatched_system_assigned_identity_annotation,
+      host_annotation_key:   "#{global_annotation_type}/system-assigned-identity",
+      host_annotation_value: "mismatched-system-assigned-identity"
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "A valid xms_mirid claim in the Azure token" do
+    context "with a valid application identity" do
+      context "and an Azure token with matching data" do
+        context "with no assigned Azure identity in application identity" do
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "does not raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+
+        context "with a user assigned Azure identity in application identity" do
+          before(:each) do
+            allow(host).to receive(:annotations)
+                             .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation])
+          end
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_user_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "does not raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+
+        context "with a system assigned Azure identity in application identity" do
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "does not raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+
+        context "where the xms mirid claim does not begin with a /" do
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_missing_initial_slash,
+              oid_token_field:       oid_token_field
+            )
+          end
+          it "does not raise an error" do
+            expect { subject }.to_not raise_error
+          end
+        end
+      end
+
+      context "and an Azure token with non-matching data" do
+        context "where the subscription id does not match the application identity" do
+          before(:each) do
+            allow(host).to receive(:annotations)
+                             .and_return([mismatched_subscription_id_annotation, resource_group_annotation])
+          end
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          end
+        end
+
+        context "where the resource group does not match the application identity" do
+          before(:each) do
+            allow(host).to receive(:annotations)
+                             .and_return([subscription_id_annotation, mismatched_resource_group_annotation])
+          end
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          end
+        end
+
+        context "where the user assigned identity does not match the application identity" do
+          before(:each) do
+            allow(host).to receive(:annotations)
+                             .and_return([subscription_id_annotation, resource_group_annotation, mismatched_user_assigned_identity_annotation])
+          end
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          end
+        end
+
+        context "where the system assigned identity does not match the application identity" do
+          before(:each) do
+            allow(host).to receive(:annotations)
+                             .and_return([subscription_id_annotation, resource_group_annotation, mismatched_system_assigned_identity_annotation])
+          end
+          subject do
+            Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+              resource_class:             resource_class,
+              validate_azure_annotations: validate_azure_annotations,
+            ).call(
+              account:               account,
+              service_id:            test_service_id,
+              username:              username,
+              xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+              oid_token_field:       oid_token_field
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          end
+        end
+      end
+
+    end
+
+    context "an invalid application identity" do
+      context "that does not have required constraints present in annotations" do
+        before(:each) do
+          allow(host).to receive(:annotations)
+                           .and_return([])
+        end
+        subject do
+          Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+            resource_class:             resource_class,
+            validate_azure_annotations: validate_azure_annotations,
+          ).call(
+            account:               account,
+            service_id:            test_service_id,
+            username:              username,
+            xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+            oid_token_field:       oid_token_field
+          )
+        end
+        it "raises an error" do
+          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::RoleMissingConstraint)
+        end
+      end
+
+      context "that has invalid constraint combination in annotations" do
+        before(:each) do
+          allow(host).to receive(:annotations)
+                           .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation, system_assigned_identity_annotation])
+        end
+        subject do
+          Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+            resource_class:             resource_class,
+            validate_azure_annotations: validate_azure_annotations,
+          ).call(
+            account:               account,
+            service_id:            test_service_id,
+            username:              username,
+            xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+            oid_token_field:       oid_token_field
+          )
+        end
+
+        it "raise an error" do
+          expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+        end
+      end
+
+      context "that has invalid Azure annotations" do
+        before(:each) do
+          allow(host).to receive(:annotations)
+                           .and_return([subscription_id_annotation, resource_group_annotation, system_assigned_identity_annotation])
+
+          allow(validate_azure_annotations).to receive(:call)
+                                                 .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
+        end
+        subject do
+          Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+            resource_class:             resource_class,
+            validate_azure_annotations: validate_azure_annotations,
+          ).call(
+            account:               account,
+            service_id:            test_service_id,
+            username:              username,
+            xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+            oid_token_field:       oid_token_field
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+                                  /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+                                )
+        end
+      end
+    end
+  end
+
+  context "An invalid xms_mirid claim in the Azure token" do
+    context "that is missing subscriptions field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+          resource_class:             resource_class,
+          validate_azure_annotations: validate_azure_annotations,
+        ).call(
+          account:               account,
+          service_id:            test_service_id,
+          username:              username,
+          xms_mirid_token_field: xms_mirid_token_missing_subscription_id_field,
+          oid_token_field:       oid_token_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing resource groups field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+          resource_class:             resource_class,
+          validate_azure_annotations: validate_azure_annotations,
+        ).call(
+          account:               account,
+          service_id:            test_service_id,
+          username:              username,
+          xms_mirid_token_field: xms_mirid_token_missing_resource_groups_field,
+          oid_token_field:       oid_token_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing providers field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+          resource_class:             resource_class,
+          validate_azure_annotations: validate_azure_annotations,
+        ).call(
+          account:               account,
+          service_id:            test_service_id,
+          username:              username,
+          xms_mirid_token_field: xms_mirid_token_missing_providers_field,
+          oid_token_field:       oid_token_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "without the proper number of fields in the providers claim" do
+      subject do
+        Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+          resource_class:             resource_class,
+          validate_azure_annotations: validate_azure_annotations,
+        ).call(
+          account:               account,
+          service_id:            test_service_id,
+          username:              username,
+          xms_mirid_token_field: invalid_xms_mirid_token_providers_field,
+          oid_token_field:       oid_token_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingProviderFieldsInXmsMirid)
+      end
+    end
+  end
+
+  context "A non-existent Role in Conjur" do
+    before(:each) do
+      allow(resource_class).to receive(:[])
+                                 .and_return(nil)
+    end
+    subject do
+      Authentication::AuthnAzure::ValidateApplicationIdentity.new(
+        resource_class:             resource_class,
+        validate_azure_annotations: validate_azure_annotations,
+      ).call(
+        account:               account,
+        service_id:            test_service_id,
+        username:              username,
+        xms_mirid_token_field: xms_mirid_token_field_system_assigned_identity,
+        oid_token_field:       oid_token_field
+      )
+    end
+
+    it "raises an error" do
+      expect { subject }.to raise_error(Errors::Authentication::Security::RoleNotFound)
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/validate_azure_annotations_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_azure_annotations_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::ValidateAzureAnnotations' do
+  include_context "azure setup"
+
+  let(:invalid_azure_annotation) { double("InvalidAzureAnnotation") }
+  let(:invalid_azure_annotation_service_id_scoped) { double("InvalidAzureAnnotationServiceIdScoped") }
+
+  before(:each) do
+    define_host_annotation(
+      host_annotation_type:  invalid_azure_annotation,
+      host_annotation_key:   "#{global_annotation_type}/non_existing",
+      host_annotation_value: "some-azure-non-existing-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  invalid_azure_annotation_service_id_scoped,
+      host_annotation_key:   "#{granular_annotation_type}/non-existing",
+      host_annotation_value: "some-invalid-existing-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  non_azure_annotation,
+      host_annotation_key:   "authn-test/non_existing",
+      host_annotation_value: "some-non-existing-value"
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "A list of annotations" do
+    context "that contain Azure globally-scoped annotations" do
+      context "that are all permitted" do
+        subject do
+          Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+            role_annotations: [subscription_id_annotation, resource_group_annotation],
+            service_id:       test_service_id
+          )
+        end
+
+        it "does not raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+
+      context "that are not permitted" do
+        subject do
+          Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+            role_annotations: [subscription_id_annotation, invalid_azure_annotation],
+            service_id:       test_service_id
+          )
+        end
+
+        it "raises a ConstraintNotSupported error" do
+          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::ConstraintNotSupported)
+        end
+      end
+    end
+
+    context "that contain Azure service-id scoped annotations" do
+      context "that are all permitted" do
+        subject do
+          Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+            role_annotations: [subscription_id_service_id_scoped_annotation, resource_group_service_id_scoped_annotation],
+            service_id:       test_service_id
+          )
+        end
+
+        it "does not raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+
+      context "that are not permitted" do
+        subject do
+          Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+            role_annotations: [subscription_id_service_id_scoped_annotation, invalid_azure_annotation_service_id_scoped],
+            service_id:       test_service_id
+          )
+        end
+
+        it "raises a ConstraintNotSupported error" do
+          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::ConstraintNotSupported)
+        end
+      end
+    end
+
+    context "that do not contain Azure-specific annotations" do
+      subject do
+        Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+          role_annotations: [non_azure_annotation],
+          service_id:       test_service_id
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "that is empty" do
+      subject do
+        Authentication::AuthnAzure::ValidateAzureAnnotations.new.call(
+          role_annotations: [],
+          service_id:       test_service_id
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Authentication::AuthnAzure::ValidateStatus do
+
+  let(:authenticator_name) { "authn-azure" }
+  let(:account) { "my-acct" }
+  let(:service) { "my-service" }
+
+  include_context "fetch secrets", %w(provider-uri)
+
+  let(:test_azure_discovery_error) { "test-azure-discovery-error" }
+
+  def mock_discover_identity_provider(is_successful:)
+    double('discovery-provider').tap do |discover_provider|
+      if is_successful
+        allow(discover_provider).to receive(:call)
+      else
+        allow(discover_provider).to receive(:call)
+                                      .and_raise(test_azure_discovery_error)
+      end
+    end
+  end
+
+  context "Required variables exist and have values" do
+    context "and Azure provider is responsive" do
+      subject do
+        Authentication::AuthnAzure::ValidateStatus.new(
+          discover_identity_provider: mock_discover_identity_provider(is_successful: true)
+        ).call(
+          account: account,
+          service_id: service
+        )
+      end
+
+      it "validates without errors" do
+        expect { subject }.to_not raise_error
+      end
+
+      it_behaves_like "it fails when variable is missing or has no value", "provider-uri"
+    end
+
+    context "and Azure provider is not responsive" do
+      subject do
+        Authentication::AuthnAzure::ValidateStatus.new(
+          discover_identity_provider: mock_discover_identity_provider(is_successful: false)
+        ).call(
+          account: account,
+          service_id: service
+        )
+      end
+
+      it "raises the error raised by discover_identity_provider" do
+        expect { subject }.to raise_error(test_azure_discovery_error)
+      end
+
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Authentication::AuthnAzure::ValidateStatus do
         Authentication::AuthnAzure::ValidateStatus.new(
           discover_identity_provider: mock_discover_identity_provider(is_successful: true)
         ).call(
-          account: account,
+          account:    account,
           service_id: service
         )
       end
@@ -44,7 +44,7 @@ RSpec.describe Authentication::AuthnAzure::ValidateStatus do
         Authentication::AuthnAzure::ValidateStatus.new(
           discover_identity_provider: mock_discover_identity_provider(is_successful: false)
         ).call(
-          account: account,
+          account:    account,
           service_id: service
         )
       end

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
+RSpec.describe 'Authentication::AuthnAzure::XmsMirid' do
 
   let(:xms_mirid_token_field) {
     "/subscriptions/some-subscription-id-value/resourcegroups/" \

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
+  
+  let(:xms_mirid_token_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.Compute/virtualMachines/some-system-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_subscription_id_field) { "/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_resource_groups_field) { "/subscriptions/some-subscription-id-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/" }
+
+  let(:xms_mirid_token_missing_initial_slash) { "subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+
+  let(:invalid_xms_mirid_token_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "A valid xms_mirid claim in the Azure token" do
+    subject do
+      Authentication::AuthnAzure::XmsMirid.new(
+        xms_mirid_token_field
+      )
+    end
+
+    it "does not raise an error" do
+      expect { subject }.to_not raise_error
+    end
+
+    context "where the xms mirid claim does not begin with a /" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_initial_slash
+        )
+      end
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+
+  context "An invalid xms_mirid claim in the Azure token" do
+    context "that is missing subscriptions field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_subscription_id_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing resource groups field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_resource_groups_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing providers field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_providers_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "without the proper number of fields in the providers claim" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          invalid_xms_mirid_token_providers_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingProviderFieldsInXmsMirid)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -3,18 +3,40 @@
 require 'spec_helper'
 
 RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
-  
-  let(:xms_mirid_token_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.Compute/virtualMachines/some-system-assigned-identity-value" }
 
-  let(:xms_mirid_token_missing_subscription_id_field) { "/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+  let(:xms_mirid_token_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.Compute/" \
+      "virtualMachines/some-system-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_resource_groups_field) { "/subscriptions/some-subscription-id-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_missing_subscription_id_field) {
+    "/resourcegroups/some-resource-group-value/providers/" \
+      "Microsoft.ManagedIdentity/userAssignedIdentities/" \
+      "some-system-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/" }
+  let(:xms_mirid_token_missing_resource_groups_field) {
+    "/subscriptions/some-subscription-id-value/providers/" \
+      "Microsoft.ManagedIdentity/some-user-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_initial_slash) { "subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+  let(:xms_mirid_token_missing_providers_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/"
+  }
 
-  let(:invalid_xms_mirid_token_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_missing_initial_slash) {
+    "subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.ManagedIdentity/" \
+      "userAssignedIdentities/some-system-assigned-identity-value"
+  }
+
+  let(:invalid_xms_mirid_token_providers_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.ManagedIdentity/" \
+      "some-user-assigned-identity-value"
+  }
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
@@ -52,7 +74,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end
@@ -64,7 +88,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end
@@ -76,7 +102,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end

--- a/spec/support/azure_spec_helper.rb
+++ b/spec/support/azure_spec_helper.rb
@@ -1,0 +1,62 @@
+shared_context "azure setup" do
+
+  let(:test_service_id) { "MockService" }
+
+  let(:subscription_id_annotation) { double("SubscriptionIdAnnotation") }
+  let(:resource_group_annotation) { double("ResourceGroupAnnotation") }
+  let(:user_assigned_identity_annotation) { double("UserAssignedIdentityAnnotation") }
+  let(:system_assigned_identity_annotation) { double("SystemAssignedIdentityAnnotation") }
+
+  let(:subscription_id_service_id_scoped_annotation) { double("SubscriptionIdServiceIdAnnotation") }
+  let(:resource_group_service_id_scoped_annotation) { double("ResourceGroupAnnotation") }
+
+  let(:global_annotation_type) { "authn-azure" }
+  let(:granular_annotation_type) { "authn-azure/#{test_service_id}" }
+
+  let(:non_azure_annotation) { double("NonAzureAnnotation") }
+
+  def define_host_annotation(host_annotation_type:, host_annotation_key:, host_annotation_value:)
+    allow(host_annotation_type).to receive(:values)
+                                     .and_return(host_annotation_type)
+    allow(host_annotation_type).to receive(:[])
+                                     .with(:name)
+                                     .and_return(host_annotation_key)
+    allow(host_annotation_type).to receive(:[])
+                                     .with(:value)
+                                     .and_return(host_annotation_value)
+  end
+
+  before(:each) do
+    define_host_annotation(
+      host_annotation_type:  subscription_id_annotation,
+      host_annotation_key:   "#{global_annotation_type}/subscription-id",
+      host_annotation_value: "some-subscription-id-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  resource_group_annotation,
+      host_annotation_key:   "#{global_annotation_type}/resource-group",
+      host_annotation_value: "some-resource-group-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  user_assigned_identity_annotation,
+      host_annotation_key:   "#{global_annotation_type}/user-assigned-identity",
+      host_annotation_value: "some-user-assigned-identity-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  system_assigned_identity_annotation,
+      host_annotation_key:   "#{global_annotation_type}/system-assigned-identity",
+      host_annotation_value: "some-system-assigned-identity-value"
+    )
+
+    define_host_annotation(
+      host_annotation_type:  subscription_id_service_id_scoped_annotation,
+      host_annotation_key:   "#{granular_annotation_type}/subscription-id",
+      host_annotation_value: "some-subscription-id-service-id-scoped-value"
+    )
+    define_host_annotation(
+      host_annotation_type:  resource_group_service_id_scoped_annotation,
+      host_annotation_key:   "#{granular_annotation_type}/resource-group",
+      host_annotation_value: "some-resource-group-service-id-scoped-value"
+    )
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
We would like to let hosts authenticate from Azure VMs using an Azure access token. This PR adds such and authenticator. The authenticator verifies the Azure access token against the Azure Identity Provider, and if the token is valid it also validates the Conjur host has the correct application identity stored in its
annotations, by comparing it to the data stored in the Azure access token.

We also added a Status Check for this authenticator and of course UTs and integration tests.

More integration tests will be added to this PR but other than that it is ready for review.