### PR TITLE
Add ruby-debug-ide gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,8 +108,8 @@ group :development, :test do
   gem 'spring'
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'
-  gem 'table_print'
   gem 'ruby-debug-ide'
+  gem 'table_print'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -105,10 +105,10 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-core', '~> 3.0'
   gem 'rspec-rails'
+  gem 'ruby-debug-ide'
   gem 'spring'
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'
-  gem 'ruby-debug-ide'
   gem 'table_print'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :development, :test do
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'
   gem 'table_print'
+  gem 'ruby-debug-ide'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-checkstyle_formatter (0.4.0)
       rubocop (>= 0.35.1)
+    ruby-debug-ide (0.7.2)
+      rake (>= 0.8.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.3.1)
     safe_yaml (1.0.5)
@@ -499,6 +501,7 @@ DEPENDENCIES
   rspec-rails
   rubocop (~> 0.58.0)
   rubocop-checkstyle_formatter
+  ruby-debug-ide
   ruby_dep (= 1.3.1)
   sequel (= 4.49.0)
   sequel-pg_advisory_locking


### PR DESCRIPTION
### What does this PR do?
It adds a `ruby-debug-ide` gem  to be able to remote debug using RubyMine IDE

### What ticket does this PR close?
It fixes the issue #1331 

### How to test it?
Perform remote debugging using the following [guide](https://github.com/cyberark/conjur/blob/master/CONTRIBUTING.md#rubymine-ide-debugging) 


