### PR TITLE
Enhance logs around client cert installment

### DIFF
--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -71,18 +71,25 @@ module Authentication
       def install_signed_cert
         pod_namespace = spiffe_id.namespace
         pod_name = spiffe_id.name
-        @logger.debug(Log::CopySSLToPod.new(pod_namespace, pod_name))
+        cert_file_path = "/etc/conjur/ssl/client.pem"
+        @logger.debug(Log::CopySSLToPod.new(
+          container_name,
+          cert_file_path,
+          pod_namespace,
+          pod_name
+        ))
 
         resp = @kubectl_exec.new.copy(
           k8s_object_lookup: k8s_object_lookup,
           pod_namespace: pod_namespace,
           pod_name: pod_name,
           container: container_name,
-          path: "/etc/conjur/ssl/client.pem",
+          path: cert_file_path,
           content: cert_to_install.to_pem,
           mode: 0o644
         )
         validate_cert_installation(resp)
+        @logger.debug(Log::CopySSLToPodSuccess.new)
       end
 
       def validate_cert_installation(resp)

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -129,8 +129,14 @@ unless defined? LogMessages::Authentication::OriginValidated
         )
 
         CopySSLToPod = ::Util::TrackableLogMessageClass.new(
-          msg:  "Copying SSL certificate to {0-pod-namespace}/{1-pod-name}",
+          msg:  "Copying SSL certificate to {0-container-name}:{1-cert-file-path} " \
+            "in {2-pod-namespace}/{3-pod-name}",
           code: "CONJ00015D"
+        )
+
+        CopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
+          msg:  "Copied SSL certificate successfully",
+          code: "CONJ00037D"
         )
 
         ValidatingHostId = ::Util::TrackableLogMessageClass.new(


### PR DESCRIPTION
Connected to #1633

The client certificate installment process can be tricky
and it can help customers to know more details about it.
We not log the container name and the path inside it to
which the certificate will be copied.

We also log a success message to indicate that to the user.
