### PR TITLE
Do not use `tap` method for logs and errors

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -119,7 +119,10 @@ class SecretsController < RestController
   private
 
   def variable_ids
-    @variable_ids ||= (params[:variable_ids] || '').split(',').compact
-      .tap { |ids| raise ArgumentError, 'variable_ids' if ids.empty? }
+    return @variable_ids if @variable_ids
+
+    @variable_ids = (params[:variable_ids] || '').split(',').compact
+    raise ArgumentError, 'variable_ids' if @variable_ids.empty?
+    @variable_ids
   end
 end

--- a/app/domain/authentication/authn_azure/decoded_token.rb
+++ b/app/domain/authentication/authn_azure/decoded_token.rb
@@ -35,9 +35,9 @@ module Authentication
       end
 
       def token_field_value(field_name)
-        @decoded_token_hash[field_name].tap do |token_field_value|
-          @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
-        end
+        token_field_value = @decoded_token_hash[field_name]
+        @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
+        token_field_value
       end
     end
   end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -125,9 +125,11 @@ module Authentication
       end
 
       def role
-        @role ||= @resource_class[role_id].tap do |role|
-          raise Errors::Authentication::Security::RoleNotFound, role_id unless role
-        end
+        return @role if @role
+
+        @role = @resource_class[role_id]
+        raise Errors::Authentication::Security::RoleNotFound, role_id unless @role
+        @role
       end
 
       def role_id

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -70,9 +70,11 @@ module Authentication
       end
 
       def host
-        @host ||= @resource_class[k8s_host.conjur_host_id].tap do |host|
-          raise SecurityErr::RoleNotFound(k8s_host.conjur_host_id) unless host
-        end
+        return @host if @host
+
+        @host = @resource_class[k8s_host.conjur_host_id]
+        raise SecurityErr::RoleNotFound(k8s_host.conjur_host_id) unless @host
+        @host
       end
 
       def pod

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -36,15 +36,18 @@ module Authentication
       private
 
       def verified_and_decoded_token
+        return @verified_and_decoded_token if @verified_and_decoded_token
+
         # @jwt_decoder.decode returns an array with one decoded token so we take the first object
-        @verified_and_decoded_token ||= @jwt_decoder.decode(
+        @verified_and_decoded_token = @jwt_decoder.decode(
           @token_jwt,
           nil, # the key will be taken from options[:jwks] if present
           should_verify,
           @verification_options
-        ).first.tap do
-          @logger.debug(Log::TokenDecodeSuccess.new)
-        end
+        ).first
+
+        @logger.debug(Log::TokenDecodeSuccess.new)
+        @verified_and_decoded_token
       rescue JWT::ExpiredSignature
         raise Err::TokenExpired
       rescue JWT::DecodeError => e

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -31,9 +31,9 @@ module Authentication
       # is used is inside of FetchProviderKeys.  This is unlikely change, and hence
       # unlikely to be a problem
       def discover_provider
-        @discovered_provider = @open_id_discovery_service.discover!(@provider_uri).tap do
-          @logger.debug(Log::IdentityProviderDiscoverySuccess.new)
-        end
+        @discovered_provider = @open_id_discovery_service.discover!(@provider_uri)
+        @logger.debug(Log::IdentityProviderDiscoverySuccess.new)
+        @discovered_provider
       rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
         raise_error(Err::ProviderDiscoveryTimeout, e)
       rescue => e

--- a/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+++ b/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
@@ -11,9 +11,9 @@ module AuthenticatorHelpers
   )
 
   def validated_env_var(var)
-    ENV[var].tap do |env_var_value|
-      raise MissingEnvVariable, var if env_var_value.blank?
-    end
+    env_var_value = ENV[var]
+    raise MissingEnvVariable, var if env_var_value.blank?
+    env_var_value
   end
 
   # Mostly to document the mutable variables that are in play.


### PR DESCRIPTION
Connected to #1540 

We decided not to use `tap` when we want to raise an error
or log a message as it is less straight-forward to the common
Ruby developer
