### PR TITLE
Test that authenticators write audit message

### DIFF
--- a/cucumber/api/features/step_definitions/logs_steps.rb
+++ b/cucumber/api/features/step_definitions/logs_steps.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-Given(/^I save my place in the log file$/) do
+# we actually don't do anything with the `_is_audit` param as audit messages
+# are written to the Rails log. We have this param for readability of the
+# cucumber steps
+
+Given(/^I save my place in the (audit )?log file$/) do |_is_audit|
   save_num_log_lines
 end
 
-And(/^The following appears in the log after my savepoint:$/) do |message|
+And(/^The following appears in the (audit )?log after my savepoint:$/) do |_is_audit, message|
   expect(num_matches_since_savepoint(message)).to be >= 1
 end
 
-And(/^The following appears ([^"]*) times? in the log after my savepoint:$/) do |occurrences, message|
+And(/^The following appears ([^"]*) times? in the (audit )?log after my savepoint:$/) do |occurrences, _is_audit, message|
   expect(num_matches_since_savepoint(message)).to eq occurrences.to_i
 end

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -35,9 +35,14 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     And I permit host "test-app" to "execute" it
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I fetch a non-assigned-identity Azure access token from inside machine
+    And I save my place in the audit log file
     When I authenticate via Azure with token as host "test-app"
     Then host "test-app" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:test-app successfully authenticated with authenticator authn-azure service cucumber:webservice:conjur/authn-azure/prod
+    """
 
   Scenario: A valid provider-uri without trailing slash works
     Given I have a "variable" resource called "test-variable"

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -177,3 +177,19 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     """
     Errors::Authentication::Security::RoleNotAuthorizedOnWebservice
     """
+
+  # This test runs a failing authentication request that is already
+  # tested in another scenario (Host without resource-group annotation is denied).
+  # We run it again here to verify that we write a message to the audit log
+  Scenario: Authentication failure is written to the audit log
+    And I have host "no-resource-group-app"
+    And I set subscription-id annotation to host "no-resource-group-app"
+    And I grant group "conjur/authn-azure/prod/apps" to host "no-resource-group-app"
+    And I fetch a non-assigned-identity Azure access token from inside machine
+    And I save my place in the audit log file
+    When I authenticate via Azure with token as host "no-resource-group-app"
+    Then it is unauthorized
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:no-resource-group-app failed to authenticate with authenticator authn-azure service cucumber:webservice:conjur/authn-azure/prod
+    """

--- a/cucumber/authenticators_ldap/features/authn_ldap.feature
+++ b/cucumber/authenticators_ldap/features/authn_ldap.feature
@@ -60,9 +60,14 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     And I store the LDAP CA certificate in "conjur/authn-ldap/secure/tls-ca-cert"
 
   Scenario: An LDAP user authorized in Conjur can login with a good password
+    Given I save my place in the log file
     When I login via LDAP as authorized Conjur user "alice"
     And I authenticate via LDAP as authorized Conjur user "alice" using key
     Then user "alice" has been authorized by Conjur
+    And The following appears in the log after my savepoint:
+    """
+    cucumber:user:alice successfully authenticated with authenticator authn-ldap service cucumber:webservice:conjur/authn-ldap/test
+    """
 
   Scenario: An LDAP user authorized in Conjur can login with a good password using TLS
     When I login via secure LDAP as authorized Conjur user "alice"
@@ -109,3 +114,15 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     """
     When I login via LDAP as authorized Conjur user "alice"
     Then it is forbidden
+
+  # This test runs a failing authentication request that is already
+  # tested in another scenario (An LDAP user authorized in Conjur can't login with a bad password).
+  # We run it again here to verify that we write a message to the audit log
+  Scenario: Authentication failure is written to the audit log
+    Given I save my place in the audit log file
+    When my LDAP password is wrong for authorized user "alice"
+    Then it is unauthorized
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:alice failed to authenticate with authenticator authn-ldap service cucumber:webservice:conjur/authn-ldap/test
+    """

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -174,8 +174,3 @@ Feature: Users can authneticate with OIDC authenticator
     """
     Errors::Authentication::OAuth::ProviderDiscoveryFailed
     """
-
-  Scenario: Performance test
-    And I fetch an ID Token for username "alice" and password "alice"
-    When I authenticate 1000 times in 10 threads via OIDC with id token
-    Then The "avg" response time should be less than "0.75" seconds

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -1,4 +1,9 @@
-Feature: Users can authneticate with OIDC authenticator
+Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
+
+  In this feature we define an OIDC authenticator in policy and perform authentication
+  with Conjur. In successful scenarios we will also define a variable and permit the host to
+  execute it, to verify not only that the host can authenticate with the OIDC
+  Authenticator, but that it can retrieve a secret using the Conjur access token.
 
   Background:
     Given a policy:

--- a/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
@@ -1,4 +1,9 @@
-Feature: Users can authenticate with OIDC authenticator
+Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
+
+  In this feature we define an OIDC Authenticator with a configuration
+  mistake. Each test will verify that we fail the authentication in such a case
+  and log the relevant error for the user to re-configure the authenticator
+  properly
 
   Scenario: id-token-user-property variable missing in policy is denied
     Given a policy:

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -1,4 +1,9 @@
-Feature: Users can authneticate with OIDC authenticator
+Feature: OIDC Authenticator - Performance tests
+
+  In this feature we test that OIDC Authenticator performance is meeting
+  the SLA. We run multiple authn-oidc requests in multiple threads and verify
+  that the average time of a request is no more that the agreed time.
+  We test both successful requests and unsuccessful requests.
 
   Background:
     Given a policy:
@@ -32,7 +37,11 @@ Feature: Users can authneticate with OIDC authenticator
     And I am the super-user
     And I successfully set OIDC variables
 
-  Scenario: Performance test
+  Scenario: successful requests
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate 1000 times in 10 threads via OIDC with id token
     Then The "avg" response time should be less than "0.75" seconds
+
+  Scenario: Unsuccessful requests with an invalid token
+    When I authenticate 1000 times in 10 threads via OIDC with invalid id token
+    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -1,0 +1,38 @@
+Feature: Users can authneticate with OIDC authenticator
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-oidc/keycloak
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for Keycloak, based on Open ID Connect.
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: id-token-user-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !user alice
+
+    - !grant
+      role: !group conjur/authn-oidc/keycloak/users
+      member: !user alice
+    """
+    And I am the super-user
+    And I successfully set OIDC variables
+
+  Scenario: Performance test
+    And I fetch an ID Token for username "alice" and password "alice"
+    When I authenticate 1000 times in 10 threads via OIDC with id token
+    Then The "avg" response time should be less than "0.75" seconds

--- a/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
@@ -1,4 +1,8 @@
-Feature: Users can authenticate with OIDC & LDAP authenticators
+Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authenticators
+
+  In this feature we define an OIDC authenticator and LDAP authenticator
+  in policy and perform authentication with Conjur. This test verifies that the
+  two authenticators can live side by side without affecting each other.
 
   Background:
     # Configure OIDC authenticator

--- a/cucumber/authenticators_oidc/features/authn_status_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_status_oidc.feature
@@ -1,4 +1,4 @@
-Feature: OIDC Authenticator status check
+Feature: OIDC Authenticator - Status Check
 
   Scenario: A properly configured OIDC authenticator returns a successful response
     Given a policy:


### PR DESCRIPTION
When Conjur users perform authentication request we write audit messages for success and failures.
We write the messages to the audit log, which is actually the Rails log (which is derived from the  value of RAILS_ENV).

This PR verifies that the LDAP, Azure and OIDC authenticators write audit messages.

I didn't add tests for other authenticators for the following reasons:
- `authn-k8s`: we currently don't have an ability to read the Conjur log
- `authn-iam`: we don't have integration tests for this authenticator
- `authn`: we don't have integration tests for this authenticator