### PR TITLE
Update PR template to highlight docs changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,5 @@ Connected to #[relevant GitHub issues, eg 76]
 - [ ] The changes in this PR do not require tests
 
 #### Documentation
-- [ ] This PR does not require updating any documentation
-- [ ] Docs were updated in this PR, or there is a follow-on issue to update docs
+- [ ] This PR does not require updating any documentation, or
+- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,6 @@ Connected to #[relevant GitHub issues, eg 76]
 - [ ] This PR includes new unit and integration tests to go with the code changes, or
 - [ ] The changes in this PR do not require tests
 
-#### Follow-on issues
-- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
-- [ ] No follow-up issues are required
+#### Documentation
+- [ ] This PR does not require updating any documentation
+- [ ] Docs were updated in this PR, or there is a follow-on issue to update docs


### PR DESCRIPTION
### What does this PR do?
It's been noted in some recent changes that no corresponding changes
were made to the README, and no follow-up issues were logged to edit
the official docs. This commit updates the PR template to remove the
sort of ambiguous "follow up issues" section in favor of a section that focuses
on documentation, and asks the PR author to verify that they have either included
docs changes in their PR or filed a follow-up issue with the requested changes.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Follow-on issues
- [ ] Follow-up issue(s) have been logged (and links included below) to update documentation or related projects, or
- [x] No follow-up issues are required
