### PR TITLE
Disable FIPS mode using OPENSSL_FIPS_ENABLED env var

### DIFF
--- a/config/initializers/fips.rb
+++ b/config/initializers/fips.rb
@@ -11,8 +11,9 @@ Digest::SHA1 = OpenSSL::Digest::SHA1
 # Activate warning messages again
 $VERBOSE = original_verbose
 
-# enable FIPS mode
-OpenSSL.fips_mode = true
+# by default FIPS mode is enabled
+# disable FIPS mode only if OPENSSL_FIPS_ENABLED environment variable is present and has false value
+OpenSSL.fips_mode = !(ENV["OPENSSL_FIPS_ENABLED"].present? && ENV["OPENSSL_FIPS_ENABLED"] == 'false')
 
 # each of the following 3rd party overridden is required since a non FIPS complaint encryption method is used
 # if a non-complaint FIPS method like MD5 is used or a direct use of Digest::encryption-method


### PR DESCRIPTION
### What does this PR do?
OpenSSL FIPS mode is enabled by default
It will be disabled if and only if OPENSSL_FIPS_ENABLED env var is present and has false value