### PR TITLE
Update k8s test infra to use API v1

### DIFF
--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
+  labels:
+    app: postgres
 spec:
   ports:
   - port: 5432
@@ -14,6 +16,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: conjur
+  labels:
+    app: conjur
 spec:
   ports:
   - port: 80
@@ -27,6 +31,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
+  labels:
+    app: nginx
 spec:
   ports:
   - port: 443
@@ -34,12 +40,17 @@ spec:
   selector:
     app: nginx-authn-k8s
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
+  labels:
+    app: postgres
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
   template:
     metadata:
       labels:
@@ -53,12 +64,17 @@ spec:
         - name: POSTGRES_HOST_AUTH_METHOD
           value: trust
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: conjur
+  name: conjur-authn-k8s
+  labels:
+    app: conjur-authn-k8s
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: conjur-authn-k8s
   template:
     metadata:
       labels:
@@ -101,12 +117,17 @@ spec:
           emptyDir:
             medium: Memory
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cucumber
+  name: cucumber-authn-k8s
+  labels:
+    app: cucumber-authn-k8s
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cucumber-authn-k8s
   template:
     metadata:
       labels:
@@ -131,12 +152,17 @@ spec:
         - name: CONJUR_AUTHN_K8S_TEST_NAMESPACE
           value: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: conjur-cli
+  labels:
+    app: conjur-cli
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: conjur-cli
   template:
     metadata:
       labels:
@@ -156,12 +182,17 @@ spec:
         - name: CONJUR_AUTHN_LOGIN
           value: admin
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx
+  name: nginx-authn-k8s
+  labels:
+    app: nginx-authn-k8s
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-authn-k8s
   template:
     metadata:
       labels:

--- a/ci/authn-k8s/dev/dev_inventory.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory.template.yaml
@@ -3,19 +3,24 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory
+  labels:
+    app: inventory
 spec:
   ports:
   - port: 80
     name: http
   selector:
-    app: inventory
+    app: inventory-deployment
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: inventory-deployment
   template:
     metadata:
       labels:

--- a/ci/authn-k8s/dev/dev_inventory_deployment_config.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_deployment_config.template.yaml
@@ -16,6 +16,9 @@ metadata:
   name: inventory-deployment-cfg
 spec:
   replicas: 1
+    selector:
+      matchLabels:
+        app: inventory-deployment-cfg
   template:
     metadata:
       labels:

--- a/ci/authn-k8s/dev/dev_inventory_stateful.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_stateful.template.yaml
@@ -3,19 +3,26 @@ apiVersion: v1
 kind: Service
 metadata:
   name: inventory-headless
+  labels:
+    app: inventory-headless
 spec:
+  selector:
+    app: inventory-stateful
   ports:
   - port: 80
   clusterIP: None
-  selector:
-    app: inventory-stateful
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: inventory-stateful
+  labels:
+    app: inventory-stateful
 spec:
   serviceName: inventory-headless
+  selector:
+    matchLabels:
+      app: inventory-stateful
   replicas: 1
   template:
     metadata:

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -63,7 +63,7 @@ function finish {
 trap finish EXIT
 
 export TEMPLATE_TAG=gke.
-export API_VERSION=rbac.authorization.k8s.io/v1beta1
+export API_VERSION=rbac.authorization.k8s.io/v1
 
 function main() {
   sourceFunctions


### PR DESCRIPTION
As of K8s 1.16+ some older API versions (v1beta1) are deprecated, and our CI
will fail on clusters running K8s 1.16+

This PR updates our CI manifests to use `v1` of the k8s API in our tests.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
