### PR TITLE
Fix Policy Load Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The default content type for requests is now set at the beginning of the
   Rack middleware chain, so that the content type is available for
   subsequent middleware ([cyberark/conjur#1622](https://github.com/cyberark/conjur/issues/1622))
+- The default content type middleware now correctly checks for the
+  absence of the `Content-Type` header
+  ([cyberark/conjur#1622](https://github.com/cyberark/conjur/issues/1622))
 
 ## [1.7.3] - 2020-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   FIPS Compliant mode is slightly slower then non-FIPS compliant
   ([cyberark/conjur#1527](https://github.com/cyberark/conjur/issues/1527))
 
+### Fixed
+- The default content type for requests is now set at the beginning of the
+  Rack middleware chain, so that the content type is available for
+  subsequent middleware ([cyberark/conjur#1622](https://github.com/cyberark/conjur/issues/1622))
+
 ## [1.7.3] - 2020-06-11
 
 ### Fixed

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,21 +51,5 @@ module Conjur
     # Whether to dump the schema after successful migrations.
     # Defaults to false in production and test, true otherwise.
     config.sequel.schema_dump = false
-
-    # Token authentication is optional for authn routes, and it's not applied at all to authentication.
-    config.middleware.use Conjur::Rack::Authenticator,
-      optional: [
-        /^\/authn-[^\/]+\//,
-        /^\/authn\//,
-        /^\/public_keys\//
-      ],
-      except: [
-        /^\/authn-[^\/]+\/.*\/authenticate$/,
-        /^\/authn\/.*\/authenticate$/,
-        /^\/host_factories\/hosts$/,
-        /^\/assets\/.*/,
-        /^\/authenticators$/,
-        /^\/$/
-      ]
   end
 end

--- a/config/initializers/default_content_type.rb
+++ b/config/initializers/default_content_type.rb
@@ -1,5 +1,0 @@
-require 'rack/default_content_type'
-
-Rails.application.configure do
-  config.middleware.use ::Rack::DefaultContentType
-end

--- a/config/initializers/rack_middleware.rb
+++ b/config/initializers/rack_middleware.rb
@@ -1,0 +1,30 @@
+require 'rack/default_content_type'
+
+# This is where we introduce custom middleware that interacts with Rack
+# and Rails to change how requests are handled.
+Rails.application.configure do
+
+  # This configures which paths do and do not require token authentication.
+  # Token authentication is optional for authn routes, and it's not applied at
+  # all to authentication, host factories, or static assets (e.g. images, CSS)
+  config.middleware.use(Conjur::Rack::Authenticator,
+  optional: [
+    /^\/authn-[^\/]+\//,
+    /^\/authn\//,
+    /^\/public_keys\//
+  ],
+  except: [
+    /^\/authn-[^\/]+\/.*\/authenticate$/,
+    /^\/authn\/.*\/authenticate$/,
+    /^\/host_factories\/hosts$/,
+    /^\/assets\/.*/,
+    /^\/authenticators$/,
+    /^\/$/
+  ])
+
+  # We want to ensure requests have an expected content type
+  # before other middleware runs to make sure any body parsing
+  # attempts are handled correctly. So we add this middleware
+  # to the start of the Rack middleware chain.
+  config.middleware.insert_before(0, ::Rack::DefaultContentType)
+end

--- a/cucumber/api/features/policy_load.feature
+++ b/cucumber/api/features/policy_load.feature
@@ -79,17 +79,8 @@ Feature: Updating policies
     Then the HTTP response status code is 403
 
   Scenario: A policy with special characters and no content type header
-    When I set the "Content-Type" header to ""
-    And I POST "/policies/cucumber/policy/dev/db" with body:
-    """
-    - !variable
-      id: simple/basic/variable
-    - !variable
-      id: simple/space filled/variable
-    - !variable
-      id: simple/special @#$%^&*(){}[].,+/variable
-    """
-    Then the HTTP response status code is 201
+    When I use curl to load a policy with special characters and no content type
+    Then the command is successful
 
   Scenario: A large policy with no content type header
     When I clear the "Content-Type" header

--- a/cucumber/api/features/policy_load.feature
+++ b/cucumber/api/features/policy_load.feature
@@ -90,3 +90,8 @@ Feature: Updating policies
       id: simple/special @#$%^&*(){}[].,+/variable
     """
     Then the HTTP response status code is 201
+
+  Scenario: A large policy with no content type header
+    When I clear the "Content-Type" header
+    And I load a large policy with POST
+    Then the HTTP response status code is 201

--- a/cucumber/api/features/step_definitions/policy_load_steps.rb
+++ b/cucumber/api/features/step_definitions/policy_load_steps.rb
@@ -1,0 +1,18 @@
+When(/^I load a large policy with POST$/) do
+  # Generate a large policy with 1000 variables, sampled from
+  # an example PAS synchronizer policy
+  policy_body = "- &my-variables\n" + [*1..1000].map do |i|
+    <<-POLICY
+  - !variable
+    id: epv_safe_#{i}/password
+    annotations:
+      cyberark-vault: 'true'
+    POLICY
+  end.join("\n")
+
+  path = '/policies/cucumber/policy/dev/db'
+
+  try_request true do
+    post_json path, policy_body
+  end
+end

--- a/cucumber/api/features/step_definitions/policy_load_steps.rb
+++ b/cucumber/api/features/step_definitions/policy_load_steps.rb
@@ -1,3 +1,7 @@
+# Let's you reference the global variables such as `$?` using less 
+# cryptic names like `$CHILD_STATUS`
+require 'English'
+
 When(/^I load a large policy with POST$/) do
   # Generate a large policy with 1000 variables, sampled from
   # an example PAS synchronizer policy
@@ -15,4 +19,40 @@ When(/^I load a large policy with POST$/) do
   try_request true do
     post_json path, policy_body
   end
+end
+
+When('I use curl to load a policy with special characters and no content type') do
+  # Policy with special characters, sampled from a PAS synchronizer test policy
+  policy_body = <<~POLICY
+    - !variable
+      id: AccountWithSpecialCharacters~!@#$%^&(){}[]-+=,Name/password
+  POLICY
+
+  auth_token = current_user_credentials.dig(:headers, :authorization)
+
+  url_path = '/policies/cucumber/policy/dev/db'
+
+  # `--no-buffer` allows to close the pipe in popen without getting a curl error
+  # `--output ...` prevents curl from trying to write to stdout, causing an io error
+  command = <<~COMMAND
+    curl --silent \
+      --no-buffer \
+      --fail \
+      --output /dev/null \
+      --header 'Content-Type:' \
+      --header 'Authorization: #{auth_token}' \
+      --data-binary '@-' \
+      #{full_conjur_url(url_path)}
+  COMMAND
+
+  IO.popen(command, "r+") do |pipe|
+    pipe.puts policy_body
+    pipe.close_write
+  end
+
+  @command_result = $CHILD_STATUS.success?
+end
+
+Then('the command is successful') do
+  expect(@command_result).to be(true)
 end

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -9,6 +9,10 @@ Given(/^I set the "([^"]*)" header to "([^"]*)"$/) do |header, value|
   headers[header] = value
 end
 
+Given(/^I clear the "([^"]*)" header$/) do |header|
+  headers[header] = nil
+end
+
 When(/^I( (?:can|successfully))? GET "([^"]*)"$/) do |can, path|
   try_request can do
     get_json path

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -268,6 +268,10 @@ module RestHelpers
     RestClient::Resource.new(Conjur::Authn::API.host, current_user_basic_auth(password))
   end
 
+  def full_conjur_url(path)
+    URI.parse(Conjur.configuration.appliance_url + path)
+  end
+
   def try_request can
     yield
   rescue RestClient::Exception


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR fixes two issues in policy loading:

* Not setting the default content type for policy (`yaml`) before other Rack middleware that uses it.
* A logic bug in the default content type middleware for a missing `Content-Type` header.

### What ticket does this PR close?
Connected to #1622
Connected to #1621

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
