### PR TITLE
Remove unused file from dev Dockerfile

### DIFF
--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -23,7 +23,6 @@ RUN gem install -N -v 1.16.2 bundler
 
 RUN mkdir -p /src/conjur-server
 
-ADD .irbrc /root
 ADD .pryrc /root
 
 WORKDIR /src/conjur-server


### PR DESCRIPTION
In commit [1aba9d5359871d1fd281454f6aeebc41d76be424](https://github.com/cyberark/conjur/commit/1aba9d5359871d1fd281454f6aeebc41d76be424) we removed the file `.irbrc` as it is not needed anymore but we were still
referring to it in `Dockerfile.dev` so `dev/start` failed to run
(build was still green as we don't run this script in Jenkins).
