### PR TITLE
Add log after fetching Identity Provider Keys

### DIFF
--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -46,6 +46,7 @@ module Authentication
 
         @jwks = provider_keys.jwks
         @algs = provider_keys.algorithms
+        @logger.debug(Log::IdentityProviderKeysFetchedFromCache.new)
       end
 
       # ensure_keys_are_fresh will try to verify and decode the token and if it

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -47,8 +47,13 @@ unless defined? LogMessages::Authentication::OriginValidated
         )
 
         FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
-          msg:  "Fetched Identity Provider keys successfully",
+          msg:  "Fetched Identity Provider keys from provider successfully",
           code: "CONJ00009D"
+        )
+
+        IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
+          msg:  "Fetched Identity Provider keys from cache successfully",
+          code: "CONJ00017D"
         )
 
         ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(


### PR DESCRIPTION
This log message was removed because I thought it is duplicated.
It actually isn't and tells us that the keys were retrieved from
the cache. The other message (`CONJ00009D`) will be written only
if we don't have the keys in the cache and we need to get them
from the provider.

Note that if we get the keys from the provider, both messages
will be written to the log.