### PR TITLE
add nmap to the DEV image to test tls

### DIFF
--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -12,6 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     unattended-upgrades \
     vim \
+    nmap \
     curl \
     wget \
     syslog-ng \


### PR DESCRIPTION
### What does this PR do?
nmap is added install list in the dev/Dockerfile
nmap is used in testing to verify that weak tls version are not in use by the appliance.

### What ticket does this PR close?
https://github.com/conjurinc/AAM/issues/221

