### PR TITLE
Remove cyberark/conjur-aws from landing page

### DIFF
--- a/docs/_data/repositories/core.yml
+++ b/docs/_data/repositories/core.yml
@@ -13,9 +13,6 @@ section:
       - name: cyberark/conjur-oss-helm-chart
         url: https://github.com/cyberark/conjur-oss-helm-chart
         description: Helm chart for deploying the Conjur server.
-      - name: cyberark/conjur-aws
-        url: https://github.com/cyberark/conjur-aws
-        description: AWS CloudFormation templates for deploying the Conjur server.
   - name: Conjur SDK
     description: Conjur Command Line Interface (CLI) and Client Libraries.
     repos:


### PR DESCRIPTION
At current, `cyberark/conjur-aws` is broken and needs more work to get
to a good state. We are reviewing whether AMIs are actually the recommended
path for deploying Conjur OSS to AWS, so it's possible we will not restore this
repo to its prior state. For now, we should remove it from the landing page.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
