### PR TITLE
Update to allow releasing from a branch

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -3,4 +3,4 @@
 export DEBUG=true
 export GLI_DEBUG=true
 
-./docker-debify publish $(cat VERSION_APPLIANCE) possum
+./docker-debify publish -c stable $(cat VERSION_APPLIANCE) possum

--- a/release
+++ b/release
@@ -66,7 +66,7 @@ echo "The next release will be: $version"
 
 # Make sure we have the most recent changes, without destroying local changes.
 git stash
-git pull --rebase origin master
+git pull --rebase origin $(git rev-parse --abbrev-ref HEAD)
 git stash pop
 
 # Perform a commit, tag, and push. The tag needs to be present before the commit


### PR DESCRIPTION
### What does this PR do?
These changes make debian packages built from a branch available to
any project consuming 'stable' components, removing the need to
have matching branch names in all downstream projects.  It also
allows the `release` script to be run from a branch and have it
work appropriately with that branch rather than just `master`

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
