### PR TITLE
Specify and Default to Ruby 2.5 in Gemfile and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update -y && \
                        tzdata \
                        # needed to build some gem native extensions:
                        libz-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/ruby2.5 /usr/bin/ruby \
+    && ln -sf /usr/bin/gem2.5 /usr/bin/gem
 
 RUN gem install -N -v 1.17.3 bundler
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # make sure to use tls for github
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 
-#ruby=ruby-2.5.1
+ruby '~> 2.5.1'
 #ruby-gemset=conjur
 
 gem 'command_class'


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates the Gemfile to specify that Conjur expects Ruby 2.5. This provides a more explicit error when attempting to use a different version of Ruby.

The PR also updates the Dockerfile to update the `ruby` and `gem` symlinks to explicitly point to Ruby 2.5. This is because the Ubuntu 20.04 base images defaults to Ruby 2.7 now, with no clear, better way to change the default.

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
