### PR TITLE
Add rake task, which gets next available error code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,6 +323,19 @@ root@9feae5e5e001:/src/conjur-server# cucumber --profile authenticators    # run
 root@9feae5e5e001:/src/conjur-server# cucumber --profile api cucumber/api/features/resource_list.feature
 ```
 
+### Rake Tasks
+
+Rake tasks are easy to run from within the `conjur` server container:
+
+- Get the next available error code from [errors](./app/domain/errors.rb)
+  ```sh-session
+  root@aa8bc35ba7f4:/src/conjur-server# rake error_code:next
+  ```
+    The output will be similar to
+  ```sh-session
+  The next available error number is 63 ( CONJ00063E )
+  ```
+
 ## Pull Request Workflow
 
 1. [Fork the project](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)

--- a/lib/tasks/next_available_error.rake
+++ b/lib/tasks/next_available_error.rake
@@ -1,0 +1,8 @@
+require 'util/error_code'
+
+namespace :error_code do
+  task :next do
+    error_code = Error::ConjurCode.new('./app/domain/errors.rb')
+    error_code.print_next_available
+  end
+end

--- a/lib/util/error_code.rb
+++ b/lib/util/error_code.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Error
+  # helps get information regarding current error codes.
+  class ConjurCode
+    def initialize(path)
+      @path = path
+      validate
+    end
+
+    def print_next_available
+      id = next_code_id
+      unless id
+        $stderr.puts "The path doesn't contain any files with Conjur error codes"
+        return
+      end
+      puts format("The next available error number is %d ( CONJ%05dE )", id, id)
+    end
+
+    # separate data-gathering from printing
+    def next_code_id
+      max_code = existing_codes.max
+      max_code ? max_code + 1 : nil
+    end
+
+    def existing_codes
+      codes = File.foreach(@path).map do |line|
+        match = /code: \"CONJ(?<num>[0-9]+)E\"/.match(line)
+        match ? match[:num].to_i : nil
+      end
+      codes.compact
+    end
+
+    def validate
+      return if File.file?(@path)
+      raise format("The following path:%s was not found", @path)
+    end
+  end
+end

--- a/spec/app/domain/util/errors/empty
+++ b/spec/app/domain/util/errors/empty
@@ -1,0 +1,1 @@
+There are no error codes in here!!

--- a/spec/app/domain/util/errors/valid
+++ b/spec/app/domain/util/errors/valid
@@ -1,0 +1,24 @@
+
+# frozen_string_literal: true
+
+require 'util/trackable_error_class'
+
+module Errors
+  module Conjur
+
+    RequiredResourceMissing = Util::TrackableErrorClass.new(
+      msg:  "Missing required resource: {0-resource-name}",
+      code: "CONJ00001E"
+    )
+
+    RequiredSecretMissing = Util::TrackableErrorClass.new(
+      msg:  "Missing value for resource: {0-resource-name}",
+      code: "CONJ00002E"
+    )
+
+    RequiredSecretMissing = Util::TrackableErrorClass.new(
+      msg:  "Missing value for resource: {0-resource-name}",
+      code: "CONJ00004E"
+    )
+  end
+end

--- a/spec/app/domain/util/trackable_error_spec.rb
+++ b/spec/app/domain/util/trackable_error_spec.rb
@@ -21,3 +21,35 @@ RSpec.describe 'Util::TrackableErrorClass' do
     end
   end
 end
+
+require 'util/error_code'
+
+describe Error::ConjurCode do
+  let(:error_code_valid) do
+    Error::ConjurCode.new('./spec/app/domain/util/errors/valid')
+  end
+  let(:error_code_invalid) { Error::ConjurCode.new('invalid_file_path') }
+  let(:error_code_empty) do
+   Error::ConjurCode.new('./spec/app/domain/util/errors/empty')
+  end
+  
+  it 'raises error when file path is invalid' do
+    expect { error_code_invalid }.to raise_error(RuntimeError)
+  end
+
+  it 'outputs the next available error code' do 
+    expect do
+      error_code_valid.print_next_available
+    end.to output(
+      "The next available error number is 5 ( CONJ00005E )\n"
+    ).to_stdout
+  end
+
+  it 'outputs that the file lacks error codes' do 
+    expect do
+      error_code_empty.print_next_available
+    end.to output(
+      "The path doesn't contain any files with Conjur error codes\n"
+    ).to_stderr
+  end
+end


### PR DESCRIPTION
### What does this PR do?
makes it easier to get next available error number available for use

### What ticket does this PR close?
N/A

### How to test?
1. ./build.sh
2. cd dev
3. ./start
4. rake error_code:next and it should print out the number 58

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [X] No follow-up issues are required
