### PR TITLE
Fix markdown link syntax in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change ActiveSupport to use sha1 instead of md5
 - Authentication audit events now use separate operations for `authenticate`,
   `login`, and `validate-status` workflows
-  ((cyberark/conjur#1054)[https://github.com/cyberark/conjur/issues/1054]).
+  ([cyberark/conjur#1054](https://github.com/cyberark/conjur/issues/1054)).
 
 ### Added
 - The Kubernetes authentication '/inject-client-cert` endpoint now generates


### PR DESCRIPTION
This PR fixes a markdown link syntax issue from https://github.com/cyberark/conjur/pull/1541
