### PR TITLE
Conjur is tested with Azure system assigned identities

### DIFF
--- a/ci/authn-azure/check_dependencies.sh
+++ b/ci/authn-azure/check_dependencies.sh
@@ -23,7 +23,7 @@ check_env_var "USER_ASSIGNED_IDENTITY_CLIENT_ID"
 
 # These variables should come from Jenkins
 check_env_var "AZURE_AUTHN_INSTANCE_IP"
-#check_env_var "SYSTEM_ASSIGNED_IDENTITY" # TODO: add this once available
+check_env_var "SYSTEM_ASSIGNED_IDENTITY"
 
 echo "Required environment variables for authn-azure tests exist"
 

--- a/ci/authn-azure/get_system_assigned_identity.sh
+++ b/ci/authn-azure/get_system_assigned_identity.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+### Retrieves a System Assigned Identity access token from Azure metadata service and
+### returns the System Assigned Identity Object ID
+
+main() {
+  azure_access_token="$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true | jq -r '.access_token')"
+
+  decoded_token_payload=$(decode_jwt_payload "$azure_access_token")
+
+  object_id="$(echo "$decoded_token_payload" | jq -r '.oid')"
+
+  echo "$object_id"
+}
+
+# Decodes the payload of a given JWT
+decode_jwt_payload(){
+  decode_jwt_part "$1" 2
+}
+
+# Decodes a JWT and returns either the header or the payload
+# $1 - the encoded JWT
+# $2 - the required part: 1 for header, 2 for payload, 3 for signature
+decode_jwt_part(){
+  jwt_part_to_decode="$(get_jwt_part "$1" "$2")"
+
+  decoded_jwt_part="$(decode_base64 "$jwt_part_to_decode")"
+
+  echo "$decoded_jwt_part"
+}
+
+# Splits a given JWT and returns the required part
+# $1 - the encoded JWT
+# $2 - the required part: 1 for header, 2 for payload, 3 for signature
+get_jwt_part(){
+  echo -n $1 | cut -d "." -f $2
+}
+
+# Decodes a given data that is base64 encoded
+decode_base64() {
+  local len=$((${#1} % 4))
+  local result="$1"
+  if [ $len -eq 2 ]; then result="$1"'=='
+  elif [ $len -eq 3 ]; then result="$1"'='
+  fi
+  echo "$result" | tr '_-' '/+' | openssl enc -d -base64
+}
+
+main

--- a/ci/authn-azure/secrets.yml
+++ b/ci/authn-azure/secrets.yml
@@ -1,3 +1,8 @@
+# Variables listed in this file are required in order to run the authn-azure tests.
+#
+# NOTE: we also need the variables AZURE_AUTHN_INSTANCE_IP & SYSTEM_ASSIGNED_IDENTITY
+#       but they will come from the Jenkins stage that allocates the Azure VM
+
 AZURE_TENANT_ID: !var ci/azure/tenant-id
 AZURE_SUBSCRIPTION_ID: !var ci/azure/subscription-id
 AZURE_RESOURCE_GROUP: !var ci/azure/authn-test/resource-group
@@ -5,5 +10,3 @@ USER_ASSIGNED_IDENTITY: !var ci/azure/authn-test/user-assigned-id
 USER_ASSIGNED_IDENTITY_CLIENT_ID: !var ci/azure/authn-test/user-assigned-id-client-id
 AZURE_AUTHN_INSTANCE_USERNAME: !var ci/azure/authn-test/instance-user
 AZURE_AUTHN_INSTANCE_PASSWORD: !var ci/azure/authn-test/instance-password
-
-# TODO: add system-assigned identity

--- a/ci/test
+++ b/ci/test
@@ -204,9 +204,7 @@ _get_azure_env_args() {
   azure_env_args="$azure_env_args -e AZURE_AUTHN_INSTANCE_PASSWORD=$AZURE_AUTHN_INSTANCE_PASSWORD"
   azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY=$USER_ASSIGNED_IDENTITY"
   azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY_CLIENT_ID=$USER_ASSIGNED_IDENTITY_CLIENT_ID"
-
-# TODO: add this once available
-#  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
+  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
   echo "${azure_env_args}"
 }
 

--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -24,7 +24,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
     Then it is unauthorized
@@ -57,7 +57,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
     Then it is unauthorized
@@ -82,8 +82,8 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
-    And I successfully set Azure variables with the correct values
-    And I fetch an Azure access token from inside machine
+    And I successfully set Azure provider-uri variable with the correct values
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
     Then it is unauthorized
@@ -114,8 +114,8 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
-    And I successfully set Azure variables with the correct values
-    And I fetch an Azure access token from inside machine
+    And I successfully set Azure provider-uri variable with the correct values
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
     Then it is forbidden
@@ -147,7 +147,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
     Then it is bad gateway

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -25,7 +25,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
         resource: !webservice
     """
     And I am the super-user
-    And I successfully set Azure variables with the correct values
+    And I successfully set Azure provider-uri variable with the correct values
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
@@ -34,7 +34,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     Given I have a "variable" resource called "test-variable"
     And I permit host "test-app" to "execute" it
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate via Azure with token as host "test-app"
     Then host "test-app" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
@@ -43,19 +43,19 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     Given I have a "variable" resource called "test-variable"
     And I permit host "test-app" to "execute" it
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     When I successfully set Azure provider-uri variable without trailing slash
     And I authenticate via Azure with token as host "test-app"
     Then host "test-app" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
 
   Scenario: Changing provider-uri dynamically reflects on the ID Provider endpoint
-    Given I fetch an Azure access token from inside machine
+    Given I fetch a non-assigned-identity Azure access token from inside machine
     And I authenticate via Azure with token as host "test-app"
     And host "test-app" has been authorized by Conjur
     # Update provider uri to a different hostname and verify `provider-uri` has changed
     When I add the secret value "https://different-provider:8443" to the resource "cucumber:variable:conjur/authn-azure/prod/provider-uri"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     And I authenticate via Azure with token as host "test-app"
     Then it is bad gateway
@@ -64,8 +64,8 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     CONJ00007D Working with Identity Provider https://different-provider:8443
     """
     # Check recovery to a valid provider uri
-    When I successfully set Azure variables with the correct values
-    And I fetch an Azure access token from inside machine
+    When I successfully set Azure provider-uri variable with the correct values
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I authenticate via Azure with token as host "test-app"
     And host "test-app" has been authorized by Conjur
 

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -22,7 +22,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
         resource: !webservice
     """
     And I am the super-user
-    And I successfully set Azure variables with the correct values
+    And I successfully set Azure provider-uri variable with the correct values
 
   Scenario: Host with user-assigned-identity annotation is authorized
     And I have host "user-assigned-identity-app"
@@ -30,7 +30,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I set resource-group annotation to host "user-assigned-identity-app"
     And I set user-assigned-identity annotation to host "user-assigned-identity-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "user-assigned-identity-app"
-    And I fetch a user-assigned Azure access token from inside machine
+    And I fetch a user-assigned-identity Azure access token from inside machine
     When I authenticate via Azure with token as host "user-assigned-identity-app"
     Then host "user-assigned-identity-app" has been authorized by Conjur
 
@@ -38,7 +38,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I have host "no-resource-group-app"
     And I set subscription-id annotation to host "no-resource-group-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-resource-group-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "no-resource-group-app"
     Then it is unauthorized
@@ -51,7 +51,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I have host "no-subscription-id-app"
     And I set resource-group annotation to host "no-subscription-id-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-subscription-id-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "no-subscription-id-app"
     Then it is unauthorized
@@ -63,7 +63,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
   Scenario: Host without any Azure annotation is denied
     And I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "no-azure-annotations-app"
     Then it is unauthorized
@@ -79,7 +79,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I set resource-group annotation to host "incorrect-subscription-id-app"
     And I set subscription-id annotation with incorrect value to host "incorrect-subscription-id-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-subscription-id-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "incorrect-subscription-id-app"
     Then it is unauthorized
@@ -93,7 +93,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I set subscription-id annotation to host "incorrect-resource-group-app"
     And I set resource-group annotation with incorrect value to host "incorrect-resource-group-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-resource-group-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "incorrect-resource-group-app"
     Then it is unauthorized
@@ -102,13 +102,13 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::AuthnAzure::InvalidApplicationIdentity
     """
 
-  Scenario: Host with incorrect user-assigned-identity annotation is authorized
+  Scenario: Host with incorrect user-assigned-identity annotation is denied
     And I have host "incorrect-user-assigned-identity-app"
     And I set subscription-id annotation to host "incorrect-user-assigned-identity-app"
     And I set resource-group annotation to host "incorrect-user-assigned-identity-app"
     And I set user-assigned-identity annotation with incorrect value to host "incorrect-user-assigned-identity-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "incorrect-user-assigned-identity-app"
-    And I fetch a user-assigned Azure access token from inside machine
+    And I fetch a user-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "incorrect-user-assigned-identity-app"
     Then it is unauthorized
@@ -118,7 +118,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     """
 
   Scenario: Non-existing host is denied
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "non-existing-app"
     Then it is unauthorized
@@ -130,7 +130,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
   Scenario: Host that is not in the permitted group is denied
     And I have host "non-permitted-app"
     And I set Azure annotations to host "non-permitted-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "non-permitted-app"
     Then it is forbidden

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -24,24 +24,24 @@ Feature: Azure Authenticator - Performance tests
         resource: !webservice
     """
     And I am the super-user
-    And I successfully set Azure variables with the correct values
+    And I successfully set Azure provider-uri variable with the correct values
     And I have host "test-app"
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
 
   Scenario: successful requests
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
     Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
 
   Scenario: Unsuccessful requests with an invalid token
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"
     Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
 
   Scenario: Unsuccessful requests with invalid application identity
     Given I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
-    And I fetch an Azure access token from inside machine
+    And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "no-azure-annotations-app"
     Then The "avg" Azure Authentication request response time should be less than "0.75" seconds

--- a/cucumber/authenticators_azure/features/authn_status_azure.feature
+++ b/cucumber/authenticators_azure/features/authn_status_azure.feature
@@ -44,7 +44,7 @@ Feature: Azure Authenticator - Status Check
       member: !user alice
     """
     And I am the super-user
-    And I successfully set Azure variables with the correct values
+    And I successfully set Azure provider-uri variable with the correct values
     And I login as "alice"
     When I GET "/authn-azure/prod/cucumber/status"
     Then the HTTP response status code is 200

--- a/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
+++ b/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
@@ -75,7 +75,7 @@ Given(/^I set Azure annotations to host "([^"]*)"$/) do |hostname|
   set_annotation_to_resource("authn-azure/resource-group", azure_resource_group)
 end
 
-Given(/^I set (subscription-id|resource-group|user-assigned-identity) annotation (with incorrect value )?to host "([^"]*)"$/) do |annotation_name, incorrect_value, hostname|
+Given(/^I set (subscription-id|resource-group|user-assigned-identity|system-assigned-identity) annotation (with incorrect value )?to host "([^"]*)"$/) do |annotation_name, incorrect_value, hostname|
   i_have_a_resource "host", hostname
 
   case annotation_name
@@ -85,6 +85,8 @@ Given(/^I set (subscription-id|resource-group|user-assigned-identity) annotation
     annotation_correct_value = azure_resource_group
   when "user-assigned-identity"
     annotation_correct_value = user_assigned_identity
+  when "system-assigned-identity"
+    annotation_correct_value = system_assigned_identity
   else
     raise "incorrect annotation name #{annotation_name}"
   end

--- a/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
+++ b/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
@@ -1,4 +1,4 @@
-Given(/^I successfully set Azure variables with the correct values$/) do
+Given(/^I successfully set Azure provider-uri variable with the correct values$/) do
   create_and_set_azure_provider_uri_variable
 end
 
@@ -10,12 +10,13 @@ Given(/^I successfully set Azure provider-uri variable without trailing slash$/)
   create_and_set_azure_provider_uri_variable(azure_provider_uri.chop)
 end
 
-Given(/I fetch an Azure access token from inside machine/) do
-  retrieve_system_assigned_azure_access_token
-end
-
-Given(/I fetch a user-assigned Azure access token from inside machine/) do
-  retrieve_user_assigned_azure_access_token
+Given(/I fetch a (non|system|user)-assigned-identity Azure access token from inside machine/) do |identity_type|
+  case identity_type
+  when "non", "system"
+    retrieve_system_assigned_azure_access_token
+  when "user"
+    retrieve_user_assigned_azure_access_token
+  end
 end
 
 Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |empty |invalid )?token as (user|host) "([^"]*)"/) do |num_requests, num_threads, token_state, role_type, username|

--- a/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
+++ b/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
@@ -73,10 +73,9 @@ module AuthnAzureHelper
     @azure_resource_group ||= validated_env_var('AZURE_RESOURCE_GROUP')
   end
 
-  # TODO: add this once available
-  # def system_assigned_identity
-  #   @system_assigned_identity ||= validated_env_var('SYSTEM_ASSIGNED_IDENTITY')
-  # end
+  def system_assigned_identity
+    @system_assigned_identity ||= validated_env_var('SYSTEM_ASSIGNED_IDENTITY')
+  end
 
   def user_assigned_identity
     @user_assigned_identity ||= validated_env_var('USER_ASSIGNED_IDENTITY')

--- a/dev/cli
+++ b/dev/cli
@@ -62,9 +62,7 @@ function enable_azure() {
   azure_env_args="$azure_env_args -e AZURE_RESOURCE_GROUP=$AZURE_RESOURCE_GROUP"
   azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY=$USER_ASSIGNED_IDENTITY"
   azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY_CLIENT_ID=$USER_ASSIGNED_IDENTITY_CLIENT_ID"
-
- # TODO: add this once available
-#  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
+  azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
 
   env_args="$env_args $azure_env_args"
 }


### PR DESCRIPTION
Connected to #1434 

We would like to test scenarios where the host that authenticates
with authn-azure has a system-assigned-identity annotation.

The scenarios include:
  - host with correct value succeeds
  - host with incorrect value fails
  - host with both system-assigned-identity and -assigned-identity annotations fails