### PR TITLE
cleanup policies_version and orchestrate

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -375,7 +375,7 @@ detectors:
     - HostBuilder#create
     - HostBuilder#find_and_rotate
     - Loader::Orchestrate#create_schema
-    - Loader::Orchestrate#load
+    - Loader::Orchestrate#store_policy_in_db
     - Loader::Orchestrate#load_records
     - Loader::Handlers::Password#store_passwords
     - Loader::Orchestrate#table_data
@@ -468,6 +468,8 @@ detectors:
     - conjur_api
     - RestHelpers
     - CAHelpers
+    - PoliciesController#create_roles
+    - PoliciesController#actor_roles
 
   LongParameterList:
     exclude:

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -16,56 +16,58 @@ class PoliciesController < RestController
   def put
     authorize :update
 
-    load_policy perform_automatic_deletion: true, delete_permitted: true, update_permitted: true
+    policy = save_submitted_policy(delete_permitted: true)
+    replace_policy = Loader::ReplacePolicy.from_policy(policy)
+    created_roles = perform(replace_policy)
+
+    render json: {
+      created_roles: created_roles,
+      version: policy.version
+    }, status: :created
   end
 
   def patch
     authorize :update
 
-    load_policy perform_automatic_deletion: false, delete_permitted: true, update_permitted: true
+    policy = save_submitted_policy(delete_permitted: true)
+    modify_policy = Loader::ModifyPolicy.from_policy(policy)
+    created_roles = perform(modify_policy)
+
+    render json: {
+      created_roles: created_roles,
+      version: policy.version
+    }, status: :created
   end
 
   def post
     authorize :create
 
-    load_policy perform_automatic_deletion: false, delete_permitted: false, update_permitted: false
+    policy = save_submitted_policy(delete_permitted: false)
+    create_policy = Loader::CreatePolicy.from_policy(policy)
+    created_roles = perform(create_policy)
+
+    render json: {
+      created_roles: created_roles,
+      version: policy.version
+    }, status: :created
   end
 
   protected
 
-  def load_policy perform_automatic_deletion:, delete_permitted:, update_permitted:
-    policy_text = request.raw_post
-
-    policy_version = PolicyVersion.new \
-      role: current_user, policy: resource, policy_text: policy_text
-    policy_version.perform_automatic_deletion = perform_automatic_deletion
-    policy_version.delete_permitted = delete_permitted
-    policy_version.update_permitted = update_permitted
-    policy_version.save
-    loader = Loader::Orchestrate.new policy_version
-    loader.load
-
-    created_roles = loader.new_roles.select do |role|
-      %w(user host).member?(role.kind)
-    end.inject({}) do |memo, role|
-      credentials = Credentials[role: role] || Credentials.create(role: role)
-      memo[role.id] = { id: role.id, api_key: credentials.api_key }
-      memo
-    end
-
-    render json: {
-      created_roles: created_roles,
-      version: policy_version.version
-    }, status: :created
+  # Returns newly created roles
+  def perform(policy_action)
+    policy_action.call
+    new_actor_roles = actor_roles(policy_action.new_roles)
+    create_roles(new_actor_roles)
   end
 
   def find_or_create_root_policy
-    Loader::Types.find_or_create_root_policy account
+    Loader::Types.find_or_create_root_policy(account)
   end
 
   private
 
-  def concurrent_load _exception
+  def concurrent_load(_exception)
     response.headers['Retry-After'] = retry_delay
     render json: {
       error: {
@@ -79,5 +81,29 @@ class PoliciesController < RestController
   # It's randomized to avoid request bunching.
   def retry_delay
     rand 1..8
+  end
+
+  def save_submitted_policy(delete_permitted:)
+    policy_version = PolicyVersion.new(
+      role: current_user,
+      policy: resource,
+      policy_text: request.raw_post
+    )
+    policy_version.delete_permitted = delete_permitted
+    policy_version.save
+  end
+
+  def actor_roles(roles)
+    roles.select do |role|
+      %w(user host).member?(role.kind)
+    end
+  end
+
+  def create_roles(actor_roles)
+    actor_roles.each_with_object({}) do |role, memo|
+      credentials = Credentials[role: role] || Credentials.create(role: role)
+      role_id = role.id
+      memo[role_id] = { id: role_id, api_key: credentials.api_key }
+    end
   end
 end

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -79,25 +79,23 @@ module Loader
       policy_version.policy.id
     end
 
-    def load
+    def setup_db_for_new_policy
       perform_deletion
 
       create_schema
 
       load_records
+    end
 
-      if policy_version.perform_automatic_deletion?
-        delete_removed
-      end
-
+    # TODO: consider renaming this method
+    def delete_shadowed_and_duplicate_rows
       eliminate_shadowed
 
       eliminate_duplicates_exact
+    end
 
-      if policy_version.update_permitted?
-        update_changed
-      end
-
+    # TODO: consider renaming this method
+    def store_policy_in_db
       eliminate_duplicates_pk
 
       insert_new
@@ -152,8 +150,6 @@ module Loader
         io.read
       end
     end
-
-    protected
 
     # Delete rows in the existing policy which do not exist in the new policy.
     # Matching rows are selected by primary keys only, using a LEFT JOIN between the
@@ -382,6 +378,81 @@ module Loader
 
     def db
       Sequel::Model.db
+    end
+  end
+
+  # Responsible for creating policy. Called when a POST request is received
+  class CreatePolicy
+    def initialize(loader)
+      @loader = loader
+    end
+
+    def self.from_policy(policy_version)
+      CreatePolicy.new(Loader::Orchestrate.new(policy_version))
+    end
+
+    def call
+      @loader.setup_db_for_new_policy
+
+      @loader.delete_shadowed_and_duplicate_rows
+
+      @loader.store_policy_in_db
+    end
+
+    def new_roles
+      @loader.new_roles
+    end
+  end
+
+  # Responsible for replacing policy. Called when a PUT request is received
+  class ReplacePolicy
+    def initialize(loader)
+      @loader = loader
+    end
+
+    def self.from_policy(policy_version)
+      ReplacePolicy.new(Loader::Orchestrate.new(policy_version))
+    end
+
+    def call
+      @loader.setup_db_for_new_policy
+
+      @loader.delete_removed
+      
+      @loader.delete_shadowed_and_duplicate_rows
+
+      @loader.update_changed
+
+      @loader.store_policy_in_db
+    end
+
+    def new_roles
+      @loader.new_roles
+    end
+  end
+
+  # Responsible for modifying policy. Called when a PATCH request is received
+  class ModifyPolicy
+    def initialize(loader)
+      @loader = loader
+    end
+
+    def self.from_policy(policy_version)
+      ModifyPolicy.new(Loader::Orchestrate.new(policy_version))
+    end
+
+    def call
+      @loader.setup_db_for_new_policy
+      
+      @loader.delete_shadowed_and_duplicate_rows
+
+      @loader.update_changed
+
+      @loader.store_policy_in_db
+    end
+
+    def new_roles
+      @loader.new_roles
     end
   end
 end

--- a/app/models/policy_version.rb
+++ b/app/models/policy_version.rb
@@ -30,7 +30,7 @@ class PolicyVersion < Sequel::Model(:policy_versions)
 
   one_to_many :policy_log, key: %i(policy_id version)
 
-  attr_accessor :parse_error, :policy_filename, :perform_automatic_deletion, :delete_permitted, :update_permitted
+  attr_accessor :parse_error, :policy_filename, :delete_permitted
 
   alias id resource_id
   alias current_user role
@@ -56,20 +56,9 @@ class PolicyVersion < Sequel::Model(:policy_versions)
     policy.kind == "policy" && policy.identifier == "root"
   end
 
-  # Indicates whether records that exist in the database but not in the policy 
-  # update should be deleted.
-  def perform_automatic_deletion?
-    !!@perform_automatic_deletion
-  end
-
   # Indicates whether explicit deletion is permitted.
   def delete_permitted?
     !!@delete_permitted
-  end
-
-  # Indicates whether updates to existing data fields are permitted.
-  def update_permitted?
-    !!@update_permitted
   end
 
   def validate

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -3,38 +3,45 @@
 require 'spec_helper'
 
 describe Loader::Orchestrate do
-  def policy_path path
+  def policy_path(path)
     File.expand_path("loader_fixtures/#{path}", File.dirname(__FILE__))
   end
 
-  def expectation_path path
+  def expectation_path(path)
     File.expand_path("loader_expectations/#{path}", File.dirname(__FILE__))
   end
 
-  def load_base_policy path
+  def load_base_policy(path)
     require 'root_loader'
     RootLoader.load 'rspec', policy_path(path)
   end
 
-  def load_policy_update path
-    version = PolicyVersion.new.tap do |version|
-      version.policy = resource_policy
-      version.role = role_user_admin
-      version.policy_text = File.read(policy_path(path))
-      version.perform_automatic_deletion = perform_automatic_deletion
-      version.delete_permitted = delete_permitted
-      version.update_permitted = update_permitted
-      version.validate
-      expect(version.errors.to_a).to eq([])
-      expect(version.valid?).to be_truthy
-      version.save
-    end
-    Loader::Orchestrate.new(version).tap do |loader|
-      loader.load
-    end
+  def save_policy(path)
+    policy_ver = PolicyVersion.new(
+      policy: resource_policy,
+      role: role_user_admin,
+      policy_text: File.read(policy_path(path)),
+      delete_permitted: delete_permitted,
+    )
+    policy_ver.validate
+    expect(policy_ver.errors.to_a).to eq([])
+    expect(policy_ver.valid?).to be_truthy
+    policy_ver.save
   end
 
-  def verify_data path
+  def replace_policy_with(path)
+    version = save_policy(path)
+    policy_action = Loader::ReplacePolicy.from_policy(version)
+    policy_action.call
+  end
+
+  def modify_policy_with(path)
+    version = save_policy(path)
+    policy_action = Loader::ModifyPolicy.from_policy(version)
+    policy_action.call
+  end
+
+  def verify_data(path)
     if ENV['DUMP_DATA']
       File.write expectation_path(path), print_public
     end
@@ -53,8 +60,6 @@ describe Loader::Orchestrate do
     Loader::Orchestrate.table_data 'rspec', "#{schemata.primary_schema}__"
   }
   let(:delete_permitted) { true }
-  let(:update_permitted) { true }
-  let(:perform_automatic_deletion) { true }
 
   context "with a minimal base policy" do
     let(:base_policy_path) { 'empty.yml' }
@@ -65,58 +70,51 @@ describe Loader::Orchestrate do
 
     context "with attempted policy update" do
       it "applies the policy update" do
-        load_policy_update 'simple.yml'
+        replace_policy_with 'simple.yml'
         verify_data 'updated/simple.txt'
       end
       it "creates a host factory" do
-        load_policy_update 'host_factory.yml'
+        replace_policy_with 'host_factory.yml'
         verify_data 'updated/host_factory.txt'
       end
       it "adds a layer to a host factory" do
-        load_policy_update 'host_factory.yml'
-        load_policy_update 'host_factory_new_layer.yml'
+        replace_policy_with 'host_factory.yml'
+        replace_policy_with 'host_factory_new_layer.yml'
         verify_data 'updated/host_factory_new_layer.txt'
       end
       it "removes a layer from a host factory" do
-        load_policy_update 'host_factory_new_layer.yml'
-        load_policy_update 'host_factory.yml'
+        replace_policy_with 'host_factory_new_layer.yml'
+        replace_policy_with 'host_factory.yml'
         verify_data 'updated/host_factory.txt'
       end
       it "doesn't affect a record in a different account" do
         Role.where(Sequel.function("account", :role_id) => 'acct1').delete
         Role.create(role_id: 'acct1:group:the-policy/group-a')
-        load_policy_update 'simple.yml'
+        replace_policy_with 'simple.yml'
 
         expect(Role['acct1:group:the-policy/group-a']).to be
         verify_data 'updated/simple_with_foreign_role.txt'
       end
       it "removes a record in a different account which is managed by the same policy" do
         Role.create(role_id: 'acct1:group:simple/group-a', policy_id: 'rspec:policy:the-policy')
-        load_policy_update 'simple.yml'
+        replace_policy_with 'simple.yml'
 
         expect(Role['acct1:group:simple/group-a']).to_not be
         verify_data 'updated/simple.txt'
       end
     end
 
-    context "and policy update" do
-      before do
-        load_policy_update 'simple.yml'
-      end
-      context "a subsequent policy update" do
-        before do
-          load_policy_update 'extended.yml'
-        end
-        it "applies the policy update" do
-          verify_data 'updated/extended.txt'
-        end
-        context "when deletion is disabled" do
-          let(:perform_automatic_deletion) { false }
 
-          it "doesn't delete removed records" do
-            verify_data 'updated/extended_without_deletion.txt'
-          end
-        end
+    context "and two subsequent policy updates" do
+      it "removed records are deleted" do
+        replace_policy_with 'simple.yml'
+        replace_policy_with 'extended.yml'
+        verify_data 'updated/extended.txt'
+      end
+      it "removed records are kept" do 
+        modify_policy_with 'simple.yml'
+        modify_policy_with 'extended.yml'
+        verify_data 'updated/extended_without_deletion.txt'
       end
     end
   end
@@ -125,7 +123,7 @@ describe Loader::Orchestrate do
     let(:base_policy_path) { 'simple_base.yml' }
     context "and policy update" do
       it "applies the policy update" do
-        load_policy_update 'extended.yml'
+        replace_policy_with 'extended.yml'
         verify_data 'updated/extended_simple_base.txt'
       end
     end


### PR DESCRIPTION
### What does this PR do?
It untangles the perform_automatic_deletion and update_permitted attributes from [policy_version.rb](app/models/policy_version.rb) and the load function within [orchestrate.rb](app/models/loader/orchestrate.rb). In addition, there was some cleanup in order to make [policies_controller.rb](app/controllers/policies_controller.rb) easier to read. There aren't additional tests, this PR is simply a small cleanup. A reviewer should start, by looking at [policy_version.rb](app/models/policy_version.rb) and [orchestrate.rb](app/models/loader/orchestrate.rb). Then proceed to [policies_controller.rb](app/controllers/policies_controller.rb)


### What ticket does this PR close?
#1530 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
