### PR TITLE
Increase Simplecov Reliability

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,7 @@
 SimpleCov.start 'rails' do
   command_name "SimpleCov #{rand(1000000)}"
   coverage_dir File.join(ENV['REPORT_ROOT'] || __dir__, 'coverage')
-  merge_timeout 1800 # Set largest gap between resultsets of 30 minutes
+  merge_timeout 7200 # Set largest gap between resultsets of 30 minutes
   # any custom configs like groups and filters can be here at a central place
 end
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,24 +126,11 @@ pipeline {
           steps { sh 'ci/test rspec_audit'}
         }
       }
-      post {
-        always {
-          junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/api/features/reports/**/*.xml,cucumber/policy/features/reports/**/*.xml,cucumber/authenticators/features/reports/**/*.xml'
-          cucumber fileIncludePattern: '**/cucumber_results.json', sortingMethod: 'ALPHABETICAL'
-        }
-      }
     }
 
     stage('Submit Coverage Report'){
       steps{
-        script {
-          try {
-            sh 'ci/submit-coverage'
-          } finally {
-            archiveArtifacts artifacts: "coverage/.resultset*.json", fingerprint: false
-            publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
-          }
-        }
+        sh 'ci/submit-coverage'
       }
     }
 
@@ -177,6 +164,12 @@ pipeline {
       }
     }
     always {
+      archiveArtifacts artifacts: "container_logs/*/*", fingerprint: false, allowEmptyArchive: true
+      archiveArtifacts artifacts: "coverage/.resultset*.json", fingerprint: false, allowEmptyArchive: true
+      archiveArtifacts artifacts: "ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json", fingerprint: false, allowEmptyArchive: true
+      publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
+      junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/api/features/reports/**/*.xml,cucumber/policy/features/reports/**/*.xml,cucumber/authenticators/features/reports/**/*.xml'
+      cucumber fileIncludePattern: '**/cucumber_results.json', sortingMethod: 'ALPHABETICAL'
       cleanupAndNotify(currentBuild.currentResult, '#conjur-core', '', true)
     }
   }

--- a/ci/test
+++ b/ci/test
@@ -187,6 +187,7 @@ _build_conjur() (
 # NOTE: See linked to issue at top of file.  This code in particular is can be
 #   simplified, and we need to figure out if we want it to run by default.
 docker_diagnostics() {
+  local testSet="${1}"
   # Read the running containers names into an array.
   #
   # Note on bash trickiness: The backslash is required in \$NF because we want
@@ -199,21 +200,21 @@ docker_diagnostics() {
   readarray -t cont_names < <(docker ps --all | \
     awk "/${COMPOSE_PROJECT_NAME}/{print \$NF}")
 
-  # Print docker inspect info
+  # Store container logs for archiving
+  echo "Writing Container logs to container_logs/<testset>/container[-inspect].log"
+  container_log_dir="$(git rev-parse --show-toplevel)/container_logs/${testSet}"
+  mkdir -p "${container_log_dir}"
   for name in "${cont_names[@]}"; do
-    echo "CONTAINER: ${name}"
-    docker inspect "$name"
-  done
-
-  # Print container logs
-  for name in "${cont_names[@]}"; do
-    echo "CONTAINER: ${name}"
-    docker logs "$name"
+    docker inspect "$name" > "${container_log_dir}/${name}-inspect.log"
+    docker logs "$name" > "${container_log_dir}/${name}.log"
   done
 }
 
 _finish() {
-  docker_diagnostics
+  local testSet="${1}"
+  docker_diagnostics "${testSet}"
+  # Give SimpleCov time to generate reports.
+  sleep 15
   docker-compose down --rmi 'local' --volumes || true
 }
 
@@ -264,15 +265,16 @@ _wait_for_keycloak() {
 }
 
 _main() {
-  local testdir="$1"; shift
-  
+  local testdir="${1}"; shift
+  local testSet="${1}"
+
   # If there are no arguments, show help
   if [[ "${#@}" -eq 0 || "$1" == 'help' ]]; then
     help
     exit 1
   fi
-
-  [[ -z "$KEEP_CONTAINERS" ]] && trap _finish EXIT
+  # shellcheck disable=SC2064
+  [[ -z "$KEEP_CONTAINERS" ]] && trap "_finish ${testSet}" EXIT
 
   export TAG=$(_build_conjur "$testdir")
   cd "${testdir}"
@@ -352,7 +354,7 @@ _run_cucumber() {
   docker-compose run --no-deps $notty --rm $cucumber_env_args \
      -e CONJUR_AUTHN_API_KEY=$api_key \
      -e CUCUMBER_NETWORK=$(_find_cucumber_network) \
-     cucumber -ec "$@" || { echo "Tests failed, Printing Conjur logs"; docker-compose logs conjur; exit 1; }
+     cucumber -ec "$@"
 }
 
 _run_cucumber_tests() {
@@ -378,8 +380,6 @@ _run_cucumber_tests() {
   # kill the process to write the report. The container is kept alive
   # using an infinite sleep in the at_exit hook (see .simplecov).
   docker-compose exec -T conjur bash -c "pkill -f 'puma 3'"
-
-  [[ -z "$KEEP_CONTAINERS" ]] && docker-compose down --rmi 'local' --volumes
 }
 
 _run_cucumber_shell() {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'simplecov'
 SimpleCov.command_name "SimpleCov #{rand(1000000)}"
-SimpleCov.merge_timeout 1800
+SimpleCov.merge_timeout 7200
 SimpleCov.start
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'


### PR DESCRIPTION
### What does this PR do?
Adds delay between puma being killed (which triggers simplecov to write
it's report) and docker-compose down being executed. Previously this was
a race and sometimes the report would be written in time, othertimes an
empty file was left.

Also:
  * Increases simplecov mergetimeout again, theres no downside to
    increasing this and will prevent issues if there are more than 30
    minutes between test branches completing.

  * Writes container logs to files for local viewing or archiving in
    Jenkins. https://github.com/cyberark/conjur/commit/13270ef056c8d95973460d03eff5b241fb81ddae Added functionality to
    print container outputs to the console, this extends that to
    separate logs files. 

  * Move archiveArtifacts steps to post/always so they aren't skipped
    if earlier stages fail.


### What ticket does this PR close?

Related: conjurinc/ops#575

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
