### PR TITLE
1535 authn k8s id source bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Policy load API endpoints now default to the `application/x-yaml` content-type
   if no content type is provided in the request
   ([conjurinc/dap-support#74](https://github.com/conjurinc/dap-support/issues/74)).
+- The k8s authenticator correctly authenticates an app using the host ID to specify
+  the k8s resource constraints and an annotation to specify the authenticator
+  container name using the "authn-k8s" prefix
+  ([cyberark/conjur#1535](https://github.com/cyberark/conjur/issues/1535),
+  [conjurinc/dap-support#79](https://github.com/conjurinc/dap-support/issues/79)).
 
 ### Changed
 - Change ActiveSupport to use sha1 instead of md5

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -208,8 +208,12 @@ module Authentication
         constraint.tr('_', '-')
       end
 
+      # We expect the application identity to be defined by the host's annotations
+      # if any of the constraint annotations is present.
       def application_identity_in_annotations?
-        @application_identity_in_annotations ||= @host_annotations.select { |a| a.values[:name].start_with?("authn-k8s/") }.any?
+        @application_identity_in_annotations ||= annotation_type_constraints.any? do |constraint|
+          constraint_from_annotation(constraint)
+        end
       end
 
       def host_id_namespace_scoped?

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
           it "does not raise an error" do
             expect { subject }.not_to raise_error
           end
+
+          context "when using authenticator container name annotation" do
+            let(:host_annotations) { [container_name_annotation] }
+  
+            it "does not raise an error" do
+              expect { subject }.not_to raise_error
+            end
+          end
         end
 
         context "when is not namespace scoped" do

--- a/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/application_identity_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe Authentication::AuthnK8s::ApplicationIdentity do
         end
 
         context "where a constraint is missing a slash after authn-k8s" do
-          let(:host_annotations) { [namespace_annotation, container_name_annotation] }
+          let(:host_annotations) { [service_account_annotation, namespace_annotation, container_name_annotation] }
 
           before(:each) do
             allow(namespace_annotation).to receive(:[])


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates the k8s authenticator to support specifying the authenticator container
name with an annotation, while also using the host ID to specify the k8s resource constraints.

See connected issue for background on why this change was made.

### What ticket does this PR close?
Connected to #1535

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
