### PR TITLE
update websocket-extensions version from 0.1.4 to 0.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
       websocket
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xdg (2.2.3)
 
 PLATFORMS


### PR DESCRIPTION
### What does this PR do?
Update websocket-extensions from 0.1.4 to 0.1.5.
websocket-extensions 0.1.4 fails trivy scan.

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
