### PR TITLE
Update debify version

### DIFF
--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -2,9 +2,7 @@
 FROM @@image@@
 
 RUN apt-get update -y && \
-    apt-get install -y ruby2.5 \
-                       ruby2.5-dev \
-                       zlib1g-dev \
+    apt-get install -y zlib1g-dev \
                        liblzma-dev
 
 ENV BUNDLER_VERSION 2.1.4

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-export DEBIFY_IMAGE='registry.tld/conjurinc/debify:1.11'
+export DEBIFY_IMAGE='registry.tld/conjurinc/debify:1.11.5'
 
 docker run --rm $DEBIFY_IMAGE config script > docker-debify
 chmod +x docker-debify


### PR DESCRIPTION
Update Debify image which contain ruby2.5 compiled with OpenSSL FIPS compliance
