### PR TITLE
Use strict mode for cucumber CI tests

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -373,7 +373,11 @@ _run_cucumber_tests() {
 
   # Run the tests
   _run_cucumber "$cucumber_env_args" \
-     "bundle exec cucumber -p $profile --format json --out cucumber/$profile/cucumber_results.json --format junit --out cucumber/$profile/features/reports"
+     "bundle exec cucumber \
+     --strict \
+     -p $profile \
+     --format json --out cucumber/$profile/cucumber_results.json \
+     --format junit --out cucumber/$profile/features/reports"
 
   # Simplecov writes its report using an at_exit ruby hook. If the container
   # is killed before ruby, the report doesn't get written. So here we

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -32,16 +32,16 @@ Feature: Azure Authenticator - Performance tests
   Scenario: successful requests
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
-    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+    Then The "avg" Azure Authentication request responds in less than "0.75" seconds
 
   Scenario: Unsuccessful requests with an invalid token
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"
-    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+    Then The "avg" Azure Authentication request responds in less than "0.75" seconds
 
   Scenario: Unsuccessful requests with invalid application identity
     Given I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "no-azure-annotations-app"
-    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+    Then The "avg" Azure Authentication request responds in less than "0.75" seconds

--- a/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
+++ b/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
@@ -61,7 +61,9 @@ Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |em
   @azure_perf_results = results.map(&:real)
 end
 
-Then(/^The "([^"]*)" Azure Authentication request response time should be less than "([^"]*)" seconds?$/) do |type, threshold|
+Then(
+  "The {string} Azure Authentication request responds in less than {string} second(s)"
+) do |type, threshold|
   type = type.downcase.to_sym
   raise "Unexpected Type" unless %i(max avg).include?(type)
   results     = @azure_perf_results

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -44,4 +44,4 @@ Feature: OIDC Authenticator - Performance tests
 
   Scenario: Unsuccessful requests with an invalid token
     When I authenticate 1000 times in 10 threads via OIDC with invalid id token
-    Then The "avg" Azure Authentication request response time should be less than "0.75" seconds
+    Then The "avg" response time should be less than "0.75" seconds


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

Cucumber tests were running without `--strict` mode, which means that _unimplemented_ step definitions to not fail the build.  Which is very much not what we want.

Fixes bug in OIDC performance test which had been undetected previously because we weren't using `--strict` mode.

### What ticket does this PR close?

#1546 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
