### PR TITLE
Add Client IP to Audit Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   message ID `password` ([cyberark/conjur#1548](https://github.com/cyberark/conjur/issues/1548))
 - API key rotations (`PUT /:authenticator/:account/api_key`) now produce audit events with
   message ID `api-key` ([cyberark/conjur#1549](https://github.com/cyberark/conjur/issues/1549))
+- All audit events now contain the IP address of the client that initiated the
+  API request (e.g. `[client@43868 ip="172.24.0.5"]`)
+  ([cyberark/conjur#1550](https://github.com/cyberark/conjur/issues/1550))
 
 ## [1.7.4] - 2020-06-17
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -51,7 +51,8 @@ class AuthenticateController < ApplicationController
       authenticator_name: params[:authenticator],
       service_id: params[:service_id],
       account: params[:account],
-      username: ::Role.username_from_roleid(current_user.role_id)
+      username: ::Role.username_from_roleid(current_user.role_id),
+      origin: request.ip
     )
   end
 
@@ -112,6 +113,7 @@ class AuthenticateController < ApplicationController
     Authentication::AuthnK8s::InjectClientCert.new.(
       conjur_account: ENV['CONJUR_ACCOUNT'],
       service_id: params[:service_id],
+      origin: request.ip,
       csr: request.body.read,
       # The host-id is split in the client where the suffix is in the CSR
       # and the prefix is in the header. This is done to maintain backwards-compatibility

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -52,7 +52,7 @@ class AuthenticateController < ApplicationController
       service_id: params[:service_id],
       account: params[:account],
       username: ::Role.username_from_roleid(current_user.role_id),
-      origin: request.ip
+      client_ip: request.ip
     )
   end
 
@@ -82,7 +82,7 @@ class AuthenticateController < ApplicationController
       account:            params[:account],
       username:           params[:id],
       credentials:        request.body.read,
-      origin:             request.ip,
+      client_ip:          request.ip,
       request:            request
     )
   end
@@ -103,7 +103,7 @@ class AuthenticateController < ApplicationController
       account:            params[:account],
       username:           nil,
       credentials:        request.body.read,
-      origin:             request.ip,
+      client_ip:          request.ip,
       request:            request
     )
   end
@@ -111,13 +111,14 @@ class AuthenticateController < ApplicationController
   def k8s_inject_client_cert
     # TODO: add this to initializer
     Authentication::AuthnK8s::InjectClientCert.new.(
-      conjur_account: ENV['CONJUR_ACCOUNT'],
-      service_id: params[:service_id],
-      origin: request.ip,
-      csr: request.body.read,
+      conjur_account:   ENV['CONJUR_ACCOUNT'],
+      service_id:       params[:service_id],
+      client_ip:        request.ip,
+      csr:              request.body.read,
+      
       # The host-id is split in the client where the suffix is in the CSR
       # and the prefix is in the header. This is done to maintain backwards-compatibility
-      host_id_prefix: request.headers["Host-Id-Prefix"]
+      host_id_prefix:   request.headers["Host-Id-Prefix"]
     )
     head :ok
   rescue => e

--- a/app/controllers/concerns/basic_authenticator.rb
+++ b/app/controllers/concerns/basic_authenticator.rb
@@ -41,7 +41,7 @@ module BasicAuthenticator
       account:            params[:account],
       username:           username,
       credentials:        password,
-      origin:             request.ip,
+      client_ip:          request.ip,
       request:            request
     )
   end

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -38,7 +38,8 @@ class CredentialsController < ApplicationController
 
     Commands::Credentials::ChangePassword.new.call(
       role: @role,
-      password: password
+      password: password,
+      client_ip: request.ip
     )
         
     head 204
@@ -50,7 +51,8 @@ class CredentialsController < ApplicationController
   def rotate_api_key
     Commands::Credentials::RotateApiKey.new.call(
       role_to_rotate: authentication.apply_to_role,
-      authenticated_role: authentication.authenticated_role
+      authenticated_role: authentication.authenticated_role,
+      client_ip: request.ip
     )
     render plain: @role.credentials.api_key
   end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -87,7 +87,8 @@ class PoliciesController < RestController
     policy_version = PolicyVersion.new(
       role: current_user,
       policy: resource,
-      policy_text: request.raw_post
+      policy_text: request.raw_post,
+      client_ip: request.ip
     )
     policy_version.delete_permitted = delete_permitted
     policy_version.save

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -58,6 +58,7 @@ class ResourcesController < RestController
     Audit.logger.log(
       Audit::Event::Check.new(
         user: current_user,
+        client_ip: request.ip,
         resource: resource,
         privilege: privilege,
         role: assumed_role,

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -74,7 +74,8 @@ class RolesController < RestController
         Audit::Event::Policy.new(
           operation: :add,
           subject: Audit::Subject::RoleMembership.new(membership.pk_hash),
-          user: current_user
+          user: current_user,
+          client_ip: request.ip
         )
       )
     end
@@ -99,7 +100,8 @@ class RolesController < RestController
       Audit::Event::Policy.new(
         operation: :remove,
         subject: Audit::Subject::RoleMembership.new(membership.pk_hash),
-        user: current_user
+        user: current_user,
+        client_ip: request.ip
       )
     )
 

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -20,7 +20,12 @@ class SecretsController < RestController
 
     head :created
   ensure
-    update_info = error_info.merge(resource: resource, user: @current_user)
+    update_info = error_info.merge(
+      resource: resource, 
+      user: @current_user,
+      client_ip: request.ip
+    )
+
     Audit.logger.log(
       Audit::Event::Update.new(update_info)
     )
@@ -75,7 +80,8 @@ class SecretsController < RestController
     fetch_info = error_info.merge(
       resource: resource,
       version: version,
-      user: current_user
+      user: current_user,
+      client_ip: request.ip
     )
 
     Audit.logger.log(

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -22,7 +22,7 @@ module Authentication
     extend Forwardable
     def_delegators(
       :@authenticator_input, :authenticator_name, :account, :username,
-      :webservice, :origin, :role
+      :webservice, :client_ip, :role
     )
 
     def call
@@ -73,7 +73,7 @@ module Authentication
       @validate_origin.(
         account: account,
         username: username,
-        origin: origin
+        client_ip: client_ip
       )
     end
 
@@ -83,7 +83,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            true,
           error_message:      nil
         )
@@ -96,7 +96,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -83,6 +83,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            true,
           error_message:      nil
         )
@@ -95,6 +96,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/authentication/authenticator_input.rb
+++ b/app/domain/authentication/authenticator_input.rb
@@ -12,7 +12,7 @@ module Authentication
     attribute :account, ::Types::NonEmptyString
     attribute :username, ::Types::NonEmptyString.optional
     attribute :credentials, ::Types::String.optional
-    attribute :origin, ::Types::NonEmptyString
+    attribute :client_ip, ::Types::NonEmptyString
     attribute :request, ::Types::Any
 
     # Creates a copy of this object with the attributes updated by those

--- a/app/domain/authentication/authenticator_status_input.rb
+++ b/app/domain/authentication/authenticator_status_input.rb
@@ -11,6 +11,7 @@ module Authentication
     attribute :service_id, ::Types::NonEmptyString.optional
     attribute :account, ::Types::NonEmptyString
     attribute :username, ::Types::NonEmptyString
+    attribute :origin, ::Types::String
 
     def webservice
       status_webservice.parent_webservice

--- a/app/domain/authentication/authenticator_status_input.rb
+++ b/app/domain/authentication/authenticator_status_input.rb
@@ -11,7 +11,7 @@ module Authentication
     attribute :service_id, ::Types::NonEmptyString.optional
     attribute :account, ::Types::NonEmptyString
     attribute :username, ::Types::NonEmptyString
-    attribute :origin, ::Types::String
+    attribute :client_ip, ::Types::String
 
     def webservice
       status_webservice.parent_webservice

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -21,7 +21,7 @@ module Authentication
         validate_pod_request:   ValidatePodRequest.new,
         audit_log:              ::Audit.logger
       },
-      inputs: %i(conjur_account service_id csr host_id_prefix origin)
+      inputs: %i(conjur_account service_id csr host_id_prefix client_ip)
     ) do
 
       # :reek:TooManyStatements
@@ -196,7 +196,7 @@ module Authentication
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
             role: host,
-            client_ip: @origin,
+            client_ip: @client_ip,
             success: true,
             error_message: nil
           )
@@ -209,7 +209,7 @@ module Authentication
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
             role: host,
-            client_ip: @origin,
+            client_ip: @client_ip,
             success: false,
             error_message: err.message
           )

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -21,7 +21,7 @@ module Authentication
         validate_pod_request:   ValidatePodRequest.new,
         audit_log:              ::Audit.logger
       },
-      inputs: %i(conjur_account service_id csr host_id_prefix)
+      inputs: %i(conjur_account service_id csr host_id_prefix origin)
     ) do
 
       # :reek:TooManyStatements
@@ -196,6 +196,7 @@ module Authentication
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
             role: host,
+            client_ip: @origin,
             success: true,
             error_message: nil
           )
@@ -208,6 +209,7 @@ module Authentication
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
             role: host,
+            client_ip: @origin,
             success: false,
             error_message: err.message
           )

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -23,7 +23,9 @@ module Authentication
     ) do
 
       extend Forwardable
-      def_delegators :@authenticator_input, :service_id, :authenticator_name, :account, :username, :webservice, :credentials, :origin, :role
+      def_delegators :@authenticator_input, :service_id, :authenticator_name,
+                     :account, :username, :webservice, :credentials, :client_ip,
+                     :role
 
       def call
         validate_account_exists
@@ -131,7 +133,7 @@ module Authentication
         @validate_origin.(
           account: account,
           username: username,
-          origin: origin
+          client_ip: client_ip
         )
       end
 
@@ -141,7 +143,7 @@ module Authentication
             authenticator_name: authenticator_name,
             service:            webservice,
             role:               role,
-            client_ip:          origin,
+            client_ip:          client_ip,
             success:            true,
             error_message:      nil
           )
@@ -154,7 +156,7 @@ module Authentication
             authenticator_name: authenticator_name,
             service:            webservice,
             role:               role,
-            client_ip:          origin,
+            client_ip:          client_ip,
             success:            false,
             error_message:      err.message
           )

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -141,6 +141,7 @@ module Authentication
             authenticator_name: authenticator_name,
             service:            webservice,
             role:               role,
+            client_ip:          origin,
             success:            true,
             error_message:      nil
           )
@@ -153,6 +154,7 @@ module Authentication
             authenticator_name: authenticator_name,
             service:            webservice,
             role:               role,
+            client_ip:          origin,
             success:            false,
             error_message:      err.message
           )

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -21,7 +21,7 @@ module Authentication
     extend Forwardable
     def_delegators(
       :@authenticator_input, :authenticator_name, :account, :username,
-      :webservice, :role, :origin
+      :webservice, :role, :client_ip
     )
 
     def call
@@ -77,7 +77,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            true,
           error_message:      nil
         )
@@ -90,7 +90,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -21,7 +21,7 @@ module Authentication
     extend Forwardable
     def_delegators(
       :@authenticator_input, :authenticator_name, :account, :username,
-      :webservice, :role
+      :webservice, :role, :origin
     )
 
     def call
@@ -77,6 +77,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            true,
           error_message:      nil
         )
@@ -89,6 +90,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -11,11 +11,11 @@ module Authentication
       role_cls: ::Role,
       logger:   Rails.logger
     },
-    inputs: %i(account username origin)
+    inputs: %i(account username client_ip)
   ) do
 
     def call
-      raise Err::InvalidOrigin unless role.valid_origin?(@origin)
+      raise Err::InvalidOrigin unless role.valid_origin?(@client_ip)
       @logger.debug(LogMessages::Authentication::OriginValidated.new.to_s)
     end
 

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -26,7 +26,7 @@ module Authentication
 
     extend Forwardable
     def_delegators :@authenticator_status_input, :authenticator_name, :account,
-      :username, :webservice, :status_webservice, :role, :origin
+                   :username, :webservice, :status_webservice, :role, :client_ip
 
     def call
       validate_authenticator_exists
@@ -91,7 +91,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            true,
           error_message:      nil
         )
@@ -104,7 +104,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
-          client_ip:          origin,
+          client_ip:          client_ip,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -25,7 +25,8 @@ module Authentication
   ) do
 
     extend Forwardable
-    def_delegators :@authenticator_status_input, :authenticator_name, :account, :username, :webservice, :status_webservice, :role
+    def_delegators :@authenticator_status_input, :authenticator_name, :account,
+      :username, :webservice, :status_webservice, :role, :origin
 
     def call
       validate_authenticator_exists
@@ -90,6 +91,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            true,
           error_message:      nil
         )
@@ -102,6 +104,7 @@ module Authentication
           authenticator_name: authenticator_name,
           service:            webservice,
           role:               role,
+          client_ip:          origin,
           success:            false,
           error_message:      err.message
         )

--- a/app/domain/commands/credentials/change_password.rb
+++ b/app/domain/commands/credentials/change_password.rb
@@ -14,7 +14,7 @@ module Commands
       # dependency that it will use to save the new password.
       # This should be addressed to make the database dependency explicit:
       # https://github.com/cyberark/conjur/issues/1611
-      inputs: %i(role password)
+      inputs: %i(role password client_ip)
     ) do
 
       def call
@@ -38,7 +38,11 @@ module Commands
 
       def audit_success
         @audit_log.log(
-          ::Audit::Event::Password.new(user_id: @role.id, success: true)
+          ::Audit::Event::Password.new(
+            user_id: @role.id,
+            client_ip: @client_ip,
+            success: true
+          )
         )
       end
 
@@ -46,6 +50,7 @@ module Commands
         @audit_log.log(
           ::Audit::Event::Password.new(
             user_id: @role.id,
+            client_ip: @client_ip,
             success: false,
             error_message: err.message
           )

--- a/app/domain/commands/credentials/rotate_api_key.rb
+++ b/app/domain/commands/credentials/rotate_api_key.rb
@@ -14,7 +14,7 @@ module Commands
       dependencies: {
         audit_log: ::Audit.logger
       },
-      inputs: %i(role_to_rotate authenticated_role)
+      inputs: %i(role_to_rotate authenticated_role client_ip)
     ) do
 
       def call
@@ -41,6 +41,7 @@ module Commands
           ::Audit::Event::ApiKey.new(
             authenticated_role_id: @authenticated_role.id,
             rotated_role_id: @role_to_rotate.id,
+            client_ip: @client_ip,
             success: true
           )
         )
@@ -51,6 +52,7 @@ module Commands
           ::Audit::Event::ApiKey.new(
             authenticated_role_id: @authenticated_role.id,
             rotated_role_id: @role_to_rotate.id,
+            client_ip: @client_ip,
             success: false,
             error_message: err.message
           )

--- a/app/models/audit/event/api_key.rb
+++ b/app/models/audit/event/api_key.rb
@@ -1,11 +1,19 @@
 module Audit
   module Event
 
-    # As a value object, it is okay that this class has :reek:TooManyInstanceVariables
+    # Note: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class ApiKey
-      def initialize(authenticated_role_id:, rotated_role_id:, success:, error_message: nil)
+      def initialize(
+        authenticated_role_id:,
+        rotated_role_id:,
+        client_ip:,
+        success:,
+        error_message: nil
+      )
         @authenticated_role_id = authenticated_role_id
         @rotated_role_id = rotated_role_id
+        @client_ip = client_ip
         @success = success
         @error_message = error_message
 
@@ -41,7 +49,8 @@ module Audit
       def structured_data
         {
           SDID::AUTH => { user: @authenticated_role_id },
-          SDID::SUBJECT => { role: @rotated_role_id }
+          SDID::SUBJECT => { role: @rotated_role_id },
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -1,10 +1,18 @@
 module Audit
   module Event
     # Note: Breaking this class up further would harm clarity.
-    # :reek:TooManyInstanceVariables
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Authn
-      def initialize(role:, authenticator_name:, service:, success:, operation:)
+      def initialize(
+        role:,
+        client_ip:,
+        authenticator_name:,
+        service:,
+        success:,
+        operation:
+      )
         @role = role
+        @client_ip = client_ip
         @authenticator_name = authenticator_name
         @service = service
         @success = success
@@ -52,7 +60,8 @@ module Audit
       def structured_data
         {
           SDID::SUBJECT => { role: @role&.id },
-          SDID::AUTH => auth_stuctured_data
+          SDID::AUTH => auth_stuctured_data,
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/authn/authenticate.rb
+++ b/app/models/audit/event/authn/authenticate.rb
@@ -3,6 +3,8 @@ require 'forwardable'
 module Audit
   module Event
     class Authn
+      # Note: Breaking this class up further would harm clarity.
+      # :reek:TooManyInstanceVariables and :reek:TooManyParameters
       class Authenticate
         extend Forwardable
         def_delegators(
@@ -12,6 +14,7 @@ module Audit
 
         def initialize(
           role:,
+          client_ip:,
           authenticator_name:,
           service:,
           success:,
@@ -21,6 +24,7 @@ module Audit
           @error_message = error_message
           @authn = Authn.new(
             role: role,
+            client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
             success: success,

--- a/app/models/audit/event/authn/inject_client_cert.rb
+++ b/app/models/audit/event/authn/inject_client_cert.rb
@@ -3,6 +3,8 @@ require 'forwardable'
 module Audit
   module Event
     class Authn
+      # Note: Breaking this class up further would harm clarity.
+      # :reek:TooManyInstanceVariables and :reek:TooManyParameters
       class InjectClientCert
         extend Forwardable
         def_delegators(
@@ -12,6 +14,7 @@ module Audit
 
         def initialize(
           role:,
+          client_ip:,
           authenticator_name:,
           service:,
           success:,
@@ -21,6 +24,7 @@ module Audit
           @error_message = error_message
           @authn = Authn.new(
             role: role,
+            client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
             success: success,

--- a/app/models/audit/event/authn/login.rb
+++ b/app/models/audit/event/authn/login.rb
@@ -3,6 +3,8 @@ require 'forwardable'
 module Audit
   module Event
     class Authn
+      # Note: Breaking this class up further would harm clarity.
+      # :reek:TooManyInstanceVariables and :reek:TooManyParameters
       class Login
         extend Forwardable
         def_delegators(
@@ -12,6 +14,7 @@ module Audit
 
         def initialize(
           role:,
+          client_ip:,
           authenticator_name:,
           service:,
           success:,
@@ -21,6 +24,7 @@ module Audit
           @error_message = error_message
           @authn = Authn.new(
             role: role,
+            client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
             success: success,

--- a/app/models/audit/event/authn/validate_status.rb
+++ b/app/models/audit/event/authn/validate_status.rb
@@ -3,6 +3,8 @@ require 'forwardable'
 module Audit
   module Event
     class Authn
+      # Note: Breaking this class up further would harm clarity.
+      # :reek:TooManyInstanceVariables and :reek:TooManyParameters
       class ValidateStatus
         extend Forwardable
         def_delegators(
@@ -12,6 +14,7 @@ module Audit
 
         def initialize(
           role:,
+          client_ip:,
           authenticator_name:,
           service:,
           success:,
@@ -21,6 +24,7 @@ module Audit
           @error_message = error_message
           @authn = Authn.new(
             role: role,
+            client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
             success: success,

--- a/app/models/audit/event/check.rb
+++ b/app/models/audit/event/check.rb
@@ -1,10 +1,18 @@
 module Audit
   module Event
     # Note: Breaking this class up further would harm clarity.
-    # :reek:TooManyInstanceVariables
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Check
-      def initialize(user:, resource:, privilege:, role:, success:)
+      def initialize(
+        user:,
+        client_ip:,
+        resource:,
+        privilege:,
+        role:,
+        success:
+      )
         @user = user
+        @client_ip = client_ip
         @resource = resource
         @privilege = privilege
         @role = role
@@ -44,7 +52,8 @@ module Audit
             resource: @resource.id,
             role: @role.id,
             privilege: @privilege
-          }
+          },
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/fetch.rb
+++ b/app/models/audit/event/fetch.rb
@@ -1,10 +1,18 @@
 module Audit
   module Event
     # Note: Breaking this class up further would harm clarity.
-    # :reek:TooManyInstanceVariables
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Fetch
-      def initialize(user:, resource:, success:, version:, error_message: nil)
+      def initialize(
+        user:,
+        client_ip:,
+        resource:,
+        success:,
+        version:,
+        error_message: nil
+      )
         @user = user
+        @client_ip = client_ip
         @resource = resource
         @success = success
         @error_message = error_message
@@ -44,7 +52,8 @@ module Audit
       def structured_data
         {
           SDID::AUTH => { user: @user.id },
-          SDID::SUBJECT => subject_sd_value
+          SDID::SUBJECT => subject_sd_value,
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/password.rb
+++ b/app/models/audit/event/password.rb
@@ -1,9 +1,17 @@
 module Audit
   module Event
+    # Note: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Password
 
-      def initialize(user_id:, success:, error_message: nil)
+      def initialize(
+        user_id:,
+        client_ip:,
+        success:,
+        error_message: nil
+      )
         @user_id = user_id
+        @client_ip = client_ip
         @success = success
         @error_message = error_message
 
@@ -43,7 +51,8 @@ module Audit
       def structured_data
         {
           SDID::AUTH => { user: @user_id },
-          SDID::SUBJECT => { user: @user_id }
+          SDID::SUBJECT => { user: @user_id },
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/policy.rb
+++ b/app/models/audit/event/policy.rb
@@ -1,17 +1,21 @@
 module Audit
   module Event
+    # Note: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Policy
 
       def initialize(
         operation:,
         subject:,
         user: nil,
-        policy_version: nil
+        policy_version: nil,
+        client_ip: nil
       )
         @operation = operation
         @subject = subject
         @user = user
         @policy_version = policy_version
+        @client_ip = client_ip
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -48,7 +52,8 @@ module Audit
         {
           SDID::AUTH => { user: @user&.id },
           SDID::SUBJECT => @subject.to_h,
-          SDID::ACTION => { operation: @operation }
+          SDID::ACTION => { operation: @operation },
+          SDID::CLIENT => { ip: client_ip }
         }.tap do |sd|
           if @policy_version
             sd[SDID::POLICY] = {
@@ -71,6 +76,10 @@ module Audit
 
       def user
         @user || @policy_version.role
+      end
+
+      def client_ip
+        @client_ip || @policy_version.client_ip
       end
     end
   end

--- a/app/models/audit/event/update.rb
+++ b/app/models/audit/event/update.rb
@@ -1,9 +1,18 @@
 module Audit
   module Event
+    # Note: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Update
 
-      def initialize(user:, resource:, success:, error_message: nil)
+      def initialize(
+        user:,
+        client_ip:,
+        resource:,
+        success:,
+        error_message: nil
+      )
         @user = user
+        @client_ip = client_ip
         @resource = resource
         @success = success
         @error_message = error_message
@@ -50,7 +59,8 @@ module Audit
       def structured_data
         {
           SDID::AUTH => { user: @user.id },
-          SDID::SUBJECT => Subject::Resource.new(@resource.pk_hash).to_h
+          SDID::SUBJECT => Subject::Resource.new(@resource.pk_hash).to_h,
+          SDID::CLIENT => { ip: @client_ip }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/sdid.rb
+++ b/app/models/audit/sdid.rb
@@ -2,6 +2,8 @@
 
 module Audit
   # RFC5424 structured data IDs for Conjur-specific audit fields.
+  # NOTE: SDID is a container of constants for audit and so exhibits
+  # :reek:TooManyConstants.
   module SDID
     # Conjur's Private Enterprise Number
     # cf. https://pen.iana.org
@@ -14,5 +16,6 @@ module Audit
     AUTH = conjur_sdid 'auth'
     SUBJECT = conjur_sdid 'subject'
     ACTION = conjur_sdid 'action'
+    CLIENT = conjur_sdid 'client'
   end
 end

--- a/app/models/policy_version.rb
+++ b/app/models/policy_version.rb
@@ -10,6 +10,7 @@
 #
 # * +role+ the authenticated role who performed the policy load.
 # * +created_at+ a timestamp.
+# * +client_ip+ the IP address of the client that loaded the policy.
 # * +policy_text+ the text of the policy itself.
 # * +policy_sha256+ the SHA-256 of the policy in hex digest form.
 #

--- a/db/migrate/20200605203735_add_policy_version_client_ip.rb
+++ b/db/migrate/20200605203735_add_policy_version_client_ip.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :policy_versions do
+      add_column :client_ip, String
+    end
+  end
+end

--- a/spec/app/domain/authentication/authenticate_spec.rb
+++ b/spec/app/domain/authentication/authenticate_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Authentication::Authenticate' do
         account:            'my-acct',
         username:           'my-user',
         credentials:        'my-pw',
-        origin:             '127.0.0.1',
+        client_ip:          '127.0.0.1',
         request:            nil
       )
 
@@ -106,7 +106,7 @@ RSpec.describe 'Authentication::Authenticate' do
           account:            'my-acct',
           username:           'my-user',
           credentials:        'my-pw',
-          origin:             '127.0.0.1',
+          client_ip:          '127.0.0.1',
           request:            nil
         )
 
@@ -143,7 +143,7 @@ RSpec.describe 'Authentication::Authenticate' do
             account:            'my-acct',
             username:           'my-user',
             credentials:        'my-pw',
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            nil
           )
 
@@ -179,7 +179,7 @@ RSpec.describe 'Authentication::Authenticate' do
             account:            'my-acct',
             username:           'my-user',
             credentials:        'my-pw',
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            nil
           )
 
@@ -215,7 +215,7 @@ RSpec.describe 'Authentication::Authenticate' do
             account:            'my-acct',
             username:           'my-user',
             credentials:        'my-pw',
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            nil
           )
 

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
               account:            account,
               username:           'my-user',
               credentials:        request_body(authenticate_azure_token_request),
-              origin:             '127.0.0.1',
+              client_ip:          '127.0.0.1',
               request:            authenticate_azure_token_request
             )
 
@@ -98,7 +98,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
               account:            'my-acct',
               username:           nil,
               credentials:        request_body(authenticate_azure_token_request),
-              origin:             '127.0.0.1',
+              client_ip:          '127.0.0.1',
               request:            authenticate_azure_token_request
             )
 
@@ -130,7 +130,7 @@ RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
               account:            'my-acct',
               username:           nil,
               credentials:        request_body(authenticate_azure_token_request),
-              origin:             '127.0.0.1',
+              client_ip:          '127.0.0.1',
               request:            authenticate_azure_token_request
             )
 

--- a/spec/app/domain/authentication/authn-oidc/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/authenticator_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
               account:            'my-acct',
               username:           nil,
               credentials:        request_body(authenticate_id_token_request),
-              origin:             '127.0.0.1',
+              client_ip:          '127.0.0.1',
               request:            authenticate_id_token_request
             )
 
@@ -137,7 +137,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request
           )
 
@@ -173,7 +173,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request
           )
 
@@ -209,7 +209,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request_missing_id_token_username_field),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request_missing_id_token_username_field
           )
 
@@ -245,7 +245,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request_empty_id_token_username_field),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request_empty_id_token_username_field
           )
 
@@ -282,7 +282,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request_missing_id_token_field),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request_missing_id_token_field
           )
 
@@ -314,7 +314,7 @@ RSpec.describe Authentication::AuthnOidc::Authenticator do
             account:            'my-acct',
             username:           nil,
             credentials:        request_body(authenticate_id_token_request_empty_id_token_field),
-            origin:             '127.0.0.1',
+            client_ip:          '127.0.0.1',
             request:            authenticate_id_token_request_empty_id_token_field
           )
 

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
   let(:service_id) { "ServiceName" }
   let(:common_name) { "CommonName.#{spiffe_namespace}.Resource.Id" }
   let(:host_id_prefix) { "host.some-policy" }
+  let(:origin) { "test origin" }
   let(:nil_host_id_prefix) { nil }
   let(:csr) { "CSR" }
 
@@ -175,7 +176,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                             service_id: service_id,
                             csr: csr,
-                            host_id_prefix: host_id_prefix) }.to raise_error(error_type, missing_spiffe_id_error)
+                            host_id_prefix: host_id_prefix,
+                            origin: origin) }.to raise_error(error_type, missing_spiffe_id_error)
         end
       end
     end
@@ -194,7 +196,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
         expect { injector.(conjur_account: account,
                           service_id: service_id,
                           csr: csr,
-                          host_id_prefix: host_id_prefix) }.to raise_error(RuntimeError, pod_validation_error)
+                          host_id_prefix: host_id_prefix,
+                          origin: origin) }.to raise_error(RuntimeError, pod_validation_error)
       end
     end
 
@@ -240,7 +243,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                             service_id: service_id,
                             csr: csr,
-                            host_id_prefix: host_id_prefix) }.to raise_error(RuntimeError, expected_error_text)
+                            host_id_prefix: host_id_prefix,
+                            origin: origin) }.to raise_error(RuntimeError, expected_error_text)
         end
       end
 
@@ -259,7 +263,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                             service_id: service_id,
                             csr: csr,
-                            host_id_prefix: host_id_prefix) }.to raise_error(error_type, expected_full_error_text)
+                            host_id_prefix: host_id_prefix,
+                            origin: origin) }.to raise_error(error_type, expected_full_error_text)
         end
       end
 
@@ -277,7 +282,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                             service_id: service_id,
                             csr: csr,
-                            host_id_prefix: host_id_prefix) }.to raise_error(error_type, expected_full_error_text)
+                            host_id_prefix: host_id_prefix,
+                            origin: origin) }.to raise_error(error_type, expected_full_error_text)
         end
       end
 
@@ -286,7 +292,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                              service_id: service_id,
                              csr: csr,
-                             host_id_prefix: host_id_prefix) }.to_not raise_error
+                             host_id_prefix: host_id_prefix,
+                             origin: origin) }.to_not raise_error
         end
 
         it "throws no errors if copy is successful and error stream is empty string" do
@@ -297,7 +304,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                              service_id: service_id,
                              csr: csr,
-                             host_id_prefix: host_id_prefix) }.to_not raise_error
+                             host_id_prefix: host_id_prefix,
+                             origin: origin) }.to_not raise_error
         end
 
         it "uses policy-defined container name if set" do
@@ -322,7 +330,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           expect { injector.(conjur_account: account,
                              service_id: service_id,
                              csr: csr,
-                             host_id_prefix: host_id_prefix) }.to_not raise_error
+                             host_id_prefix: host_id_prefix,
+                             origin: origin) }.to_not raise_error
         end
 
         context "when the Host-Id-Prefix parameter doesn't exist" do
@@ -330,7 +339,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
             injector.(conjur_account: account,
               service_id: service_id,
               csr: csr,
-              host_id_prefix: nil_host_id_prefix)
+              host_id_prefix: nil_host_id_prefix,
+              origin: origin)
           end
 
           it "updates the common-name to the hard coded prefix and raises no error" do
@@ -345,7 +355,8 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
             injector.(conjur_account: account,
               service_id: service_id,
               csr: csr,
-              host_id_prefix: host_id_prefix)
+              host_id_prefix: host_id_prefix,
+              origin: origin)
           end
 
           it "updates the common-name to the value of Host-Id-Prefix and raises no error" do

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
   let(:service_id) { "ServiceName" }
   let(:common_name) { "CommonName.#{spiffe_namespace}.Resource.Id" }
   let(:host_id_prefix) { "host.some-policy" }
-  let(:origin) { "test origin" }
+  let(:client_ip) { "test client IP" }
   let(:nil_host_id_prefix) { nil }
   let(:csr) { "CSR" }
 
@@ -177,7 +177,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                             service_id: service_id,
                             csr: csr,
                             host_id_prefix: host_id_prefix,
-                            origin: origin) }.to raise_error(error_type, missing_spiffe_id_error)
+                            client_ip: client_ip) }.to raise_error(error_type, missing_spiffe_id_error)
         end
       end
     end
@@ -197,7 +197,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                           service_id: service_id,
                           csr: csr,
                           host_id_prefix: host_id_prefix,
-                          origin: origin) }.to raise_error(RuntimeError, pod_validation_error)
+                          client_ip: client_ip) }.to raise_error(RuntimeError, pod_validation_error)
       end
     end
 
@@ -244,7 +244,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                             service_id: service_id,
                             csr: csr,
                             host_id_prefix: host_id_prefix,
-                            origin: origin) }.to raise_error(RuntimeError, expected_error_text)
+                            client_ip: client_ip) }.to raise_error(RuntimeError, expected_error_text)
         end
       end
 
@@ -264,7 +264,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                             service_id: service_id,
                             csr: csr,
                             host_id_prefix: host_id_prefix,
-                            origin: origin) }.to raise_error(error_type, expected_full_error_text)
+                            client_ip: client_ip) }.to raise_error(error_type, expected_full_error_text)
         end
       end
 
@@ -283,7 +283,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                             service_id: service_id,
                             csr: csr,
                             host_id_prefix: host_id_prefix,
-                            origin: origin) }.to raise_error(error_type, expected_full_error_text)
+                            client_ip: client_ip) }.to raise_error(error_type, expected_full_error_text)
         end
       end
 
@@ -293,7 +293,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                              service_id: service_id,
                              csr: csr,
                              host_id_prefix: host_id_prefix,
-                             origin: origin) }.to_not raise_error
+                             client_ip: client_ip) }.to_not raise_error
         end
 
         it "throws no errors if copy is successful and error stream is empty string" do
@@ -305,7 +305,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                              service_id: service_id,
                              csr: csr,
                              host_id_prefix: host_id_prefix,
-                             origin: origin) }.to_not raise_error
+                             client_ip: client_ip) }.to_not raise_error
         end
 
         it "uses policy-defined container name if set" do
@@ -331,7 +331,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
                              service_id: service_id,
                              csr: csr,
                              host_id_prefix: host_id_prefix,
-                             origin: origin) }.to_not raise_error
+                             client_ip: client_ip) }.to_not raise_error
         end
 
         context "when the Host-Id-Prefix parameter doesn't exist" do
@@ -340,7 +340,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
               service_id: service_id,
               csr: csr,
               host_id_prefix: nil_host_id_prefix,
-              origin: origin)
+              client_ip: client_ip)
           end
 
           it "updates the common-name to the hard coded prefix and raises no error" do
@@ -356,7 +356,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
               service_id: service_id,
               csr: csr,
               host_id_prefix: host_id_prefix,
-              origin: origin)
+              client_ip: client_ip)
           end
 
           it "updates the common-name to the value of Host-Id-Prefix and raises no error" do

--- a/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_ldap/authenticator_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Authentication::AuthnLdap::Authenticator do
       service_id:         'test',
       account:            'test',
       username:           username,
-      credentials:       password,
-      origin:             '127.0.0.1',
+      credentials:        password,
+      client_ip:          '127.0.0.1',
       request:            nil
     )
   end

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe Authentication::ValidateStatus do
       allow(status_input).to receive(:username)
                                .and_return(test_user_id)
 
+      allow(status_input).to receive(:origin)
+                               .and_return(test_origin)
+
       allow(status_input).to receive(:role)
                                .and_return(mock_role_class)
     end

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Authentication::ValidateStatus do
       allow(status_input).to receive(:username)
                                .and_return(test_user_id)
 
-      allow(status_input).to receive(:origin)
-                               .and_return(test_origin)
+      allow(status_input).to receive(:client_ip)
+                               .and_return(test_client_ip)
 
       allow(status_input).to receive(:role)
                                .and_return(mock_role_class)

--- a/spec/app/domain/commands/credentials/change_password_spec.rb
+++ b/spec/app/domain/commands/credentials/change_password_spec.rb
@@ -4,18 +4,24 @@ describe Commands::Credentials::ChangePassword do
   let(:credentials) { double(Credentials) }
   let(:role) { double(Role, id: 'role', credentials: credentials) }
   let(:password) { 'the_password' }
+  let(:client_ip) { 'my-client-ip' }
 
   let(:err_message) { 'the error message' }
 
   let(:audit_log) { double(::Audit.logger)}
   
   let(:audit_success) do
-    ::Audit::Event::Password.new(user_id: role.id, success: true)
+    ::Audit::Event::Password.new(
+      user_id: role.id,
+      client_ip: client_ip,
+      success: true
+    )
   end
   
   let(:audit_failure) do
     ::Audit::Event::Password.new(
       user_id: role.id,
+      client_ip: client_ip,
       success: false,
       error_message: err_message
     )
@@ -37,7 +43,7 @@ describe Commands::Credentials::ChangePassword do
     expect(audit_log).to receive(:log).with(audit_success)
 
     # Call the command
-    subject.call(role: role,  password: password)
+    subject.call(role: role,  password: password, client_ip: client_ip)
   end
 
   it 'bubbles up exceptions' do 
@@ -50,6 +56,8 @@ describe Commands::Credentials::ChangePassword do
     expect(audit_log).to receive(:log).with(audit_failure)
 
     # Expect the command to raise the original exception
-    expect { subject.call(role: role,  password: password) }.to raise_error(err_message)
+    expect do
+      subject.call(role: role,  password: password, client_ip: client_ip)
+    end.to raise_error(err_message)
   end
 end

--- a/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
+++ b/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
@@ -7,6 +7,8 @@ describe Commands::Credentials::RotateApiKey do
   let(:other_credentials) { double(Credentials) }
   let(:other_role) { double(Role, id: 'other role', credentials: other_credentials) }
 
+  let(:client_ip) { 'my-client-ip' }
+
   let(:role_to_rotate) { role }
 
   let(:err_message) { 'the error message' }
@@ -17,6 +19,7 @@ describe Commands::Credentials::RotateApiKey do
     ::Audit::Event::ApiKey.new(
       authenticated_role_id: role.id,
       rotated_role_id: role_to_rotate.id,
+      client_ip: client_ip,
       success: true
     )
   end
@@ -25,6 +28,7 @@ describe Commands::Credentials::RotateApiKey do
     ::Audit::Event::ApiKey.new(
       authenticated_role_id: role.id,
       rotated_role_id: role_to_rotate.id,
+      client_ip: client_ip,
       success: false,
       error_message: err_message
     )
@@ -49,7 +53,11 @@ describe Commands::Credentials::RotateApiKey do
       expect(audit_log).to receive(:log).with(audit_success)
 
       # Call the command
-      subject.call(role_to_rotate: role, authenticated_role: role)
+      subject.call(
+        role_to_rotate: role, 
+        authenticated_role: role, 
+        client_ip: client_ip
+      )
     end
 
     it 'bubbles up exceptions' do 
@@ -67,7 +75,11 @@ describe Commands::Credentials::RotateApiKey do
 
       # Expect the command to raise the original exception
       expect do
-        subject.call(role_to_rotate: role, authenticated_role: role)
+        subject.call(
+          role_to_rotate: role,
+          authenticated_role: role,
+          client_ip: client_ip
+        )
       end.to raise_error(err_message)
     end
   end
@@ -84,7 +96,11 @@ describe Commands::Credentials::RotateApiKey do
       expect(audit_log).to receive(:log).with(audit_success)
 
       # Call the command
-      subject.call(role_to_rotate: other_role, authenticated_role: role)
+      subject.call(
+        role_to_rotate: other_role,
+        authenticated_role: role,
+        client_ip: client_ip
+      )
     end
 
     it 'bubbles up exceptions' do 
@@ -98,7 +114,11 @@ describe Commands::Credentials::RotateApiKey do
 
       # Expect the command to raise the original exception
       expect do
-        subject.call(role_to_rotate: other_role, authenticated_role: role)
+        subject.call(
+          role_to_rotate: other_role,
+          authenticated_role: role,
+          client_ip: client_ip
+        )
       end.to raise_error(err_message)
     end
   end

--- a/spec/models/audit/event/api_key_spec.rb
+++ b/spec/models/audit/event/api_key_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 describe Audit::Event::ApiKey do
   let(:role_id) { 'rspec:user:my_user' }
   let(:other_role_id) { 'rspec:user:other_user' }
-
   let(:rotated_role_id) { role_id }
-
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -13,6 +12,7 @@ describe Audit::Event::ApiKey do
     Audit::Event::ApiKey.new(
       authenticated_role_id: role_id,
       rotated_role_id: rotated_role_id,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -35,6 +35,8 @@ describe Audit::Event::ApiKey do
       )
     end
 
+    it_behaves_like 'structured data includes client IP address'
+
     context 'when user rotates another role\'s key' do
       let(:rotated_role_id) { other_role_id }
 
@@ -43,6 +45,8 @@ describe Audit::Event::ApiKey do
           'rspec:user:my_user successfully rotated the api key for rspec:user:other_user'
         )
       end
+
+      it_behaves_like 'structured data includes client IP address'
     end
   end
 
@@ -61,6 +65,7 @@ describe Audit::Event::ApiKey do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
 
+    it_behaves_like 'structured data includes client IP address'
 
     context 'when user rotates another role\'s key' do
       let(:rotated_role_id) { other_role_id }
@@ -71,6 +76,8 @@ describe Audit::Event::ApiKey do
           'rspec:user:other_user: failed rotation'
         )
       end
+
+      it_behaves_like 'structured data includes client IP address'
     end
   end
 end

--- a/spec/models/audit/event/authn/authenticate_spec.rb
+++ b/spec/models/audit/event/authn/authenticate_spec.rb
@@ -5,6 +5,7 @@ describe Audit::Event::Authn::Authenticate do
   let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -13,6 +14,7 @@ describe Audit::Event::Authn::Authenticate do
       role: role,
       authenticator_name: authenticator_name,
       service: service,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -36,6 +38,8 @@ describe Audit::Event::Authn::Authenticate do
         'my-authenticator service rspec:webservice:my-service'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -52,5 +56,7 @@ describe Audit::Event::Authn::Authenticate do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/authn/inject_client_cert_spec.rb
+++ b/spec/models/audit/event/authn/inject_client_cert_spec.rb
@@ -5,6 +5,7 @@ describe Audit::Event::Authn::InjectClientCert do
   let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -13,6 +14,7 @@ describe Audit::Event::Authn::InjectClientCert do
       role: role,
       authenticator_name: authenticator_name,
       service: service,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -36,6 +38,8 @@ describe Audit::Event::Authn::InjectClientCert do
         'authenticator my-authenticator service rspec:webservice:my-service'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -52,5 +56,7 @@ describe Audit::Event::Authn::InjectClientCert do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/authn/login_spec.rb
+++ b/spec/models/audit/event/authn/login_spec.rb
@@ -5,6 +5,7 @@ describe Audit::Event::Authn::Login do
   let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -13,6 +14,7 @@ describe Audit::Event::Authn::Login do
       role: role,
       authenticator_name: authenticator_name,
       service: service,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -36,6 +38,8 @@ describe Audit::Event::Authn::Login do
         'my-authenticator service rspec:webservice:my-service'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -52,5 +56,7 @@ describe Audit::Event::Authn::Login do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/authn/validate_status_spec.rb
+++ b/spec/models/audit/event/authn/validate_status_spec.rb
@@ -5,6 +5,7 @@ describe Audit::Event::Authn::ValidateStatus do
   let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -14,6 +15,7 @@ describe Audit::Event::Authn::ValidateStatus do
       authenticator_name: authenticator_name,
       service: service,
       success: success,
+      client_ip: client_ip,
       error_message: error_message
     )
   end
@@ -36,6 +38,8 @@ describe Audit::Event::Authn::ValidateStatus do
         'my-authenticator service rspec:webservice:my-service'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -52,5 +56,7 @@ describe Audit::Event::Authn::ValidateStatus do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/check_spec.rb
+++ b/spec/models/audit/event/check_spec.rb
@@ -6,6 +6,7 @@ describe Audit::Event::Check do
   let(:resource) { double('my-resource', id: 'rspec:variable:my_var') }
   let(:privilege) { 'execute' }
   let(:role) { double('my-host', id: 'rspec:host:my_host') }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
 
   subject do
@@ -14,6 +15,7 @@ describe Audit::Event::Check do
       resource: resource,
       privilege: privilege,
       role: role,
+      client_ip: client_ip,
       success: success
     )
   end
@@ -36,6 +38,8 @@ describe Audit::Event::Check do
         'rspec:variable:my_var (success)'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -51,5 +55,7 @@ describe Audit::Event::Check do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/fetch_spec.rb
+++ b/spec/models/audit/event/fetch_spec.rb
@@ -4,7 +4,7 @@ describe Audit::Event::Fetch do
 
   let(:user) { double('my-user', id: 'rspec:user:my_user') }
   let(:resource) { double('my-resource', id: 'rspec:variable:my_var') }
-  
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:version) { 1 }
   let(:error_message) { nil }
@@ -15,6 +15,7 @@ describe Audit::Event::Fetch do
       user: user,
       resource: resource,
       version: version,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -36,6 +37,8 @@ describe Audit::Event::Fetch do
         'rspec:user:my_user fetched version 1 of rspec:variable:my_var'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -52,5 +55,7 @@ describe Audit::Event::Fetch do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/password_spec.rb
+++ b/spec/models/audit/event/password_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 describe Audit::Event::Password do
   let(:role_id) { 'rspec:user:my_user' }
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
   subject do
     Audit::Event::Password.new(
       user_id: role_id,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -29,6 +31,8 @@ describe Audit::Event::Password do
         'rspec:user:my_user successfully changed their password'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -44,5 +48,7 @@ describe Audit::Event::Password do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/policy_spec.rb
+++ b/spec/models/audit/event/policy_spec.rb
@@ -8,8 +8,16 @@ describe Audit::Event::Policy do
       resource_id: 'rspec:variable:my_var'
     )
   end
+  let(:client_ip) { 'my-client-ip' }
   let(:operation) { '' }
-  let(:policy_version) { double('the-policy-version') }
+  let(:policy_version) do
+    double(
+      'the-policy-version',
+      id: 'rspec:policy:my_policy', 
+      client_ip: client_ip,
+      version: 1
+    )
+  end
 
   subject do
     Audit::Event::Policy.new(
@@ -38,6 +46,8 @@ describe Audit::Event::Policy do
         'rspec:user:my_user added resource rspec:variable:my_var'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context "when operation is 'remove'" do
@@ -48,6 +58,8 @@ describe Audit::Event::Policy do
         'rspec:user:my_user removed resource rspec:variable:my_var'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context "when operation is 'change'" do
@@ -58,5 +70,7 @@ describe Audit::Event::Policy do
         'rspec:user:my_user changed resource rspec:variable:my_var'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/models/audit/event/update_spec.rb
+++ b/spec/models/audit/event/update_spec.rb
@@ -3,8 +3,15 @@ require 'spec_helper'
 describe Audit::Event::Update do
 
   let(:user) { double('my-user', id: 'rspec:user:my_user') }
-  let(:resource) { double('my-resource', id: 'rspec:variable:my_var') }
-  
+  let(:resource) do
+    double(
+      'my-resource',
+      id: 'rspec:variable:my_var',
+      # This is required for the Audit::Resource subject creation
+      pk_hash: { resource_id: 'rspec:variable:my_var' }
+    )
+  end
+  let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
 
@@ -13,6 +20,7 @@ describe Audit::Event::Update do
     Audit::Event::Update.new(
       user: user,
       resource: resource,
+      client_ip: client_ip,
       success: success,
       error_message: error_message
     )
@@ -34,6 +42,8 @@ describe Audit::Event::Update do
         'rspec:user:my_user updated rspec:variable:my_var'
       )
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 
   context 'when a failure occurs' do
@@ -49,5 +59,7 @@ describe Audit::Event::Update do
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
     end
+
+    it_behaves_like 'structured data includes client IP address'
   end
 end

--- a/spec/support/audit_event_spec_helper.rb
+++ b/spec/support/audit_event_spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for "structured data includes client IP address" do
+  it 'contains the client IP address' do
+    expect(subject.structured_data).to match(hash_including({
+      Audit::SDID::CLIENT => { ip: client_ip }
+    }))
+  end
+end

--- a/spec/support/security_specs_helper.rb
+++ b/spec/support/security_specs_helper.rb
@@ -8,6 +8,7 @@ shared_context "security mocks" do
   let(:fake_authenticator_name) { 'authn-x' }
   let(:fake_service_id) { 'fake-service-id' }
   let(:test_user_id) { 'some-user' }
+  let(:test_origin) { 'test-origin' }
   let(:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
   let(:mocked_origin_validator) { double("ValidateOrigin") }
   let(:mocked_account_validator) { double("ValidateAccountExists") }

--- a/spec/support/security_specs_helper.rb
+++ b/spec/support/security_specs_helper.rb
@@ -8,7 +8,7 @@ shared_context "security mocks" do
   let(:fake_authenticator_name) { 'authn-x' }
   let(:fake_service_id) { 'fake-service-id' }
   let(:test_user_id) { 'some-user' }
-  let(:test_origin) { 'test-origin' }
+  let(:test_client_ip) { 'test-client-up' }
   let(:two_authenticator_env) { "#{fake_authenticator_name}/service1, #{fake_authenticator_name}/service2" }
   let(:mocked_origin_validator) { double("ValidateOrigin") }
   let(:mocked_account_validator) { double("ValidateAccountExists") }


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates all audit events to include the caller's client IP address.

- _How should the reviewer approach this PR, especially if manual tests are required?_

The container image `registry.tld/conjur-appliance:5.9.0-20200609134725-fe79d95` may be used to evaluate this change manually, for example in [dap-intro](https://github.com/conjurdemos/dap-intro/tree/master/demos/cluster).

- _Example Audit Event_

Example audit record after this change, with the addition of `[client@43868 ip="172.24.0.5"]`:
```
<37>1 2020-05-28T20:43:35.602+00:00 ce1fd1ccf9ac conjur 728c4c1f-b027-4bf2-861b-47f3b756d559 policy [auth@43868 user="demo:user:admin"][subject@43868 role="demo:group:staging/myapp/secrets-users" member="demo:group:developers"][action@43868 operation="add"][client@43868 ip="172.24.0.5"][policy@43868 id="demo:policy:root" version="3"][meta sequenceId="150"] demo:user:admin added membership of demo:group:developers in demo:group:staging/myapp/secrets-users
```

- _Appliance Build_

https://jenkins.conjur.net/job/conjurinc--appliance/job/1550-audit-client-ip-refactored/

### What ticket does this PR close?
Connected to #1550

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

R&D Docs Issue: https://github.com/cyberark/dap-wiki/issues/45
