### PR TITLE
Update FIPS mode logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Log the OpenSSL FIPS mode after Rails is initialized for both OSS and DAP.
+  [cyberark/conjur#1684](https://github.com/cyberark/conjur/pull/1684)
+
 ## [1.8.0] - 2020-07-10
 ### Changed
 - Use OpenSSL 1.0.2u to support FIPS compliance.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,12 @@ rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 
-Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode))
+# Logging the FIPS mode needs to happen in the `before_fork` callback to ensure
+# that the Rails and domain libraries have been loaded. Otherwise this will
+# fail when started as a `puma` command, rather than using `rails server`.
+before_fork do
+  Rails.logger.info(LogMessages::Conjur::FipsModeStatus.new(OpenSSL.fips_mode))
+end
 
 on_worker_boot do
   # https://groups.google.com/forum/#!topic/sequel-talk/LBAtdstVhWQ


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates the FIPS mode logging to ensure all of the logging dependencies are loaded. Otherwise this will fail in the appliance.
