### PR TITLE
Refactor default api key /authn/authenticator to a Command Class

### DIFF
--- a/spec/app/domain/authentication/authn/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn/authenticator_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::Authn::Authenticator' do
+  include_context "authn setup"
+
+  context "An Authn authenticator" do
+    context "that receives an authentication request" do
+      context "with valid credentials" do
+        subject do
+          ::Authentication::Authn::Authenticator.new(
+            role_cls:        role_cls,
+            credentials_cls: valid_api_key_credentials
+          ).call(
+            authenticator_input: input
+          )
+        end
+
+        it "does not raise an error" do
+          expect {subject}.to_not raise_error
+        end
+
+        it "returns true" do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context "with a non-existing role" do
+        subject do
+          ::Authentication::Authn::Authenticator.new(
+            role_cls:        role_cls,
+            credentials_cls: non_existing_role_credentials
+          ).call(
+            authenticator_input: input
+          )
+        end
+
+        it "does not raise an error" do
+          expect {subject}.to_not raise_error
+        end
+
+        it "returns false" do
+          expect(subject).to eq(false)
+        end
+      end
+
+      context "with an invalid api key" do
+        subject do
+          ::Authentication::Authn::Authenticator.new(
+            role_cls:        role_cls,
+            credentials_cls: invalid_api_key_credentials
+          ).call(
+            authenticator_input: input
+          )
+        end
+
+        it "does not raise an error" do
+          expect {subject}.to_not raise_error
+        end
+
+        it "returns false" do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn/login_spec.rb
+++ b/spec/app/domain/authentication/authn/login_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::Authn::Login' do
+  include_context "authn setup"
+
+  context "An Authn authenticator" do
+    context "that receives a login request" do
+      context "with valid credentials" do
+        subject do
+          ::Authentication::Authn::Login.new(
+            role_cls:        role_cls,
+            credentials_cls: credentials_cls
+          ).call(
+            authenticator_input: input
+          )
+        end
+
+        it "does not raise an error" do
+          expect {subject}.to_not raise_error
+        end
+
+        it "returns a non nil value" do
+          expect(subject).not_to eq(nil)
+        end
+      end
+
+      context "with a non-existing role" do
+        subject do
+          ::Authentication::Authn::Login.new(
+            role_cls:        role_cls,
+            credentials_cls: non_existing_role_credentials
+          ).call(
+            authenticator_input: input
+          )
+        end
+
+        it "does not raise an error" do
+          expect {subject}.to_not raise_error
+        end
+
+        it "returns nil" do
+          expect(subject).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/authn_spec_helper.rb
+++ b/spec/support/authn_spec_helper.rb
@@ -1,0 +1,57 @@
+shared_context "authn setup" do
+  let(:input) do
+    ::Authentication::AuthenticatorInput.new(
+      authenticator_name: 'authn',
+      service_id:         'service',
+      account:            'account',
+      username:           'username',
+      credentials:        'creds',
+      client_ip:          '127.0.0.1',
+      request:            nil
+    )
+  end
+
+  let(:role_cls) { double("Role") }
+  def role_cls
+    double('Role').tap do |role|
+      allow(role).to(
+        receive(:roleid_from_username)
+      ).and_return(
+        "account:user:username"
+      )
+    end
+  end
+
+  let(:credentials_cls) { double("Credentials") }
+  def credentials_cls
+    double('Credentials').tap do |creds|
+      allow(creds).to receive(:[]).and_return(creds)
+      allow(creds).to receive(:authenticate).and_return(true)
+      allow(creds).to receive(:api_key).and_return('a valid api key')
+    end
+  end
+
+  let(:non_existing_role_credentials) { double("Credentials") }
+  def non_existing_role_credentials
+    double('Credentials').tap do |creds|
+      allow(creds).to receive(:[]).and_return(nil)
+    end
+  end
+
+
+  let(:invalid_api_key_credentials) { double("Credentials") }
+  def invalid_api_key_credentials
+    double('Credentials').tap do |creds|
+      allow(creds).to receive(:[]).and_return(creds)
+      allow(creds).to receive(:valid_api_key?).and_return(false)
+    end
+  end
+
+  let(:valid_api_key_credentials) { double("Credentials") }
+  def valid_api_key_credentials
+    double('Credentials').tap do |creds|
+      allow(creds).to receive(:[]).and_return(creds)
+      allow(creds).to receive(:valid_api_key?).and_return(true)
+    end
+  end
+end


### PR DESCRIPTION
### Apply the [CommandClass](https://github.com/jonahx/command_class) pattern onto Authn::Authenticator

Authenticators in Conjur follow the [CommandClass](https://github.com/jonahx/command_class) pattern.
Authn::Authenticator is one of the early authenticators which did not follow this pattern.

### Change in this PR
Apply the [CommandClass](https://github.com/jonahx/command_class) pattern on Authn::Aauthenticator to align with other authenticators.
As part of the  [proxy validation epic changes](https://github.com/conjurinc/appliance/issues/1273) the authenticator has been refactored to a command class and unit tests has been added, in order to prepare for the upcoming changes required to support this epic .

### Related Issue
[https://github.com/cyberark/conjur/issues/1662](url)
