### PR TITLE
bump conjur-policy-parser to v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Postgres advisory lock used for rotation
+- Updated conjur-policy-parser to
+  [v3.0.4](https://github.com/conjurinc/conjur-policy-parser/blob/master/CHANGELOG.md#v304).
 
 ## [1.4.7] - 2020-03-12
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'ruby_dep', '= 1.3.1'
  # Pinned to update for role member search, using ref so merging and removing the branch doesn't
  # immediately break this link
 gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'
-gem 'conjur-policy-parser', '>= 3.0.3',
+gem 'conjur-policy-parser', '>= 3.0.4',
   github: 'cyberark/conjur-policy-parser', branch: 'master'
 gem 'conjur-rack', '~> 3.1'
 gem 'conjur-rack-heartbeat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/cyberark/conjur-policy-parser.git
-  revision: 7aa082b27e40c56e252a96b6be4270f5820d2023
+  revision: d30e220260c7925386904dc0dfc5f86164db4488
   branch: master
   specs:
-    conjur-policy-parser (3.0.3)
+    conjur-policy-parser (3.0.4)
       activesupport (>= 4.2)
       safe_yaml
 
@@ -469,7 +469,7 @@ DEPENDENCIES
   conjur-api!
   conjur-cli (~> 6.1)
   conjur-debify
-  conjur-policy-parser (>= 3.0.3)!
+  conjur-policy-parser (>= 3.0.4)!
   conjur-rack (~> 3.1)
   conjur-rack-heartbeat
   csr


### PR DESCRIPTION
#### What does this PR do?
bumps conjur-policy-parser to v3.04 to ensure when a policy is uploaded with duplicate members on a resource it fails
#### What ticket does this PR close?
#1262 and #1263 
#### Where should the reviewer start?
Gemfile, GemfileLock, CHANGELOG
#### How should this be manually tested?
You can test by uploading the policies within the tickets and ensure an error is thrown. In addition, tests were added within conjur-policy-parser to ensure these scenarios fail. Make sure not to use the project's cli
#### Screenshot
Error given when using the policy found in #1263 
![Screen Shot 2020-03-20 at 2 18 45 PM](https://user-images.githubusercontent.com/39734739/77194215-eb729000-6ab5-11ea-8ce1-6dd0af8d5c6f.png)
#### Has the Version and Changelog been updated?
Changelog has been