### PR TITLE
Use ValidateSecurity class in ValidatePodRequest

### DIFF
--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -49,6 +49,10 @@ module Authentication
         Rails.logger.debug(Log::HostIdFromCommonName.new(host_id))
         host_id
       end
+
+      def k8s_host_name
+        @common_name.k8s_host_name
+      end
     end
   end
 end


### PR DESCRIPTION
Connected to #1525 

We have a general class that handles the security validations for
authenticators (validate the webservice exists, it is enabled and the
user has permissions on it). This class was not used in ValidatePodRequest
and instead, it handled its own security. This was not ideal as some code was
duplicated and also it didn't perform some operations that are imeplemented in
ValidateSecurity (e.g raise a proper error if the account doesn't exist).

In addition, the spec of this file didn't inject the dependencies properly and
although they were defined in the spec, they were not really used. This commit fixes that.
