### PR TITLE
Validate origin before credentials

### DIFF
--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -22,8 +22,8 @@ module Authentication
     def call
       validate_authenticator_exists
       validate_security
-      validate_credentials
       validate_origin
+      validate_credentials
       audit_success
       new_token
     rescue => e

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -20,8 +20,7 @@ module Authentication
   ) do
 
     extend Forwardable
-    def_delegators :@authenticator_input, :authenticator_name, :account,
-      :username, :webservice
+    def_delegators :@authenticator_input, :authenticator_name, :account, :username, :webservice, :origin, :role
 
     def call
       validate_authenticator_exists
@@ -59,13 +58,19 @@ module Authentication
     end
 
     def validate_origin
-      @validate_origin.(input: @authenticator_input)
+      @validate_origin.(
+        account: account,
+        username: username,
+        origin: origin
+      )
     end
 
     def audit_success
       @log_audit_event.(
         event: ::Authentication::AuditEvent::Authenticate,
-        authenticator_input: @authenticator_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: true,
         message: nil
       )
@@ -74,7 +79,9 @@ module Authentication
     def audit_failure(err)
       @log_audit_event.(
         event: ::Authentication::AuditEvent::Authenticate,
-        authenticator_input: @authenticator_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: false,
         message: err.message
       )

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -19,6 +19,10 @@ module Authentication
     inputs:       %i(authenticator_input authenticators enabled_authenticators)
   ) do
 
+    extend Forwardable
+    def_delegators :@authenticator_input, :authenticator_name, :account,
+      :username, :webservice
+
     def call
       validate_authenticator_exists
       validate_security
@@ -34,11 +38,11 @@ module Authentication
     private
 
     def authenticator
-      @authenticator = @authenticators[@authenticator_input.authenticator_name]
+      @authenticator = @authenticators[authenticator_name]
     end
 
     def validate_authenticator_exists
-      raise Err::AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+      raise Err::AuthenticatorNotFound, authenticator_name unless authenticator
     end
 
     def validate_credentials
@@ -47,9 +51,9 @@ module Authentication
 
     def validate_security
       @validate_security.(
-        webservice: @authenticator_input.webservice,
-        account: @authenticator_input.account,
-        user_id: @authenticator_input.username,
+        webservice: webservice,
+        account: account,
+        user_id: username,
         enabled_authenticators: @enabled_authenticators
       )
     end
@@ -78,8 +82,8 @@ module Authentication
 
     def new_token
       @token_factory.signed_token(
-        account:  @authenticator_input.account,
-        username: @authenticator_input.username
+        account:  account,
+        username: username
       )
     end
 

--- a/app/domain/authentication/authn_oidc/authenticate.rb
+++ b/app/domain/authentication/authn_oidc/authenticate.rb
@@ -30,7 +30,7 @@ module Authentication
     ) do
 
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :webservice, :credentials
+      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :webservice, :credentials, :origin, :role
 
       def call
         validate_account_exists
@@ -126,14 +126,19 @@ module Authentication
       end
 
       def validate_origin
-        @validate_origin.(input: @authenticator_input)
-        @logger.debug(LogMessages::Authentication::OriginValidated.new.to_s)
+        @validate_origin.(
+          account: account,
+          username: username,
+          origin: origin
+        )
       end
 
       def audit_success
         @log_audit_event.(
           event: ::Authentication::AuditEvent::Authenticate,
-          authenticator_input: @authenticator_input,
+          authenticator_name: authenticator_name,
+          webservice: webservice,
+          role: role,
           success: true,
           message: nil
         )
@@ -142,7 +147,9 @@ module Authentication
       def audit_failure(err)
         @log_audit_event.(
           event: ::Authentication::AuditEvent::Authenticate,
-          authenticator_input: @authenticator_input,
+          authenticator_name: authenticator_name,
+          webservice: webservice,
+          role: role,
           success: false,
           message: err.message
         )

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -8,15 +8,15 @@ module Authentication
       resource_cls: ::Resource,
       audit_log: ::Audit.logger
     },
-    inputs:       %i(authenticator_input event success message)
+    inputs:       %i(authenticator_name webservice role event success message)
   ) do
 
     def call
-      return unless role
+      return unless @role
 
       @event.new(
-        role: role,
-        authenticator_name: @authenticator_input.authenticator_name,
+        role: @role,
+        authenticator_name: @authenticator_name,
         service: @resource_cls[webservice_id],
         success: @success,
         error_message: @message
@@ -26,11 +26,7 @@ module Authentication
     private
 
     def webservice_id
-      @authenticator_input.webservice.resource_id
-    end
-
-    def role
-      @authenticator_input.role
+      @webservice.resource_id
     end
   end
 end

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -18,7 +18,7 @@ module Authentication
   ) do
 
     extend Forwardable
-    def_delegators :@authenticator_input, :authenticator_name, :account, :username, :webservice
+    def_delegators :@authenticator_input, :authenticator_name, :account, :username, :webservice, :role
 
     def call
       validate_authenticator_exists
@@ -61,7 +61,9 @@ module Authentication
     def audit_success
       @log_audit_event.(
         event: ::Authentication::AuditEvent::Login,
-        authenticator_input: @authenticator_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: true,
         message: nil
       )
@@ -70,7 +72,9 @@ module Authentication
     def audit_failure(err)
       @log_audit_event.(
         event: ::Authentication::AuditEvent::Login,
-        authenticator_input: @authenticator_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: false,
         message: err.message
       )

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -17,6 +17,9 @@ module Authentication
     inputs:       %i(authenticator_input authenticators enabled_authenticators)
   ) do
 
+    extend Forwardable
+    def_delegators :@authenticator_input, :authenticator_name, :account, :username, :webservice
+
     def call
       validate_authenticator_exists
       validate_security
@@ -31,7 +34,7 @@ module Authentication
     private
 
     def authenticator
-      @authenticator = @authenticators[@authenticator_input.authenticator_name]
+      @authenticator = @authenticators[authenticator_name]
     end
 
     def key
@@ -39,7 +42,7 @@ module Authentication
     end
 
     def validate_authenticator_exists
-      raise Err::AuthenticatorNotFound, @authenticator_input.authenticator_name unless authenticator
+      raise Err::AuthenticatorNotFound, authenticator_name unless authenticator
     end
 
     def validate_credentials
@@ -48,7 +51,7 @@ module Authentication
 
     def validate_security
       @validate_security.(
-        webservice: @authenticator_input.webservice,
+        webservice: webservice,
         account: account,
         user_id: username,
         enabled_authenticators: @enabled_authenticators
@@ -82,14 +85,6 @@ module Authentication
 
     def role
       @role_cls.by_login(username, account: account)
-    end
-
-    def username
-      @authenticator_input.username
-    end
-
-    def account
-      @authenticator_input.account
     end
   end
 end

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -8,19 +8,21 @@ module Authentication
 
   ValidateOrigin ||= CommandClass.new(
     dependencies: {
-      role_cls: ::Role
+      role_cls: ::Role,
+      logger:   Rails.logger
     },
-    inputs: %i(input)
+    inputs: %i(account username origin)
   ) do
 
     def call
-      raise Err::InvalidOrigin unless role.valid_origin?(@input.origin)
+      raise Err::InvalidOrigin unless role.valid_origin?(@origin)
+      @logger.debug(LogMessages::Authentication::OriginValidated.new.to_s)
     end
 
     private
 
     def role
-      @role_cls.by_login(@input.username, account: @input.account)
+      @role_cls.by_login(@username, account: @account)
     end
   end
 end

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -25,7 +25,7 @@ module Authentication
   ) do
 
     extend Forwardable
-    def_delegators :@authenticator_status_input, :authenticator_name, :account, :username, :webservice, :status_webservice
+    def_delegators :@authenticator_status_input, :authenticator_name, :account, :username, :webservice, :status_webservice, :role
 
     def call
       validate_authenticator_exists
@@ -87,7 +87,9 @@ module Authentication
     def audit_success
       @log_audit_event.(
         event: ::Authentication::AuditEvent::ValidateStatus,
-        authenticator_input: @authenticator_status_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: true,
         message: nil
       )
@@ -96,7 +98,9 @@ module Authentication
     def audit_failure(err)
       @log_audit_event.(
         event: ::Authentication::AuditEvent::ValidateStatus,
-        authenticator_input: @authenticator_status_input,
+        authenticator_name: authenticator_name,
+        webservice: webservice,
+        role: role,
         success: false,
         message: err.message
       )

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -110,6 +110,9 @@ RSpec.describe Authentication::ValidateStatus do
 
       allow(status_input).to receive(:username)
                                .and_return(test_user_id)
+
+      allow(status_input).to receive(:role)
+                               .and_return(mock_role_class)
     end
   end
 


### PR DESCRIPTION
Connected to #1568

It makes sense to validate the origin of the request before
validating the credentials. Before we validate that the credentials
are correct, we need to validate that the role _can_ authenticate,
same as we do with the security. We first verify that the request can
be authenticated and then validate it is authenticated.
