### PR TITLE
Add a test case for resource list acting_as

### DIFF
--- a/cucumber/api/features/resource_list_by_role.feature
+++ b/cucumber/api/features/resource_list_by_role.feature
@@ -27,3 +27,7 @@ Feature: List resources for another role
     When I successfully GET "/resources?acting_as=cucumber:user:alice"
     Then the resource list should contain "variable" "dev/dev-var"
     And the resource list should not contain "variable" "prod/prod-var"
+
+  Scenario: Attempting to retrieve the resource list for a different role but without giving the account in the ID results in a 403
+    When I GET "/resources?acting_as=user:alice"
+    Then the HTTP response status code is 403


### PR DESCRIPTION
### What does this PR do?
During an effort to document the `acting_as` query parameter for the `resources`
route, it was raised that failing to specify the account in the fully qualified
ID of the role results in a 403. We may want to alter this behavior at some
point, but in the meantime it does not appear that we have a test that documents
this functionality. This commit adds a test, so that when/if we change this
behavior in the future, it will be clear that we have broken expected behavior
by breaking this test.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
