### PR TITLE
Remove image push to quay.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adds a `CertMissingCNEntry` error to improve visibility of Kubernetes authenticator failures ([cyberark/conjur#1278](cyberark/conjur/issues/1278)).
 - Logs the authenticator used when the `authentication-container-name` annotation is missing ([conjurinc/dap-support#69](https://github.com/conjurinc/dap-support/issues/69)) - [PR](https://github.com/cyberark/conjur/pull/1526).
 
+### Removed
+- Images are no longer published to Quay.io.
+
 ### Security
 - Upgraded Rails to `v5.2.4.3` to resolve [CVE-2020-8164](https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Conjur
 
 [![Conjur on DockerHub](https://img.shields.io/docker/pulls/cyberark/conjur.svg)](https://hub.docker.com/r/cyberark/conjur/)
-[![Conjur on Quay.io](https://img.shields.io/badge/quay%20build-automated-0db7ed.svg)](https://quay.io/repository/cyberark/conjur)
 [![Maintainability](https://api.codeclimate.com/v1/badges/3754a79b22b9430040ba/maintainability)](https://codeclimate.com/github/cyberark/conjur/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/3754a79b22b9430040ba/test_coverage)](https://codeclimate.com/github/cyberark/conjur/test_coverage)
 
@@ -9,7 +8,6 @@
 [![Follow Conjur on Twitter](https://img.shields.io/twitter/follow/conjurinc.svg?style=social&label=Follow%20%40ConjurInc)][twitter]
 
 [commons]: https://discuss.cyberarkcommons.org/c/conjur/5 "Find answers on CyberArk Commons"
-[quay]: https://quay.io/repository/cyberark/conjur "Conjur container image on Quay.io"
 [twitter]: https://twitter.com/intent/user?screen_name=ConjurInc "Follow Conjur on Twitter"
 
 Conjur provides secrets management and application identity for modern infrastructure:

--- a/push-image.sh
+++ b/push-image.sh
@@ -18,9 +18,6 @@ IMAGE_NAME=cyberark/conjur
 # both old-style 'conjur' and new-style 'cyberark/conjur'
 INTERNAL_IMAGES=`echo $CONJUR_REGISTRY/{conjur,$IMAGE_NAME}`
 
-# for releases, push to dockerhub and quay.io in addition to our registry
-RELEASE_IMAGES=`echo $INTERNAL_IMAGES {,quay.io/}$IMAGE_NAME`
-
 function main() {
   echo "TAG = $TAG"
   echo "VERSION = $VERSION"
@@ -43,11 +40,11 @@ function main() {
   git fetch --tags || : # Jenkins brokenness workaround
   local git_description=`git describe`
 
-  # if on tag matching the VERSION, also push releases to dockerhub and quay
+  # if on tag matching the VERSION, also push releases to dockerhub
   if [[ $git_description = v$VERSION ]]; then
     echo "Revision $git_description matches version exactly, pushing releases..."
     for v in latest $VERSION `gen_versions $VERSION`; do
-      tag_and_push $v $RELEASE_IMAGES
+      tag_and_push $v $IMAGE_NAME
     done
   else
     echo "Revision $git_description does not match version $VERSION exactly, not releasing."


### PR DESCRIPTION
### What does this PR do?
We no longer maintain an account at quay.io, so this PR removes the image publish step to that registry.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
