### PR TITLE
Use SHA1 instead of MD5 for hashing for FIPS compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Postgres advisory lock used for rotation
+- Use SHA1 instead of MD5 to generate non-sensitive digests 
 
 ## [1.4.7] - 2020-03-12
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - K8s hosts' application identity is extracted from annotations or id. If it is
-  defined in annotations it will taken from there and if not, it will be taken 
+  defined in annotations it will taken from there and if not, it will be taken
   from the id.
 
 ## [1.4.5] - 2019-12-22

--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -10,4 +10,5 @@ Rails.application.configure do
   config.middleware.use Rack::RememberUuid
   config.audit_socket = '/run/conjur/audit.socket'
   config.audit_database ||= 'postgres://:5433/audit'
+  config.active_support.use_sha1_digests = true
 end


### PR DESCRIPTION
## What does this PR do?
This PR changes Rails to use SHA1 instead of MD5 to generate non-sensitive digests. This change is required for FIPS compliance.

#### Any background context you want to provide?
none
#### What ticket does this PR close?
Connected to cyberark/conjur#1418

#### Where should the reviewer start?
The change is minor: `config/environments/appliance.rb`

#### Has the Version and Changelog been updated?
The Changelog has been updated.

#### Questions:
> Does this work have automated integration and unit tests?
No new tests were added, but the current test suite passes.
