### PR TITLE
Fixes support for deployment k8s authen for k8s 1.16 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Postgres advisory lock used for rotation
 - Updated conjur-policy-parser to
   [v3.0.4](https://github.com/conjurinc/conjur-policy-parser/blob/master/CHANGELOG.md#v304).
+- Fix support for using deployment as K8s authentication resource type for Kubernetes >= 1.16 (#1440)
 
 ## [1.4.7] - 2020-03-12
 

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -152,13 +152,36 @@ module Authentication
       def k8s_clients
         @clients ||= [
           kubectl_client,
-          KubeClientFactory.client(api: 'apis/apps', version: 'v1beta2', host_url: api_url, options: options),
-          KubeClientFactory.client(api: 'apis/apps', version: 'v1beta1', host_url: api_url, options: options),
-          KubeClientFactory.client(api: 'apis/extensions', version: 'v1beta1', host_url: api_url, options: options),
+          KubeClientFactory.client(
+            api: 'apis/apps', version: 'v1', host_url: api_url,
+            options: options
+          ),
+          KubeClientFactory.client(
+            api: 'apis/apps', version: 'v1beta2', host_url: api_url,
+            options: options
+          ),
+          KubeClientFactory.client(
+            api: 'apis/apps', version: 'v1beta1', host_url: api_url,
+            options: options
+          ),
+          KubeClientFactory.client(
+            api: 'apis/extensions', version: 'v1', host_url: api_url,
+            options: options
+          ),
+          KubeClientFactory.client(
+            api: 'apis/extensions', version: 'v1beta1', host_url: api_url,
+            options: options
+          ),
           # OpenShift 3.3 DeploymentConfig
-          KubeClientFactory.client(api: 'oapi', version: 'v1', host_url: api_url, options: options),
+          KubeClientFactory.client(
+            api: 'oapi', version: 'v1', host_url: api_url,
+            options: options
+          ),
           # OpenShift 3.7 DeploymentConfig
-          KubeClientFactory.client(api: 'apis/apps.openshift.io', version: 'v1', host_url: api_url, options: options)
+          KubeClientFactory.client(
+            api: 'apis/apps.openshift.io', version: 'v1', host_url: api_url,
+            options: options
+          )
         ]
       end
 


### PR DESCRIPTION
#### What does this PR do?
This change fixes support for using a deployment name as a Kubernetes
authenticator ID for Kubernetes server version 1.16 or newer.

This support had been broken for Kubernetes versions 1.16 or newer
because the server support for deployments (and some other Kubernetes
resources) using the deprecated api/v1beta1 endpoints was removed as
of Kubernetes 1.16, and the Kubernetes client that we use in the
Conjur Kubernetes authenticator was not updated.

The authenticator client had support for:
- Group: api (core), Version: v1

But was missing support for:
- Group: apis/apps, Version: v1
- Group: apis/extensions, Version: v1

The fix is to add explicit support for the missing apps/extensions
endpoints.

This change also adds some sorely needed debug level messages to
help with triage/troubleshooting of this client.

Fixes Issue #1440

#### Any background context you want to provide?
#### What ticket does this PR close?
Fixes Issue #1440

#### Where should the reviewer start?
#### How should this be manually tested?
#### Screenshots (if appropriate)
#### Has the Version and Changelog been updated?
CHANGELOG.md was updated.

#### Questions:
> Does this work have automated integration and unit tests?

> Can we make a blog post, video, or animated GIF of this?

> Has this change been documented (Readme, docs, etc.)?

> Does the knowledge base need an update?
