### PR TITLE
Remove Err and Log definitions

### DIFF
--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -4,7 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  Err ||= Errors::Authentication
   # Possible Errors Raised:
   # AuthenticatorNotFound, InvalidCredentials
 
@@ -45,11 +44,11 @@ module Authentication
     end
 
     def validate_authenticator_exists
-      raise Err::AuthenticatorNotFound, authenticator_name unless authenticator
+      raise Errors::Authentication::AuthenticatorNotFound, authenticator_name unless authenticator
     end
 
     def validate_credentials
-      raise Err::InvalidCredentials unless authenticator.valid?(@authenticator_input)
+      raise Errors::Authentication::InvalidCredentials unless authenticator.valid?(@authenticator_input)
     end
 
     def validate_webservice_is_whitelisted

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -4,9 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  # Possible Errors Raised:
-  # AuthenticatorNotFound, InvalidCredentials
-
   Authenticate ||= CommandClass.new(
     dependencies: {
       token_factory:                       TokenFactory.new,

--- a/app/domain/authentication/authenticator_class.rb
+++ b/app/domain/authentication/authenticator_class.rb
@@ -5,13 +5,12 @@
 module Authentication
   class AuthenticatorClass
 
+    # Possible Errors Raised:
+    # DoesntStartWithAuthn, NotNamedAuthenticator, MissingValidMethod
+
     # Represents the rules any authenticator class must conform to
-    #
     class Validation
 
-      Err = Errors::Authentication::AuthenticatorClass
-      # Possible Errors Raised:
-      # DoesntStartWithAuthn, NotNamedAuthenticator, MissingValidMethod
 
       def initialize(cls)
         @cls = cls
@@ -26,9 +25,9 @@ module Authentication
       end
 
       def validate!
-        raise Err::DoesntStartWithAuthn, own_name unless valid_name?
-        raise Err::NotNamedAuthenticator, parent_name unless valid_parent_name?
-        raise Err::MissingValidMethod, own_name unless valid_interface?
+        raise Errors::Authentication::AuthenticatorClass::DoesntStartWithAuthn, own_name unless valid_name?
+        raise Errors::Authentication::AuthenticatorClass::NotNamedAuthenticator, parent_name unless valid_parent_name?
+        raise Errors::Authentication::AuthenticatorClass::MissingValidMethod, own_name unless valid_interface?
       end
 
       private

--- a/app/domain/authentication/authenticator_class.rb
+++ b/app/domain/authentication/authenticator_class.rb
@@ -5,12 +5,8 @@
 module Authentication
   class AuthenticatorClass
 
-    # Possible Errors Raised:
-    # DoesntStartWithAuthn, NotNamedAuthenticator, MissingValidMethod
-
     # Represents the rules any authenticator class must conform to
     class Validation
-
 
       def initialize(cls)
         @cls = cls

--- a/app/domain/authentication/authn_azure/application_identity.rb
+++ b/app/domain/authentication/authn_azure/application_identity.rb
@@ -1,8 +1,6 @@
 module Authentication
   module AuthnAzure
 
-    Log = LogMessages::Authentication::AuthnAzure
-
     class ApplicationIdentity
 
       def initialize(role_annotations:, service_id:, logger:)

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -3,11 +3,6 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    Err = Errors::Authentication::AuthnAzure
-    Log = LogMessages::Authentication::AuthnAzure
-    # Possible Errors Raised:
-    # TokenFieldNotFoundOrEmpty, MissingRequestParam
-
     Authenticator = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets:   Authentication::Util::FetchAuthenticatorSecrets.new,

--- a/app/domain/authentication/authn_azure/decoded_token.rb
+++ b/app/domain/authentication/authn_azure/decoded_token.rb
@@ -28,7 +28,11 @@ module Authentication
       end
 
       def validate_token_field_exists(field_name)
-        @logger.debug(LogMessages::Authentication::AuthnAzure::ValidatingTokenFieldExists.new(field_name))
+        @logger.debug(
+          LogMessages::Authentication::AuthnAzure::ValidatingTokenFieldExists.new(
+            field_name
+          )
+        )
         if @decoded_token_hash[field_name].to_s.empty?
           raise Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty, field_name
         end
@@ -36,7 +40,12 @@ module Authentication
 
       def token_field_value(field_name)
         token_field_value = @decoded_token_hash[field_name]
-        @logger.debug(LogMessages::Authentication::AuthnAzure::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
+        @logger.debug(
+          LogMessages::Authentication::AuthnAzure::ExtractedFieldFromAzureToken.new(
+            field_name,
+            token_field_value
+          )
+        )
         token_field_value
       end
     end

--- a/app/domain/authentication/authn_azure/decoded_token.rb
+++ b/app/domain/authentication/authn_azure/decoded_token.rb
@@ -28,15 +28,15 @@ module Authentication
       end
 
       def validate_token_field_exists(field_name)
-        @logger.debug(Log::ValidatingTokenFieldExists.new(field_name))
+        @logger.debug(LogMessages::Authentication::AuthnAzure::ValidatingTokenFieldExists.new(field_name))
         if @decoded_token_hash[field_name].to_s.empty?
-          raise Err::TokenFieldNotFoundOrEmpty, field_name
+          raise Errors::Authentication::AuthnAzure::TokenFieldNotFoundOrEmpty, field_name
         end
       end
 
       def token_field_value(field_name)
         token_field_value = @decoded_token_hash[field_name]
-        @logger.debug(Log::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
+        @logger.debug(LogMessages::Authentication::AuthnAzure::ExtractedFieldFromAzureToken.new(field_name, token_field_value))
         token_field_value
       end
     end

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -53,7 +53,9 @@ module Authentication
         else
           @token_identity[:system_assigned_identity] = @oid_token_field
         end
-        @logger.debug(LogMessages::Authentication::AuthnAzure::ExtractedApplicationIdentityFromToken.new)
+        @logger.debug(
+          LogMessages::Authentication::AuthnAzure::ExtractedApplicationIdentityFromToken.new
+        )
       end
 
       def validate_azure_annotations_are_permitted
@@ -82,7 +84,8 @@ module Authentication
 
       def validate_constraint_exists constraint
         unless application_identity.constraints[constraint]
-          raise Errors::Authentication::AuthnAzure::RoleMissingConstraint, annotation_type_constraint(constraint)
+          raise Errors::Authentication::AuthnAzure::RoleMissingConstraint,
+                annotation_type_constraint(constraint)
         end
       end
 
@@ -93,7 +96,8 @@ module Authentication
 
         identifiers_constraints = application_identity.constraints.keys & identifiers
         unless identifiers_constraints.length <= 1
-          raise Errors::Authentication::IllegalConstraintCombinations, annotation_type_constraints(identifiers_constraints)
+          raise Errors::Authentication::IllegalConstraintCombinations,
+                annotation_type_constraints(identifiers_constraints)
         end
       end
 
@@ -102,7 +106,8 @@ module Authentication
           annotation_type  = constraint[0].to_s
           annotation_value = constraint[1]
           unless annotation_value == @token_identity[annotation_type.to_sym]
-            raise Errors::Authentication::AuthnAzure::InvalidApplicationIdentity, annotation_type_constraint(annotation_type)
+            raise Errors::Authentication::AuthnAzure::InvalidApplicationIdentity,
+                  annotation_type_constraint(annotation_type)
           end
         end
         @logger.debug(LogMessages::Authentication::AuthnAzure::ValidatedApplicationIdentity.new)

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -3,10 +3,6 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity, XmsMiridParseError,
-    # MissingRequiredFieldsInXmsMirid, MissingProviderFieldsInXmsMirid, MissingConstraint,
-    # IllegalConstraintCombinations
-
     ValidateApplicationIdentity = CommandClass.new(
       dependencies: {
         role_class:                 ::Role,

--- a/app/domain/authentication/authn_azure/validate_application_identity.rb
+++ b/app/domain/authentication/authn_azure/validate_application_identity.rb
@@ -3,8 +3,6 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    Log = LogMessages::Authentication::AuthnAzure
-    Err = Errors::Authentication::AuthnAzure
     # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity, XmsMiridParseError,
     # MissingRequiredFieldsInXmsMirid, MissingProviderFieldsInXmsMirid, MissingConstraint,
     # IllegalConstraintCombinations
@@ -59,7 +57,7 @@ module Authentication
         else
           @token_identity[:system_assigned_identity] = @oid_token_field
         end
-        @logger.debug(Log::ExtractedApplicationIdentityFromToken.new)
+        @logger.debug(LogMessages::Authentication::AuthnAzure::ExtractedApplicationIdentityFromToken.new)
       end
 
       def validate_azure_annotations_are_permitted
@@ -88,7 +86,7 @@ module Authentication
 
       def validate_constraint_exists constraint
         unless application_identity.constraints[constraint]
-          raise Err::RoleMissingConstraint, annotation_type_constraint(constraint)
+          raise Errors::Authentication::AuthnAzure::RoleMissingConstraint, annotation_type_constraint(constraint)
         end
       end
 
@@ -108,10 +106,10 @@ module Authentication
           annotation_type  = constraint[0].to_s
           annotation_value = constraint[1]
           unless annotation_value == @token_identity[annotation_type.to_sym]
-            raise Err::InvalidApplicationIdentity, annotation_type_constraint(annotation_type)
+            raise Errors::Authentication::AuthnAzure::InvalidApplicationIdentity, annotation_type_constraint(annotation_type)
           end
         end
-        @logger.debug(Log::ValidatedApplicationIdentity.new)
+        @logger.debug(LogMessages::Authentication::AuthnAzure::ValidatedApplicationIdentity.new)
       end
 
       def annotation_type_constraints constraints

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -29,7 +29,10 @@ module Authentication
         prefixed_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]
           next if prefixed_permitted_constraints(prefix).include?(annotation_name)
-          raise Errors::Authentication::AuthnAzure::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+          raise Errors::Authentication::AuthnAzure::ConstraintNotSupported.new(
+            annotation_name.gsub(prefix, ""),
+            permitted_constraints
+          )
         end
       end
 

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -3,9 +3,6 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity,
-    # ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
-
     ValidateAzureAnnotations = CommandClass.new(
       dependencies: {
         logger: Rails.logger

--- a/app/domain/authentication/authn_azure/validate_azure_annotations.rb
+++ b/app/domain/authentication/authn_azure/validate_azure_annotations.rb
@@ -3,8 +3,6 @@ require 'command_class'
 module Authentication
   module AuthnAzure
 
-    Log = LogMessages::Authentication::AuthnAzure
-    Err = Errors::Authentication::AuthnAzure
     # Possible Errors Raised: RoleNotFound, InvalidApplicationIdentity,
     # ConstraintNotSupported, MissingConstraint, IllegalConstraintCombinations
 
@@ -34,7 +32,7 @@ module Authentication
         prefixed_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]
           next if prefixed_permitted_constraints(prefix).include?(annotation_name)
-          raise Err::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
+          raise Errors::Authentication::AuthnAzure::ConstraintNotSupported.new(annotation_name.gsub(prefix, ""), permitted_constraints)
         end
       end
 

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -1,11 +1,6 @@
 module Authentication
   module AuthnAzure
 
-    Err = Errors::Authentication::AuthnAzure
-    # Possible Errors Raised:
-    #   ProviderDiscoveryTimeout, ProviderDiscoveryFailed
-    #   RequiredResourceMissing, RequiredSecretMissing
-
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,

--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -46,17 +46,24 @@ module Authentication
           .map { |x| [x.first, x.drop(1)] }.to_h
       rescue => e
         # this should never occur, it's here to enhance supportability in case it does
-        raise Errors::Authentication::AuthnAzure::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+        raise Errors::Authentication::AuthnAzure::XmsMiridParseError.new(
+          @xms_mirid_token_field,
+          e.inspect
+        )
       end
 
       def validate
         missing_keys = REQUIRED_KEYS - @mirid_parts_hash.keys
         unless missing_keys.empty?
-          raise Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+          raise Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid.new(
+            missing_keys,
+            @xms_mirid_token_field
+          )
         end
 
         unless @mirid_parts_hash["providers"].length == 3
-          raise Errors::Authentication::AuthnAzure::InvalidProviderFieldsInXmsMirid, @xms_mirid_token_field
+          raise Errors::Authentication::AuthnAzure::InvalidProviderFieldsInXmsMirid,
+                @xms_mirid_token_field
         end
       end
     end

--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -1,8 +1,6 @@
 module Authentication
   module AuthnAzure
 
-    Err = Errors::Authentication::AuthnAzure
-
     class XmsMirid
 
       REQUIRED_KEYS = %w(subscriptions resourcegroups providers).freeze
@@ -48,17 +46,17 @@ module Authentication
           .map { |x| [x.first, x.drop(1)] }.to_h
       rescue => e
         # this should never occur, it's here to enhance supportability in case it does
-        raise Err::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
+        raise Errors::Authentication::AuthnAzure::XmsMiridParseError.new(@xms_mirid_token_field, e.inspect)
       end
 
       def validate
         missing_keys = REQUIRED_KEYS - @mirid_parts_hash.keys
         unless missing_keys.empty?
-          raise Err::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
+          raise Errors::Authentication::AuthnAzure::MissingRequiredFieldsInXmsMirid.new(missing_keys, @xms_mirid_token_field)
         end
 
         unless @mirid_parts_hash["providers"].length == 3
-          raise Err::InvalidProviderFieldsInXmsMirid, @xms_mirid_token_field
+          raise Errors::Authentication::AuthnAzure::InvalidProviderFieldsInXmsMirid, @xms_mirid_token_field
         end
       end
     end

--- a/app/domain/authentication/authn_iam/authenticator.rb
+++ b/app/domain/authentication/authn_iam/authenticator.rb
@@ -20,12 +20,20 @@ module Authentication
       end
 
       def identity_hash(response)
-        Rails.logger.debug(LogMessages::Authentication::AuthnIam::GetCallerIdentityBody.new(response.body))
+        Rails.logger.debug(
+          LogMessages::Authentication::AuthnIam::GetCallerIdentityBody.new(
+            response.body
+          )
+        )
 
         if response.code < 300
           Hash.from_xml(response.body)
         else
-          Rails.logger.error(Errors::Authentication::AuthnIam::IdentityVerificationErrorCode.new(response.code))
+          Rails.logger.error(
+            Errors::Authentication::AuthnIam::IdentityVerificationErrorCode.new(
+              response.code
+            )
+          )
           false
         end
       end
@@ -40,7 +48,12 @@ module Authentication
         aws_user_id = response_hash["GetCallerIdentityResponse"]["GetCallerIdentityResult"]["UserId"]
         host_to_match = "#{host_prefix}/#{aws_account_id}/#{aws_role_name}"
 
-        Rails.logger.debug(LogMessages::Authentication::AuthnIam::AttemptToMatchHost.new(aws_user_id, host_to_match))
+        Rails.logger.debug(
+          LogMessages::Authentication::AuthnIam::AttemptToMatchHost.new(
+            aws_user_id,
+            host_to_match
+          )
+        )
 
         login.eql? host_to_match
       end

--- a/app/domain/authentication/authn_iam/authenticator.rb
+++ b/app/domain/authentication/authn_iam/authenticator.rb
@@ -6,10 +6,8 @@ module Authentication
   module AuthnIam
     class Authenticator
 
-      Err = Errors::Authentication::AuthnIam
-      Log = LogMessages::Authentication::AuthnIam
-      # Possible Errors Raised:
-      # InvalidAWSHeaders
+    # Possible Errors Raised:
+    # InvalidAWSHeaders
 
       def initialize(env:)
         @env = env
@@ -25,12 +23,12 @@ module Authentication
       end
 
       def identity_hash(response)
-        Rails.logger.debug(Log::GetCallerIdentityBody.new(response.body))
+        Rails.logger.debug(LogMessages::Authentication::AuthnIam::GetCallerIdentityBody.new(response.body))
 
         if response.code < 300
           Hash.from_xml(response.body)
         else
-          Rails.logger.error(Err::IdentityVerificationErrorCode.new(response.code))
+          Rails.logger.error(Errors::Authentication::AuthnIam::IdentityVerificationErrorCode.new(response.code))
           false
         end
       end
@@ -45,7 +43,7 @@ module Authentication
         aws_user_id = response_hash["GetCallerIdentityResponse"]["GetCallerIdentityResult"]["UserId"]
         host_to_match = "#{host_prefix}/#{aws_account_id}/#{aws_role_name}"
 
-        Rails.logger.debug(Log::AttemptToMatchHost.new(aws_user_id, host_to_match))
+        Rails.logger.debug(LogMessages::Authentication::AuthnIam::AttemptToMatchHost.new(aws_user_id, host_to_match))
 
         login.eql? host_to_match
       end
@@ -55,12 +53,12 @@ module Authentication
       end
 
       def response_from_signed_request(aws_headers)
-        Rails.logger.debug(Log::RetrieveIamIdentity.new)
+        Rails.logger.debug(LogMessages::Authentication::AuthnIam::RetrieveIamIdentity.new)
         begin
           RestClient.get(aws_signed_url, headers = aws_headers)
         rescue RestClient::ExceptionWithResponse => e
-          Rails.logger.error(Err::VerificationError.new(e.to_s))
-          raise Err::InvalidAWSHeaders, e.to_s
+          Rails.logger.error(Errors::Authentication::AuthnIam::VerificationError.new(e.to_s))
+          raise Errors::Authentication::AuthnIam::InvalidAWSHeaders, e.to_s
         end
       end
     end

--- a/app/domain/authentication/authn_iam/authenticator.rb
+++ b/app/domain/authentication/authn_iam/authenticator.rb
@@ -6,9 +6,6 @@ module Authentication
   module AuthnIam
     class Authenticator
 
-    # Possible Errors Raised:
-    # InvalidAWSHeaders
-
       def initialize(env:)
         @env = env
       end

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -3,8 +3,6 @@
 module Authentication
   module AuthnK8s
 
-    Log = LogMessages::Authentication::AuthnK8s
-    Err = Errors::Authentication::AuthnK8s
     # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
     # ScopeNotSupported, InvalidHostId
 
@@ -79,7 +77,7 @@ module Authentication
         validate_permitted_scope
 
         # validate that a constraint exists on the namespace
-        raise Err::MissingNamespaceConstraint unless namespace
+        raise Errors::Authentication::AuthnK8s::MissingNamespaceConstraint unless namespace
 
         validate_constraint_combinations
       end
@@ -149,7 +147,7 @@ module Authentication
         prefixed_k8s_annotations(prefix).each do |annotation|
           annotation_name = annotation[:name]
           next if prefixed_permitted_annotations(prefix).include?(annotation_name)
-          raise Err::ScopeNotSupported.new(annotation_name.gsub(prefix, ""), annotation_type_constraints)
+          raise Errors::Authentication::AuthnK8s::ScopeNotSupported.new(annotation_name.gsub(prefix, ""), annotation_type_constraints)
         end
       end
 
@@ -178,16 +176,16 @@ module Authentication
       end
 
       def validate_host_id
-        Rails.logger.debug(Log::ValidatingHostId.new(@host_id))
+        Rails.logger.debug(LogMessages::Authentication::AuthnK8s::ValidatingHostId.new(@host_id))
 
         valid_host_id = host_id_suffix.length == 3
-        raise Err::InvalidHostId, @host_id unless valid_host_id
+        raise Errors::Authentication::AuthnK8s::InvalidHostId, @host_id unless valid_host_id
 
         return if host_id_namespace_scoped?
 
         constraint       = host_id_suffix[-2]
         valid_constraint = permitted_constraints.include?(constraint)
-        raise Err::ScopeNotSupported.new(constraint, permitted_constraints) unless valid_constraint
+        raise Errors::Authentication::AuthnK8s::ScopeNotSupported.new(constraint, permitted_constraints) unless valid_constraint
       end
 
       def permitted_constraints

--- a/app/domain/authentication/authn_k8s/application_identity.rb
+++ b/app/domain/authentication/authn_k8s/application_identity.rb
@@ -3,9 +3,6 @@
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised: MissingNamespaceConstraint, IllegalConstraintCombinations,
-    # ScopeNotSupported, InvalidHostId
-
     # This class defines an application identity of a given conjur host.
     # The constructor initializes an ApplicationIdentity object and validates that
     # it is configured correctly.

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -42,7 +42,10 @@ module Authentication
 
       def validate_common_name_matches
         return if host_and_cert_cn_match?
-        raise Errors::Authentication::AuthnK8s::CommonNameDoesntMatchHost.new(cert.common_name, host_common_name)
+        raise Errors::Authentication::AuthnK8s::CommonNameDoesntMatchHost.new(
+          cert.common_name,
+          host_common_name
+        )
       end
 
       def validate_cert_isnt_expired

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -5,7 +5,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    Err ||= Errors::Authentication::AuthnK8s
     # Possible Errors Raised:
     # MissingClientCertificate, UntrustedClientCertificate, CommonNameDoesntMatchHost, ClientCertificateExpired
 
@@ -37,20 +36,20 @@ module Authentication
       end
 
       def validate_cert_exists
-        raise Err::MissingClientCertificate unless header_cert_str
+        raise Errors::Authentication::AuthnK8s::MissingClientCertificate unless header_cert_str
       end
 
       def validate_cert_is_trusted
-        raise Err::UntrustedClientCertificate unless ca_can_verify_cert?
+        raise Errors::Authentication::AuthnK8s::UntrustedClientCertificate unless ca_can_verify_cert?
       end
 
       def validate_common_name_matches
         return if host_and_cert_cn_match?
-        raise Err::CommonNameDoesntMatchHost.new(cert.common_name, host_common_name)
+        raise Errors::Authentication::AuthnK8s::CommonNameDoesntMatchHost.new(cert.common_name, host_common_name)
       end
 
       def validate_cert_isnt_expired
-        raise Err::ClientCertificateExpired if cert_expired?
+        raise Errors::Authentication::AuthnK8s::ClientCertificateExpired if cert_expired?
       end
 
       def cert

--- a/app/domain/authentication/authn_k8s/authenticator.rb
+++ b/app/domain/authentication/authn_k8s/authenticator.rb
@@ -5,9 +5,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised:
-    # MissingClientCertificate, UntrustedClientCertificate, CommonNameDoesntMatchHost, ClientCertificateExpired
-
     Authenticator ||= CommandClass.new(
       dependencies: {validate_pod_request: ValidatePodRequest.new},
       inputs: [:authenticator_input]

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -40,7 +40,11 @@ module Authentication
       # that happens in the "authenticate" request will work, as the signed certificate
       # contains the full host-id.
       def update_csr_common_name
-        @logger.debug(LogMessages::Authentication::AuthnK8s::SetCommonName.new(full_host_name))
+        @logger.debug(
+          LogMessages::Authentication::AuthnK8s::SetCommonName.new(
+            full_host_name
+          )
+        )
         smart_csr.common_name = full_host_name
       end
 
@@ -90,7 +94,8 @@ module Authentication
       def validate_cert_installation(resp)
         error_stream = resp[:error]
         return if error_stream.nil? || error_stream.empty?
-        raise Errors::Authentication::AuthnK8s::CertInstallationError, cert_error(error_stream)
+        raise Errors::Authentication::AuthnK8s::CertInstallationError,
+              cert_error(error_stream)
       end
 
       def pod_request

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -5,8 +5,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    Log ||= LogMessages::Authentication::AuthnK8s
-    Err ||= Errors::Authentication::AuthnK8s
     # Possible Errors Raised:
     # CSRIsMissingSpiffeId, CertInstallationError
 
@@ -45,7 +43,7 @@ module Authentication
       # that happens in the "authenticate" request will work, as the signed certificate
       # contains the full host-id.
       def update_csr_common_name
-        @logger.debug(Log::SetCommonName.new(full_host_name))
+        @logger.debug(LogMessages::Authentication::AuthnK8s::SetCommonName.new(full_host_name))
         smart_csr.common_name = full_host_name
       end
 
@@ -72,7 +70,7 @@ module Authentication
         pod_namespace = spiffe_id.namespace
         pod_name = spiffe_id.name
         cert_file_path = "/etc/conjur/ssl/client.pem"
-        @logger.debug(Log::CopySSLToPod.new(
+        @logger.debug(LogMessages::Authentication::AuthnK8s::CopySSLToPod.new(
           container_name,
           cert_file_path,
           pod_namespace,
@@ -89,13 +87,13 @@ module Authentication
           mode: 0o644
         )
         validate_cert_installation(resp)
-        @logger.debug(Log::CopySSLToPodSuccess.new)
+        @logger.debug(LogMessages::Authentication::AuthnK8s::CopySSLToPodSuccess.new)
       end
 
       def validate_cert_installation(resp)
         error_stream = resp[:error]
         return if error_stream.nil? || error_stream.empty?
-        raise Err::CertInstallationError, cert_error(error_stream)
+        raise Errors::Authentication::AuthnK8s::CertInstallationError, cert_error(error_stream)
       end
 
       def pod_request
@@ -133,7 +131,7 @@ module Authentication
       end
 
       def validate_spiffe_id_exists
-        raise Err::CSRIsMissingSpiffeId unless smart_csr.spiffe_id
+        raise Errors::Authentication::AuthnK8s::CSRIsMissingSpiffeId unless smart_csr.spiffe_id
       end
 
       def smart_csr

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -5,9 +5,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised:
-    # CSRIsMissingSpiffeId, CertInstallationError
-
     KUBERNETES_AUTHENTICATOR_NAME = 'authn-k8s'
 
     InjectClientCert ||= CommandClass.new(

--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -22,7 +22,10 @@ module Authentication
       def self.from_csr(account:, service_name:, csr:)
         cn = csr.common_name
         unless cn
-          raise Errors::Authentication::AuthnK8s::CSRMissingCNEntry.new(csr.subject_to_s, csr.spiffe_id.to_s)
+          raise Errors::Authentication::AuthnK8s::CSRMissingCNEntry.new(
+            csr.subject_to_s,
+            csr.spiffe_id.to_s
+          )
         end
         new(account: account, service_name: service_name, common_name: cn)
       end
@@ -31,7 +34,10 @@ module Authentication
         smart_cert = ::Util::OpenSsl::X509::SmartCert.new(cert)
         cn = smart_cert.common_name
         unless cn
-          raise Errors::Authentication::AuthnK8s::CertMissingCNEntry.new(smart_cert.smart_subject.to_s, smart_cert.san.to_s)
+          raise Errors::Authentication::AuthnK8s::CertMissingCNEntry.new(
+            smart_cert.smart_subject.to_s,
+            smart_cert.san.to_s
+          )
         end
         new(account: account, service_name: service_name, common_name: cn)
       end
@@ -44,7 +50,9 @@ module Authentication
 
       def conjur_host_id
         host_id = "#{@account}:" + @common_name.k8s_host_name.sub('host/', 'host:')
-        Rails.logger.debug(LogMessages::Authentication::AuthnK8s::HostIdFromCommonName.new(host_id))
+        Rails.logger.debug(
+          LogMessages::Authentication::AuthnK8s::HostIdFromCommonName.new(host_id)
+        )
         host_id
       end
 

--- a/app/domain/authentication/authn_k8s/k8s_host.rb
+++ b/app/domain/authentication/authn_k8s/k8s_host.rb
@@ -14,8 +14,6 @@ require 'forwardable'
 module Authentication
   module AuthnK8s
 
-    Err ||= Errors::Authentication::AuthnK8s
-
     class K8sHost
       extend Forwardable
 
@@ -24,7 +22,7 @@ module Authentication
       def self.from_csr(account:, service_name:, csr:)
         cn = csr.common_name
         unless cn
-          raise Err::CSRMissingCNEntry.new(csr.subject_to_s, csr.spiffe_id.to_s)
+          raise Errors::Authentication::AuthnK8s::CSRMissingCNEntry.new(csr.subject_to_s, csr.spiffe_id.to_s)
         end
         new(account: account, service_name: service_name, common_name: cn)
       end
@@ -33,7 +31,7 @@ module Authentication
         smart_cert = ::Util::OpenSsl::X509::SmartCert.new(cert)
         cn = smart_cert.common_name
         unless cn
-          raise Err::CertMissingCNEntry.new(smart_cert.smart_subject.to_s, smart_cert.san.to_s)
+          raise Errors::Authentication::AuthnK8s::CertMissingCNEntry.new(smart_cert.smart_subject.to_s, smart_cert.san.to_s)
         end
         new(account: account, service_name: service_name, common_name: cn)
       end
@@ -46,7 +44,7 @@ module Authentication
 
       def conjur_host_id
         host_id = "#{@account}:" + @common_name.k8s_host_name.sub('host/', 'host:')
-        Rails.logger.debug(Log::HostIdFromCommonName.new(host_id))
+        Rails.logger.debug(LogMessages::Authentication::AuthnK8s::HostIdFromCommonName.new(host_id))
         host_id
       end
 

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -5,7 +5,6 @@
 #
 module Authentication
   module AuthnK8s
-    #TODO: rename to K8sApiFacade
 
     VARIABLE_BEARER_TOKEN ||= 'kubernetes/service-account-token'
     VARIABLE_CA_CERT ||= 'kubernetes/ca-cert'
@@ -14,8 +13,7 @@ module Authentication
     SERVICEACCOUNT_CA_PATH ||= File.join(SERVICEACCOUNT_DIR, 'ca.crt').freeze
     SERVICEACCOUNT_TOKEN_PATH ||= File.join(SERVICEACCOUNT_DIR, 'token').freeze
 
-    Err ||= Errors::Authentication::AuthnK8s
-
+    #TODO: rename to K8sApiFacade
     class K8sObjectLookup
 
       class K8sForbiddenError < RuntimeError; end
@@ -42,7 +40,7 @@ module Authentication
           VARIABLE_CA_CERT
         )
 
-        raise Err::MissingCertificate if cert.blank?
+        raise Errors::Authentication::AuthnK8s::MissingCertificate if cert.blank?
         cert
       end
 

--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -24,7 +24,8 @@ module Authentication
         def for_resource resource_type
           const_get(resource_type.classify)
         rescue NameError
-          raise Errors::Authentication::AuthnK8s::UnknownK8sResourceType, resource_type.inspect
+          raise Errors::Authentication::AuthnK8s::UnknownK8sResourceType,
+                resource_type.inspect
         end
       end
 
@@ -66,7 +67,10 @@ module Authentication
         def validate_pod
           replica_set_ref = pod_owner_refs&.find { |ref| ref.kind == "ReplicaSet" }
           unless replica_set_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicaSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'ReplicaSet'
+            )
           end
 
           replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
@@ -74,7 +78,10 @@ module Authentication
 
           deployment_ref = replica_set_owner_refs&.find { |ref| ref.kind == "Deployment" }
           unless deployment_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'Deployment')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'Deployment'
+            )
           end
 
           deployment = k8s_object_lookup.find_object_by_name "deployment", deployment_ref.name, namespace
@@ -94,7 +101,10 @@ module Authentication
         def validate_pod
           replication_resource_ref = pod_owner_refs&.find { |ref| ref.kind == "Replicationresource" }
           unless replication_resource_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicationController')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'ReplicationController'
+            )
           end
 
           replication_resource = k8s_object_lookup.find_object_by_name(
@@ -108,7 +118,10 @@ module Authentication
           deployment_config_ref = replication_resource_owner_refs&.find { |ref| ref.kind == "DeploymentConfig" }
 
           unless deployment_config_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'DeploymentConfig')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'DeploymentConfig'
+            )
           end
 
           deployment_config = k8s_object_lookup.find_object_by_name "deployment_config",
@@ -129,7 +142,10 @@ module Authentication
         def validate_pod
           replica_set_ref = pod_owner_refs&.find { |ref| ref.kind == "ReplicaSet" }
           unless replica_set_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicaSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'ReplicaSet'
+            )
           end
 
           replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
@@ -162,7 +178,10 @@ module Authentication
         def validate_pod
           stateful_set_ref = pod_owner_refs&.find { |ref| ref.kind == "StatefulSet" }
           unless stateful_set_ref
-            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'StatefulSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
+              pod_name,
+              'StatefulSet'
+            )
           end
 
           stateful_set = k8s_object_lookup.find_object_by_name "stateful_set", stateful_set_ref.name, namespace
@@ -182,7 +201,10 @@ module Authentication
         # The pod is always a member of itself.
         def validate_pod
           unless self.name == pod.metadata.name
-            raise Errors::Authentication::AuthnK8s::PodNameMismatchError.new(pod_name, self.name.inspect)
+            raise Errors::Authentication::AuthnK8s::PodNameMismatchError.new(
+              pod_name,
+              self.name.inspect
+            )
           end
         end
       end

--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -16,16 +16,15 @@
 # member of the Conjur role (= Kubernetes resource) that it wants to authenticate as.
 module Authentication
   module AuthnK8s
-    module K8sResolver
 
-      Err ||= Errors::Authentication::AuthnK8s
+    module K8sResolver
 
       class << self
         # Gets a resolver class for a resource type.
         def for_resource resource_type
           const_get(resource_type.classify)
         rescue NameError
-          raise Err::UnknownK8sResourceType, resource_type.inspect
+          raise Errors::Authentication::AuthnK8s::UnknownK8sResourceType, resource_type.inspect
         end
       end
 
@@ -67,7 +66,7 @@ module Authentication
         def validate_pod
           replica_set_ref = pod_owner_refs&.find { |ref| ref.kind == "ReplicaSet" }
           unless replica_set_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'ReplicaSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicaSet')
           end
 
           replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
@@ -75,13 +74,13 @@ module Authentication
 
           deployment_ref = replica_set_owner_refs&.find { |ref| ref.kind == "Deployment" }
           unless deployment_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'Deployment')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'Deployment')
           end
 
           deployment = k8s_object_lookup.find_object_by_name "deployment", deployment_ref.name, namespace
 
           unless self.name == deployment.metadata.name
-            raise Err::PodRelationMismatchError.new(
+            raise Errors::Authentication::AuthnK8s::PodRelationMismatchError.new(
               pod_name,
               'Deployment',
               deployment.metadata.name.inspect,
@@ -95,7 +94,7 @@ module Authentication
         def validate_pod
           replication_resource_ref = pod_owner_refs&.find { |ref| ref.kind == "Replicationresource" }
           unless replication_resource_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'ReplicationController')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicationController')
           end
 
           replication_resource = k8s_object_lookup.find_object_by_name(
@@ -109,14 +108,14 @@ module Authentication
           deployment_config_ref = replication_resource_owner_refs&.find { |ref| ref.kind == "DeploymentConfig" }
 
           unless deployment_config_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'DeploymentConfig')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'DeploymentConfig')
           end
 
           deployment_config = k8s_object_lookup.find_object_by_name "deployment_config",
             deployment_config_ref.name, namespace
 
           unless self.name == deployment_config.metadata.name
-            raise Err::PodRelationMismatchError.new(
+            raise Errors::Authentication::AuthnK8s::PodRelationMismatchError.new(
               pod_name,
               'DeploymentConfig',
               deployment_config.metadata.name.inspect,
@@ -130,13 +129,13 @@ module Authentication
         def validate_pod
           replica_set_ref = pod_owner_refs&.find { |ref| ref.kind == "ReplicaSet" }
           unless replica_set_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'ReplicaSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'ReplicaSet')
           end
 
           replica_set = k8s_object_lookup.find_object_by_name "replica_set", replica_set_ref.name, namespace
 
           unless self.name == replica_set.metadata.name
-            raise Err::PodRelationMismatchError.new(
+            raise Errors::Authentication::AuthnK8s::PodRelationMismatchError.new(
               pod_name,
               'ReplicaSet',
               replica_set.metadata.name.inspect,
@@ -149,7 +148,7 @@ module Authentication
       class ServiceAccount < Base
         def validate_pod
           unless self.name == pod.spec.serviceAccountName
-            raise Err::PodRelationMismatchError.new(
+            raise Errors::Authentication::AuthnK8s::PodRelationMismatchError.new(
               pod_name,
               'ServiceAccount',
               pod.spec.serviceAccountName.inspect,
@@ -163,13 +162,13 @@ module Authentication
         def validate_pod
           stateful_set_ref = pod_owner_refs&.find { |ref| ref.kind == "StatefulSet" }
           unless stateful_set_ref
-            raise Err::PodMissingRelationError.new(pod_name, 'StatefulSet')
+            raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(pod_name, 'StatefulSet')
           end
 
           stateful_set = k8s_object_lookup.find_object_by_name "stateful_set", stateful_set_ref.name, namespace
 
           unless self.name == stateful_set.metadata.name
-            raise Err::PodRelationMismatchError.new(
+            raise Errors::Authentication::AuthnK8s::PodRelationMismatchError.new(
               pod_name,
               'StatefulSetName',
               stateful_set.metadata.name.inspect,
@@ -183,7 +182,7 @@ module Authentication
         # The pod is always a member of itself.
         def validate_pod
           unless self.name == pod.metadata.name
-            raise Err::PodNameMismatchError.new(pod_name, self.name.inspect)
+            raise Errors::Authentication::AuthnK8s::PodNameMismatchError.new(pod_name, self.name.inspect)
           end
         end
       end

--- a/app/domain/authentication/authn_k8s/kube_client_factory.rb
+++ b/app/domain/authentication/authn_k8s/kube_client_factory.rb
@@ -10,9 +10,8 @@ require 'uri'
 #
 module Authentication
   module AuthnK8s
-    module KubeClientFactory
 
-      Err = Errors::Authentication::AuthnK8s
+    module KubeClientFactory
 
       def self.client(api: 'api', version: 'v1', host_url: nil, options: nil)
         full_url = "#{host_url}/#{api}"
@@ -27,7 +26,7 @@ module Authentication
         def validate_host_url! host_url
           raise if URI.parse(host_url).host.empty?
         rescue
-          raise Err::InvalidApiUrl, host_url
+          raise Errors::Authentication::AuthnK8s::InvalidApiUrl, host_url
         end
       end
     end

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -32,7 +32,12 @@ module Authentication
 
         wait_for_close_message
 
-        raise Errors::Authentication::AuthnK8s::CommandTimedOut.new(@container, @pod_name) unless @channel_closed
+        unless @channel_closed
+          raise Errors::Authentication::AuthnK8s::CommandTimedOut.new(
+            @container,
+            @pod_name
+          )
+        end
 
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 
@@ -46,7 +51,9 @@ module Authentication
         if hs_error
           ws_client.emit(:error, "Websocket handshake error: #{hs_error.inspect}")
         else
-          @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelOpen.new(@pod_name))
+          @logger.debug(
+            LogMessages::Authentication::AuthnK8s::PodChannelOpen.new(@pod_name)
+          )
 
           if stdin
             data = WebSocketMessage.channel_byte('stdin') + body
@@ -63,24 +70,40 @@ module Authentication
         msg_data = wsmsg.data
 
         if msg_type == :binary
-          @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelData.new(@pod_name, wsmsg.channel_name, msg_data))
+          @logger.debug(
+            LogMessages::Authentication::AuthnK8s::PodChannelData.new(
+              @pod_name,
+              wsmsg.channel_name,
+              msg_data
+            )
+          )
           @message_log.save_message(wsmsg)
         elsif msg_type == :close
-          @logger.debug(LogMessages::Authentication::AuthnK8s::PodMessageData.new(@pod_name, "close", msg_data))
+          @logger.debug(
+            LogMessages::Authentication::AuthnK8s::PodMessageData.new(
+              @pod_name,
+              "close",
+              msg_data
+            )
+          )
           ws_client.close
         end
       end
 
       def on_close
         @channel_closed = true
-        @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelClosed.new(@pod_name))
+        @logger.debug(
+          LogMessages::Authentication::AuthnK8s::PodChannelClosed.new(@pod_name)
+        )
       end
 
       def on_error(err)
         @channel_closed = true
 
         error_info = err.inspect
-        @logger.debug(LogMessages::Authentication::AuthnK8s::PodError.new(@pod_name, error_info))
+        @logger.debug(
+          LogMessages::Authentication::AuthnK8s::PodError.new(@pod_name, error_info)
+        )
         @message_log.save_error_string(error_info)
       end
 

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -9,9 +9,6 @@ require 'websocket-client-simple'
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised:
-    # CommandTimedOut
-
     KubectlExec ||= CommandClass.new(
       dependencies: { logger: Rails.logger,
                       timeout: 5.seconds },

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -9,8 +9,6 @@ require 'websocket-client-simple'
 module Authentication
   module AuthnK8s
 
-    Log ||= LogMessages::Authentication::AuthnK8s
-    Err ||= Errors::Authentication::AuthnK8s
     # Possible Errors Raised:
     # CommandTimedOut
 
@@ -37,7 +35,7 @@ module Authentication
 
         wait_for_close_message
 
-        raise Err::CommandTimedOut.new(@container, @pod_name) unless @channel_closed
+        raise Errors::Authentication::AuthnK8s::CommandTimedOut.new(@container, @pod_name) unless @channel_closed
 
         # TODO: raise an `WebsocketServerFailure` here in the case of ws :error
 
@@ -51,7 +49,7 @@ module Authentication
         if hs_error
           ws_client.emit(:error, "Websocket handshake error: #{hs_error.inspect}")
         else
-          @logger.debug(Log::PodChannelOpen.new(@pod_name))
+          @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelOpen.new(@pod_name))
 
           if stdin
             data = WebSocketMessage.channel_byte('stdin') + body
@@ -68,24 +66,24 @@ module Authentication
         msg_data = wsmsg.data
 
         if msg_type == :binary
-          @logger.debug(Log::PodChannelData.new(@pod_name, wsmsg.channel_name, msg_data))
+          @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelData.new(@pod_name, wsmsg.channel_name, msg_data))
           @message_log.save_message(wsmsg)
         elsif msg_type == :close
-          @logger.debug(Log::PodMessageData.new(@pod_name, "close", msg_data))
+          @logger.debug(LogMessages::Authentication::AuthnK8s::PodMessageData.new(@pod_name, "close", msg_data))
           ws_client.close
         end
       end
 
       def on_close
         @channel_closed = true
-        @logger.debug(Log::PodChannelClosed.new(@pod_name))
+        @logger.debug(LogMessages::Authentication::AuthnK8s::PodChannelClosed.new(@pod_name))
       end
 
       def on_error(err)
         @channel_closed = true
 
         error_info = err.inspect
-        @logger.debug(Log::PodError.new(@pod_name, error_info))
+        @logger.debug(LogMessages::Authentication::AuthnK8s::PodError.new(@pod_name, error_info))
         @message_log.save_error_string(error_info)
       end
 

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -24,7 +24,10 @@ module Authentication
 
       def validate_namespace
         return if application_identity.namespace == @spiffe_id.namespace
-        raise Errors::Authentication::AuthnK8s::NamespaceMismatch.new(@spiffe_id.namespace, application_identity.namespace)
+        raise Errors::Authentication::AuthnK8s::NamespaceMismatch.new(
+          @spiffe_id.namespace,
+          application_identity.namespace
+        )
       end
 
       def validate_pod_properties
@@ -34,7 +37,12 @@ module Authentication
       end
 
       def validate_container
-        raise Errors::Authentication::AuthnK8s::ContainerNotFound, application_identity.container_name, @host_id unless container
+        unless container
+          raise Errors::Authentication::AuthnK8s::ContainerNotFound.new(
+            application_identity.container_name,
+            @host_id
+          )
+        end
       end
 
       def validate_pod_metadata
@@ -48,7 +56,10 @@ module Authentication
           )
 
           unless resource_object
-            raise Errors::Authentication::AuthnK8s::K8sResourceNotFound.new(resource_type, resource_name, application_identity.namespace)
+            raise Errors::Authentication::AuthnK8s::K8sResourceNotFound.new(
+              resource_type, resource_name,
+              application_identity.namespace
+            )
           end
 
           @k8s_resolver

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -4,7 +4,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    Err ||= Errors::Authentication::AuthnK8s
     # Possible Errors Raised: NamespaceMismatch, ContainerNotFound,
     # K8sResourceNotFound
 
@@ -28,7 +27,7 @@ module Authentication
 
       def validate_namespace
         return if application_identity.namespace == @spiffe_id.namespace
-        raise Err::NamespaceMismatch.new(@spiffe_id.namespace, application_identity.namespace)
+        raise Errors::Authentication::AuthnK8s::NamespaceMismatch.new(@spiffe_id.namespace, application_identity.namespace)
       end
 
       def validate_pod_properties
@@ -38,7 +37,7 @@ module Authentication
       end
 
       def validate_container
-        raise Err::ContainerNotFound, application_identity.container_name, @host_id unless container
+        raise Errors::Authentication::AuthnK8s::ContainerNotFound, application_identity.container_name, @host_id unless container
       end
 
       def validate_pod_metadata
@@ -52,7 +51,7 @@ module Authentication
           )
 
           unless resource_object
-            raise Err::K8sResourceNotFound.new(resource_type, resource_name, application_identity.namespace)
+            raise Errors::Authentication::AuthnK8s::K8sResourceNotFound.new(resource_type, resource_name, application_identity.namespace)
           end
 
           @k8s_resolver

--- a/app/domain/authentication/authn_k8s/validate_application_identity.rb
+++ b/app/domain/authentication/authn_k8s/validate_application_identity.rb
@@ -4,9 +4,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised: NamespaceMismatch, ContainerNotFound,
-    # K8sResourceNotFound
-
     ValidateApplicationIdentity ||= CommandClass.new(
       dependencies: {
         resource_class:             ::Resource,

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -47,7 +47,12 @@ module Authentication
       end
 
       def validate_pod_exists
-        raise Errors::Authentication::AuthnK8s::PodNotFound.new(pod_name, pod_namespace) unless pod
+        unless pod
+          raise Errors::Authentication::AuthnK8s::PodNotFound.new(
+            pod_name,
+            pod_namespace
+          )
+        end
       end
 
       def validate_application_identity
@@ -77,7 +82,11 @@ module Authentication
         return @host if @host
 
         @host = @resource_class[k8s_host.conjur_host_id]
-        raise Errors::Authentication::Security::RoleNotFound(k8s_host.conjur_host_id) unless @host
+        unless @host
+          raise Errors::Authentication::Security::RoleNotFound(
+            k8s_host.conjur_host_id
+          )
+        end
         @host
       end
 

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -5,9 +5,6 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    # Possible Errors Raised:
-    # PodNotFound
-
     ValidatePodRequest ||= CommandClass.new(
       dependencies: {
         resource_class:                      Resource,

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -5,11 +5,8 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    Err         = Errors::Authentication::AuthnK8s
-    SecurityErr = Errors::Authentication::Security
     # Possible Errors Raised:
-    # WebserviceNotFound, RoleNotAuthorizedOnResource, PodNotFound
-    # ContainerNotFound, ScopeNotSupported, K8sResourceNotFound
+    # PodNotFound
 
     ValidatePodRequest ||= CommandClass.new(
       dependencies: {
@@ -53,7 +50,7 @@ module Authentication
       end
 
       def validate_pod_exists
-        raise Err::PodNotFound.new(pod_name, pod_namespace) unless pod
+        raise Errors::Authentication::AuthnK8s::PodNotFound.new(pod_name, pod_namespace) unless pod
       end
 
       def validate_application_identity
@@ -83,7 +80,7 @@ module Authentication
         return @host if @host
 
         @host = @resource_class[k8s_host.conjur_host_id]
-        raise SecurityErr::RoleNotFound(k8s_host.conjur_host_id) unless @host
+        raise Errors::Authentication::Security::RoleNotFound(k8s_host.conjur_host_id) unless @host
         @host
       end
 

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -94,8 +94,15 @@ module Authentication
       end
 
       def validate_conjur_username
-        raise Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
-        raise Errors::Authentication::AuthnOidc::AdminAuthenticationDenied if admin?(conjur_username)
+        if conjur_username.to_s.empty?
+          raise Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty,
+                id_token_username_field
+        end
+
+        if admin?(conjur_username)
+          raise Errors::Authentication::AuthnOidc::AdminAuthenticationDenied
+        end
+
         @logger.debug(LogMessages::Authentication::AuthnOidc::ExtractedUsernameFromIDToked.new(conjur_username, id_token_username_field))
       end
 

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -1,9 +1,6 @@
 module Authentication
   module AuthnOidc
 
-    # Possible Errors Raised:
-    # IdTokenFieldNotFoundOrEmpty, AdminAuthenticationDenied
-
     Authenticator ||= CommandClass.new(
       dependencies: {
         enabled_authenticators:              Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV),

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -1,8 +1,6 @@
 module Authentication
   module AuthnOidc
 
-    Log ||= LogMessages::Authentication::AuthnOidc
-    Err ||= Errors::Authentication::AuthnOidc
     # Possible Errors Raised:
     # IdTokenFieldNotFoundOrEmpty, AdminAuthenticationDenied
 
@@ -99,9 +97,9 @@ module Authentication
       end
 
       def validate_conjur_username
-        raise Err::IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
-        raise Err::AdminAuthenticationDenied if admin?(conjur_username)
-        @logger.debug(Log::ExtractedUsernameFromIDToked.new(conjur_username, id_token_username_field))
+        raise Errors::Authentication::AuthnOidc::IdTokenFieldNotFoundOrEmpty, id_token_username_field if conjur_username.to_s.empty?
+        raise Errors::Authentication::AuthnOidc::AdminAuthenticationDenied if admin?(conjur_username)
+        @logger.debug(LogMessages::Authentication::AuthnOidc::ExtractedUsernameFromIDToked.new(conjur_username, id_token_username_field))
       end
 
       def conjur_username

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -1,11 +1,6 @@
 module Authentication
   module AuthnOidc
 
-    Err = Errors::Authentication::AuthnOidc
-    # Possible Errors Raised:
-    #   ProviderDiscoveryTimeout
-    #   ProviderDiscoveryFailed
-
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -3,9 +3,6 @@ require 'jwt'
 module Authentication
   module Jwt
 
-    # Possible Errors Raised:
-    # TokenExpired, TokenDecodeFailed, TokenVerificationFailed
-
     # This class verifies and decodes a JWT token. It doesn't connect with the issuer
     # of the token for verification. If a token verification is needed, a verification_options
     # object should be provided with the JWKs & algorithms required for the verification.

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -3,8 +3,6 @@ require 'jwt'
 module Authentication
   module Jwt
 
-    Err = Errors::Authentication::Jwt
-    Log = LogMessages::Authentication::Jwt
     # Possible Errors Raised:
     # TokenExpired, TokenDecodeFailed, TokenVerificationFailed
 
@@ -46,15 +44,15 @@ module Authentication
           @verification_options
         ).first
 
-        @logger.debug(Log::TokenDecodeSuccess.new)
+        @logger.debug(LogMessages::Authentication::Jwt::TokenDecodeSuccess.new)
         @verified_and_decoded_token
       rescue JWT::ExpiredSignature
-        raise Err::TokenExpired
+        raise Errors::Authentication::Jwt::TokenExpired
       rescue JWT::DecodeError => e
-        @logger.debug(Log::TokenDecodeFailed.new(e.inspect))
-        raise Err::TokenDecodeFailed, e.inspect
+        @logger.debug(LogMessages::Authentication::Jwt::TokenDecodeFailed.new(e.inspect))
+        raise Errors::Authentication::Jwt::TokenDecodeFailed, e.inspect
       rescue => e
-        raise Err::TokenVerificationFailed, e.inspect
+        raise Errors::Authentication::Jwt::TokenVerificationFailed, e.inspect
       end
 
       def should_verify

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -4,7 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  Err ||= Errors::Authentication
   # Possible Errors Raised:
   # AuthenticatorNotFound, InvalidCredentials
 
@@ -47,11 +46,11 @@ module Authentication
     end
 
     def validate_authenticator_exists
-      raise Err::AuthenticatorNotFound, authenticator_name unless authenticator
+      raise Errors::Authentication::AuthenticatorNotFound, authenticator_name unless authenticator
     end
 
     def validate_credentials
-      raise Err::InvalidCredentials unless key
+      raise Errors::Authentication::InvalidCredentials unless key
     end
 
     def validate_webservice_is_whitelisted

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -4,9 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  # Possible Errors Raised:
-  # AuthenticatorNotFound, InvalidCredentials
-
   Login ||= CommandClass.new(
     dependencies: {
       validate_webservice_is_whitelisted:  ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -17,7 +17,11 @@ module Authentication
       private
 
       def log_provider_uri
-        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderUri.new(@provider_uri))
+        @logger.debug(
+          LogMessages::Authentication::OAuth::IdentityProviderUri.new(
+            @provider_uri
+          )
+        )
       end
 
       # returns an OpenIDConnect::Discovery::Provider::Config::Resource instance.
@@ -26,7 +30,9 @@ module Authentication
       # unlikely to be a problem
       def discover_provider
         @discovered_provider = @open_id_discovery_service.discover!(@provider_uri)
-        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderDiscoverySuccess.new)
+        @logger.debug(
+          LogMessages::Authentication::OAuth::IdentityProviderDiscoverySuccess.new
+        )
         @discovered_provider
       rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
         raise_error(Errors::Authentication::OAuth::ProviderDiscoveryTimeout, e)

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -1,10 +1,6 @@
 module Authentication
   module OAuth
 
-    # Possible Errors Raised:
-    #   ProviderDiscoveryTimeout
-    #   ProviderDiscoveryFailed
-
     DiscoverIdentityProvider = CommandClass.new(
       dependencies: {
         logger:                    Rails.logger,

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -1,8 +1,6 @@
 module Authentication
   module OAuth
 
-    Log = LogMessages::Authentication::OAuth
-    Err = Errors::Authentication::OAuth
     # Possible Errors Raised:
     #   ProviderDiscoveryTimeout
     #   ProviderDiscoveryFailed
@@ -23,7 +21,7 @@ module Authentication
       private
 
       def log_provider_uri
-        @logger.debug(Log::IdentityProviderUri.new(@provider_uri))
+        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderUri.new(@provider_uri))
       end
 
       # returns an OpenIDConnect::Discovery::Provider::Config::Resource instance.
@@ -32,12 +30,12 @@ module Authentication
       # unlikely to be a problem
       def discover_provider
         @discovered_provider = @open_id_discovery_service.discover!(@provider_uri)
-        @logger.debug(Log::IdentityProviderDiscoverySuccess.new)
+        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderDiscoverySuccess.new)
         @discovered_provider
       rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
-        raise_error(Err::ProviderDiscoveryTimeout, e)
+        raise_error(Errors::Authentication::OAuth::ProviderDiscoveryTimeout, e)
       rescue => e
-        raise_error(Err::ProviderDiscoveryFailed, e)
+        raise_error(Errors::Authentication::OAuth::ProviderDiscoveryFailed, e)
       end
 
       def raise_error(error_class, original_error)

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -36,7 +36,10 @@ module Authentication
         @logger.debug(LogMessages::Authentication::OAuth::FetchProviderKeysSuccess.new)
         ProviderKeys.new(jwks, algs)
       rescue => e
-        raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(@provider_uri, e.inspect)
+        raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(
+          @provider_uri,
+          e.inspect
+        )
       end
     end
   end

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -3,9 +3,6 @@ require 'json'
 module Authentication
   module OAuth
 
-    # Possible Errors Raised:
-    #   FetchProviderKeysFailed
-
     FetchProviderKeys = CommandClass.new(
       dependencies: {
         logger:                 Rails.logger,

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -3,11 +3,7 @@ require 'json'
 module Authentication
   module OAuth
 
-    Log = LogMessages::Authentication::OAuth
-    Err = Errors::Authentication::OAuth
     # Possible Errors Raised:
-    #   ProviderDiscoveryTimeout
-    #   ProviderDiscoveryFailed
     #   FetchProviderKeysFailed
 
     FetchProviderKeys = CommandClass.new(
@@ -40,10 +36,10 @@ module Authentication
           keys: @discovered_provider.jwks
         }
         algs = @discovered_provider.id_token_signing_alg_values_supported
-        @logger.debug(Log::FetchProviderKeysSuccess.new)
+        @logger.debug(LogMessages::Authentication::OAuth::FetchProviderKeysSuccess.new)
         ProviderKeys.new(jwks, algs)
       rescue => e
-        raise Err::FetchProviderKeysFailed.new(@provider_uri, e.inspect)
+        raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(@provider_uri, e.inspect)
       end
     end
   end

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -41,7 +41,9 @@ module Authentication
 
         @jwks = provider_keys.jwks
         @algs = provider_keys.algorithms
-        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderKeysFetchedFromCache.new)
+        @logger.debug(
+          LogMessages::Authentication::OAuth::IdentityProviderKeysFetchedFromCache.new
+        )
       end
 
       # ensure_keys_are_fresh will try to verify and decode the token and if it
@@ -57,7 +59,9 @@ module Authentication
       def ensure_keys_are_fresh
         verified_and_decoded_token
       rescue
-        @logger.debug(LogMessages::Authentication::OAuth::ValidateProviderKeysAreUpdated.new)
+        @logger.debug(
+          LogMessages::Authentication::OAuth::ValidateProviderKeysAreUpdated.new
+        )
         # maybe failed due to keys rotation. Force cache to read it again
         fetch_provider_keys(force_read: true)
       end

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -3,11 +3,6 @@ require 'jwt'
 module Authentication
   module OAuth
 
-    Err = Errors::Authentication::OAuth
-    Log = LogMessages::Authentication::OAuth
-    # Possible Errors Raised:
-    # TokenExpired, TokenDecodeFailed, TokenVerificationFailed
-
     # This class decodes and verifies JWT tokens, issued by an OAuthn 2.0 Identity Provider.
     # It first retrieves the JWKs from the identity provider and sets them as verification options
     # for Authentication::Jwt::VerifyAndDecodeToken. That class does the offline verification and decode,
@@ -46,7 +41,7 @@ module Authentication
 
         @jwks = provider_keys.jwks
         @algs = provider_keys.algorithms
-        @logger.debug(Log::IdentityProviderKeysFetchedFromCache.new)
+        @logger.debug(LogMessages::Authentication::OAuth::IdentityProviderKeysFetchedFromCache.new)
       end
 
       # ensure_keys_are_fresh will try to verify and decode the token and if it
@@ -62,7 +57,7 @@ module Authentication
       def ensure_keys_are_fresh
         verified_and_decoded_token
       rescue
-        @logger.debug(Log::ValidateProviderKeysAreUpdated.new)
+        @logger.debug(LogMessages::Authentication::OAuth::ValidateProviderKeysAreUpdated.new)
         # maybe failed due to keys rotation. Force cache to read it again
         fetch_provider_keys(force_read: true)
       end

--- a/app/domain/authentication/security/validate_role_can_access_webservice.rb
+++ b/app/domain/authentication/security/validate_role_can_access_webservice.rb
@@ -6,10 +6,6 @@ module Authentication
 
   module Security
 
-    # Possible Errors Raised:
-    # AccountNotDefined, WebserviceNotFound,
-    # RoleNotFound, RoleNotAuthorizedOnResource
-
     ValidateRoleCanAccessWebservice ||= CommandClass.new(
       dependencies: {
         role_class:                 ::Role,

--- a/app/domain/authentication/security/validate_webservice_is_whitelisted.rb
+++ b/app/domain/authentication/security/validate_webservice_is_whitelisted.rb
@@ -6,9 +6,6 @@ module Authentication
 
   module Security
 
-    # Possible Errors Raised:
-    # AccountNotDefined, AuthenticatorNotWhitelisted
-
     ValidateWebserviceIsWhitelisted ||= CommandClass.new(
       dependencies: {
         role_class:              ::Role,

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -2,9 +2,6 @@
 
 module Authentication
 
-  # Possible Errors Raised:
-  # InvalidOrigin, RoleNotFound
-
   ValidateOrigin ||= CommandClass.new(
     dependencies: {
       role_cls: ::Role,

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -2,7 +2,6 @@
 
 module Authentication
 
-  Err ||= Errors::Authentication
   # Possible Errors Raised:
   # InvalidOrigin, RoleNotFound
 
@@ -15,7 +14,7 @@ module Authentication
   ) do
 
     def call
-      raise Err::InvalidOrigin unless role.valid_origin?(@client_ip)
+      raise Errors::Authentication::InvalidOrigin unless role.valid_origin?(@client_ip)
       @logger.debug(LogMessages::Authentication::OriginValidated.new.to_s)
     end
 
@@ -25,7 +24,7 @@ module Authentication
       return @role if @role
 
       @role = @role_cls.by_login(@username, account: @account)
-      raise Err::Security::RoleNotFound, role_id unless @role
+      raise Errors::Authentication::Security::RoleNotFound, role_id unless @role
       @role
     end
 

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -44,7 +44,9 @@ module Authentication
     end
 
     def validate_authenticator_implements_status_check
-      raise Errors::Authentication::StatusNotImplemented, authenticator_name unless authenticator.class.method_defined?(:status)
+      unless authenticator.class.method_defined?(:status)
+        raise Errors::Authentication::StatusNotImplemented, authenticator_name
+      end
     end
 
     def validate_user_has_access_to_status_webservice

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -4,11 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  # Possible Errors Raised:
-  # AuthenticatorNotFound, StatusNotImplemented, AccountNotDefined
-  # WebserviceNotFound, RoleNotFound, RoleNotAuthorizedOnResource,
-  # AuthenticatorNotWhitelisted
-
   ValidateStatus ||= CommandClass.new(
     dependencies: {
       validate_webservice_is_whitelisted:  ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'command_class'
-require 'authentication/webservices'
 
 module Authentication
 

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -4,8 +4,6 @@ require 'command_class'
 
 module Authentication
 
-  Err ||= Errors::Authentication
-
   # Possible Errors Raised:
   # AuthenticatorNotFound, StatusNotImplemented, AccountNotDefined
   # WebserviceNotFound, RoleNotFound, RoleNotAuthorizedOnResource,
@@ -47,11 +45,11 @@ module Authentication
     private
 
     def validate_authenticator_exists
-      raise Err::AuthenticatorNotFound, authenticator_name unless authenticator
+      raise Errors::Authentication::AuthenticatorNotFound, authenticator_name unless authenticator
     end
 
     def validate_authenticator_implements_status_check
-      raise Err::StatusNotImplemented, authenticator_name unless authenticator.class.method_defined?(:status)
+      raise Errors::Authentication::StatusNotImplemented, authenticator_name unless authenticator.class.method_defined?(:status)
     end
 
     def validate_user_has_access_to_status_webservice

--- a/app/domain/conjur/fetch_required_secrets.rb
+++ b/app/domain/conjur/fetch_required_secrets.rb
@@ -2,7 +2,7 @@ require 'command_class'
 
 module Conjur
 
-  FetchRequiredSecrets = ::CommandClass.new(
+  FetchRequiredSecrets ||= CommandClass.new(
     dependencies: { resource_class: ::Resource },
     inputs: [:resource_ids]
   ) do

--- a/app/domain/conjur/fetch_required_secrets.rb
+++ b/app/domain/conjur/fetch_required_secrets.rb
@@ -2,9 +2,6 @@ require 'command_class'
 
 module Conjur
 
-  # Possible Errors Raised:
-  # RequiredResourceMissing, RequiredSecretMissing
-
   FetchRequiredSecrets = ::CommandClass.new(
     dependencies: { resource_class: ::Resource },
     inputs: [:resource_ids]

--- a/app/domain/conjur/fetch_required_secrets.rb
+++ b/app/domain/conjur/fetch_required_secrets.rb
@@ -2,7 +2,8 @@ require 'command_class'
 
 module Conjur
 
-  Err = Errors::Conjur
+  # Possible Errors Raised:
+  # RequiredResourceMissing, RequiredSecretMissing
 
   FetchRequiredSecrets = ::CommandClass.new(
     dependencies: { resource_class: ::Resource },
@@ -19,13 +20,13 @@ module Conjur
 
     def validate_resources_exist
       resources.each do |id, rsc|
-        raise Err::RequiredResourceMissing, id unless rsc
+        raise Errors::Conjur::RequiredResourceMissing, id unless rsc
       end
     end
 
     def validate_secrets_exist
       secrets.each do |id, secret|
-        raise Err::RequiredSecretMissing, id unless secret
+        raise Errors::Conjur::RequiredSecretMissing, id unless secret
       end
     end
 

--- a/app/domain/conjur/fetch_required_secrets.rb
+++ b/app/domain/conjur/fetch_required_secrets.rb
@@ -1,5 +1,4 @@
 require 'command_class'
-require 'util/error_class'
 
 module Conjur
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -3,17 +3,17 @@
 module Errors
   module Conjur
 
-    RequiredResourceMissing = Util::TrackableErrorClass.new(
+    RequiredResourceMissing = ::Util::TrackableErrorClass.new(
       msg:  "Missing required resource: {0-resource-name}",
       code: "CONJ00036E"
     )
 
-    RequiredSecretMissing = Util::TrackableErrorClass.new(
+    RequiredSecretMissing = ::Util::TrackableErrorClass.new(
       msg:  "Missing value for resource: {0-resource-name}",
       code: "CONJ00037E"
     )
 
-    InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
+    InsufficientPasswordComplexity = ::Util::TrackableErrorClass.new(
       msg:  "The password you have chosen does not meet the complexity requirements. " \
           "Choose a password that includes: 12-128 characters, 2 uppercase letters, " \
           "2 lowercase letters, 1 digit, 1 special character",

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -2,362 +2,357 @@
 
 require 'util/trackable_error_class'
 
-unless defined? Errors::Authentication::AuthenticatorNotFound
-  # This wrapper prevents classes from being loaded by Rails
-  # auto-load. #TODO: fix this in a proper manner
+module Errors
+  module Conjur
 
-  module Errors
-    module Conjur
+    RequiredResourceMissing = Util::TrackableErrorClass.new(
+      msg:  "Missing required resource: {0-resource-name}",
+      code: "CONJ00036E"
+    )
 
-      RequiredResourceMissing = Util::TrackableErrorClass.new(
-        msg:  "Missing required resource: {0-resource-name}",
-        code: "CONJ00036E"
-      )
+    RequiredSecretMissing = Util::TrackableErrorClass.new(
+      msg:  "Missing value for resource: {0-resource-name}",
+      code: "CONJ00037E"
+    )
 
-      RequiredSecretMissing = Util::TrackableErrorClass.new(
-        msg:  "Missing value for resource: {0-resource-name}",
-        code: "CONJ00037E"
-      )
-
-      InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
-        msg:  "The password you have chosen does not meet the complexity requirements. " \
+    InsufficientPasswordComplexity = Util::TrackableErrorClass.new(
+      msg:  "The password you have chosen does not meet the complexity requirements. " \
           "Choose a password that includes: 12-128 characters, 2 uppercase letters, " \
           "2 lowercase letters, 1 digit, 1 special character",
-        code: "CONJ00046E"
+      code: "CONJ00046E"
+    )
+
+  end
+
+  module Authentication
+
+    AuthenticatorNotFound = ::Util::TrackableErrorClass.new(
+      msg:  "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
+      code: "CONJ00001E"
+    )
+
+    InvalidCredentials = ::Util::TrackableErrorClass.new(
+      msg:  "Invalid credentials",
+      code: "CONJ00002E"
+    )
+
+    InvalidOrigin = ::Util::TrackableErrorClass.new(
+      msg:  "Invalid origin",
+      code: "CONJ00003E"
+    )
+
+    StatusNotImplemented = ::Util::TrackableErrorClass.new(
+      msg:  "Status check not implemented for authenticator '{0-authenticator-name}'",
+      code: "CONJ00056E"
+    )
+
+    IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
+      msg:  "Application identity includes an illegal resource constraint combination - '{0-constraints}'",
+      code: "CONJ00055E"
+    )
+
+    module AuthenticatorClass
+
+      DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-authenticator-parent-name}' is not a valid authenticator "\
+            "parent module because it does not begin with 'Authn'",
+        code: "CONJ00038E"
+      )
+
+      NotNamedAuthenticator = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-authenticator-name}' is not a valid authenticator name. " \
+            "The actual class implementing the authenticator must be named 'Authenticator'",
+        code: "CONJ00039E"
+      )
+
+      MissingValidMethod = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-authenticator-name}' is not a valid authenticator because " \
+            "it does not have a `:valid?(input)` method.",
+        code: "CONJ00040E"
       )
 
     end
 
-    module Authentication
+    module Security
 
-      AuthenticatorNotFound = ::Util::TrackableErrorClass.new(
-        msg:  "Authenticator '{0-authenticator-name}' is not implemented in Conjur",
-        code: "CONJ00001E"
+      AuthenticatorNotWhitelisted = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-authenticator-name}' is not enabled",
+        code: "CONJ00004E"
       )
 
-      InvalidCredentials = ::Util::TrackableErrorClass.new(
-        msg:  "Invalid credentials",
-        code: "CONJ00002E"
+      WebserviceNotFound = ::Util::TrackableErrorClass.new(
+        msg:  "Webservice '{0-webservice-name}' not found",
+        code: "CONJ00005E"
       )
 
-      InvalidOrigin = ::Util::TrackableErrorClass.new(
-        msg:  "Invalid origin",
-        code: "CONJ00003E"
+      RoleNotAuthorizedOnResource = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-role-name}' does not have '{1-privilege}' privilege on {2-resource-name}",
+        code: "CONJ00006E"
       )
 
-      StatusNotImplemented = ::Util::TrackableErrorClass.new(
-        msg:  "Status check not implemented for authenticator '{0-authenticator-name}'",
-        code: "CONJ00056E"
+      RoleNotFound = ::Util::TrackableErrorClass.new(
+        msg:  "'{0-role-name}' not found",
+        code: "CONJ00007E"
       )
 
-      IllegalConstraintCombinations = ::Util::TrackableErrorClass.new(
-        msg:  "Application identity includes an illegal resource constraint combination - '{0-constraints}'",
-        code: "CONJ00055E"
+      AccountNotDefined = ::Util::TrackableErrorClass.new(
+        msg:  "Account '{0-account-name}' is not defined in Conjur",
+        code: "CONJ00008E"
       )
 
-      module AuthenticatorClass
+    end
 
-        DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-authenticator-parent-name}' is not a valid authenticator "\
-            "parent module because it does not begin with 'Authn'",
-          code: "CONJ00038E"
-        )
+    module RequestBody
 
-        NotNamedAuthenticator = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-authenticator-name}' is not a valid authenticator name. " \
-            "The actual class implementing the authenticator must be named 'Authenticator'",
-          code: "CONJ00039E"
-        )
+      MissingRequestParam = ::Util::TrackableErrorClass.new(
+        msg:  "Field '{0-field-name}' is missing or empty in request body",
+        code: "CONJ00009E"
+      )
 
-        MissingValidMethod = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-authenticator-name}' is not a valid authenticator because " \
-            "it does not have a `:valid?(input)` method.",
-          code: "CONJ00040E"
-        )
+    end
 
-      end
+    module OAuth
 
-      module Security
+      ProviderDiscoveryTimeout = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to discover Identity Provider with timeout error (Provider URI: '{0}'). Reason: '{1}'",
+        code: "CONJ00010E"
+      )
 
-        AuthenticatorNotWhitelisted = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-authenticator-name}' is not enabled",
-          code: "CONJ00004E"
-        )
+      ProviderDiscoveryFailed = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to discover Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
+        code: "CONJ00011E"
+      )
 
-        WebserviceNotFound = ::Util::TrackableErrorClass.new(
-          msg:  "Webservice '{0-webservice-name}' not found",
-          code: "CONJ00005E"
-        )
+      FetchProviderKeysFailed = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
+        code: "CONJ00012E"
+      )
 
-        RoleNotAuthorizedOnResource = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-role-name}' does not have '{1-privilege}' privilege on {2-resource-name}",
-          code: "CONJ00006E"
-        )
+    end
 
-        RoleNotFound = ::Util::TrackableErrorClass.new(
-          msg:  "'{0-role-name}' not found",
-          code: "CONJ00007E"
-        )
+    module Jwt
 
-        AccountNotDefined = ::Util::TrackableErrorClass.new(
-          msg:  "Account '{0-account-name}' is not defined in Conjur",
-          code: "CONJ00008E"
-        )
+      TokenExpired = ::Util::TrackableErrorClass.new(
+        msg:  "Token expired",
+        code: "CONJ00016E"
+      )
 
-      end
+      TokenDecodeFailed = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to decode token (3rdPartyError ='{0}')",
+        code: "CONJ00035E"
+      )
 
-      module RequestBody
+      TokenVerificationFailed = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to verify token (3rdPartyError ='{0}')",
+        code: "CONJ00015E"
+      )
 
-        MissingRequestParam = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' is missing or empty in request body",
-          code: "CONJ00009E"
-        )
+    end
 
-      end
+    module AuthnOidc
 
-      module OAuth
-
-        ProviderDiscoveryTimeout = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to discover Identity Provider with timeout error (Provider URI: '{0}'). Reason: '{1}'",
-          code: "CONJ00010E"
-        )
-
-        ProviderDiscoveryFailed = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to discover Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
-          code: "CONJ00011E"
-        )
-
-        FetchProviderKeysFailed = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to fetch keys from Identity Provider (Provider URI: '{0}'). Reason: '{1}'",
-          code: "CONJ00012E"
-        )
-
-      end
-
-      module Jwt
-
-        TokenExpired = ::Util::TrackableErrorClass.new(
-          msg:  "Token expired",
-          code: "CONJ00016E"
-        )
-
-        TokenDecodeFailed = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to decode token (3rdPartyError ='{0}')",
-          code: "CONJ00035E"
-        )
-
-        TokenVerificationFailed = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to verify token (3rdPartyError ='{0}')",
-          code: "CONJ00015E"
-        )
-
-      end
-
-      module AuthnOidc
-
-        IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' not found or empty in ID token. " \
+      IdTokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+        msg:  "Field '{0-field-name}' not found or empty in ID token. " \
             "This field is defined in the id-token-user-property variable.",
-          code: "CONJ00013E"
-        )
+        code: "CONJ00013E"
+      )
 
-        AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
-          msg:  "Admin user is not allowed to authenticate with OIDC",
-          code: "CONJ00017E"
-        )
+      AdminAuthenticationDenied = ::Util::TrackableErrorClass.new(
+        msg:  "Admin user is not allowed to authenticate with OIDC",
+        code: "CONJ00017E"
+      )
 
-      end
+    end
 
-      module AuthnIam
+    module AuthnIam
 
-        InvalidAWSHeaders = ::Util::TrackableErrorClass.new(
-          msg:  "Invalid or expired AWS headers: {0}",
-          code: "CONJ00018E"
-        )
+      InvalidAWSHeaders = ::Util::TrackableErrorClass.new(
+        msg:  "Invalid or expired AWS headers: {0}",
+        code: "CONJ00018E"
+      )
 
-        VerificationError = ::Util::TrackableLogMessageClass.new(
-          msg:  "Verification of IAM identity failed with exception: {0-exception}",
-          code: "CONJ00063E"
-        )
+      VerificationError = ::Util::TrackableLogMessageClass.new(
+        msg:  "Verification of IAM identity failed with exception: {0-exception}",
+        code: "CONJ00063E"
+      )
 
-        IdentityVerificationErrorCode = ::Util::TrackableLogMessageClass.new(
-          msg:  "Verification of IAM identity failed with HTTP code: {0-http-code}",
-          code: "CONJ00064E"
-        )
+      IdentityVerificationErrorCode = ::Util::TrackableLogMessageClass.new(
+        msg:  "Verification of IAM identity failed with HTTP code: {0-http-code}",
+        code: "CONJ00064E"
+      )
 
-      end
+    end
 
-      module AuthnK8s
+    module AuthnK8s
 
-        CSRIsMissingSpiffeId = ::Util::TrackableErrorClass.new(
-          msg:  'CSR must contain SPIFFE ID SAN',
-          code: "CONJ00022E"
-        )
+      CSRIsMissingSpiffeId = ::Util::TrackableErrorClass.new(
+        msg:  'CSR must contain SPIFFE ID SAN',
+        code: "CONJ00022E"
+      )
 
-        PodNotFound = ::Util::TrackableErrorClass.new(
-          msg:  "No pod found for '{0-pod-name}' in namespace '{1}'",
-          code: "CONJ00024E"
-        )
+      PodNotFound = ::Util::TrackableErrorClass.new(
+        msg:  "No pod found for '{0-pod-name}' in namespace '{1}'",
+        code: "CONJ00024E"
+      )
 
-        ScopeNotSupported = ::Util::TrackableErrorClass.new(
-          msg:  "Resource type '{0}' is not a supported application identity. " \
+      ScopeNotSupported = ::Util::TrackableErrorClass.new(
+        msg:  "Resource type '{0}' is not a supported application identity. " \
             "The supported resources are '{1}'",
-          code: "CONJ00025E"
-        )
+        code: "CONJ00025E"
+      )
 
-        K8sResourceNotFound = ::Util::TrackableErrorClass.new(
-          msg:  "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
-          code: "CONJ00026E"
-        )
+      K8sResourceNotFound = ::Util::TrackableErrorClass.new(
+        msg:  "Kubernetes {0-resource-name} {1-object-name} not found in namespace {2}",
+        code: "CONJ00026E"
+      )
 
-        CertInstallationError = ::Util::TrackableErrorClass.new(
-          msg:  "Certificate could not be copied to pod: {0}",
-          code: "CONJ00027E"
-        )
+      CertInstallationError = ::Util::TrackableErrorClass.new(
+        msg:  "Certificate could not be copied to pod: {0}",
+        code: "CONJ00027E"
+      )
 
-        ContainerNotFound = ::Util::TrackableErrorClass.new(
-          msg:  "Container {0} was not found in the pod. Host id: {1}",
-          code: "CONJ00028E"
-        )
+      ContainerNotFound = ::Util::TrackableErrorClass.new(
+        msg:  "Container {0} was not found in the pod. Host id: {1}",
+        code: "CONJ00028E"
+      )
 
-        MissingClientCertificate = ::Util::TrackableErrorClass.new(
-          msg:  "Client SSL certificate is missing from the header",
-          code: "CONJ00029E"
-        )
+      MissingClientCertificate = ::Util::TrackableErrorClass.new(
+        msg:  "Client SSL certificate is missing from the header",
+        code: "CONJ00029E"
+      )
 
-        UntrustedClientCertificate = ::Util::TrackableErrorClass.new(
-          msg:  "Client certificate cannot be verified by certification authority",
-          code: "CONJ00030E"
-        )
+      UntrustedClientCertificate = ::Util::TrackableErrorClass.new(
+        msg:  "Client certificate cannot be verified by certification authority",
+        code: "CONJ00030E"
+      )
 
-        CommonNameDoesntMatchHost = ::Util::TrackableErrorClass.new(
-          msg:  "Client certificate CN must match host name. Cert CN: {0}. " \
+      CommonNameDoesntMatchHost = ::Util::TrackableErrorClass.new(
+        msg:  "Client certificate CN must match host name. Cert CN: {0}. " \
             "Host name: {1}.",
-          code: "CONJ00031E"
-        )
+        code: "CONJ00031E"
+      )
 
-        ClientCertificateExpired = ::Util::TrackableErrorClass.new(
-          msg:  "Client certificate expired",
-          code: "CONJ00032E"
-        )
+      ClientCertificateExpired = ::Util::TrackableErrorClass.new(
+        msg:  "Client certificate expired",
+        code: "CONJ00032E"
+      )
 
-        CommandTimedOut = ::Util::TrackableErrorClass.new(
-          msg:  "Command timed out in container '{0}' of pod '{1}'",
-          code: "CONJ00033E"
-        )
+      CommandTimedOut = ::Util::TrackableErrorClass.new(
+        msg:  "Command timed out in container '{0}' of pod '{1}'",
+        code: "CONJ00033E"
+      )
 
-        MissingServiceAccountDir = ::Util::TrackableErrorClass.new(
-          msg:  "Kubernetes serviceaccount dir '{0}' does not exist",
-          code: "CONJ00034E"
-        )
+      MissingServiceAccountDir = ::Util::TrackableErrorClass.new(
+        msg:  "Kubernetes serviceaccount dir '{0}' does not exist",
+        code: "CONJ00034E"
+      )
 
-        UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
-          msg:  "Unknown Kubernetes resource type '{0}'",
-          code: "CONJ00041E"
-        )
+      UnknownK8sResourceType = ::Util::TrackableErrorClass.new(
+        msg:  "Unknown Kubernetes resource type '{0}'",
+        code: "CONJ00041E"
+      )
 
-        InvalidApiUrl = ::Util::TrackableErrorClass.new(
-          msg:  "Received invalid Kubernetes API url: '{0}'",
-          code: "CONJ00042E"
-        )
+      InvalidApiUrl = ::Util::TrackableErrorClass.new(
+        msg:  "Received invalid Kubernetes API url: '{0}'",
+        code: "CONJ00042E"
+      )
 
-        MissingCertificate = ::Util::TrackableErrorClass.new(
-          msg:  "No Kubernetes API certificate available",
-          code: "CONJ00043E"
-        )
+      MissingCertificate = ::Util::TrackableErrorClass.new(
+        msg:  "No Kubernetes API certificate available",
+        code: "CONJ00043E"
+      )
 
-        MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
-          msg:  "Host does not have a namespace constraint",
-          code: "CONJ00045E"
-        )
+      MissingNamespaceConstraint = ::Util::TrackableErrorClass.new(
+        msg:  "Host does not have a namespace constraint",
+        code: "CONJ00045E"
+      )
 
-        NamespaceMismatch = ::Util::TrackableErrorClass.new(
-          msg:  "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
+      NamespaceMismatch = ::Util::TrackableErrorClass.new(
+        msg:  "Namespace in SPIFFE ID '{0-spiffe-namespace}' must match namespace " \
             "implied by application identity '{1-application-identity-namespace}'",
-          code: "CONJ00023E"
-        )
+        code: "CONJ00023E"
+      )
 
-        CSRMissingCNEntry = ::Util::TrackableErrorClass.new(
-          msg:  "CSR [subject: '{0-subject}', spiffe_id: '{1-spiffe-id}'] must have a CN (common name) entry.",
-          code: "CONJ00058E"
-        )
+      CSRMissingCNEntry = ::Util::TrackableErrorClass.new(
+        msg:  "CSR [subject: '{0-subject}', spiffe_id: '{1-spiffe-id}'] must have a CN (common name) entry.",
+        code: "CONJ00058E"
+      )
 
-        CertMissingCNEntry = ::Util::TrackableErrorClass.new(
-          msg:  "Cert [subject: '{0-subject}', san: '{1-san}'] must have a CN (common name) entry.",
-          code: "CONJ00059E"
-        )
+      CertMissingCNEntry = ::Util::TrackableErrorClass.new(
+        msg:  "Cert [subject: '{0-subject}', san: '{1-san}'] must have a CN (common name) entry.",
+        code: "CONJ00059E"
+      )
 
-        PodNameMismatchError = ::Util::TrackableErrorClass.new(
-          msg:  "Pod: {0-pod-name} does not match: {1-actual-resource-name}.",
-          code: "CONJ00060E"
-        )
+      PodNameMismatchError = ::Util::TrackableErrorClass.new(
+        msg:  "Pod: {0-pod-name} does not match: {1-actual-resource-name}.",
+        code: "CONJ00060E"
+      )
 
-        PodRelationMismatchError = ::Util::TrackableErrorClass.new(
-          msg:  "Pod: {0-pod-name}, {1-resource-type}: {2-expected-resource-name}, does not match: " \
+      PodRelationMismatchError = ::Util::TrackableErrorClass.new(
+        msg:  "Pod: {0-pod-name}, {1-resource-type}: {2-expected-resource-name}, does not match: " \
                   "{3-actual-resource-name}.",
-          code: "CONJ00061E"
-        )
+        code: "CONJ00061E"
+      )
 
-        PodMissingRelationError = ::Util::TrackableErrorClass.new(
-          msg:  "Pod: {0-pod-name} does not belong to a {1-resource-type}.",
-          code: "CONJ00062E"
-        )
+      PodMissingRelationError = ::Util::TrackableErrorClass.new(
+        msg:  "Pod: {0-pod-name} does not belong to a {1-resource-type}.",
+        code: "CONJ00062E"
+      )
 
-        InvalidHostId = ::Util::TrackableErrorClass.new(
-          msg:  "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
-          code: "CONJ00048E"
-        )
-      end
+      InvalidHostId = ::Util::TrackableErrorClass.new(
+        msg:  "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
+        code: "CONJ00048E"
+      )
+    end
 
-      module AuthnAzure
+    module AuthnAzure
 
-        RoleMissingConstraint = ::Util::TrackableErrorClass.new(
-          msg:  "Role does not have the required constraint: {0-constraint}",
-          code: "CONJ00057E"
-        )
+      RoleMissingConstraint = ::Util::TrackableErrorClass.new(
+        msg:  "Role does not have the required constraint: {0-constraint}",
+        code: "CONJ00057E"
+      )
 
-        InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
-          msg:  "Application identity field '{0-field-name}' does not match " \
+      InvalidApplicationIdentity = ::Util::TrackableErrorClass.new(
+        msg:  "Application identity field '{0-field-name}' does not match " \
             "application identity in Azure token",
-          code: "CONJ00049E"
-        )
+        code: "CONJ00049E"
+      )
 
-        ConstraintNotSupported = ::Util::TrackableErrorClass.new(
-          msg:  "Constraint type '{0}' is not a supported application identity. " \
+      ConstraintNotSupported = ::Util::TrackableErrorClass.new(
+        msg:  "Constraint type '{0}' is not a supported application identity. " \
             "The supported resources are '{1}'",
-          code: "CONJ00050E"
-        )
+        code: "CONJ00050E"
+      )
 
-        TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
-          msg:  "Field '{0-field-name}' not found or empty in token",
-          code: "CONJ00051E"
-        )
+      TokenFieldNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
+        msg:  "Field '{0-field-name}' not found or empty in token",
+        code: "CONJ00051E"
+      )
 
-        XmsMiridParseError = ::Util::TrackableErrorClass.new(
-          msg:  "Failed to parse xms_mirid {0}. Reason: {1}",
-          code: "CONJ00052E"
-        )
+      XmsMiridParseError = ::Util::TrackableErrorClass.new(
+        msg:  "Failed to parse xms_mirid {0}. Reason: {1}",
+        code: "CONJ00052E"
+      )
 
-        MissingRequiredFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
-          msg:  "Required fields {0} are missing in xms_mirid {1}",
-          code: "CONJ00053E"
-        )
+      MissingRequiredFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+        msg:  "Required fields {0} are missing in xms_mirid {1}",
+        code: "CONJ00053E"
+      )
 
-        InvalidProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
-          msg:  "Provider fields are in invalid format in xms_mirid {1}. " \
+      InvalidProviderFieldsInXmsMirid = ::Util::TrackableErrorClass.new(
+        msg:  "Provider fields are in invalid format in xms_mirid {1}. " \
                 "xms_mirid must contain the resource provider namespace, the " \
                 "resource type, and the resource name",
-          code: "CONJ00054E"
-        )
-      end
-    end
-
-    module Util
-
-      ConcurrencyLimitReachedBeforeCacheInitialization = ::Util::TrackableErrorClass.new(
-        msg:  "Concurrency limited cache reached before cache initialized",
-        code: "CONJ00044E"
+        code: "CONJ00054E"
       )
     end
+  end
+
+  module Util
+
+    ConcurrencyLimitReachedBeforeCacheInitialization = ::Util::TrackableErrorClass.new(
+      msg:  "Concurrency limited cache reached before cache initialized",
+      code: "CONJ00044E"
+    )
   end
 end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'util/trackable_error_class'
-
 module Errors
   module Conjur
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -4,7 +4,7 @@ module LogMessages
 
   module Conjur
 
-    PrimarySchema = Util::TrackableErrorClass.new(
+    PrimarySchema = ::Util::TrackableLogMessageClass.new(
       msg:  "Primary schema is {0-primary-schema}",
       code: "CONJ00034I"
     )

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'util/trackable_log_message_class'
-
 module LogMessages
 
   module Conjur

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -2,223 +2,218 @@
 
 require 'util/trackable_log_message_class'
 
-unless defined? LogMessages::Authentication::OriginValidated
-  # This wrapper prevents classes from being loaded by Rails
-  # auto-load. #TODO: fix this in a proper manner
+module LogMessages
 
-  module LogMessages
+  module Conjur
 
-    module Conjur
+    PrimarySchema = Util::TrackableErrorClass.new(
+      msg:  "Primary schema is {0-primary-schema}",
+      code: "CONJ00034I"
+    )
 
-      PrimarySchema = Util::TrackableErrorClass.new(
-        msg:  "Primary schema is {0-primary-schema}",
-        code: "CONJ00034I"
-      )
+  end
 
-    end
+  module Authentication
 
-    module Authentication
+    OriginValidated = ::Util::TrackableLogMessageClass.new(
+      msg:  "Origin validated",
+      code: "CONJ00003D"
+    )
 
-      OriginValidated = ::Util::TrackableLogMessageClass.new(
-        msg:  "Origin validated",
-        code: "CONJ00003D"
-      )
+    ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
+      msg:  "Validating annotations with prefix {0-prefix}",
+      code: "CONJ00025D"
+    )
 
-      ValidatingAnnotationsWithPrefix = ::Util::TrackableLogMessageClass.new(
-        msg:  "Validating annotations with prefix {0-prefix}",
-        code: "CONJ00025D"
-      )
+    RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
+      msg:  "Retrieved value of annotation {0-annotation-name}",
+      code: "CONJ00024D"
+    )
 
-      RetrievedAnnotationValue = ::Util::TrackableLogMessageClass.new(
-        msg:  "Retrieved value of annotation {0-annotation-name}",
-        code: "CONJ00024D"
-      )
-
-      ContainerNameAnnotationDefaultValue = ::Util::TrackableLogMessageClass.new(
-        msg:  "Annotation '{0-authentication-container-annotation-name}' not found. " \
+    ContainerNameAnnotationDefaultValue = ::Util::TrackableLogMessageClass.new(
+      msg:  "Annotation '{0-authentication-container-annotation-name}' not found. " \
                 "Using default value '{1-default-authentication-container}'",
-        code: "CONJ00033D"
+      code: "CONJ00033D"
+    )
+
+    module OAuth
+
+      IdentityProviderUri = ::Util::TrackableLogMessageClass.new(
+        msg:  "Working with Identity Provider {0-provider-uri}",
+        code: "CONJ00007D"
       )
 
-      module OAuth
+      IdentityProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
+        msg:  "Identity Provider discovery succeeded",
+        code: "CONJ00008D"
+      )
 
-        IdentityProviderUri = ::Util::TrackableLogMessageClass.new(
-          msg:  "Working with Identity Provider {0-provider-uri}",
-          code: "CONJ00007D"
-        )
+      FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
+        msg:  "Fetched Identity Provider keys from provider successfully",
+        code: "CONJ00009D"
+      )
 
-        IdentityProviderDiscoverySuccess = ::Util::TrackableLogMessageClass.new(
-          msg:  "Identity Provider discovery succeeded",
-          code: "CONJ00008D"
-        )
+      IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
+        msg:  "Fetched Identity Provider keys from cache successfully",
+        code: "CONJ00017D"
+      )
 
-        FetchProviderKeysSuccess = ::Util::TrackableLogMessageClass.new(
-          msg:  "Fetched Identity Provider keys from provider successfully",
-          code: "CONJ00009D"
-        )
+      ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
+        msg:  "Validating that Identity Provider keys are up to date",
+        code: "CONJ00019D"
+      )
 
-        IdentityProviderKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
-          msg:  "Fetched Identity Provider keys from cache successfully",
-          code: "CONJ00017D"
-        )
+    end
 
-        ValidateProviderKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
-          msg:  "Validating that Identity Provider keys are up to date",
-          code: "CONJ00019D"
-        )
+    module Jwt
 
-      end
+      TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
+        msg:  "Token decoded successfully",
+        code: "CONJ00005D"
+      )
 
-      module Jwt
+      TokenDecodeFailed = ::Util::TrackableLogMessageClass.new(
+        msg:  "Failed to decode the token with the error '{0-exception}'",
+        code: "CONJ00018D"
+      )
 
-        TokenDecodeSuccess = ::Util::TrackableLogMessageClass.new(
-          msg:  "Token decoded successfully",
-          code: "CONJ00005D"
-        )
+    end
 
-        TokenDecodeFailed = ::Util::TrackableLogMessageClass.new(
-          msg:  "Failed to decode the token with the error '{0-exception}'",
-          code: "CONJ00018D"
-        )
+    module AuthnOidc
 
-      end
+      ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
+        msg:  "Extracted username '{0}' from ID token field '{1-id-token-username-field}'",
+        code: "CONJ00004D"
+      )
 
-      module AuthnOidc
+    end
 
-        ExtractedUsernameFromIDToked = ::Util::TrackableLogMessageClass.new(
-          msg:  "Extracted username '{0}' from ID token field '{1-id-token-username-field}'",
-          code: "CONJ00004D"
-        )
+    module AuthnK8s
 
-      end
+      PodChannelOpen = ::Util::TrackableLogMessageClass.new(
+        msg:  "Pod '{0-pod-name}' : channel open",
+        code: "CONJ00010D"
+      )
 
-      module AuthnK8s
+      PodChannelClosed = ::Util::TrackableLogMessageClass.new(
+        msg:  "Pod '{0-pod-name}' : channel closed",
+        code: "CONJ00011D"
+      )
 
-        PodChannelOpen = ::Util::TrackableLogMessageClass.new(
-          msg:  "Pod '{0-pod-name}' : channel open",
-          code: "CONJ00010D"
-        )
+      PodChannelData = ::Util::TrackableLogMessageClass.new(
+        msg:  "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
+        code: "CONJ00012D"
+      )
 
-        PodChannelClosed = ::Util::TrackableLogMessageClass.new(
-          msg:  "Pod '{0-pod-name}' : channel closed",
-          code: "CONJ00011D"
-        )
+      PodMessageData = ::Util::TrackableLogMessageClass.new(
+        msg:  "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
+        code: "CONJ00013D"
+      )
 
-        PodChannelData = ::Util::TrackableLogMessageClass.new(
-          msg:  "Pod '{0-pod-name}', channel '{1-cahnnel-name}': {2-message-data}",
-          code: "CONJ00012D"
-        )
+      PodError = ::Util::TrackableLogMessageClass.new(
+        msg:  "Pod '{0-pod-name}' error : '{1}'",
+        code: "CONJ00014D"
+      )
 
-        PodMessageData = ::Util::TrackableLogMessageClass.new(
-          msg:  "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
-          code: "CONJ00013D"
-        )
-
-        PodError = ::Util::TrackableLogMessageClass.new(
-          msg:  "Pod '{0-pod-name}' error : '{1}'",
-          code: "CONJ00014D"
-        )
-
-        CopySSLToPod = ::Util::TrackableLogMessageClass.new(
-          msg:  "Copying SSL certificate to {0-container-name}:{1-cert-file-path} " \
+      CopySSLToPod = ::Util::TrackableLogMessageClass.new(
+        msg:  "Copying SSL certificate to {0-container-name}:{1-cert-file-path} " \
             "in {2-pod-namespace}/{3-pod-name}",
-          code: "CONJ00015D"
-        )
+        code: "CONJ00015D"
+      )
 
-        CopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
-          msg:  "Copied SSL certificate successfully",
-          code: "CONJ00037D"
-        )
+      CopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
+        msg:  "Copied SSL certificate successfully",
+        code: "CONJ00037D"
+      )
 
-        ValidatingHostId = ::Util::TrackableLogMessageClass.new(
-          msg:  "Validating host id {0}",
-          code: "CONJ00026D"
-        )
+      ValidatingHostId = ::Util::TrackableLogMessageClass.new(
+        msg:  "Validating host id {0}",
+        code: "CONJ00026D"
+      )
 
-        HostIdFromCommonName = ::Util::TrackableLogMessageClass.new(
-          msg:  "Host id {0} extracted from CSR common name",
-          code: "CONJ00027D"
-        )
+      HostIdFromCommonName = ::Util::TrackableLogMessageClass.new(
+        msg:  "Host id {0} extracted from CSR common name",
+        code: "CONJ00027D"
+      )
 
-        SetCommonName = ::Util::TrackableLogMessageClass.new(
-          msg:  "Setting common name to {0-full-host-name}",
-          code: "CONJ00028D"
-        )
-      end
+      SetCommonName = ::Util::TrackableLogMessageClass.new(
+        msg:  "Setting common name to {0-full-host-name}",
+        code: "CONJ00028D"
+      )
+    end
 
-      module AuthnIam
+    module AuthnIam
 
-        GetCallerIdentityBody = ::Util::TrackableLogMessageClass.new(
-          msg:  "AWS IAM get_caller_identity body:\n {0-response-body}",
-          code: "CONJ00034D"
-        )
+      GetCallerIdentityBody = ::Util::TrackableLogMessageClass.new(
+        msg:  "AWS IAM get_caller_identity body:\n {0-response-body}",
+        code: "CONJ00034D"
+      )
 
-        AttemptToMatchHost = ::Util::TrackableLogMessageClass.new(
-          msg:  "IAM Role authentication attempt by AWS user {0-aws-user-id} " \
+      AttemptToMatchHost = ::Util::TrackableLogMessageClass.new(
+        msg:  "IAM Role authentication attempt by AWS user {0-aws-user-id} " \
                   "with host to match = {1-host-to-match}",
-          code: "CONJ00035D"
-        )
-
-        RetrieveIamIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Retrieving IAM identity",
-          code: "CONJ00036D"
-        )
-
-      end
-
-      module AuthnAzure
-
-        ExtractedApplicationIdentityFromToken = ::Util::TrackableLogMessageClass.new(
-          msg:  "Extracted application identity from token",
-          code: "CONJ00029D"
-        )
-
-        ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
-          msg:  "Application identity validated",
-          code: "CONJ00030D"
-        )
-
-        ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
-          msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
-          code: "CONJ00031D"
-        )
-
-        ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
-          msg:  "Validating that field '{0}' exists in token",
-          code: "CONJ00032D"
-        )
-
-      end
-    end
-
-    module Util
-
-      RateLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg:  "Rate limited cache updated successfully",
-        code: "CONJ00016D"
+        code: "CONJ00035D"
       )
 
-      RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
-        msg:  "Rate limited cache reached the '{0-limit}' limit and will not " \
+      RetrieveIamIdentity = ::Util::TrackableLogMessageClass.new(
+        msg:  "Retrieving IAM identity",
+        code: "CONJ00036D"
+      )
+
+    end
+
+    module AuthnAzure
+
+      ExtractedApplicationIdentityFromToken = ::Util::TrackableLogMessageClass.new(
+        msg:  "Extracted application identity from token",
+        code: "CONJ00029D"
+      )
+
+      ValidatedApplicationIdentity = ::Util::TrackableLogMessageClass.new(
+        msg:  "Application identity validated",
+        code: "CONJ00030D"
+      )
+
+      ExtractedFieldFromAzureToken = ::Util::TrackableLogMessageClass.new(
+        msg:  "Extracted field '{0-field-name}' with value {1-field-value} from token",
+        code: "CONJ00031D"
+      )
+
+      ValidatingTokenFieldExists = ::Util::TrackableLogMessageClass.new(
+        msg:  "Validating that field '{0}' exists in token",
+        code: "CONJ00032D"
+      )
+
+    end
+  end
+
+  module Util
+
+    RateLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
+      msg:  "Rate limited cache updated successfully",
+      code: "CONJ00016D"
+    )
+
+    RateLimitedCacheLimitReached = ::Util::TrackableLogMessageClass.new(
+      msg:  "Rate limited cache reached the '{0-limit}' limit and will not " \
               "call target for the next '{1-seconds}' seconds",
-        code: "CONJ00020D"
-      )
+      code: "CONJ00020D"
+    )
 
-      ConcurrencyLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
-        msg:  "Concurrency limited cache updated successfully",
-        code: "CONJ00021D"
-      )
+    ConcurrencyLimitedCacheUpdated = ::Util::TrackableLogMessageClass.new(
+      msg:  "Concurrency limited cache updated successfully",
+      code: "CONJ00021D"
+    )
 
-      ConcurrencyLimitedCacheReached = ::Util::TrackableLogMessageClass.new(
-        msg:  "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
-        code: "CONJ00022D"
-      )
+    ConcurrencyLimitedCacheReached = ::Util::TrackableLogMessageClass.new(
+      msg:  "Concurrency limited cache reached the '{0-limit}' limit and will not call target",
+      code: "CONJ00022D"
+    )
 
-      ConcurrencyLimitedCacheConcurrentRequestsUpdated = ::Util::TrackableLogMessageClass.new(
-        msg:  "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
-        code: "CONJ00023D"
-      )
+    ConcurrencyLimitedCacheConcurrentRequestsUpdated = ::Util::TrackableLogMessageClass.new(
+      msg:  "Concurrency limited cache concurrent requests updated to '{0-concurrent-requests}'",
+      code: "CONJ00023D"
+    )
 
-    end
   end
 end

--- a/app/domain/types.rb
+++ b/app/domain/types.rb
@@ -6,6 +6,5 @@ require 'dry-struct'
 module Types
   include Dry::Types.module
 
-  NonEmptyString = Types::Strict::String.constrained(format: /\S+/)
+  NonEmptyString ||= Types::Strict::String.constrained(format: /\S+/)
 end
-

--- a/app/domain/util/concurrency_limited_cache.rb
+++ b/app/domain/util/concurrency_limited_cache.rb
@@ -23,13 +23,19 @@ module Util
     def call(**args)
       @concurrency_mutex.synchronize do
         if @concurrent_requests >= @max_concurrent_requests
-          @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests))
+          @logger.debug(
+            LogMessages::Util::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests)
+          )
           raise Errors::Util::ConcurrencyLimitReachedBeforeCacheInitialization unless @cache.key?(args)
           return @cache[args]
         end
 
         @concurrent_requests += 1
-        @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
+        @logger.debug(
+          LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(
+            @concurrent_requests
+          )
+        )
       end
 
       @semaphore.synchronize do
@@ -52,7 +58,11 @@ module Util
     def decrease_concurrent_requests
       unless @concurrent_requests.zero?
         @concurrent_requests -= 1
-        @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
+        @logger.debug(
+          LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(
+            @concurrent_requests
+          )
+        )
       end
     end
   end

--- a/app/domain/util/concurrency_limited_cache.rb
+++ b/app/domain/util/concurrency_limited_cache.rb
@@ -1,7 +1,7 @@
 module Util
 
-  Log ||= LogMessages::Util
-  Err ||= Errors::Util
+  # Possible Errors Raised:
+  # ConcurrencyLimitReachedBeforeCacheInitialization
 
   class ConcurrencyLimitedCache
 
@@ -26,13 +26,13 @@ module Util
     def call(**args)
       @concurrency_mutex.synchronize do
         if @concurrent_requests >= @max_concurrent_requests
-          @logger.debug(Log::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests))
-          raise Err::ConcurrencyLimitReachedBeforeCacheInitialization unless @cache.key?(args)
+          @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheReached.new(@max_concurrent_requests))
+          raise Errors::Util::ConcurrencyLimitReachedBeforeCacheInitialization unless @cache.key?(args)
           return @cache[args]
         end
 
         @concurrent_requests += 1
-        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
+        @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
       end
 
       @semaphore.synchronize do
@@ -45,7 +45,7 @@ module Util
 
     def recalculate(args)
       @cache[args] = @target.call(**args)
-      @logger.debug(Log::ConcurrencyLimitedCacheUpdated.new)
+      @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheUpdated.new)
       decrease_concurrent_requests
     rescue => e
       decrease_concurrent_requests
@@ -55,7 +55,7 @@ module Util
     def decrease_concurrent_requests
       unless @concurrent_requests.zero?
         @concurrent_requests -= 1
-        @logger.debug(Log::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
+        @logger.debug(LogMessages::Util::ConcurrencyLimitedCacheConcurrentRequestsUpdated.new(@concurrent_requests))
       end
     end
   end

--- a/app/domain/util/concurrency_limited_cache.rb
+++ b/app/domain/util/concurrency_limited_cache.rb
@@ -1,8 +1,5 @@
 module Util
 
-  # Possible Errors Raised:
-  # ConcurrencyLimitReachedBeforeCacheInitialization
-
   class ConcurrencyLimitedCache
 
     # NOTE: "callable" is anything with a "call" method

--- a/app/domain/util/rate_limited_cache.rb
+++ b/app/domain/util/rate_limited_cache.rb
@@ -55,7 +55,12 @@ module Util
 
     def recalculate(args)
       if too_many_requests?(args)
-        @logger.debug(LogMessages::Util::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval))
+        @logger.debug(
+          LogMessages::Util::RateLimitedCacheLimitReached.new(
+            @refreshes_per_interval,
+            @rate_limit_interval
+          )
+        )
         return
       end
       @cache[args] = @target.call(**args)

--- a/app/domain/util/rate_limited_cache.rb
+++ b/app/domain/util/rate_limited_cache.rb
@@ -1,6 +1,5 @@
 module Util
 
-  Log ||= LogMessages::Util
   # This can wrap any "callable" object (anything with a `call` method)
   # to add caching with optional force refreshing, where the refreshing
   # is itself subject to rate limiting.
@@ -56,11 +55,11 @@ module Util
 
     def recalculate(args)
       if too_many_requests?(args)
-        @logger.debug(Log::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval))
+        @logger.debug(LogMessages::Util::RateLimitedCacheLimitReached.new(@refreshes_per_interval, @rate_limit_interval))
         return
       end
       @cache[args] = @target.call(**args)
-      @logger.debug(Log::RateLimitedCacheUpdated.new)
+      @logger.debug(LogMessages::Util::RateLimitedCacheUpdated.new)
       @refresh_history[args].push(@time.now)
     end
 

--- a/app/domain/util/trackable_error_class.rb
+++ b/app/domain/util/trackable_error_class.rb
@@ -3,7 +3,6 @@
 # A factory for creating an ErrorClass with an error code prefix
 #
 module Util
-
   class TrackableErrorClass
     def self.new(msg:, code:)
       ErrorClass.new("#{code} #{msg}")

--- a/app/domain/util/trackable_log_message_class.rb
+++ b/app/domain/util/trackable_log_message_class.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'util/log_message_class'
-
 # A factory for creating a LogMessage with a code prefix
 #
 module Util

--- a/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+++ b/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'util/error_class'
-
 # Utility methods for authenticators
 #
 module AuthenticatorHelpers

--- a/spec/app/domain/util/open_ssl/x509/shared_context.rb
+++ b/spec/app/domain/util/open_ssl/x509/shared_context.rb
@@ -1,8 +1,3 @@
-require 'util/open_ssl/x509/certificate'
-require 'util/open_ssl/x509/smart_csr'
-require 'util/open_ssl/x509/smart_cert'
-require 'util/open_ssl/x509/quick_csr'
-
 RSpec.shared_context "certificate testing" do
 
   let(:common_name) { 'example.com' }


### PR DESCRIPTION
Note: it is best to review this PR through the commits

### What does this PR do?

#### Remove Err and Log definitions from top of classes

Each time we used an error class, or a log message class,
we would define its module at the top of the file. This was done
so when you call the class it would be concise without the whole path.

This approach led to issues where because we used memoization to init these
constants, they would sometimes mismatch what is written. For example,
if we had `Err ||= Errors::Authentication::AuthnAzure` in the top of the class
then sometimes the actual value of `Err` was `Errors::Authentication` because it was
already initialized with that value and the memoization meant that we don't initialize
it again.

A solution for that was to remove the memoization whenever this happened but then we had
another issue, where we got "already initialized constant" warnings. This happens because
now we initialize the same constant over and over again (e.g Err = Errors::Authentication::AuthnAzure).

Adding to the above the advantage of the explicit readability of calling error classes with their
full path led to the conclusion that we should remove the definition of `Err` and `Log` from the
top of classes, and call the full path each time.

#### Remove possible errors raised comments

We currently add a comment to each command class where we
specify the possible errors that are raised by this class.

This comment is hard-coded and it is the responsibility of the
developers to maintain it. The problem with this comment is that
it is not generated from anywhere and is not verified by code.

This leads us to a lot of cases where we move errors and forget to
update the comment so the comments are not accurate. Also, because
it is not verified then some classes have it and some classes do not.

It is better to not have any data at all than to have data that is incorrect,
thus we should remove these comments until they are forced by code of the
CommandClass interface.

### What ticket does this PR close?
Connected to #972 

#### Change log
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] The changes in this PR do not require additional tests

#### Documentation
- [x] This PR does not require updating any documentation
