### PR TITLE
Add safer data-handling in ConjurCA

### DIFF
--- a/app/domain/repos/conjur_ca.rb
+++ b/app/domain/repos/conjur_ca.rb
@@ -14,12 +14,18 @@ module Repos
     #
     def self.ca(resource_id)
       ca_info = ::Conjur::CaInfo.new(resource_id)
-      stored_cert = Resource[ca_info.cert_id].last_secret.value
-      stored_key = Resource[ca_info.key_id].last_secret.value
+      ca_cert_id = ca_info.cert_id
+      ca_key_id = ca_info.key_id
+      ca_secrets = fetch_required_secrets.(resource_ids: [ca_cert_id, ca_key_id])
+      stored_cert = ca_secrets[ca_cert_id]
+      stored_key = ca_secrets[ca_key_id]
       ca_cert = OpenSSL::X509::Certificate.new(stored_cert)
       ca_key = OpenSSL::PKey::RSA.new(stored_key)
       ::Util::OpenSsl::CA.new(ca_cert, ca_key)
     end
 
+    def self.fetch_required_secrets
+      @fetch_required_secrets ||= ::Conjur::FetchRequiredSecrets.new
+    end
   end
 end


### PR DESCRIPTION
### What does this PR do?
In order to avoid NoMethodError that can be raised when the ConjurCA relevant resources is missing/have no value, added custom exceptions which inform the proper error.

### What ticket does this PR close?
resolves #1315 

### Checklists
- Reproduce the bug by deploy current version
- Deploy a new env with the these changes
- Test authn k8s works fine
- Test the new exceptions raised when ConjurCa has malformed data.

#### Change log
- This PR does not include user-facing changes and doesn't require a CHANGELOG update

