### PR TITLE
Use database query to filter role memberships by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Host Factory Host creation no longer makes unecessary database queries, causing
+  performance issues with large numbers of created hosts
+  ([cyberark/conjur#1605](https://github.com/cyberark/conjur/issues/1605))
+
 ## [1.7.2] - 2020-06-08
 
 ### Fixed

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -127,9 +127,9 @@ class Role < Sequel::Model
 
   # All Roles of kind "layer" which this role is a direct member of.
   def layers
-    memberships_as_member.select do |membership|
-      membership.role.kind == "layer"
-    end.map(&:role)
+    memberships_as_member_dataset
+      .where(Sequel.lit('kind(role_id) = \'layer\''))
+      .map(&:role)
   end
 
   def direct_memberships_dataset(search_options = {})


### PR DESCRIPTION
# What does this PR do?
- _What's changed? Why were these changes made?_

Previously each membership role was queried individually from the database to
check its "kind" and find the layers. This led to massive performance degredation
with a large number of memberships, as is the case with a host factory creating
many (100s) of hosts.

This PR implements that filter entirely in SQL to avoid the round trips and
improve performance at scale.

### What ticket does this PR close?
Connected to #1605

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
