### PR TITLE
Fix status page title regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Title of status page is now `Conjur Status` again, rather than only
+  `Conjur` ([conjurinc/dap-support](https://github.com/conjurinc/dap-support/issues/75)).
+
 ## [1.6.0] - 2020-04-14
 
 ### Changed

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width">
 
     <link rel="stylesheet" href="/css/status-page.css">
-    <title>Conjur</title>
+    <title>Conjur Status</title>
   </head>
   <body>
 

--- a/spec/views/status_spec.rb
+++ b/spec/views/status_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe "status/index" do
+  # The title text, 'Conjur Status', is a well-known
+  # string that Conjur health probes are configured to
+  # inspect the response for.
+  it "includes the text 'Conjur Status'" do
+    render
+
+    expect(rendered).to include 'Conjur Status'
+  end
+end


### PR DESCRIPTION
When we re-wrote the status page, the title was inadvertantly changed from
`Conjur Status` to just `Conjur`. This caused a failure in health checks that
verified response content using the page title.

### What does this PR do?
- _What's changed? Why were these changes made?_

This PR corrects the status page regression.

### What ticket does this PR close?
Connected to https://github.com/conjurinc/dap-support/issues/75

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
