### PR TITLE
Raise proper error in case user not defined with `authn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - The Conjur version is now printed on server startup, after running `conjurctl server`
   ([cyberark/conjur#1590](https://github.com/cyberark/conjur/pull/1590))
+- Raise proper error of an authn request with a non-existing user to the `authn`
+  authenticator ([cyberark/conjur#1591](https://github.com/cyberark/conjur/pull/1591))
 
 ## [1.7.1] - 2020-06-03
 

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -4,7 +4,7 @@ module Authentication
 
   Err ||= Errors::Authentication
   # Possible Errors Raised:
-  # InvalidOrigin
+  # InvalidOrigin, RoleNotFound
 
   ValidateOrigin ||= CommandClass.new(
     dependencies: {
@@ -22,7 +22,15 @@ module Authentication
     private
 
     def role
-      @role_cls.by_login(@username, account: @account)
+      return @role if @role
+
+      @role = @role_cls.by_login(@username, account: @account)
+      raise Err::Security::RoleNotFound, role_id unless @role
+      @role
+    end
+
+    def role_id
+      @role_id ||= @role_cls.roleid_from_username(@account, @username)
     end
   end
 end

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -5,6 +5,8 @@ policy: >
 
 api: >
   --format pretty
+  -r cucumber/api/features/support/logs_helpers.rb
+  -r cucumber/api/features/step_definitions/logs_steps.rb
   -r cucumber/api
   cucumber/api
 

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -57,3 +57,12 @@ Feature: Exchange a role's API key for a signed authentication token
 
     When I POST "/authn/cucumber/alice/authenticate" with plain text body "wrong-api-key"
     Then the HTTP response status code is 401
+
+  Scenario: A non existing user cannot authenticate
+    Given I save my place in the log file
+    When I POST "/authn/cucumber/non-existing/authenticate"
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotFound
+    """


### PR DESCRIPTION
Connected to #1593 

In case a user sends an authn request with the `authn` authenticator,
and the user is not defined in Conjur, the log message will show:
`Authentication Error: #<NoMethodError: undefined method `valid_origin?' for nil:NilClass>`.

This is not informative and doesn't tell the user the real story. This commit will change
the message to:
`Authentication Error: #<Errors::Authentication::Security::RoleNotFound: CONJ00007E ‘cucumber:user:non-existing-user’ not found>`
