### PR TITLE
Add Audit Event for API Key Rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   absence of the `Content-Type` header
   ([cyberark/conjur#1622](https://github.com/cyberark/conjur/issues/1622))
 
+### Added
+- Password changes (`PUT /authn/:account/password`) now produce audit events with
+  message ID `password` ([cyberark/conjur#1548](https://github.com/cyberark/conjur/issues/1548))
+- API key rotations (`PUT /:authenticator/:account/api_key`) now produce audit events with
+  message ID `api-key` ([cyberark/conjur#1549](https://github.com/cyberark/conjur/issues/1549))
+
 ## [1.7.3] - 2020-06-11
 
 ### Fixed
 - Host Factory Host creation no longer makes unecessary database queries, causing
   performance issues with large numbers of created hosts
   ([cyberark/conjur#1605](https://github.com/cyberark/conjur/issues/1605))
-
-### Added
-- Password changes (`PUT /authn/:account/password`) now produce audit events with
-  message ID `password` ([cyberark/conjur#1548](https://github.com/cyberark/conjur/issues/1548))
 
 ## [1.7.2] - 2020-06-08
 

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -49,7 +49,8 @@ class CredentialsController < ApplicationController
   # The new API key is in the request body.
   def rotate_api_key
     Commands::Credentials::RotateApiKey.new.call(
-      role: @role
+      role_to_rotate: authentication.apply_to_role,
+      authenticated_role: authentication.authenticated_role
     )
     render plain: @role.credentials.api_key
   end

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -48,8 +48,9 @@ class CredentialsController < ApplicationController
   #
   # The new API key is in the request body.
   def rotate_api_key
-    @role.credentials.rotate_api_key
-    @role.credentials.save
+    Commands::Credentials::RotateApiKey.new.call(
+      role: @role
+    )
     render plain: @role.credentials.api_key
   end
   

--- a/app/domain/commands/credentials/change_password.rb
+++ b/app/domain/commands/credentials/change_password.rb
@@ -38,14 +38,14 @@ module Commands
 
       def audit_success
         @audit_log.log(
-          ::Audit::Event::Password.new(user: @role, success: true)
+          ::Audit::Event::Password.new(user_id: @role.id, success: true)
         )
       end
 
       def audit_failure(err)
         @audit_log.log(
           ::Audit::Event::Password.new(
-            user: @role,
+            user_id: @role.id,
             success: false,
             error_message: err.message
           )

--- a/app/domain/commands/credentials/rotate_api_key.rb
+++ b/app/domain/commands/credentials/rotate_api_key.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'command_class'
+
+module Commands
+  module Credentials
+
+    # In might seem unnecessary to move this behavior into a command class.
+    # However, we factor this out now to prepare for A) adding audit decorations
+    # to this operation, and B) those audit events including the requestor's
+    # client IP address, which will be an input to this CommandClass, rather than
+    # to the Credential model's method.
+    RotateApiKey ||= CommandClass.new(
+      dependencies: {},
+      inputs: %i(role)
+    ) do
+
+      def call
+        rotate_api_key
+      end
+
+      private
+
+      def rotate_api_key
+        credentials.rotate_api_key
+        credentials.save
+      end
+
+      def credentials
+        @role.credentials
+      end
+    end
+  end
+end

--- a/app/models/audit/event/api_key.rb
+++ b/app/models/audit/event/api_key.rb
@@ -1,0 +1,95 @@
+module Audit
+  module Event
+
+    # As a value object, it is okay that this class has :reek:TooManyInstanceVariables
+    class ApiKey
+      def initialize(authenticated_role_id:, rotated_role_id:, success:, error_message: nil)
+        @authenticated_role_id = authenticated_role_id
+        @rotated_role_id = rotated_role_id
+        @success = success
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      def message
+        attempted_action.message(
+          success_msg: success_message,
+          failure_msg: failure_message,
+          error_msg: @error_message
+        )
+      end
+
+      def message_id
+        'api-key'
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @authenticated_role_id },
+          SDID::SUBJECT => { role: @rotated_role_id }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def success_message
+        if user_rotating_their_own_key?
+          "#{@authenticated_role_id} successfully rotated their API key"
+        else
+          "#{@authenticated_role_id} successfully rotated the api key for #{@rotated_role_id}"
+        end
+      end
+
+      def failure_message
+        if user_rotating_their_own_key?
+          "#{@authenticated_role_id} failed to rotate their API key"
+        else
+          "#{@authenticated_role_id} failed to rotate the api key for #{@rotated_role_id}"
+        end
+      end
+      
+      # True if the role requesting the rotation is the same role
+      # the rotation is for. In other words, when you rotate your own
+      # API key
+      def user_rotating_their_own_key?
+        @authenticated_role_id == @rotated_role_id
+      end
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'rotate'
+        )
+      end
+    end
+  end
+end

--- a/app/models/audit/event/comparable_event.rb
+++ b/app/models/audit/event/comparable_event.rb
@@ -1,0 +1,18 @@
+module Audit
+  module Event
+    class ComparableEvent
+      def initialize(evt)
+        @evt = evt
+      end
+
+      def ==(other)
+        @evt.progname == other.progname &&
+          @evt.severity == other.severity &&
+          @evt.message == other.message &&
+          @evt.message_id == other.message_id &&
+          @evt.structured_data == other.structured_data &&
+          @evt.facility == other.facility
+      end
+    end
+  end
+end

--- a/app/models/audit/event/password.rb
+++ b/app/models/audit/event/password.rb
@@ -2,8 +2,8 @@ module Audit
   module Event
     class Password
 
-      def initialize(user:, success:, error_message: nil)
-        @user = user
+      def initialize(user_id:, success:, error_message: nil)
+        @user_id = user_id
         @success = success
         @error_message = error_message
 
@@ -28,12 +28,10 @@ module Audit
         message
       end
 
-      # It's clearer to simply call the #id attribute multiple times, rather
-      # than factor it out, even though it reeks of :reek:DuplicateMethodCall
       def message
         attempted_action.message(
-          success_msg: "#{@user.id} successfully changed their password",
-          failure_msg: "#{@user.id} failed to change their password",
+          success_msg: "#{@user_id} successfully changed their password",
+          failure_msg: "#{@user_id} failed to change their password",
           error_msg: @error_message
         )
       end
@@ -42,12 +40,10 @@ module Audit
         'password'
       end
 
-      # It's clearer to simply call the #id attribute multiple times, rather
-      # than factor it out, even though it reeks of :reek:DuplicateMethodCall
       def structured_data
         {
-          SDID::AUTH => { user: @user.id },
-          SDID::SUBJECT => { user: @user.id }
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => { user: @user_id }
         }.merge(
           attempted_action.action_sd
         )

--- a/app/models/audit/event/password.rb
+++ b/app/models/audit/event/password.rb
@@ -6,6 +6,9 @@ module Audit
         @user = user
         @success = success
         @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -56,6 +59,10 @@ module Audit
         # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
         # is deprecated.
         Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
       end
 
       private

--- a/spec/app/domain/commands/credentials/change_password_spec.rb
+++ b/spec/app/domain/commands/credentials/change_password_spec.rb
@@ -10,12 +10,12 @@ describe Commands::Credentials::ChangePassword do
   let(:audit_log) { double(::Audit.logger)}
   
   let(:audit_success) do
-    ::Audit::Event::Password.new(user: role, success: true)
+    ::Audit::Event::Password.new(user_id: role.id, success: true)
   end
   
   let(:audit_failure) do
     ::Audit::Event::Password.new(
-      user: role,
+      user_id: role.id,
       success: false,
       error_message: err_message
     )

--- a/spec/app/domain/commands/credentials/change_password_spec.rb
+++ b/spec/app/domain/commands/credentials/change_password_spec.rb
@@ -2,25 +2,23 @@ require 'spec_helper'
 
 describe Commands::Credentials::ChangePassword do
   let(:credentials) { double(Credentials) }
-  let(:role) { double(Role, credentials: credentials) }
+  let(:role) { double(Role, id: 'role', credentials: credentials) }
   let(:password) { 'the_password' }
 
   let(:err_message) { 'the error message' }
 
   let(:audit_log) { double(::Audit.logger)}
-  let(:audit_success) { double("Successful audit event") }
-  let(:audit_failure) { double("Failed audit event") }
-
-  before do
-    # Set up our audit event to return either the success or failure
-    # audit event, depending on the arguments received
-    allow(::Audit::Event::Password).to receive(:new)
-      .with(user: role, success: true)
-      .and_return(audit_success)
-
-    allow(::Audit::Event::Password).to receive(:new)
-      .with(user: role, success: false, error_message: err_message)
-      .and_return(audit_failure)
+  
+  let(:audit_success) do
+    ::Audit::Event::Password.new(user: role, success: true)
+  end
+  
+  let(:audit_failure) do
+    ::Audit::Event::Password.new(
+      user: role,
+      success: false,
+      error_message: err_message
+    )
   end
 
   subject do 

--- a/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
+++ b/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Commands::Credentials::RotateApiKey do
+  let(:credentials) { double(Credentials) }
+  let(:role) { double(Role, credentials: credentials) }
+
+  let(:err_message) { 'the error message' }
+
+  subject do 
+    Commands::Credentials::RotateApiKey.new
+  end
+
+  it 'updates the password for the given User' do
+    # Expect it to rotate the api key on the credentials model, and to save it
+    expect(credentials).to receive(:rotate_api_key)
+    expect(credentials).to receive(:save)
+
+    # Call the command
+    subject.call(role: role)
+  end
+
+  it 'bubbles up exceptions' do 
+    # Assume the database update fails. This could be caused by an
+    # invalid password, database issues, etc.
+    allow(credentials).to receive(:rotate_api_key)
+    allow(credentials).to receive(:save).and_raise(err_message)
+
+    # Expect the command to raise the original exception
+    expect { subject.call(role: role) }.to raise_error(err_message)
+  end
+end

--- a/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
+++ b/spec/app/domain/commands/credentials/rotate_api_key_spec.rb
@@ -2,30 +2,104 @@ require 'spec_helper'
 
 describe Commands::Credentials::RotateApiKey do
   let(:credentials) { double(Credentials) }
-  let(:role) { double(Role, credentials: credentials) }
+  let(:role) { double(Role, id: 'role', credentials: credentials) }
+
+  let(:other_credentials) { double(Credentials) }
+  let(:other_role) { double(Role, id: 'other role', credentials: other_credentials) }
+
+  let(:role_to_rotate) { role }
 
   let(:err_message) { 'the error message' }
 
+  let(:audit_log) { double(::Audit.logger) }
+
+  let(:audit_success) do
+    ::Audit::Event::ApiKey.new(
+      authenticated_role_id: role.id,
+      rotated_role_id: role_to_rotate.id,
+      success: true
+    )
+  end
+
+  let(:audit_failure) do
+    ::Audit::Event::ApiKey.new(
+      authenticated_role_id: role.id,
+      rotated_role_id: role_to_rotate.id,
+      success: false,
+      error_message: err_message
+    )
+  end
+
   subject do 
-    Commands::Credentials::RotateApiKey.new
+    Commands::Credentials::RotateApiKey.new(
+      audit_log: audit_log
+    )
   end
 
-  it 'updates the password for the given User' do
-    # Expect it to rotate the api key on the credentials model, and to save it
-    expect(credentials).to receive(:rotate_api_key)
-    expect(credentials).to receive(:save)
+  context 'when rotating own API key' do
+    it 'updates the key' do
+      # Normally command inputs should not be mocked, however to seperate
+      # the role "value" from the rotation and database operations would require
+      # refactoring the Credentials controller. So the correct solution is out
+      # of scope.
+      expect(credentials).to receive(:rotate_api_key)
+      expect(credentials).to receive(:save)
 
-    # Call the command
-    subject.call(role: role)
+      # Expect it to log a successful audit message
+      expect(audit_log).to receive(:log).with(audit_success)
+
+      # Call the command
+      subject.call(role_to_rotate: role, authenticated_role: role)
+    end
+
+    it 'bubbles up exceptions' do 
+      # See note above. The command inputs should not typicially be mocked.
+      # However, the refactoring to support the correct solution is
+      # out of scope.
+      #
+      # Assume the database update fails. This could be caused by an
+      # invalid password, database issues, etc.
+      allow(credentials).to receive(:rotate_api_key)
+      allow(credentials).to receive(:save).and_raise(err_message)
+
+      # Expect it to log a failed audit message
+      expect(audit_log).to receive(:log).with(audit_failure)
+
+      # Expect the command to raise the original exception
+      expect do
+        subject.call(role_to_rotate: role, authenticated_role: role)
+      end.to raise_error(err_message)
+    end
   end
 
-  it 'bubbles up exceptions' do 
-    # Assume the database update fails. This could be caused by an
-    # invalid password, database issues, etc.
-    allow(credentials).to receive(:rotate_api_key)
-    allow(credentials).to receive(:save).and_raise(err_message)
+  context "when rotating another's API key" do
+    let(:role_to_rotate) { other_role }
 
-    # Expect the command to raise the original exception
-    expect { subject.call(role: role) }.to raise_error(err_message)
+    it 'updates the key' do
+      # Expect it to rotate the api key on the credentials model, and to save it
+      expect(other_credentials).to receive(:rotate_api_key)
+      expect(other_credentials).to receive(:save)
+
+      # Expect it to log a successful audit message
+      expect(audit_log).to receive(:log).with(audit_success)
+
+      # Call the command
+      subject.call(role_to_rotate: other_role, authenticated_role: role)
+    end
+
+    it 'bubbles up exceptions' do 
+      # Assume the database update fails. This could be caused by an
+      # invalid password, database issues, etc.
+      allow(other_credentials).to receive(:rotate_api_key)
+      allow(other_credentials).to receive(:save).and_raise(err_message)
+
+      # Expect it to log a failed audit message
+      expect(audit_log).to receive(:log).with(audit_failure)
+
+      # Expect the command to raise the original exception
+      expect do
+        subject.call(role_to_rotate: other_role, authenticated_role: role)
+      end.to raise_error(err_message)
+    end
   end
 end

--- a/spec/models/audit/event/api_key_spec.rb
+++ b/spec/models/audit/event/api_key_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Audit::Event::ApiKey do
+  let(:role_id) { 'rspec:user:my_user' }
+  let(:other_role_id) { 'rspec:user:other_user' }
+
+  let(:rotated_role_id) { role_id }
+
+  let(:success) { true }
+  let(:error_message) { nil }
+
+  subject do
+    Audit::Event::ApiKey.new(
+      authenticated_role_id: role_id,
+      rotated_role_id: rotated_role_id,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message)
+        .to eq("rspec:user:my_user successfully rotated their API key")
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq('rspec:user:my_user successfully rotated their API key')
+    end
+
+    context 'when user rotates another role\'s key' do
+      let(:rotated_role_id) { other_role_id }
+
+      it 'renders to string correctly' do
+        expect(subject.to_s).to eq(
+          'rspec:user:my_user successfully rotated the api key for rspec:user:other_user'
+        )
+      end
+    end
+  end
+
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+    let(:error_message) { 'failed rotation' }
+
+    it 'produces the expected message' do
+      expect(subject.message)
+        .to eq("rspec:user:my_user failed to rotate their API key: failed rotation")
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+
+    context 'when user rotates another role\'s key' do
+      let(:rotated_role_id) { other_role_id }
+
+      it 'renders to string correctly' do
+        expect(subject.to_s).to eq(
+          'rspec:user:my_user failed to rotate the api key for rspec:user:other_user: failed rotation'
+        )
+      end
+    end
+  end
+end

--- a/spec/models/audit/event/password_spec.rb
+++ b/spec/models/audit/event/password_spec.rb
@@ -2,13 +2,12 @@ require 'spec_helper'
 
 describe Audit::Event::Password do
   let(:role_id) { 'rspec:user:my_user' }
-  let(:user) { double('The User', id: role_id) }
   let(:success) { true }
   let(:error_message) { nil }
 
   subject do
     Audit::Event::Password.new(
-      user: user,
+      user_id: role_id,
       success: success,
       error_message: error_message
     )


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR adds an audit log message for API key rotations events using the API endpoint `PUT /:authenticator/:account/api_key`.

- _How should the reviewer approach this PR, especially if manual tests are required?_

The container image `registry.tld/conjur-appliance:5.9.0-20200612203143-b8c6a2f` may be used to evaluate this change manually, for example in [dap-intro](https://github.com/conjurdemos/dap-intro/tree/master/demos/cluster).

- _Example audit message_

**Successful API Key Rotation for Own Role:**
```
<86>1 2020-06-12T13:28:52.245+00:00 6cc8d001f840 conjur 1d9b2ba1-7a81-45fd-95e8-632e351d9a5a api-key [auth@43868 user="demo:user:admin"][subject@43868 role="demo:user:admin"][action@43868 result="success" operation="rotate"][meta sequenceId="3"] demo:user:admin successfully rotated their API key
```

**Successful API Key Rotation for Another Role:**
```
<86>1 2020-06-12T13:35:52.062+00:00 6cc8d001f840 conjur fb291c77-da64-4b86-8374-c06d9da537e6 api-key [auth@43868 user="demo:user:admin"][subject@43868 role="demo:user:marcel.calisto"][action@43868 result="success" operation="rotate"][meta sequenceId="2"] demo:user:admin successfully rotated the api key for demo:user:marcel.calisto
```

- _Appliance Build_

https://jenkins.conjur.net/job/conjurinc--appliance/job/1549-audit-api-key-rotation/

### What ticket does this PR close?
Connected to #1549

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

R&D Docs (`dap-wiki`) PR: [cyberark/dap-wiki#29](https://github.com/cyberark/dap-wiki/pull/29)
