### PR TITLE
Add Audit Event for Password Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   performance issues with large numbers of created hosts
   ([cyberark/conjur#1605](https://github.com/cyberark/conjur/issues/1605))
 
+### Added
+- Password changes (`PUT /authn/:account/password`) now produce audit events with
+  message ID `password` ([cyberark/conjur#1548](https://github.com/cyberark/conjur/issues/1548))
+
 ## [1.7.2] - 2020-06-08
 
 ### Fixed

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -36,8 +36,11 @@ class CredentialsController < ApplicationController
   def update_password
     password = request.body.read
 
-    @role.credentials.password = password
-    @role.credentials.save(raise_on_save_failure: true)
+    Commands::Credentials::ChangePassword.new.call(
+      role: @role,
+      password: password
+    )
+        
     head 204
   end
   

--- a/app/domain/commands/credentials/change_password.rb
+++ b/app/domain/commands/credentials/change_password.rb
@@ -19,6 +19,10 @@ module Commands
 
       def call
         change_password
+        audit_success
+      rescue => e
+        audit_failure(e)
+        raise e
       end
 
       private
@@ -30,6 +34,22 @@ module Commands
 
       def credentials
         @role.credentials
+      end
+
+      def audit_success
+        @audit_log.log(
+          ::Audit::Event::Password.new(user: @role, success: true)
+        )
+      end
+
+      def audit_failure(err)
+        @audit_log.log(
+          ::Audit::Event::Password.new(
+            user: @role,
+            success: false,
+            error_message: err.message
+          )
+        )
       end
     end
   end

--- a/app/domain/commands/credentials/change_password.rb
+++ b/app/domain/commands/credentials/change_password.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'command_class'
+
+module Commands
+  module Credentials
+
+    ChangePassword ||= CommandClass.new(
+      dependencies: {
+        audit_log: ::Audit.logger
+      },
+
+      # `role` is not a pure input, but comes with an implicit database
+      # dependency that it will use to save the new password.
+      # This should be addressed to make the database dependency explicit:
+      # https://github.com/cyberark/conjur/issues/1611
+      inputs: %i(role password)
+    ) do
+
+      def call
+        change_password
+      end
+
+      private
+
+      def change_password
+        credentials.password = @password
+        credentials.save(raise_on_save_failure: true)
+      end
+
+      def credentials
+        @role.credentials
+      end
+    end
+  end
+end

--- a/app/models/audit/event/password.rb
+++ b/app/models/audit/event/password.rb
@@ -1,0 +1,71 @@
+module Audit
+  module Event
+    class Password
+
+      def initialize(user:, success:, error_message: nil)
+        @user = user
+        @success = success
+        @error_message = error_message
+      end
+
+      # Note: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      # It's clearer to simply call the #id attribute multiple times, rather
+      # than factor it out, even though it reeks of :reek:DuplicateMethodCall
+      def message
+        attempted_action.message(
+          success_msg: "#{@user.id} successfully changed their password",
+          failure_msg: "#{@user.id} failed to change their password",
+          error_msg: @error_message
+        )
+      end
+
+      def message_id
+        'password'
+      end
+
+      # It's clearer to simply call the #id attribute multiple times, rather
+      # than factor it out, even though it reeks of :reek:DuplicateMethodCall
+      def structured_data
+        {
+          SDID::AUTH => { user: @user.id },
+          SDID::SUBJECT => { user: @user.id }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'change'
+        )
+      end
+    end
+  end
+end

--- a/spec/app/domain/commands/credentials/change_password_spec.rb
+++ b/spec/app/domain/commands/credentials/change_password_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Commands::Credentials::ChangePassword do
+  let(:credentials) { double(Credentials) }
+  let(:role) { double(Role, credentials: credentials) }
+  let(:password) { 'the_password' }
+
+  let(:err_message) { 'the error message' }
+
+  subject do 
+    Commands::Credentials::ChangePassword.new
+  end
+
+  it 'updates the password for the given User' do
+    # Expect it to update the credentials model on the provided
+    # role, with the given password
+    expect(credentials).to receive(:password=).with(password)
+    expect(credentials).to receive(:save)
+
+    # Call the command
+    subject.call(role: role,  password: password)
+  end
+
+  it 'bubbles up exceptions' do 
+    # Assume the database update fails. This could be caused by an
+    # invalid password, database issues, etc.
+    allow(credentials).to receive(:password=)
+    allow(credentials).to receive(:save).and_raise(err_message)
+
+    # Expect the command to raise the original exception
+    expect { subject.call(role: role,  password: password) }.to raise_error(err_message)
+  end
+end

--- a/spec/app/domain/commands/credentials/change_password_spec.rb
+++ b/spec/app/domain/commands/credentials/change_password_spec.rb
@@ -7,8 +7,26 @@ describe Commands::Credentials::ChangePassword do
 
   let(:err_message) { 'the error message' }
 
+  let(:audit_log) { double(::Audit.logger)}
+  let(:audit_success) { double("Successful audit event") }
+  let(:audit_failure) { double("Failed audit event") }
+
+  before do
+    # Set up our audit event to return either the success or failure
+    # audit event, depending on the arguments received
+    allow(::Audit::Event::Password).to receive(:new)
+      .with(user: role, success: true)
+      .and_return(audit_success)
+
+    allow(::Audit::Event::Password).to receive(:new)
+      .with(user: role, success: false, error_message: err_message)
+      .and_return(audit_failure)
+  end
+
   subject do 
-    Commands::Credentials::ChangePassword.new
+    Commands::Credentials::ChangePassword.new(
+      audit_log: audit_log
+      )
   end
 
   it 'updates the password for the given User' do
@@ -16,6 +34,9 @@ describe Commands::Credentials::ChangePassword do
     # role, with the given password
     expect(credentials).to receive(:password=).with(password)
     expect(credentials).to receive(:save)
+
+    # Expect it to log a successful audit message
+    expect(audit_log).to receive(:log).with(audit_success)
 
     # Call the command
     subject.call(role: role,  password: password)
@@ -26,6 +47,9 @@ describe Commands::Credentials::ChangePassword do
     # invalid password, database issues, etc.
     allow(credentials).to receive(:password=)
     allow(credentials).to receive(:save).and_raise(err_message)
+
+    # Expect it to log a failed audit message
+    expect(audit_log).to receive(:log).with(audit_failure)
 
     # Expect the command to raise the original exception
     expect { subject.call(role: role,  password: password) }.to raise_error(err_message)

--- a/spec/models/audit/event/password_spec.rb
+++ b/spec/models/audit/event/password_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Audit::Event::Password do
+  let(:role_id) { 'rspec:user:my_user' }
+  let(:user) { double('The User', id: role_id) }
+  let(:success) { true }
+  let(:error_message) { nil }
+
+  subject do
+    Audit::Event::Password.new(
+      user: user,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message)
+        .to eq("rspec:user:my_user successfully changed their password")
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq('rspec:user:my_user successfully changed their password')
+    end
+  end
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+    let(:error_message) { 'invalid password' }
+
+    it 'produces the expected message' do
+      expect(subject.message)
+        .to eq("rspec:user:my_user failed to change their password: invalid password")
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+  end
+end


### PR DESCRIPTION
**NOTE:** This PR is blocked until the [parent branch](https://github.com/cyberark/conjur/pull/1574) is merged.

---

### What does this PR do?
- _What's changed? Why were these changes made?_

This PR adds an audit log message for password changes events using the API endpoint `PUT /authn/:account/password` 

- _How should the reviewer approach this PR, especially if manual tests are required?_

The container image `registry.tld/conjur-appliance:5.9.0-20200610203923-d5e10a1` may be used to evaluate this change manually, for example in [dap-intro](https://github.com/conjurdemos/dap-intro/tree/master/demos/cluster).

- _Example audit message_

**Successful Password Change:**
```
<86>1 2020-06-10T21:04:53.745+00:00 60aa5330d24b conjur fb98c0b8-136e-4f6f-ab35-1f545acadba0 password [auth@43868 user="demo:user:admin"][subject@43868 user="demo:user:admin"][action@43868 result="success" operation="change"][meta sequenceId="3"] demo:user:admin successfully changed their password
```

**Failed Password Change:**
```
<84>1 2020-06-10T21:03:32.205+00:00 60aa5330d24b conjur 74acf74b-7743-41d7-be1d-1dc060356d26 password [auth@43868 user="demo:user:admin"][subject@43868 user="demo:user:admin"][action@43868 result="failure" operation="change"][meta sequenceId="5"] demo:user:admin failed to change their password: password CONJ00046E The password you have chosen does not meet the complexity requirements. Choose a password that includes: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit, 1 special character
```

- _Appliance Build_

https://jenkins.conjur.net/job/conjurinc--appliance/job/1548-audit-password-change/

### What ticket does this PR close?
Connected to #1548

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

R&D Docs (`dap-wiki`) PR: [cyberark/dap-wiki#29](https://github.com/cyberark/dap-wiki/pull/29)
