### PR TITLE
Add default content type for Policy load API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Title of status page is now `Conjur Status` again, rather than only
   `Conjur` ([conjurinc/dap-support](https://github.com/conjurinc/dap-support/issues/75)).
+- Policy load API endpoints now default to the `application/x-yaml` content-type
+  if no content type is provided in the request
+  ([conjurinc/dap-support#74](https://github.com/conjurinc/dap-support/issues/74)).
 
 ### Changed
 - Change ActiveSupport to use sha1 instead of md5

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,6 +60,12 @@ class ApplicationController < ActionController::API
 
   around_action :run_with_transaction
 
+  # sets the default content type header on incoming requests that match the
+  # path_match regex
+  def self.set_default_content_type_for_path(path_match, content_type)
+    ::Rack::DefaultContentType.content_type_by_path[path_match] = content_type
+  end
+
   private
 
   # Wrap the request in a transaction.

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -9,6 +9,10 @@ class PoliciesController < RestController
 
   rescue_from Sequel::UniqueConstraintViolation, with: :concurrent_load
 
+  # Conjur policies are YAML documents, so we assume that if no content-type
+  # is provided in the request.
+  set_default_content_type_for_path(%r{^\/policies}, 'application/x-yaml')
+
   def put
     authorize :update
 

--- a/config/initializers/default_content_type.rb
+++ b/config/initializers/default_content_type.rb
@@ -1,0 +1,5 @@
+require 'rack/default_content_type'
+
+Rails.application.configure do
+  config.middleware.use ::Rack::DefaultContentType
+end

--- a/cucumber/api/features/policy_load.feature
+++ b/cucumber/api/features/policy_load.feature
@@ -78,3 +78,15 @@ Feature: Updating policies
     """
     Then the HTTP response status code is 403
 
+  Scenario: A policy with special characters and no content type header
+    When I set the "Content-Type" header to ""
+    And I POST "/policies/cucumber/policy/dev/db" with body:
+    """
+    - !variable
+      id: simple/basic/variable
+    - !variable
+      id: simple/space filled/variable
+    - !variable
+      id: simple/special @#$%^&*(){}[].,+/variable
+    """
+    Then the HTTP response status code is 201

--- a/lib/rack/default_content_type.rb
+++ b/lib/rack/default_content_type.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module Rack
+
+  # DefaultContentType is a Rack middleware that supports
+  # providing a default Content-Type header for requests
+  # to specific paths that do not include a Content-Type
+  # header in the request.
+  #
+  # Default content types are configured by adding entries
+  # to the Rack::DefaultContentType.default_content_types
+  # class member hash.
+  #
+  # Each hash key must be a regular expression to test
+  # request paths for a match. The hash value is the content
+  # type string to add to the request.
+  #
+  class DefaultContentType
+
+    # A Hash-like whose keys are Regex objects. It looks up values by matching
+    # keys given to its #[] method against those regexes, and returning the
+    # value of the first match.
+    class RegexHash
+      extend Forwardable
+
+      # Note: this will work with a Hash or keyword args
+      def initialize(**kwargs)
+        @vals_by_regex = kwargs
+      end
+
+      def [](key)
+        matching_re = @vals_by_regex.each_key.find { |re, _| re =~ key }
+        @vals_by_regex[matching_re] # Note: returns nil if no match
+      end
+
+      def_delegators :@vals_by_regex, :[]=
+    end
+
+    def self.content_type_by_path
+      @content_type_by_path ||= RegexHash.new
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    # :reek:DuplicateMethodCall
+    def call(env)
+      # If a content type is already present on the request, we
+      # don't need to do anything
+      if content_type_missing?(env) && default_content_type(env)
+        env['CONTENT_TYPE'] = default_content_type(env)
+        Rack::Request.new(env).body.rewind
+      end
+
+      @app.call(env)
+    end
+
+    # :reek:UtilityFunction
+    # :reek:NilCheck
+    def content_type_missing?(env)
+      env['CONTENT_TYPE']&.empty?
+    end
+
+    # :reek:UtilityFunction
+    def default_content_type(env)
+      Rack::DefaultContentType.content_type_by_path[env['PATH_INFO']]
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

If no content-type is specified in a POST request, Rack assumes the content
type is either `application/x-www-form-urlencoded` or
`multipart/form-data`.

The Conjur policy documents are YAML content, and some special
characters allowed in policy cause the Rack pody parsing to fail, leading to
a Rack error: `Invalid or incomplete POST parameters`.

This PR adds a Rack middleware that allow default content-types to be
configured on a per request path basis to better control the behavior when
no content-type is provided in the request headers.

### What ticket does this PR close?
Connected to conjurinc/dap-support#74

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
