### PR TITLE
Add UTs for Jwt::VerifyAndDecodeToken

### DIFF
--- a/spec/app/domain/authentication/jwt/verify_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/jwt/verify_and_decode_token_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Authentication::Jwt::VerifyAndDecodeToken do
+
+  let(:token_jwt) { "decoded_token" }
+  let(:mock_decoded_token) { [token_jwt] }
+  let(:verification_options) { {} }
+
+  def mock_jwt_decoder(error:)
+    double('JWT').tap do |jwt_decoder|
+      if error
+        allow(jwt_decoder).to receive(:decode)
+                                       .and_raise(error)
+      else
+        allow(jwt_decoder).to receive(:decode)
+                                       .and_return(mock_decoded_token)
+      end
+    end
+  end
+
+  context "JWT decoder succeeds to verify and decode the token" do
+    subject do
+      Authentication::Jwt::VerifyAndDecodeToken.new(
+        jwt_decoder: mock_jwt_decoder(error: false)
+      ).call(
+        token_jwt: token_jwt,
+        verification_options: verification_options
+      )
+    end
+
+    it "does not raise an error" do
+      expect { subject }.to_not raise_error
+    end
+
+    it "returns the decoded token" do
+      expect(subject).to eq(token_jwt)
+    end
+  end
+
+  context "JWT decoder fails to decode the token" do
+    subject do
+      Authentication::Jwt::VerifyAndDecodeToken.new(
+        jwt_decoder: mock_jwt_decoder(error: JWT::DecodeError)
+      ).call(
+        token_jwt: token_jwt,
+        verification_options: verification_options
+      )
+    end
+
+    it "raises a TokenDecodeFailed error" do
+      expect { subject }.to raise_error(Errors::Authentication::Jwt::TokenDecodeFailed)
+    end
+
+    context "where the token is expired" do
+      subject do
+        Authentication::Jwt::VerifyAndDecodeToken.new(
+          jwt_decoder: mock_jwt_decoder(error: JWT::ExpiredSignature)
+        ).call(
+          token_jwt: token_jwt,
+          verification_options: verification_options
+        )
+      end
+
+      it "raises a TokenExpired error" do
+        expect { subject }.to raise_error(Errors::Authentication::Jwt::TokenExpired)
+      end
+    end
+
+  end
+
+  context "JWT decoder fails to verify the token" do
+    subject do
+      Authentication::Jwt::VerifyAndDecodeToken.new(
+        jwt_decoder: mock_jwt_decoder(error: StandardError)
+      ).call(
+        token_jwt: token_jwt,
+        verification_options: verification_options
+      )
+    end
+
+    it "raises a TokenVerificationFailed error" do
+      expect { subject }.to raise_error(Errors::Authentication::Jwt::TokenVerificationFailed)
+    end
+  end
+end

--- a/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe Authentication::OAuth::DiscoverIdentityProvider do
 
-  let (:test_provider_uri) { "test-provider-uri" }
-  let (:test_error) { "test-error" }
-  let (:mock_provider) { "test-provider" }
+  let(:test_provider_uri) { "test-provider-uri" }
+  let(:test_error) { "test-error" }
+  let(:mock_provider) { "test-provider" }
 
   def mock_discovery_provider(error:)
     double('discovery_provider').tap do |discovery_provider|
@@ -37,7 +37,7 @@ RSpec.describe Authentication::OAuth::DiscoverIdentityProvider do
   end
 
   context "A non-discoverable identity provider" do
-    context "fails on timeout error" do
+    context "that fails on a timeout error" do
       subject do
         Authentication::OAuth::DiscoverIdentityProvider.new(
           open_id_discovery_service: mock_discovery_provider(error: HTTPClient::ConnectTimeoutError)
@@ -50,7 +50,7 @@ RSpec.describe Authentication::OAuth::DiscoverIdentityProvider do
         expect { subject }.to raise_error(Errors::Authentication::OAuth::ProviderDiscoveryTimeout)
       end
 
-      context "fails on general error" do
+      context "that fails on a general error" do
         subject do
           Authentication::OAuth::DiscoverIdentityProvider.new(
             open_id_discovery_service: mock_discovery_provider(error: test_error)


### PR DESCRIPTION
Add UTs that validate that:
- If the decoder succeeds then it returns the decoded token
  as one object in a list
- That we raise Jwt::TokenDecodeFailed in case the decoding failed
- That we raise Jwt::TokenExpired if the token is expired
- That we raise Jwt::TokenVerificationFailed in case the decoded failed
  to verify the token.

As we don't have a way to simulate an invalid or expired token in an
integration test, this is our way to verify our behaviour.