### PR TITLE
Log when using default authentication container name

### DIFF
--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -21,7 +21,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
       InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
         msg:  "The password you have chosen does not meet the complexity requirements. " \
-             "Choose a password that includes: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit, 1 special character",
+          "Choose a password that includes: 12-128 characters, 2 uppercase letters, " \
+          "2 lowercase letters, 1 digit, 1 special character",
         code: "CONJ00046E"
       )
 
@@ -57,8 +58,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthenticatorClass
 
         DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-authenticator-parent-name}' is not a valid authenticator parent module because it does " \
-            "not begin with 'Authn'",
+          msg:  "'{0-authenticator-parent-name}' is not a valid authenticator "\
+            "parent module because it does not begin with 'Authn'",
           code: "CONJ00038E"
         )
 
@@ -155,7 +156,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
       module AuthnOidc
 
         IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' not found or empty in ID token. This field is defined in the id-token-user-property variable.",
+          msg:  "Field '{0-field-name}' not found or empty in ID token. " \
+            "This field is defined in the id-token-user-property variable.",
           code: "CONJ00013E"
         )
 
@@ -188,7 +190,8 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         ScopeNotSupported = ::Util::TrackableErrorClass.new(
-          msg:  "Resource type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          msg:  "Resource type '{0}' is not a supported application identity. " \
+            "The supported resources are '{1}'",
           code: "CONJ00025E"
         )
 
@@ -219,7 +222,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
 
         CommonNameDoesntMatchHost = ::Util::TrackableErrorClass.new(
           msg:  "Client certificate CN must match host name. Cert CN: {0}. " \
-                "Host name: {1}. ",
+            "Host name: {1}.",
           code: "CONJ00031E"
         )
 
@@ -283,12 +286,14 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
-          msg:  "Application identity field '{0-field-name}' does not match application identity in Azure token",
+          msg:  "Application identity field '{0-field-name}' does not match " \
+            "application identity in Azure token",
           code: "CONJ00049E"
         )
 
         ConstraintNotSupported = ::Util::TrackableErrorClass.new(
-          msg:  "Constraint type '{0}' is not a supported application identity. The supported resources are '{1}'",
+          msg:  "Constraint type '{0}' is not a supported application identity. " \
+            "The supported resources are '{1}'",
           code: "CONJ00050E"
         )
 
@@ -308,7 +313,7 @@ unless defined? Errors::Authentication::AuthenticatorNotFound
         )
 
         InvalidProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
-          msg:  "Provider fields are in invalid format in xms_mirid {1}." \
+          msg:  "Provider fields are in invalid format in xms_mirid {1}. " \
                 "xms_mirid must contain the resource provider namespace, the " \
                 "resource type, and the resource name",
           code: "CONJ00054E"

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -26,8 +26,8 @@ unless defined? LogMessages::Authentication::OriginValidated
       )
 
       ContainerNameAnnotationDefaultValue = ::Util::TrackableLogMessageClass.new(
-        msg:  "Annotation '{0-authentication-container-annotation-name}' not found." \
-                " Using default value '{1-default-authentication-container}'",
+        msg:  "Annotation '{0-authentication-container-annotation-name}' not found. " \
+                "Using default value '{1-default-authentication-container}'",
         code: "CONJ00033D"
       )
 
@@ -173,7 +173,7 @@ unless defined? LogMessages::Authentication::OriginValidated
       )
 
       RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
-        msg:  "Rate limited cache reached the '{0-limit}' limit and will not" \
+        msg:  "Rate limited cache reached the '{0-limit}' limit and will not " \
               "call target for the next '{1-seconds}' seconds",
         code: "CONJ00020D"
       )

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -25,6 +25,12 @@ unless defined? LogMessages::Authentication::OriginValidated
         code: "CONJ00024D"
       )
 
+      ContainerNameAnnotationDefaultValue = ::Util::TrackableLogMessageClass.new(
+        msg:  "Annotation '{0-authentication-container-annotation-name}' not found." \
+                " Using default value '{1-default-authentication-container}'",
+        code: "CONJ00033D"
+      )
+
       module Security
 
         SecurityValidated = ::Util::TrackableLogMessageClass.new(


### PR DESCRIPTION
Connected to conjurinc/dap-support#69

If the annotation `authentication-container-name` is missing in
the host's annotations then we use a default value `authenticator`.

It can be helpful to the user to see this behaviour in the log. We already
log that an annotation was used to get this value
(e.g `Retrieved value of annotation {authn-k8s/authentication-container-name}`
but now we can also see that the default value is used.