### PR TITLE
bump conjur-policy-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Log the OpenSSL FIPS mode after Rails is initialized for both OSS and DAP.
   [cyberark/conjur#1684](https://github.com/cyberark/conjur/pull/1684)
+- Bump `conjur-policy-parser` so `revoke (member)` and `deny (role)`
+  can correctly utilize relative paths. [conjurinc/dap-support#101](https://github.com/conjurinc/dap-support/issues/101)
 
 ## [1.8.0] - 2020-07-10
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/conjur-policy-parser.git
-  revision: d30e220260c7925386904dc0dfc5f86164db4488
+  revision: 2f958c88e59671e72368bf5dbe2845cc56c77c3b
   branch: master
   specs:
     conjur-policy-parser (3.0.4)
@@ -205,7 +205,7 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)


### PR DESCRIPTION
### What does this PR do?
Bump `conjur-policy-parser` so `revoke (member)` and `deny (role)`
 can correctly utilize relative paths.

### What ticket does this PR close?
Connected to [conjurinc/dap-support#101](https://github.com/conjurinc/dap-support/issues/101)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests (they are tested in the gem's tests)

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
