### PR TITLE
Simplify PR template, add checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,8 @@ Connected to #[relevant GitHub issues, eg 76]
 - [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
 
 #### Test coverage
-- [ ] This PR includes new unit and integration tests to go with the code changes
+- [ ] This PR includes new unit and integration tests to go with the code changes, or
+- [ ] The changes in this PR do not require tests
 
 #### Follow-on issues
 - [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,8 @@ Connected to #[relevant GitHub issues, eg 76]
 - [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
 
 #### Test coverage
-- [ ] This PR includes new unit or integration tests to go with the code changes
+- [ ] This PR includes new unit and integration tests to go with the code changes
 
 #### Follow-on issues
-- [ ] Follow-up issue(s) have been logged to update documentation or related projects, or
+- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
 - [ ] No follow-up issues are required

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,20 @@
-#### What does this PR do?
-#### Any background context you want to provide?
-#### What ticket does this PR close?
-Connected to [relevant GitHub issues, eg #76]
-#### Where should the reviewer start?
-#### How should this be manually tested?
-#### Screenshots (if appropriate)
-#### Has the Version and Changelog been updated?
-#### Questions:
-> Does this work have automated integration and unit tests?
+### What does this PR do?
+- _What's changed? Why were these changes made?_
+- _How should the reviewer approach this PR, especially if manual tests are required?_
+- _Are there relevant screenshots you can add to the PR description?_
 
-> Can we make a blog post, video, or animated GIF of this?
+### What ticket does this PR close?
+Connected to #[relevant GitHub issues, eg 76]
 
-> Has this change been documented (Readme, docs, etc.)?
+### Checklists
 
-> Does the knowledge base need an update?
+#### Change log
+- [ ] The CHANGELOG has been updated, or
+- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
+
+#### Test coverage
+- [ ] This PR includes new unit or integration tests to go with the code changes
+
+#### Follow-on issues
+- [ ] Follow-up issue(s) have been logged to update documentation or related projects, or
+- [ ] No follow-up issues are required


### PR DESCRIPTION
Simplify the PR template to reduce the number of sections users are asked to fill out
Add checkboxes for the handful of primary concerns we'd like users to verify when
submitting a PR