### PR TITLE
add roles when using conjurctl policy load

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -311,6 +311,7 @@ detectors:
     exclude:
     - initialize
     - RootLoader#load
+    - RootLoader#policy_version
     - PossumWorld#authn_local_request
     - PossumWorld#create_user
     - PossumWorld#denormalize

--- a/lib/root_loader.rb
+++ b/lib/root_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 # BootstrapLoader is used to load an initial "root" policy when the database is completely empty.
 class RootLoader
   class << self
@@ -17,25 +19,60 @@ class RootLoader
         admin = ::Role[admin_id] || ::Role.create(role_id: admin_id)
         if admin_password = ENV['CONJUR_ADMIN_PASSWORD']
           $stderr.puts "Setting 'admin' password"
-          admin_credentials = Credentials[role: admin] || Credentials.create(role: admin)
-          admin_credentials.password = admin_password
-          admin_credentials.save
+          set_admin_password(admin, admin_password)
         end
 
         root_policy_resource = Loader::Types.find_or_create_root_policy(account)
+        policy_ver = policy_version(
+          role: admin, 
+          policy: root_policy_resource, 
+          filename: filename
+        )
 
-        policy_version = PolicyVersion.new role: admin, policy: root_policy_resource, policy_text: File.read(filename)
-        policy_version.policy_filename = filename
-        policy_version.perform_automatic_deletion = true
-        policy_version.delete_permitted = true
-        policy_version.update_permitted = true
-        policy_version.save
+        acc_roles = accepted_roles(policy_ver)
+        created_roles = create_roles(acc_roles)
 
-        loader = Loader::Orchestrate.new policy_version
-        loader.load
+        $stderr.puts(
+          JSON.pretty_generate(
+            created_roles: created_roles,
+            version: policy_ver.version
+          )
+        )
+
+        end_t = Time.now
+        $stderr.puts "Loaded policy in #{end_t - start_t} seconds"
       end
-      end_t = Time.now
-      $stderr.puts "Loaded policy in #{end_t - start_t} seconds"
+    end
+
+    def set_admin_password(admin_role, password)
+      admin_credentials = Credentials[role: admin_role] || Credentials.create(role: admin_role)
+      admin_credentials.password = password
+      admin_credentials.save
+    end
+
+    def create_roles accepted_roles
+      accepted_roles.each_with_object({}) do |role, memo|
+        credentials = Credentials[role: role] || Credentials.create(role: role)
+        role_id = role.id
+        memo[role_id] = { id: role_id, api_key: credentials.api_key }
+      end
+    end
+
+    def accepted_roles policy_version
+      loader = Loader::Orchestrate.new policy_version
+      loader.load
+      loader.new_roles.select do |role|
+        %w(user host).member?(role.kind)
+      end
+    end
+
+    def policy_version role:, policy:, filename:
+      policy_version = PolicyVersion.new role: role, policy: policy, policy_text: File.read(filename)
+      policy_version.policy_filename = filename
+      policy_version.perform_automatic_deletion = true
+      policy_version.delete_permitted = true
+      policy_version.update_permitted = true
+      policy_version.save
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?
When using conjurctl to load a policy, it failed to create role credentials. This PR allows the creation of roles. 

### What ticket does this PR close?
[dap-support/#80](https://github.com/conjurinc/dap-support/issues/80)

### How to test?
Check the ticket and run it locally with the appropriate image. It is expected to successfully run and output the created roles.

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

Note: I am not sure that this should be a supported feature in the future.

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [X] No follow-up issues are required
