### PR TITLE
Log Azure constraint name in annotation type

### DIFF
--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -165,6 +165,8 @@ module Authentication
         constraints.map { |constraint| annotation_type_constraint(constraint) }
       end
 
+      # converts the constraint to be in annotation style (e.g resource-group
+      # instead of resource_group) to enhance supportability
       def annotation_type_constraint constraint
         constraint.to_s.tr('_', '-')
       end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -134,7 +134,9 @@ module Authentication
       end
 
       def validate_constraint_exists constraint
-        raise Err::RoleMissingConstraint.new(constraint) unless application_identity.constraints[constraint]
+        unless application_identity.constraints[constraint]
+          raise Err::RoleMissingConstraint, annotation_type_constraint(constraint)
+        end
       end
 
       # validates that the application identity doesn't include logical constraint
@@ -144,7 +146,7 @@ module Authentication
 
         identifiers_constraints = application_identity.constraints.keys & identifiers
         unless identifiers_constraints.length <= 1
-          raise Errors::Authentication::IllegalConstraintCombinations, identifiers_constraints
+          raise Errors::Authentication::IllegalConstraintCombinations, annotation_type_constraints(identifiers_constraints)
         end
       end
 
@@ -153,10 +155,18 @@ module Authentication
           annotation_type  = constraint[0].to_s
           annotation_value = constraint[1]
           unless annotation_value == @token_identity[annotation_type.to_sym]
-            raise Err::InvalidApplicationIdentity.new(annotation_type)
+            raise Err::InvalidApplicationIdentity.new(annotation_type_constraint(annotation_type))
           end
         end
         @logger.debug(Log::ValidatedApplicationIdentity.new)
+      end
+
+      def annotation_type_constraints constraints
+        constraints.map { |constraint| annotation_type_constraint(constraint) }
+      end
+
+      def annotation_type_constraint constraint
+        constraint.to_s.tr('_', '-')
       end
 
       def role

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -29,7 +29,7 @@ module Authentication
 
       # check if annotations with the given prefix is part of the permitted list
       def validate_prefixed_permitted_annotations prefix
-        Rails.logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
+        @logger.debug(LogMessages::Authentication::ValidatingAnnotationsWithPrefix.new(prefix))
 
         prefixed_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]


### PR DESCRIPTION
We would like to log the constraints as an annotation (e.g `resource-group` instead of `resource_group`) so it is clearer to user what they need to fix.