### PR TITLE
Use FIPS compliant conjur-rack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Conjur can be configured to run in FIPS compliant or Non-FIPS compliant mode depending on requirements.
   FIPS Compliant mode is slightly slower then non-FIPS compliant
   ([cyberark/conjur#1527](https://github.com/cyberark/conjur/issues/1527))
+- Bump conjur-rack from 4.0.0 to 4.2.0 that consumes FIPS compliant slosilo(https://github.com/cyberark/conjur/issues/1527))
 
 ### Added
 - Password changes (`PUT /authn/:account/password`) now produce audit events with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,10 +115,10 @@ GEM
       conjur-cli (~> 6)
       docker-api (~> 1.33)
       gli
-    conjur-rack (4.0.0)
+    conjur-rack (4.2.0)
       conjur-api (< 6)
       rack (~> 2)
-      slosilo (~> 2.1)
+      slosilo (~> 2.2)
     conjur-rack-heartbeat (2.2.0)
       rack
     contracts (0.16.0)


### PR DESCRIPTION
Upgrade conjur-rack that consumes slosilo 2.2.1 in order to be FIPS compliant

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
