### PR TITLE
Openssl 1.0.2final

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -12,3 +12,19 @@ CVE-2019-10220
 CVE-2019-19813
 CVE-2019-19814
 CVE-2019-19816
+
+# Applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake
+# may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert"
+# TLS extension. this issue was fixed in OpenSSL 1.1.1g
+#
+# In order to support fips with openssl we are required to downgrading openssl version to 1.0.2 until openssl will
+# support fips module in newer versions
+# This vulnerability this is not relevant to us as
+# 1. The installed version (1.0.2u) does not support 1.3
+# 2. Trivy detect the usage of openssl 1.0.2 (can be reproduced with
+#    docker run -v /var/run/docker.sock:/var/run/docker.sock
+#   -v $(PWD):/workspace --rm aquasec/trivy -f json -o /workspace/scan_results-conjur-unfixed.json --no-progress
+#   --ignorefile .trivyignore registry.tld/ruby-fips-base-image-phusion:1.0.0)
+#
+# Performed by @yahalomk approved by @shaharglazner
+CVE-2020-1967

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Raise proper error of an authn request with a non-existing user to the `authn`
   authenticator ([cyberark/conjur#1591](https://github.com/cyberark/conjur/pull/1591))
 
+### Changed
+- Uses OpenSSL 1.0.2u to support FIPS compliance 
+- Conjur can be configured to run in FIPS compliant or Non-FIPS compliant mode depending on requirements.
+  FIPS Compliant mode is slightly slower then non-FIPS compliant
+
 ## [1.7.1] - 2020-06-03
 
 ### Added
@@ -59,9 +64,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - Images are no longer published to Quay.io.
-
-### Security
-- Upgraded Rails to `v5.2.4.3` to resolve [CVE-2020-8164](https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY).
 
 ## [1.6.0] - 2020-04-14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM cyberark/ubuntu-ruby-fips:20.04-latest
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \
@@ -10,19 +10,14 @@ EXPOSE 80
 
 RUN apt-get update -y && \
     apt-get -y dist-upgrade && \
-    apt-get install -y build-essential \
+    apt-get install -y libz-dev
+
+RUN apt-get install -y build-essential \
                        curl \
                        git \
-                       libpq-dev \
                        ldap-utils \
-                       postgresql-client \
-                       ruby2.5 ruby2.5-dev \
                        tzdata \
-                       # needed to build some gem native extensions:
-                       libz-dev \
     && rm -rf /var/lib/apt/lists/*
-
-RUN gem install --no-document --version 2.1.4 bundler
 
 WORKDIR /opt/conjur-server
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,10 @@ gem 'sequel-rails'
 
 gem 'activesupport'
 gem 'base32-crockford'
-gem 'bcrypt-ruby', '~> 3.0.0'
+gem 'bcrypt', '~> 3.1.2'
 gem 'gli', require: false
 gem 'listen'
-gem 'slosilo', '~> 2.1'
+gem 'slosilo', '~> 2.2'
 
 # Explicitly required as there are vulnerabilities in older versions
 gem "ffi", ">= 1.9.24"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     backports (3.17.0)
     base32-crockford (0.1.0)
     base58 (0.2.3)
-    bcrypt-ruby (3.0.1)
+    bcrypt (3.1.13)
     bindata (2.4.7)
     builder (3.2.4)
     byebug (11.1.1)
@@ -258,7 +258,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    openid_connect (1.1.8)
+    openid_connect (1.2.0)
       activemodel
       attr_required (>= 1.0.0)
       json-jwt (>= 1.5.0)
@@ -396,7 +396,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slosilo (2.1.1)
+    slosilo (2.2.1)
     spring (2.1.0)
     spring-commands-cucumber (1.0.1)
       spring (>= 0.9.1)
@@ -451,7 +451,7 @@ DEPENDENCIES
   aws-sdk-iam
   base32-crockford
   base58
-  bcrypt-ruby (~> 3.0.0)
+  bcrypt (~> 3.1.2)
   ci_reporter_rspec
   command_class
   conjur-api!
@@ -504,11 +504,11 @@ DEPENDENCIES
   ruby-debug-ide
   ruby_dep (= 1.3.1)
   sequel (= 4.49.0)
-  sequel-pg_advisory_locking
+  sequel-pg_advisory_locking`
   sequel-postgres-schemata
   sequel-rails
   simplecov (= 0.14.1)
-  slosilo (~> 2.1)
+  slosilo (~> 2.2)
   spring
   spring-commands-cucumber
   spring-commands-rspec

--- a/app/domain/util/open_ssl/x509/quick_csr.rb
+++ b/app/domain/util/open_ssl/x509/quick_csr.rb
@@ -23,7 +23,7 @@ module Util
         #
         def initialize(
           common_name:,
-          rsa_key: OpenSSL::PKey::RSA.new(1048),
+          rsa_key: OpenSSL::PKey::RSA.new(2048),
           alt_names: []
         )
           @cn = common_name

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,9 @@ function flatten() {
   local container
   container=$(docker create "$image")
   docker export "$container" | docker import \
+    --change "ENV PATH /usr/local/pgsql/bin:/var/lib/ruby/bin:/usr/local/ssl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    --change "ENV LD_LIBRARY_PATH /usr/local/ssl/lib" \
+    --change "ENV OPENSSL_FIPS 1" \
     --change "EXPOSE 80" \
     --change "ENV RAILS_ENV=production" \
     --change "WORKDIR /opt/conjur-server" \

--- a/ci/authn-oidc/keycloak/fetchCertificate
+++ b/ci/authn-oidc/keycloak/fetchCertificate
@@ -3,7 +3,7 @@
 # This script retrieves a certificate from the keycloak OIDC provider.
 # It is needed to communicate with the provider via SSL for validating ID tokens
 
-httpclient_pem_location="/var/lib/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient"
+httpclient_pem_location="/var/lib/ruby/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient"
 
 echo “keycloak cert” >> "$httpclient_pem_location/cacert.pem"
 echo =============== >> "$httpclient_pem_location/cacert.pem"

--- a/ci/authn-oidc/keycloak/standalone.xml
+++ b/ci/authn-oidc/keycloak/standalone.xml
@@ -388,7 +388,7 @@
                 <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
-                        <mechanism mechanism-name="DIGEST-MD5">
+                        <mechanism mechanism-name="DIGEST-SHA-256">
                             <mechanism-realm realm-name="ManagementRealm"/>
                         </mechanism>
                     </mechanism-configuration>
@@ -396,7 +396,7 @@
                 <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
                     <mechanism-configuration>
                         <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
-                        <mechanism mechanism-name="DIGEST-MD5">
+                        <mechanism mechanism-name="DIGEST-SHA-256">
                             <mechanism-realm realm-name="ApplicationRealm"/>
                         </mechanism>
                     </mechanism-configuration>

--- a/config/initializers/fips.rb
+++ b/config/initializers/fips.rb
@@ -1,0 +1,24 @@
+require "openssl"
+require "digest"
+
+# Suppress warning messages
+original_verbose, $VERBOSE = $VERBOSE, nil
+
+# override the default Digest with OpenSSL::Digest
+Digest::SHA256 = OpenSSL::Digest::SHA256
+Digest::SHA1 = OpenSSL::Digest::SHA1
+
+# Activate warning messages again
+$VERBOSE = original_verbose
+
+# by default FIPS mode is enabled
+# disable FIPS mode only if OPENSSL_FIPS_ENABLED environment variable is present and has false value
+OpenSSL.fips_mode = !(ENV["OPENSSL_FIPS_ENABLED"].present? && ENV["OPENSSL_FIPS_ENABLED"] == 'false')
+
+# each of the following 3rd party overridden is required since a non FIPS complaint encryption method is used
+# if a non-complaint FIPS method like MD5 is used or a direct use of Digest::encryption-method
+#  (rather than OpenSSL::Digest::encryption-method) is performed
+#  the server will crush on run time
+
+# override ActiveSupport hash_digest_class with FIPS complaint method
+ActiveSupport::Digest.hash_digest_class = OpenSSL::Digest::SHA1.new

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,25 +1,21 @@
-FROM phusion/baseimage:0.11
+    FROM cyberark/phusion-ruby-fips:0.11-latest
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
-    ruby2.5 ruby2.5-dev \
-    postgresql-client \
-    libpq-dev \
-    unattended-upgrades \
     ldap-utils \
     git \
-    update-notifier-common \
-    vim \
-    curl \
     jq \
     tzdata \
-    wget \
     libfontconfig1 \
-    libfontconfig1-dev \
+    libfontconfig1-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    unattended-upgrades \
+    vim \
+    curl \
+    wget \
+    syslog-ng \
     && rm -rf /var/lib/apt/lists/*
-
-RUN gem install --no-document --version 2.1.4 bundler
 
 RUN mkdir -p /src/conjur-server
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+
 SimpleCov.command_name "SimpleCov #{rand(1000000)}"
 SimpleCov.merge_timeout 7200
 SimpleCov.start


### PR DESCRIPTION
### What does this PR do?
- set openssl version to 1.0.2u
- enable FIPS
- override 3rd parties non FIPS complaint encryption methods

### What ticket does this PR close?
https://github.com/cyberark/conjur/issues/1527

### Checklists

#### Change log
- [v] The CHANGELOG has been updated

#### Test coverage
- [v] The changes in this PR do not require tests

#### Follow-on issues
- [v] This merge is pending slosilo merge and then fixing the Gemfile and Gemfile.lock

