### PR TITLE
Pass role_id instead of role to authn events

### DIFF
--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -77,11 +77,11 @@ module Authentication
       @audit_log.log(
         ::Audit::Event::Authn::Authenticate.new(
           authenticator_name: authenticator_name,
-          service:            webservice,
-          role:               role,
-          client_ip:          client_ip,
-          success:            true,
-          error_message:      nil
+          service: webservice,
+          role_id: audit_role_id,
+          client_ip: client_ip,
+          success: true,
+          error_message: nil
         )
       )
     end
@@ -90,13 +90,19 @@ module Authentication
       @audit_log.log(
         ::Audit::Event::Authn::Authenticate.new(
           authenticator_name: authenticator_name,
-          service:            webservice,
-          role:               role,
-          client_ip:          client_ip,
-          success:            false,
-          error_message:      err.message
+          service: webservice,
+          role_id: audit_role_id,
+          client_ip: client_ip,
+          success: false,
+          error_message: err.message
         )
       )
+    end
+
+    def audit_role_id
+      ::Audit::Event::Authn::RoleId.new(
+        role: role, account: account, username: username
+      ).to_s
     end
 
     def new_token

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -186,7 +186,9 @@ module Authentication
 
       def container_annotation_value prefix
         annotation_name = "authentication-container-name"
-        annotation = host.annotations.find { |a| a.values[:name] == "#{prefix}/#{annotation_name}" }
+        annotation = host.annotations.find do |a|
+          a.values[:name] == "#{prefix}/#{annotation_name}"
+        end
         annotation ? annotation[:value] : nil
       end
 
@@ -195,7 +197,7 @@ module Authentication
           Audit::Event::Authn::InjectClientCert.new(
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
-            role: host,
+            role_id: host.id,
             client_ip: @client_ip,
             success: true,
             error_message: nil
@@ -208,7 +210,7 @@ module Authentication
           Audit::Event::Authn::InjectClientCert.new(
             authenticator_name: KUBERNETES_AUTHENTICATOR_NAME,
             service: webservice,
-            role: host,
+            role_id: host.id,
             client_ip: @client_ip,
             success: false,
             error_message: err.message

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -143,11 +143,11 @@ module Authentication
         @audit_log.log(
           ::Audit::Event::Authn::Authenticate.new(
             authenticator_name: authenticator_name,
-            service:            webservice,
-            role:               role,
-            client_ip:          client_ip,
-            success:            true,
-            error_message:      nil
+            service: webservice,
+            role_id: audit_role_id,
+            client_ip: client_ip,
+            success: true,
+            error_message: nil
           )
         )
       end
@@ -156,13 +156,21 @@ module Authentication
         @audit_log.log(
           ::Audit::Event::Authn::Authenticate.new(
             authenticator_name: authenticator_name,
-            service:            webservice,
-            role:               role,
-            client_ip:          client_ip,
-            success:            false,
-            error_message:      err.message
+            service: webservice,
+            role_id: audit_role_id,
+            client_ip: client_ip,
+            success: false,
+            error_message: err.message
           )
         )
+      end
+
+      def audit_role_id
+        ::Audit::Event::Authn::RoleId.new(
+          role: role,
+          account: account,
+          username: username
+        ).to_s
       end
 
       def admin?(username)

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -74,7 +74,7 @@ module Authentication
         ::Audit::Event::Authn::Login.new(
           authenticator_name: authenticator_name,
           service: webservice,
-          role: role,
+          role_id: audit_role_id,
           client_ip: client_ip,
           success: true,
           error_message: nil
@@ -87,12 +87,18 @@ module Authentication
         ::Audit::Event::Authn::Login.new(
           authenticator_name: authenticator_name,
           service: webservice,
-          role: role,
+          role_id: audit_role_id,
           client_ip: client_ip,
           success: false,
           error_message: err.message
         )
       )
+    end
+
+    def audit_role_id
+      ::Audit::Event::Authn::RoleId.new(
+        role: role, account: account, username: username
+      ).to_s
     end
 
     def new_login

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -83,11 +83,11 @@ module Authentication
       @audit_log.log(
         ::Audit::Event::Authn::ValidateStatus.new(
           authenticator_name: authenticator_name,
-          service:            webservice,
-          role:               role,
-          client_ip:          client_ip,
-          success:            true,
-          error_message:      nil
+          service: webservice,
+          role_id: audit_role_id,
+          client_ip: client_ip,
+          success: true,
+          error_message: nil
         )
       )
     end
@@ -96,13 +96,21 @@ module Authentication
       @audit_log.log(
         ::Audit::Event::Authn::ValidateStatus.new(
           authenticator_name: authenticator_name,
-          service:            webservice,
-          role:               role,
-          client_ip:          client_ip,
-          success:            false,
-          error_message:      err.message
+          service: webservice,
+          role_id: audit_role_id,
+          client_ip: client_ip,
+          success: false,
+          error_message: err.message
         )
       )
+    end
+
+    def audit_role_id
+      ::Audit::Event::Authn::RoleId.new(
+        role: role,
+        account: @authenticator_status_input.account,
+        username: @authenticator_status_input.username
+      ).to_s
     end
 
     def authenticator

--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -4,14 +4,14 @@ module Audit
     # :reek:TooManyInstanceVariables and :reek:TooManyParameters
     class Authn
       def initialize(
-        role:,
+        role_id:,
         client_ip:,
         authenticator_name:,
         service:,
         success:,
         operation:
       )
-        @role = role
+        @role_id = role_id
         @client_ip = client_ip
         @authenticator_name = authenticator_name
         @service = service
@@ -37,8 +37,6 @@ module Audit
         "#{@authenticator_name} service #{service_id}"
       end
 
-      # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-      # :reek:NilCheck
       def service_id
         @service&.resource_id
       end
@@ -55,11 +53,9 @@ module Audit
         "authn"
       end
 
-      # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-      # :reek:NilCheck
       def structured_data
         {
-          SDID::SUBJECT => { role: @role&.id },
+          SDID::SUBJECT => { role: @role_id },
           SDID::AUTH => auth_stuctured_data,
           SDID::CLIENT => { ip: @client_ip }
         }.merge(

--- a/app/models/audit/event/authn/authenticate.rb
+++ b/app/models/audit/event/authn/authenticate.rb
@@ -13,17 +13,17 @@ module Audit
         )
 
         def initialize(
-          role:,
+          role_id:,
           client_ip:,
           authenticator_name:,
           service:,
           success:,
           error_message: nil
         )
-          @role = role
+          @role_id = role_id
           @error_message = error_message
           @authn = Authn.new(
-            role: role,
+            role_id: role_id,
             client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
@@ -39,16 +39,14 @@ module Audit
           message
         end
 
-        # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-        # :reek:NilCheck
         def message
           auth_description = @authn.authenticator_description
           @authn.message(
             success_msg:
-              "#{@role&.id} successfully authenticated with authenticator " \
+              "#{@role_id} successfully authenticated with authenticator " \
               "#{auth_description}",
             failure_msg:
-              "#{@role&.id} failed to authenticate with authenticator "\
+              "#{@role_id} failed to authenticate with authenticator "\
               "#{auth_description}",
             error_msg: @error_message
           )

--- a/app/models/audit/event/authn/inject_client_cert.rb
+++ b/app/models/audit/event/authn/inject_client_cert.rb
@@ -13,17 +13,17 @@ module Audit
         )
 
         def initialize(
-          role:,
+          role_id:,
           client_ip:,
           authenticator_name:,
           service:,
           success:,
           error_message: nil
         )
-          @role = role
+          @role_id = role_id
           @error_message = error_message
           @authn = Authn.new(
-            role: role,
+            role_id: role_id,
             client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
@@ -36,16 +36,14 @@ module Audit
           message
         end
 
-        # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-        # :reek:NilCheck
         def message
           auth_description = @authn.authenticator_description
           @authn.message(
             success_msg:
-              "#{@role&.id} successfully injected client certificate with " \
+              "#{@role_id} successfully injected client certificate with " \
                 "authenticator #{auth_description}",
             failure_msg:
-              "#{@role&.id} failed to inject client certificate with " \
+              "#{@role_id} failed to inject client certificate with " \
                 "authenticator #{auth_description}",
             error_msg: @error_message
           )

--- a/app/models/audit/event/authn/login.rb
+++ b/app/models/audit/event/authn/login.rb
@@ -13,17 +13,17 @@ module Audit
         )
 
         def initialize(
-          role:,
+          role_id:,
           client_ip:,
           authenticator_name:,
           service:,
           success:,
           error_message: nil
         )
-          @role = role
+          @role_id = role_id
           @error_message = error_message
           @authn = Authn.new(
-            role: role,
+            role_id: role_id,
             client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
@@ -36,16 +36,14 @@ module Audit
           message
         end
 
-        # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-        # :reek:NilCheck
         def message
           auth_description = @authn.authenticator_description
           @authn.message(
             success_msg:
-              "#{@role&.id} successfully logged in with authenticator " \
+              "#{@role_id} successfully logged in with authenticator " \
                 "#{auth_description}",
             failure_msg:
-              "#{@role&.id} failed to login with authenticator " \
+              "#{@role_id} failed to login with authenticator " \
                 "#{auth_description}",
             error_msg: @error_message
           )

--- a/app/models/audit/event/authn/role_id.rb
+++ b/app/models/audit/event/authn/role_id.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Audit
+  module Event
+    class Authn
+      # RoleId, in the context of authentication, is subtly different from an
+      # ordinary "role_id".  This is because an authn event can fail when the
+      # user or host authenticating doesn't exist.  In this case, the "role_id"
+      # becomes "what the role id would be if the user _did_ exist". In all
+      # other cases, it's the actual "role_id" for the existing user.
+      #
+      # The control parameter smell here is intentional: This is the object
+      # that is hiding the "nil"-ugliness.
+      # :reek:ControlParameter
+      class RoleId
+        ACCOUNT_PLACEHOLDER = "ACCOUNT_MISSING"
+        USERNAME_PLACEHOLDER = "USERNAME_MISSING"
+
+        # Note: "username" may refer to a user or host.
+        def initialize(role:, account:, username:)
+          @role = role
+          @account = account || ACCOUNT_PLACEHOLDER
+          @username = username || USERNAME_PLACEHOLDER
+        end
+
+        def to_s
+          @role&.id || Role.roleid_from_username(@account, @username)
+        end
+      end
+    end
+  end
+end

--- a/app/models/audit/event/authn/validate_status.rb
+++ b/app/models/audit/event/authn/validate_status.rb
@@ -13,17 +13,17 @@ module Audit
         )
 
         def initialize(
-          role:,
+          role_id:,
           client_ip:,
           authenticator_name:,
           service:,
           success:,
           error_message: nil
         )
-          @role = role
+          @role_id = role_id
           @error_message = error_message
           @authn = Authn.new(
-            role: role,
+            role_id: role_id,
             client_ip: client_ip,
             authenticator_name: authenticator_name,
             service: service,
@@ -36,16 +36,14 @@ module Audit
           message
         end
 
-        # TODO: See issue https://github.com/cyberark/conjur/issues/1608
-        # :reek:NilCheck
         def message
           auth_description = @authn.authenticator_description
           @authn.message(
             success_msg:
-              "#{@role&.id} successfully validated status for authenticator "\
+              "#{@role_id} successfully validated status for authenticator "\
                 "#{auth_description}",
             failure_msg:
-              "#{@role&.id} failed to validate status for authenticator "\
+              "#{@role_id} failed to validate status for authenticator "\
                 "#{auth_description}",
             error_msg: @error_message
           )

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -25,9 +25,15 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
 
   let(:host_annotations) { [ host_annotation_1, host_annotation_2 ] }
 
-  let(:host) { double("Host", role: host_role,
-                              identifier: host_id,
-                              annotations: host_annotations) }
+  let(:host) do
+    double(
+      "Host",
+      role: host_role,
+      identifier: host_id,
+      id: host_id,
+      annotations: host_annotations
+    )
+  end
 
   let(:webservice_resource_id) { "MockWebserviceResourceId" }
   let(:webservice_signed_cert) { double("MockWebserviceSignedCert") }

--- a/spec/models/audit/event/authn/authenticate_spec.rb
+++ b/spec/models/audit/event/authn/authenticate_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Audit::Event::Authn::Authenticate do
   let(:role_id) { 'rspec:user:my_user' }
-  let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
   let(:client_ip) { 'my-client-ip' }
@@ -11,7 +10,7 @@ describe Audit::Event::Authn::Authenticate do
 
   subject do
     Audit::Event::Authn::Authenticate.new(
-      role: role,
+      role_id: role_id,
       authenticator_name: authenticator_name,
       service: service,
       client_ip: client_ip,

--- a/spec/models/audit/event/authn/inject_client_cert_spec.rb
+++ b/spec/models/audit/event/authn/inject_client_cert_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Audit::Event::Authn::InjectClientCert do
   let(:role_id) { 'rspec:host:my_host' }
-  let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
   let(:client_ip) { 'my-client-ip' }
@@ -11,7 +10,7 @@ describe Audit::Event::Authn::InjectClientCert do
 
   subject do
     Audit::Event::Authn::InjectClientCert.new(
-      role: role,
+      role_id: role_id,
       authenticator_name: authenticator_name,
       service: service,
       client_ip: client_ip,

--- a/spec/models/audit/event/authn/login_spec.rb
+++ b/spec/models/audit/event/authn/login_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Audit::Event::Authn::Login do
   let(:role_id) { 'rspec:user:my_user' }
-  let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
   let(:client_ip) { 'my-client-ip' }
@@ -11,7 +10,7 @@ describe Audit::Event::Authn::Login do
 
   subject do
     Audit::Event::Authn::Login.new(
-      role: role,
+      role_id: role_id,
       authenticator_name: authenticator_name,
       service: service,
       client_ip: client_ip,

--- a/spec/models/audit/event/authn/role_id_spec.rb
+++ b/spec/models/audit/event/authn/role_id_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe ::Audit::Event::Authn::RoleId do
+  let(:role_id) { 'some:role:id' }
+  let(:role) { double('Role', id: role_id) }
+
+  it 'returns role.id when role is provided' do
+    subj = Audit::Event::Authn::RoleId.new(
+      role: role, account: nil, username: nil
+    )
+    expect(subj.to_s).to eq(role_id)
+  end
+
+  it 'constructs "role id" from account/username when role is missing' do
+    subj = ::Audit::Event::Authn::RoleId.new(
+      role: nil, account: 'my_account', username: 'my_username'
+    )
+    expect(subj.to_s).to eq('my_account:user:my_username')
+  end
+
+  it 'constructs a placeholder "role id" when account is missing' do
+    subj = ::Audit::Event::Authn::RoleId.new(
+      role: nil, account: nil, username: 'my_username'
+    )
+    placeholder = ::Audit::Event::Authn::RoleId::ACCOUNT_PLACEHOLDER
+    expect(subj.to_s).to eq("#{placeholder}:user:my_username")
+  end
+
+  it 'constructs a placeholder "role id" when username is missing' do
+    subj = ::Audit::Event::Authn::RoleId.new(
+      role: nil, account: 'my_account', username: nil
+    )
+    placeholder = ::Audit::Event::Authn::RoleId::USERNAME_PLACEHOLDER
+    expect(subj.to_s).to eq("my_account:user:#{placeholder}")
+  end
+end
+

--- a/spec/models/audit/event/authn/validate_status_spec.rb
+++ b/spec/models/audit/event/authn/validate_status_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe Audit::Event::Authn::ValidateStatus do
   let(:role_id) { 'rspec:user:my_user' }
-  let(:role) { double('my-role', id: role_id) }
   let(:authenticator_name) { 'my-authenticator'}
   let(:service) { double('my-service', resource_id: 'rspec:webservice:my-service') }
   let(:client_ip) { 'my-client-ip' }
@@ -11,7 +10,7 @@ describe Audit::Event::Authn::ValidateStatus do
 
   subject do
     Audit::Event::Authn::ValidateStatus.new(
-      role: role,
+      role_id: role_id,
       authenticator_name: authenticator_name,
       service: service,
       success: success,


### PR DESCRIPTION
    All of these events only ever use the "role.id" method of the "role"
    object that is passed to them, so passing the entire "role" object is
    unnecessary and misleading.
    
    We also introduce an Audit::Event::Authn::RoleId to encapsulate the
    conditional logic around the meaning of "role id" in the context of
    authentication events.

### What does this PR do?
- _What's changed? Why were these changes made?_

To simplify the interface of the audit events and consolidate the many unnecessary nil-checks being done in every audit message into a single place.


### What ticket does this PR close?

#1640 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
