### PR TITLE
Fix version link in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,7 +365,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The first tagged version.
 
 [Unreleased]: https://github.com/cyberark/conjur/compare/v1.7.3...HEAD
-[1.7.2]: https://github.com/cyberark/conjur/compare/v1.7.2...v1.7.3
+[1.7.3]: https://github.com/cyberark/conjur/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/cyberark/conjur/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/cyberark/conjur/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/cyberark/conjur/compare/v1.6.0...v1.7.0


### PR DESCRIPTION
This PR fixes a version link typo from https://github.com/cyberark/conjur/pull/1615.