### PR TITLE
Split xms_mirid logic into its own class

### DIFF
--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -5,9 +5,10 @@ module Authentication
 
     class ApplicationIdentity
 
-      def initialize(role_annotations:, service_id:)
+      def initialize(role_annotations:, service_id:, logger:)
         @role_annotations = role_annotations
         @service_id       = service_id
+        @logger           = logger
       end
 
       def constraints
@@ -32,7 +33,7 @@ module Authentication
 
         # return the value of the annotation if it exists, nil otherwise
         if annotation
-          Rails.logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
+          @logger.debug(LogMessages::Authentication::RetrievedAnnotationValue.new(name))
           annotation[:value]
         end
       end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -124,7 +124,8 @@ module Authentication
       def application_identity
         @application_identity ||= @application_identity_class.new(
           role_annotations: role.annotations,
-          service_id:       @service_id
+          service_id:       @service_id,
+          logger:           @logger
         )
       end
 

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -9,9 +9,9 @@ module Authentication
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+        discover_identity_provider:  Authentication::OAuth::DiscoverIdentityProvider.new
       },
-      inputs: %i(account service_id)
+      inputs:       %i(account service_id)
     ) do
 
       def call

--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -1,0 +1,64 @@
+module Authentication
+  module AuthnAzure
+
+    Err = Errors::Authentication::AuthnAzure
+
+    class XmsMirid
+
+      REQUIRED_KEYS = %w(subscriptions resourcegroups providers)
+
+      def initialize(xms_mirid_token_field)
+        @xms_mirid_token_field = xms_mirid_token_field
+
+        @mirid_parts_hash = mirid_parts_hash
+        validate
+      end
+
+      def subscriptions
+        @mirid_parts_hash["subscriptions"].first
+      end
+
+      def resource_groups
+        @mirid_parts_hash["resourcegroups"].first
+      end
+
+      def providers
+        @mirid_parts_hash["providers"]
+      end
+
+      private
+
+      # we expect the xms_mirid claim to be in the format of /subscriptions/<subscription-id>/...
+      # therefore, we ignore the first slash of the xms_mirid claim and group the entries in key-value pairs
+      # according to fields we need to retrieve from the claim.
+      # ultimately, transforming "/key1/value1/key2/value2" to {"key1" => "value1", "key2" => "value2"}
+      def mirid_parts_hash
+        raw_mirid_parts = @xms_mirid_token_field.split('/')
+
+        # accept also an xms_mirid field that doesn't start with a slash
+        mirid_parts = raw_mirid_parts.first == '' ?
+                        raw_mirid_parts.drop(1) :
+                        raw_mirid_parts
+
+        # transform ["subscriptions", "a", "resourcegroups", "b", "providers", "c", "d", "e"]
+        # to {"subscriptions"=>["a"], "resourcegroups"=>["b"], "providers"=>["c", "d", "e"]}
+        mirid_parts.slice_before(Regexp.new(REQUIRED_KEYS.join('|')))
+          .map{|x| [x.first, x.drop(1)] }.to_h
+      rescue => e
+        # this should never occur, it's here to enhance supportability in case it does
+        raise Err::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+      end
+
+      def validate
+        missing_keys = REQUIRED_KEYS - @mirid_parts_hash.keys
+        unless missing_keys.empty?
+          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+        end
+
+        unless @mirid_parts_hash["providers"].length == 3
+          raise Err::MissingProviderFieldsInXmsMirid, @xms_mirid_token_field
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
     subject do
       Authentication::AuthnAzure::ApplicationIdentity.new(
         role_annotations: role_annotations,
-        service_id:       test_service_id
+        service_id:       test_service_id,
+        logger:           Rails.logger
       )
     end
     context("with a global scoped constraint") do

--- a/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/application_identity_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
 
       it "has a constraints hash with its value" do
         expect(subject.constraints).to eq(
-                                         {
-                                           subscription_id:          "some-subscription-id-value",
-                                           resource_group:           "some-resource-group-value",
-                                           user_assigned_identity:   "some-user-assigned-identity-value",
-                                           system_assigned_identity: "some-system-assigned-identity-value"
-                                         }
-                                       )
+          {
+            subscription_id:          "some-subscription-id-value",
+            resource_group:           "some-resource-group-value",
+            user_assigned_identity:   "some-user-assigned-identity-value",
+            system_assigned_identity: "some-system-assigned-identity-value"
+          }
+        )
       end
     end
 
@@ -54,13 +54,13 @@ RSpec.describe Authentication::AuthnAzure::ApplicationIdentity do
 
       it "has a constraints hash with its value" do
         expect(subject.constraints).to eq(
-                                         {
-                                           subscription_id:          "some-subscription-id-service-id-scoped-value",
-                                           resource_group:           "some-resource-group-service-id-scoped-value",
-                                           user_assigned_identity:   "some-user-assigned-service-id-scoped-value",
-                                           system_assigned_identity: "some-system-assigned-service-id-scoped-value"
-                                         }
-                                       )
+          {
+            subscription_id:          "some-subscription-id-service-id-scoped-value",
+            resource_group:           "some-resource-group-service-id-scoped-value",
+            user_assigned_identity:   "some-user-assigned-service-id-scoped-value",
+            system_assigned_identity: "some-system-assigned-service-id-scoped-value"
+          }
+        )
       end
     end
 

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
                                                              .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
 
             expect { subject }.to raise_error(
-                                    /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                                  )
+              /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+            )
           end
         end
       end
@@ -152,8 +152,8 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
                                                        .and_raise('FAKE_VERIFY_AND_DECODE_ERROR')
 
             expect { subject }.to raise_error(
-                                    /FAKE_VERIFY_AND_DECODE_ERROR/
-                                  )
+              /FAKE_VERIFY_AND_DECODE_ERROR/
+            )
           end
         end
 

--- a/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_application_identity_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -93,13 +93,19 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       context "with a user assigned Azure identity in application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               resource_group_annotation,
+                               user_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -118,7 +124,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -137,13 +143,18 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       context "where the subscription id does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([mismatched_subscription_id_annotation, resource_group_annotation])
+                           .and_return(
+                             [
+                               mismatched_subscription_id_annotation,
+                               resource_group_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -153,20 +164,27 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the resource group does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, mismatched_resource_group_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               mismatched_resource_group_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -176,20 +194,28 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the user assigned identity does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, mismatched_user_assigned_identity_annotation])
+                           .and_return(
+                             [
+                               subscription_id_annotation,
+                               resource_group_annotation,
+                               mismatched_user_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -199,20 +225,27 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
 
       context "where the system assigned identity does not match the application identity" do
         before(:each) do
           allow(host).to receive(:annotations)
-                           .and_return([subscription_id_annotation, resource_group_annotation, mismatched_system_assigned_identity_annotation])
+                           .and_return(
+                             [subscription_id_annotation,
+                               resource_group_annotation,
+                               mismatched_system_assigned_identity_annotation
+                             ]
+                           )
         end
         subject do
           Authentication::AuthnAzure::ValidateApplicationIdentity.new(
             resource_class:             resource_class,
             validate_azure_annotations: validate_azure_annotations,
-            ).call(
+          ).call(
             account:               account,
             service_id:            test_service_id,
             username:              username,
@@ -222,7 +255,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity)
+          expect { subject }.to raise_error(
+            ::Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
+          )
         end
       end
     end
@@ -238,7 +273,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -247,20 +282,29 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::RoleMissingConstraint)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::RoleMissingConstraint
+        )
       end
     end
 
     context "that has invalid constraint combination in annotations" do
       before(:each) do
         allow(host).to receive(:annotations)
-                         .and_return([subscription_id_annotation, resource_group_annotation, user_assigned_identity_annotation, system_assigned_identity_annotation])
+                         .and_return(
+                           [
+                             subscription_id_annotation,
+                             resource_group_annotation,
+                             user_assigned_identity_annotation,
+                             system_assigned_identity_annotation
+                           ]
+                         )
       end
       subject do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -270,23 +314,33 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
       end
 
       it "raise an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::IllegalConstraintCombinations)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::IllegalConstraintCombinations
+        )
       end
     end
 
     context "that has invalid Azure annotations" do
       before(:each) do
         allow(host).to receive(:annotations)
-                         .and_return([subscription_id_annotation, resource_group_annotation, system_assigned_identity_annotation])
+                         .and_return(
+                           [
+                             subscription_id_annotation,
+                             resource_group_annotation,
+                             system_assigned_identity_annotation
+                           ]
+                         )
 
         allow(validate_azure_annotations).to receive(:call)
-                                               .and_raise('FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR')
+                                               .and_raise(
+                                                 'FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR'
+                                               )
       end
       subject do
         Authentication::AuthnAzure::ValidateApplicationIdentity.new(
           resource_class:             resource_class,
           validate_azure_annotations: validate_azure_annotations,
-          ).call(
+        ).call(
           account:               account,
           service_id:            test_service_id,
           username:              username,
@@ -297,8 +351,8 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
 
       it "raises an error" do
         expect { subject }.to raise_error(
-                                /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
-                              )
+          /FAKE_VALIDATE_APPLICATION_IDENTITY_ERROR/
+        )
       end
     end
   end
@@ -322,7 +376,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
     end
 
     it "raises an error" do
-      expect { subject }.to raise_error(Errors::Authentication::Security::RoleNotFound)
+      expect { subject }.to raise_error(
+        Errors::Authentication::Security::RoleNotFound
+      )
     end
   end
 end

--- a/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Authentication::AuthnAzure::ValidateStatus do
         Authentication::AuthnAzure::ValidateStatus.new(
           discover_identity_provider: mock_discover_identity_provider(is_successful: true)
         ).call(
-          account: account,
+          account:    account,
           service_id: service
         )
       end
@@ -44,7 +44,7 @@ RSpec.describe Authentication::AuthnAzure::ValidateStatus do
         Authentication::AuthnAzure::ValidateStatus.new(
           discover_identity_provider: mock_discover_identity_provider(is_successful: false)
         ).call(
-          account: account,
+          account:    account,
           service_id: service
         )
       end

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
+  
+  let(:xms_mirid_token_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.Compute/virtualMachines/some-system-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_subscription_id_field) { "/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_resource_groups_field) { "/subscriptions/some-subscription-id-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+
+  let(:xms_mirid_token_missing_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/" }
+
+  let(:xms_mirid_token_missing_initial_slash) { "subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+
+  let(:invalid_xms_mirid_token_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "A valid xms_mirid claim in the Azure token" do
+    subject do
+      Authentication::AuthnAzure::XmsMirid.new(
+        xms_mirid_token_field
+      )
+    end
+
+    it "does not raise an error" do
+      expect { subject }.to_not raise_error
+    end
+
+    context "where the xms mirid claim does not begin with a /" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_initial_slash
+        )
+      end
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+
+  context "An invalid xms_mirid claim in the Azure token" do
+    context "that is missing subscriptions field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_subscription_id_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing resource groups field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_resource_groups_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "that is missing providers field in xms_mirid" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          xms_mirid_token_missing_providers_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+      end
+
+    end
+
+    context "without the proper number of fields in the providers claim" do
+      subject do
+        Authentication::AuthnAzure::XmsMirid.new(
+          invalid_xms_mirid_token_providers_field
+        )
+      end
+      it "raises an error" do
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingProviderFieldsInXmsMirid)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -3,18 +3,40 @@
 require 'spec_helper'
 
 RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
-  
-  let(:xms_mirid_token_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.Compute/virtualMachines/some-system-assigned-identity-value" }
 
-  let(:xms_mirid_token_missing_subscription_id_field) { "/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+  let(:xms_mirid_token_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.Compute/" \
+      "virtualMachines/some-system-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_resource_groups_field) { "/subscriptions/some-subscription-id-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_missing_subscription_id_field) {
+    "/resourcegroups/some-resource-group-value/providers/" \
+      "Microsoft.ManagedIdentity/userAssignedIdentities/" \
+      "some-system-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/" }
+  let(:xms_mirid_token_missing_resource_groups_field) {
+    "/subscriptions/some-subscription-id-value/providers/" \
+      "Microsoft.ManagedIdentity/some-user-assigned-identity-value"
+  }
 
-  let(:xms_mirid_token_missing_initial_slash) { "subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/userAssignedIdentities/some-system-assigned-identity-value" }
+  let(:xms_mirid_token_missing_providers_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/"
+  }
 
-  let(:invalid_xms_mirid_token_providers_field) { "/subscriptions/some-subscription-id-value/resourcegroups/some-resource-group-value/providers/Microsoft.ManagedIdentity/some-user-assigned-identity-value" }
+  let(:xms_mirid_token_missing_initial_slash) {
+    "subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.ManagedIdentity/" \
+      "userAssignedIdentities/some-system-assigned-identity-value"
+  }
+
+  let(:invalid_xms_mirid_token_providers_field) {
+    "/subscriptions/some-subscription-id-value/resourcegroups/" \
+      "some-resource-group-value/providers/Microsoft.ManagedIdentity/" \
+      "some-user-assigned-identity-value"
+  }
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
@@ -52,7 +74,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end
@@ -64,7 +88,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end
@@ -76,7 +102,9 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateApplicationIdentity' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid)
+        expect { subject }.to raise_error(
+          ::Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid
+        )
       end
 
     end


### PR DESCRIPTION
### What does this PR do?

This PR has 2 commits. The larger one splits `xms_mirid` logic into its own class

We have too much xms_mirid logic for parsing and validations to have it
inside the general ValidateApplicationIdentity class. Moving this logic
into its own class makes it easier to read the code and test it.

The smaller commit passes the `Rails.logger` into `ApplicationIdentity` so it is easier to understand that it is a dependency and to mock it in case we want to.