### PR TITLE
Fix Conjur Debian Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 
 id_rsa*
 
+# Ignore generated debify script
+docker-debify
+
 # Ignore all logfiles and tempfiles.
 /log
 engines/conjur_audit/spec/dummy/log

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -2,8 +2,10 @@
 FROM @@image@@
 
 RUN apt-get update -y && \
-    apt-get purge -y ruby2.2 ruby2.2-dev && \
-    apt-get install -y ruby2.5 ruby2.5-dev
+    apt-get install -y ruby2.5 \
+                       ruby2.5-dev \
+                       zlib1g-dev \
+                       liblzma-dev
 
 ENV BUNDLER_VERSION 2.1.4
 RUN gem install --no-rdoc --no-ri bundler:$BUNDLER_VERSION fpm

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -17,7 +17,10 @@ WORKDIR /src/opt/conjur/project
 COPY Gemfile ./
 COPY Gemfile.lock ./
 
-RUN bundle --deployment
+
+RUN bundle config --local deployment true && \
+    bundle config --local path vendor/bundle && \
+    bundle
 RUN mkdir -p .bundle
 RUN cp /usr/local/bundle/config .bundle/config
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,6 +1,14 @@
+<% require 'securerandom' %>
+
 development:
   secret_key_base: "boop"
 test:
   secret_key_base: "boop"
 production:
-  secret_key_base: "secret_key_base is intentionally not set for this application"
+  # Conjur doesn't use HTTP cookies or Rails key generation,
+  # so we set secret_key_base to a random value on application startup. 
+  secret_key_base: <%= SecureRandom.hex(64) %>
+appliance:
+  # Conjur doesn't use HTTP cookies or Rails key generation,
+  # so we set secret_key_base to a random value on application startup.
+  secret_key_base: <%= SecureRandom.hex(64) %>

--- a/debify.sh
+++ b/debify.sh
@@ -14,4 +14,3 @@ mkdir -p opt/conjur/etc
 cp opt/conjur/possum/distrib/conjur/etc/* opt/conjur/etc/
 
 mkdir -p opt/conjur/possum/config
-ln -sf /opt/conjur/shared/config/database.yml opt/conjur/possum/config/database.yml

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -ex
-debify package \
+export DEBIFY_IMAGE='registry.tld/conjurinc/debify:1.11'
+
+docker run --rm $DEBIFY_IMAGE config script > docker-debify
+chmod +x docker-debify
+
+./docker-debify package \
   --dockerfile=Dockerfile.fpm \
   possum \
   -- \


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR fixes the debian package pipeline step that was silently broken after updating to Bundler 2
with the Rails 5 update.

- _How should the reviewer approach this PR, especially if manual tests are required?_

The commits may be reviewed independently. The package step can now also be easily run on
a local developer workstation with:

```
$ ./package.sh
```

- _Are there relevant screenshots you can add to the PR description?_

N/A

### What ticket does this PR close?
Connected to #1487

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
