### PR TITLE
Fix message for invalid providers field in xms_mirid

### DIFF
--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -58,7 +58,7 @@ module Authentication
         end
 
         unless @mirid_parts_hash["providers"].length == 3
-          raise Err::MissingProviderFieldsInXmsMirid, @xms_mirid_token_field
+          raise Err::InvalidProviderFieldsInXmsMirid, @xms_mirid_token_field
         end
       end
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -307,8 +307,10 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
           code: "CONJ00053E"
         )
 
-        MissingProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
-          msg:  "Provider fields are missing in xms_mirid {1}",
+        InvalidProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+          msg:  "Provider fields are in invalid format in xms_mirid {1}." \
+                "xms_mirid must contain the resource provider namespace, the " \
+                "resource type, and the resource name",
           code: "CONJ00054E"
         )
       end

--- a/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/xms_mirid_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Authentication::AuthnAzure::XmsMirid' do
         )
       end
       it "raises an error" do
-        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::MissingProviderFieldsInXmsMirid)
+        expect { subject }.to raise_error(::Errors::Authentication::AuthnAzure::InvalidProviderFieldsInXmsMirid)
       end
     end
   end


### PR DESCRIPTION
After we check that the length of the xms_mirid's `providers`
field equals 3 we raise the error `MissingProviderFieldsInXmsMirid`.
The field is not missing as if it were we would raise `MissingRequiredFieldsInXmsMirid`
instead.