### PR TITLE
Rollback to Ubuntu 18.04 Base Image for Conjur

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,12 @@
 # vulnerable version of Rake in their development dependencies, but do not pose 
 # a risk to Conjur.
 CVE-2020-8130
+
+
+# These vulnerabilites are present in the Ubuntu 18.04 base image and are being
+# analyzed to determined their impact on the Conjur container image.
+# Follow up issue: https://github.com/cyberark/conjur/issues/1461
+CVE-2019-10220
+CVE-2019-19813
+CVE-2019-19814
+CVE-2019-19816

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Use Ubuntu 18.04 LTS as the base image for Conjur to continue using Ruby 2.5
+  ([cyberark/conjur#1456](https://github.com/cyberark/conjur/issues/1456)).
+
 ## [1.5.1] - 2020-03-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use Ubuntu 18.04 LTS as the base image for Conjur to continue using Ruby 2.5
   ([cyberark/conjur#1456](https://github.com/cyberark/conjur/issues/1456)).
+- Conjur image now performs a `dist-upgrade` as the first image build step to
+  ensure the image includes all available vulnerability fixes in the base OS.
 
 ## [1.5.1] - 2020-03-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 EXPOSE 80
 
 RUN apt-get update -y && \
+    apt-get -y dist-upgrade && \
     apt-get install -y build-essential \
                        curl \
                        git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \
@@ -19,9 +19,7 @@ RUN apt-get update -y && \
                        tzdata \
                        # needed to build some gem native extensions:
                        libz-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -sf /usr/bin/ruby2.5 /usr/bin/ruby \
-    && ln -sf /usr/bin/gem2.5 /usr/bin/gem
+    && rm -rf /var/lib/apt/lists/*
 
 RUN gem install -N -v 1.17.3 bundler
 

--- a/lib/test/audit_sink.rb
+++ b/lib/test/audit_sink.rb
@@ -2,13 +2,12 @@
 
 module Test
   class AuditSink
-    SOCKET_PATH="audit.sock"
-
     def initialize
       delete_socket
 
       begin
-        @socket = UNIXServer.new SOCKET_PATH
+        STDERR.puts "Creating socket: #{socket_path}"
+        @socket = UNIXServer.new socket_path
       ensure
         at_exit { delete_socket }
       end
@@ -19,7 +18,7 @@ module Test
 
     def delete_socket
       @socket.close if @socket
-      File.delete(SOCKET_PATH) if File.exist?(SOCKET_PATH)
+      File.delete(socket_path) if File.exist?(socket_path)
     end
 
     def listen backlog = 1
@@ -34,6 +33,10 @@ module Test
 
     def address
       socket.addr[1]
+    end
+
+    def socket_path
+      @socket_path ||= "audit_test_#{Process.pid}_#{Thread.current.object_id}.sock"
     end
 
     attr_reader :socket, :messages


### PR DESCRIPTION
### What does this PR do?
This PR switches `cyberark/conjur` to use Ubuntu 18.04 as the base image, rather than 20.04. This is because 20.04 now ships with Ruby 2.7 and does not include packages for Ruby 2.5.

The PR also includes a fix for audit socket race collisions in the parallel CI test suites.

### What ticket does this PR close?
Connected to #1456

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [X ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [ ] No follow-up issues are required

* https://github.com/cyberark/conjur/issues/1461