### PR TITLE
Trying to make hot reloading work in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,27 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = true
+  config.cache_classes = false
+
+  # Note: This is a hack to prevent warnings like:
+  #
+  #   warning: already initialized constant LogMessages::Conjur::PrimarySchema
+  #   warning: previous definition of PrimarySchema was here
+  #
+  # These warnings only appear when "config.cache_classes" is set to "false",
+  # as it is above.  Suppressing them shouldn't be a problem in development.
+  #
+  module Warning
+    CONJUR_IGNORE_RE = Regexp.union(
+      /previous definition of [^ ]* was here/,
+      /already initialized constant/
+    )
+
+    def warn(msg)
+      return if msg =~ CONJUR_IGNORE_RE
+      super(msg)
+    end
+  end
 
   # eager_load needed to make authentication work without the hacky
   # loading code...


### PR DESCRIPTION
So far:

1. Reloading _sort of_ works again, at the expense of unititialized
   constant errors.
2. I found a hack to suppress those errors which should be ok.
3. But even with that there are still issues making this non-viable as
   of now.

To reproduce the issues:

1. Run:

       bundle exec cucumber -p api ./cucumber/api/features/login.feature:9

   It will pass.

2. Add "raise 'Blah'" above line 60 in "authenticate_controller.rb".
   Don't restart "conjurctl server".  Run the cuke command from step 1.
   again.  It will fail.  All as expected.

3. Remove the "raise 'Blah'".  Run it again without restarting.  Now the
   cuke will still fail, not as expected.  The error from the server
   logs is:

        DEBUG 2020/06/26 20:40:13 +0000 [pid=1147] [origin=127.0.0.1] [request_id=6664a988-22a3-4688-845e-02b7c5732d8a] [tid=1155] A copy of Audit::Log::SyslogAdapter has been removed from the module tree but is still active!
        /var/lib/ruby/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:495:in `load_missing_constant'
        /var/lib/ruby/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:195:in `const_missing'
        /src/conjur-server/app/models/audit/log/syslog_adapter.rb:30:in `log'
        /src/conjur-server/app/domain/authentication/login.rb:86:in `audit_failure'
        /src/conjur-server/app/domain/authentication/login.rb:33:in `rescue in call'
        /src/conjur-server/app/domain/authentication/login.rb:25:in `call'
        (eval):7:in `call'

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
