### PR TITLE
Revert "Change Rails log_level to error to prevent huge log files"

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :error
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :debug
   config.log_formatter = ConjurFormatter.new
 
   # Raises error for missing translations


### PR DESCRIPTION
This reverts commit 9f49a4c2 as we do not print the development log
anymore.

Blocked by conjurinc/appliance#1179
Connected to conjurinc/appliance#1177