### PR TITLE
Print Conjur server FIPS mode to Conjur log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - All audit events now contain the IP address of the client that initiated the
   API request (e.g. `[client@43868 ip="172.24.0.5"]`)
   ([cyberark/conjur#1550](https://github.com/cyberark/conjur/issues/1550))
+- Print Conjur server FIPS mode status ([cyberark/conjur#1654](https://github.com/cyberark/conjur/issues/1654))
 
 ## [1.7.4] - 2020-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - All audit events now contain the IP address of the client that initiated the
   API request (e.g. `[client@43868 ip="172.24.0.5"]`)
   ([cyberark/conjur#1550](https://github.com/cyberark/conjur/issues/1550))
-- Print Conjur server FIPS mode status ([cyberark/conjur#1654](https://github.com/cyberark/conjur/issues/1654))
+- Print Conjur server FIPS mode status. [cyberark/conjur#1654](https://github.com/cyberark/conjur/issues/1654)
 
 ## [1.7.4] - 2020-06-17
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -10,7 +10,7 @@ module LogMessages
     )
 
     FipsModeStatus = ::Util::TrackableLogMessageClass.new(
-      msg:  "Server set OpenSSL FIPS mode to {0}",
+      msg:  "OpenSSL FIPS mode set to {0}",
       code: "CONJ00038I"
     )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -10,7 +10,7 @@ module LogMessages
     )
 
     FipsModeStatus = ::Util::TrackableLogMessageClass.new(
-      msg:  "Conjur server set OpenSSL to run in {0} FIPS mode",
+      msg:  "Server set OpenSSL FIPS mode to {0}",
       code: "CONJ00038I"
     )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -9,6 +9,11 @@ module LogMessages
       code: "CONJ00034I"
     )
 
+    FipsModeStatus = ::Util::TrackableLogMessageClass.new(
+      msg:  "Conjur server set OpenSSL to run in {0} FIPS mode",
+      code: "CONJ00038I"
+    )
+
   end
 
   module Authentication

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,5 +23,5 @@ on_worker_boot do
 end
 
 before_fork do
-  Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode ? "" : "non"))
+  Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode))
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -22,3 +22,6 @@ on_worker_boot do
   Sequel::Model.db.disconnect
 end
 
+before_fork do
+  Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode ? "" : "non"))
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,11 +17,10 @@ rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 
+Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode))
+
 on_worker_boot do
   # https://groups.google.com/forum/#!topic/sequel-talk/LBAtdstVhWQ
   Sequel::Model.db.disconnect
 end
 
-before_fork do
-  Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode))
-end


### PR DESCRIPTION
# What does this PR do?
We would like to add to the logs whether FIPS mode is enabled or disabled to have better supportability
connected to #1654 

In case FIPS mode is enabled - CONJ00038I Server set OpenSSL FIPS mode to true
In case FIPS mode is disabled - CONJ00038I Server set OpenSSL FIPS mode to false

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
