### PR TITLE
Use `docker-debify` for debian package publishing

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -3,4 +3,4 @@
 export DEBUG=true
 export GLI_DEBUG=true
 
-debify publish $(cat VERSION_APPLIANCE) possum
+./docker-debify publish $(cat VERSION_APPLIANCE) possum


### PR DESCRIPTION
### What does this PR do?
Uses `docker-debify` to publish the debian package.