### PR TITLE
Add Pipeline Timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     timestamps()
     buildDiscarder(logRotator(numToKeepStr: '30'))
     skipDefaultCheckout()  // see 'Checkout SCM' below, once perms are fixed this is no longer needed
+    timeout(time: 1, unit: 'HOURS')
   }
 
   triggers {


### PR DESCRIPTION
### What does this PR do?
This PR adds a one hour timeout to the Jenkins pipeline for this repo.
This change was made because some builds were running indefinitely after
failures in the Azure Authenticator Preparation stage.

### What ticket does this PR close?
Connected to conjurinc/ops#589

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
