### PR TITLE
Print Conjur version only on server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The Conjur version is now printed on server startup, after running `conjurctl server`
+  ([cyberark/conjur#1590](https://github.com/cyberark/conjur/pull/1590))
 
 ## [1.7.1] - 2020-06-03
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -222,11 +222,6 @@ unless defined? LogMessages::Authentication::OriginValidated
         code: "CONJ00023D"
       )
 
-      ConjurVersionStartup = ::Util::TrackableLogMessageClass.new(
-        msg:  "Conjur v{0-conjur-version} starting up...",
-        code: "CONJ00037I"
-      )
-
     end
   end
 end

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -72,6 +72,9 @@ command :server do |c|
     end
 
     Process.fork do
+      conjur_version = File.read(File.expand_path("../VERSION", File.dirname(__FILE__))).strip
+      puts "Conjur v#{conjur_version} starting up..."
+
       exec "rails server -p #{options[:port]} -b #{options[:'bind-address']}"
     end
     Process.fork do

--- a/config/initializers/status.rb
+++ b/config/initializers/status.rb
@@ -2,5 +2,3 @@
 require 'logs'
 
 ENV["CONJUR_VERSION_DISPLAY"] = File.read(File.expand_path("../../VERSION", File.dirname(__FILE__)))
-
-Rails.logger.info(LogMessages::Util::ConjurVersionStartup.new(ENV["CONJUR_VERSION_DISPLAY"].strip))

--- a/cucumber/_authenticators_common/features/support/hooks.rb
+++ b/cucumber/_authenticators_common/features/support/hooks.rb
@@ -29,4 +29,17 @@ Before do
   #       share this code, and to it the api way (probably)
   creds.password = 'SEcret12!!!!'
   creds.save(raise_on_save_failure: true)
+
+  # Save env to revert to it after the test
+  @env = {}
+  ENV.each do |key, value|
+    @env[key] = value
+  end
+end
+
+After do
+  # Revert to original env
+  @env.each do |key, value|
+    ENV[key] = value
+  end
 end

--- a/cucumber/api/features/retrieve_api_key.feature
+++ b/cucumber/api/features/retrieve_api_key.feature
@@ -1,0 +1,14 @@
+Feature: Retrieving an API key with conjurctl
+
+  Background:
+    # We need to be in production environment to test this to demonstrate a real use-case
+    Given I set environment variable "RAILS_ENV" to "production"
+    And I set environment variable "CONJUR_LOG_LEVEL" to "info"
+
+  Scenario: Retrieve an API key
+    When I retrieve an API key for user "cucumber:user:admin" using conjurctl
+    Then the API key is correct
+
+  Scenario: Retrieve an API key of a non-existing user fails
+    When I retrieve an API key for user "cucumber:user:non-existing-user" using conjurctl
+    Then the stderr includes the error "role does not exist"

--- a/cucumber/api/features/step_definitions/conjurctl_steps.rb
+++ b/cucumber/api/features/step_definitions/conjurctl_steps.rb
@@ -1,0 +1,14 @@
+require 'open3'
+
+When(/^I retrieve an API key for user "([^"]*)" using conjurctl$/) do |user_id|
+  command = "conjurctl role retrieve-key #{user_id}"
+  @conjurctl_stdout, @conjurctl_stderr, = Open3.capture3(command)
+end
+
+Then(/^the API key is correct$/) do
+  expect(@conjurctl_stdout).to eq("#{Credentials['cucumber:user:admin'].api_key}\n")
+end
+
+Then(/^the stderr includes the error "([^"]*)"$/) do |error|
+  expect(@conjurctl_stderr).to include(error)
+end

--- a/cucumber/api/features/step_definitions/environment_steps.rb
+++ b/cucumber/api/features/step_definitions/environment_steps.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Given(/^I set environment variable "([^"]*)" to "([^"]*)"$/) do |variable_name, variable_value|
+  ENV[variable_name] = variable_value
+end

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -26,10 +26,21 @@ Before do
   Account.find_or_create_accounts_resource
   admin_role = Role.create(role_id: "cucumber:user:admin")
   Credentials.new(role: admin_role).save(raise_on_save_failure: true)
+
+  # Save env to revert to it after the test
+  @env = {}
+  ENV.each do |key, value|
+    @env[key] = value
+  end
 end
 
 After do
   FileUtils.remove_dir('cuke_export') if Dir.exists?('cuke_export')
+
+  # Revert to original env
+  @env.each do |key, value|
+    ENV[key] = value
+  end
 end
 
 Before("@logged-in") do

--- a/cucumber/authenticators/features/support/hooks.rb
+++ b/cucumber/authenticators/features/support/hooks.rb
@@ -24,4 +24,17 @@ Before do
   # this code, and to it the api way (probably)
   creds.password = 'SEcret12!!!!'
   creds.save(raise_on_save_failure: true)
+
+  # Save env to revert to it after the test
+  @env = {}
+  ENV.each do |key, value|
+    @env[key] = value
+  end
+end
+
+After do
+  # Revert to original env
+  @env.each do |key, value|
+    ENV[key] = value
+  end
 end

--- a/cucumber/policy/features/support/hooks.rb
+++ b/cucumber/policy/features/support/hooks.rb
@@ -37,4 +37,17 @@ Before do
   # this code, and to it the api way (probably)
   creds.password = 'SEcret12!!!!'
   creds.save(raise_on_save_failure: true)
+
+  # Save env to revert to it after the test
+  @env = {}
+  ENV.each do |key, value|
+    @env[key] = value
+  end
+end
+
+After do
+  # Revert to original env
+  @env.each do |key, value|
+    ENV[key] = value
+  end
 end


### PR DESCRIPTION
Connected to #1589

We recently started to print the Conjur version on server startup:
```
root@094a586bdea9:/opt/conjur-server# conjurctl server
CONJ00037I Conjur v1.7.1 starting up...
=> Booting Puma
=> Rails 5.2.4.3 application starting in production
=> Run `rails server -h` for more startup options
```

However, this message is written for every `conjurctl` command. For example:
```
root@094a586bdea9:/opt/conjur-server# conjurctl role retrieve-key cucumber:user:some-user
CONJ00037I Conjur v1.7.1 starting up...
error: role does not exist: cucumber:user:some-user
error: key retrieval failed
```

This PR changes the behaviour so that the message is printed only on server startup.

After the change, the output of `conjurctl server` is:
```
root@094a586bdea9:/opt/conjur-server# conjurctl server
Conjur v1.7.1 starting up...
=> Booting Puma
=> Rails 5.2.4.3 application starting in production
=> Run `rails server -h` for more startup options
```

and the output of `conjurctl role` is:
```
root@094a586bdea9:/opt/conjur-server# conjurctl role retrieve-key cucumber:user:some-user
error: role does not exist: cucumber:user:some-user
error: key retrieval failed
```