### PR TITLE
Log authentication and login errors in info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   FIPS Compliant mode is slightly slower then non-FIPS compliant
   ([cyberark/conjur#1527](https://github.com/cyberark/conjur/issues/1527))
 - Bump conjur-rack from 4.0.0 to 4.2.0 that consumes FIPS compliant slosilo(https://github.com/cyberark/conjur/issues/1527))
+- Print login and authentication error to the log in INFO level.
+  [cyberark/conjur#1377](https://github.com/cyberark/conjur/issues/1377)
 
 ### Added
 - Password changes (`PUT /authn/:account/password`) now produce audit events with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump conjur-rack from 4.0.0 to 4.2.0 that consumes FIPS compliant slosilo(https://github.com/cyberark/conjur/issues/1527))
 - Print login and authentication error to the log in INFO level.
   [cyberark/conjur#1377](https://github.com/cyberark/conjur/issues/1377)
+- Print proper message when user does not exist in authn or login request with
+  default authenticator.
+  [cyberark/conjur#1655](https://github.com/cyberark/conjur/issues/1655)
 
 ### Added
 - Password changes (`PUT /authn/:account/password`) now produce audit events with

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -128,10 +128,7 @@ class AuthenticateController < ApplicationController
   private
 
   def handle_login_error(err)
-    logger.info("Login Error: #{err.inspect}")
-    err.backtrace.each do |line|
-      logger.debug(line)
-    end
+    log_error(err, "Login")
 
     case err
     when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
@@ -145,10 +142,7 @@ class AuthenticateController < ApplicationController
   end
 
   def handle_authentication_error(err)
-    logger.info("Authentication Error: #{err.inspect}")
-    err.backtrace.each do |line|
-      logger.debug(line)
-    end
+    log_error(err, "Authentication")
 
     case err
     when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
@@ -187,6 +181,13 @@ class AuthenticateController < ApplicationController
 
     else
       raise Unauthorized
+    end
+  end
+
+  def log_error(err, action)
+    logger.info("#{action} Error: #{err.inspect}")
+    err.backtrace.each do |line|
+      logger.debug(line)
     end
   end
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -128,7 +128,7 @@ class AuthenticateController < ApplicationController
   private
 
   def handle_login_error(err)
-    logger.debug("Login Error: #{err.inspect}")
+    logger.info("Login Error: #{err.inspect}")
     err.backtrace.each do |line|
       logger.debug(line)
     end
@@ -144,7 +144,7 @@ class AuthenticateController < ApplicationController
   end
 
   def handle_authentication_error(err)
-    logger.debug("Authentication Error: #{err.inspect}")
+    logger.info("Authentication Error: #{err.inspect}")
     err.backtrace.each do |line|
       logger.debug(line)
     end

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -136,7 +136,8 @@ class AuthenticateController < ApplicationController
     case err
     when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
       Errors::Authentication::Security::WebserviceNotFound,
-      Errors::Authentication::Security::AccountNotDefined
+      Errors::Authentication::Security::AccountNotDefined,
+      Errors::Authentication::Security::RoleNotFound
       raise Unauthorized
     else
       raise err

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -63,6 +63,14 @@ class CredentialsController < ApplicationController
     authentication.authenticated_role = Role[token_user.roleid] if token_user?
     perform_basic_authn
     raise Unauthorized, "Client not authenticated" unless authentication.authenticated?
+  rescue => err
+    case err
+    when Errors::Authentication::Security::AccountNotDefined,
+      Errors::Authentication::Security::RoleNotFound
+      raise Unauthorized, "Client not authenticated"
+    else
+      raise err
+    end
   end
 
   # Accept params[:role]. Later it will be ignored if it refers to the same user as the token auth.

--- a/app/domain/authentication/security/validate_role_can_access_webservice.rb
+++ b/app/domain/authentication/security/validate_role_can_access_webservice.rb
@@ -18,13 +18,14 @@ module Authentication
     ) do
 
       def call
-        # No checks required for default conjur authn
+        validate_account_exists
+        validate_role_is_defined
+
+        # No further checks required for default conjur authn
         return if default_conjur_authn?
 
-        validate_account_exists
         validate_webservice_exists
-        validate_user_is_defined
-        validate_user_has_access
+        validate_role_has_access
       end
 
       private
@@ -47,11 +48,11 @@ module Authentication
         )
       end
 
-      def validate_user_is_defined
+      def validate_role_is_defined
         raise Errors::Authentication::Security::RoleNotFound, @user_id unless user_role
       end
 
-      def validate_user_has_access
+      def validate_role_has_access
         has_access = user_role.allowed_to?(@privilege, webservice_resource)
         unless has_access
           raise Errors::Authentication::Security::RoleNotAuthorizedOnResource.new(

--- a/spec/controllers/authenticate_controller_spec.rb
+++ b/spec/controllers/authenticate_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe AuthenticateController, :type => :request do
+  include_context "existing account"
+
   let(:password) { "The-Password1" }
   let(:login) { "u-#{random_hex}" }
   let(:account) { "rspec" }

--- a/spec/controllers/credentials_controller_spec.rb
+++ b/spec/controllers/credentials_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe CredentialsController, :type => :request do
+  include_context "existing account"
+
   before(:all) { Slosilo["authn:rspec"] ||= Slosilo::Key.new }
 
   let(:login) { "u-#{random_hex}" }

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+shared_context "existing account" do
+  let(:validate_account_exists) { double("ValidateAccountExists") }
+  before(:each) do
+    allow(Authentication::Security::ValidateAccountExists)
+      .to receive(:new)
+            .and_return(validate_account_exists)
+    allow(validate_account_exists).to receive(:call)
+                                          .and_return(true)
+  end
+end
+
 shared_context "authenticate Basic" do
   let(:params) { { account: account, authenticator: authenticator } }
   let(:basic_auth_header) {


### PR DESCRIPTION
Connected to #1377, #1655

### What does this PR do?
Once an authentication or login request fails, we write the reason
to the log. We currently log it in DEBUG mode which is hard to filter
out. As this info is necessary, and customers would like to get it easily,
we would like to print it in INFO level, which is the default one.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
We can't test this feature in Conjur as the log level in the tests are at DEBUG. However, [this PR](https://github.com/conjurinc/appliance/pull/1277) in the appliance will test it.

#### Documentation
- [ ] Created [this doc issue](https://github.com/cyberark/conjur-docs/issues/977). It can be done once this PR is merged.
