### PR TITLE
Print version on server startup

### DIFF
--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -222,6 +222,11 @@ unless defined? LogMessages::Authentication::OriginValidated
         code: "CONJ00023D"
       )
 
+      ConjurVersionStartup = ::Util::TrackableLogMessageClass.new(
+        msg:  "Conjur v{0-conjur-version} starting up...",
+        code: "CONJ00037I"
+      )
+
     end
   end
 end

--- a/config/initializers/status.rb
+++ b/config/initializers/status.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
+require 'logs'
 
 ENV["CONJUR_VERSION_DISPLAY"] = File.read(File.expand_path("../../VERSION", File.dirname(__FILE__)))
+
+Rails.logger.info(LogMessages::Util::ConjurVersionStartup.new(ENV["CONJUR_VERSION_DISPLAY"].strip))


### PR DESCRIPTION
Connected to [#1539](https://github.com/cyberark/conjur/issues/1531)

On Conjur startup, adding printout of "Conjur Version: XXXX", Based on file 'VERSION'. The new printout will be:
  `Conjur Version: 1.6.0`

And in the context of other printouts:
```
  API key for admin: 1pc4ves3bba8091vn2fvt11454za1k7f1z41a44g7a1m3yg0r1tks6fr
  Creating socket: audit_test_1_47298905114040.sock
  Conjur Version: 1.6.0
```
