### PR TITLE
Restore `TRUSTED_PROXIES` behavior for Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `/whoami` API endpoint for improved supportability and debugging for access
   tokens and client IP address determination. [cyberark/conjur#1697](https://github.com/cyberark/conjur/issues/1697)
 
+### Fixed
+- The `TRUSTED_PROXIES` environment variable now works correctly again after the
+  Rails 5 upgrade. This is to indicate trusted proxy IP addresses when using the
+  `X-Forwarded-For` HTTP header to identity the true client IP address of a request.
+  [cyberark/conjur#1689](https://github.com/cyberark/conjur/issues/1689)
+
 ## [1.8.1] - 2020-07-14
 ### Fixed
 - Log the OpenSSL FIPS mode after Rails is initialized for both OSS and DAP.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,8 @@ Rails.application.configure do
 
   # TODO: figure out how to make it work in a spring environment
   config.audit_socket = Test::AuditSink.instance.address
+
+  # We don't want to cache TRUSTED_PROXIES for tests so that these may
+  # be modified for different test scenarios.
+  config.conjur_disable_trusted_proxies_cache = true
 end

--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  # Save the original ip_filter to use as a fallback if TRUSTED_PROXIES
+  # is not set.
+  default_ip_filter = Rack::Request.ip_filter
+
+  # Only disable the trusted proxies cache if the config attribute exists and is
+  # truthy.
+  disable_cache = config.respond_to?(:conjur_disable_trusted_proxies_cache) &&
+    config.conjur_disable_trusted_proxies_cache
+
+  Rack::Request.ip_filter = Conjur::TrustedProxyFilter.new(
+    default_ip_filter,
+    options: {
+      disable_cache: disable_cache
+    }
+  )
+end

--- a/lib/conjur/trusted_proxy_filter.rb
+++ b/lib/conjur/trusted_proxy_filter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Conjur
+  # TrustedProxyFilter wraps the default Rack IP filtering. This allows
+  # the trusted proxies to be configured using the environment variable,
+  # `TRUSTED_PROXIES`.
+  #
+  # The value of `TRUSTED_PROXIES` must be a comma-separated list of IP
+  # addresses or IP address ranges using CIDR notation.
+  #
+  # Example: TRUSTED_PROXIES=4.4.4.4,192.168.100.0/24
+  class TrustedProxyFilter
+    def initialize(wrapped_filter, env: ENV, options: { disable_cache: true })
+      @wrapped_filter = wrapped_filter
+      @env = env
+      @options = options
+      @cached_trusted_proxies = nil
+    end
+
+    def call(ip)
+      return @wrapped_filter.call(ip) unless trusted_proxies
+
+      trusted_proxies.any? { |cidr| cidr.include?(ip) }
+    end
+
+    def trusted_proxies
+      @cached_trusted_proxies || load_trusted_proxies_from_env
+    end
+
+    # Reek flags @env['TRUSTED_PROXIES'] as :reek:DuplicateMethodCall. Refactoring
+    # this would not enhance the readability or performance.
+    def load_trusted_proxies_from_env
+      return nil unless @env['TRUSTED_PROXIES']
+
+      proxy_ips = Set.new(@env['TRUSTED_PROXIES'].split(',') + ['127.0.0.1'])
+        .collect { |cidr| IPAddr.new(cidr.strip) }
+
+      @cached_trusted_proxies = proxy_ips unless @options[:disable_cache]
+      proxy_ips
+    end
+  end
+end

--- a/spec/request/request_ip_spec.rb
+++ b/spec/request/request_ip_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These are integration tests that describe the expected client IP address
+# behavior for Conjur, considering the entire HTTP server pipeline and how it
+# handles the TCP remote IP address, the `TRUSTED_PROXIES` environment variable,
+# and the `X-Forwarded-For` HTTP header.
+#
+# These would generally be better suited as cucumber behavior tests rather than
+# RSpec tests. However, in this case we use RSpec for these integration tests for
+# two reasons:
+#
+# 1. Rspec tests are generally faster than Cucumber tests, so if we can test
+#    this appropriately in RSpec alone, we can keep the CI execution time lower.
+#
+# 2. Our cucumber tests currently can't test this as thoroughly as we can in RSpec,
+#    because of the way we are able to manipulate the environment and the TCP
+#    remote IP with RSpec and the Rails "request" test type. To do this with
+#    Cucumber would require greater control of the Docker network and containers
+#    for the Conjur cucumber tests than we have now.
+RSpec.describe "request IP address determination", type: :request do
+  def request_env(remote_addr)
+    {
+      # We can't modify the access token middleware to add an exception to our
+      # test route, so we need to create an access token for our request to use.
+      'HTTP_AUTHORIZATION' => access_token_for('admin'),
+      'REMOTE_ADDR' => remote_addr
+    }
+  end
+
+  def request_ip(remote_addr:, x_forwarded_for: nil, trusted_proxies: nil)
+    ENV['TRUSTED_PROXIES'] = trusted_proxies if trusted_proxies
+  
+    headers = {}
+    headers['X-Forwarded-For'] = x_forwarded_for if x_forwarded_for
+  
+    get '/whoami', env: request_env(remote_addr), headers: headers
+  
+    JSON.parse(response.body)['client_ip']
+  end
+
+  # --------------------------------------------------------------------
+  # Test Scenarios
+  # --------------------------------------------------------------------
+
+  # Without any other configuration in play, we expect to get the remote
+  # TCP connection IP address as the request IP address.
+  it 'returns the remote_addr with no additional config' do
+    expect(request_ip(remote_addr: '44.0.0.1')).to eq('44.0.0.1')
+  end
+
+  it 'ignores the XFF header when the remote addr is untrusted' do
+    expect(
+      request_ip(
+        remote_addr: '44.0.0.1',
+        x_forwarded_for: '3.3.3.3'
+      )
+    ).to eq('44.0.0.1')
+  end
+
+  # By default "non-routable" IP addresses are trusted (according to this
+  # regular expression: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L19)
+  #
+  # `127.0.0.1` is important as the address of the nginx proxy when used in DAP
+  it 'trusts the loopback address by default to provide XFF' do
+    expect(
+      request_ip(
+        remote_addr: '127.0.0.1',
+        x_forwarded_for: '3.3.3.3'
+      )
+    ).to eq('3.3.3.3')
+  end
+
+  it "doesn't trust the remote_addr if not included in TRUSTED_PROXIES" do
+    expect(
+      request_ip(
+        remote_addr: '44.0.0.1',
+        x_forwarded_for: '3.3.3.3',
+        trusted_proxies: '4.4.4.4'
+      )
+    ).to eq('44.0.0.1')
+  end
+
+  it "trusts 127.0.0.1 for XFF even when not included explicitly with TRUSTED_PROXIES" do
+    expect(
+      request_ip(
+        remote_addr: '127.0.0.1',
+        x_forwarded_for: '3.3.3.3',
+        trusted_proxies: '4.4.4.4'
+      )
+    ).to eq('3.3.3.3')
+  end
+  
+  it "trusts IP ranges for XFF using CIDR notation in TRUSTED_PROXIES" do
+    expect(
+      request_ip(
+        remote_addr: '5.5.5.1',
+        x_forwarded_for: '3.3.3.3',
+        trusted_proxies: '5.5.5.0/24'
+      )
+    ).to eq('3.3.3.3')
+  end
+
+  it "returns the expected IP when multiple XFF values are included" do
+    expect(
+      request_ip(
+        remote_addr: '5.5.5.1',
+        x_forwarded_for: '3.3.3.3,5.5.5.2,5.5.5.3',
+        trusted_proxies: '5.5.5.0/24'
+      )
+    ).to eq('3.3.3.3')
+  end
+
+  it "returns the expected IP when multiple ranges are included in TRUSTED_PROXIES" do
+    expect(
+      request_ip(
+        remote_addr: '4.4.4.4',
+        x_forwarded_for: '3.3.3.3,5.5.5.2,5.5.5.3',
+        trusted_proxies: '5.5.5.0/24,4.4.4.0/24'
+      )
+    ).to eq('3.3.3.3')
+  end
+
+  it "returns the right-most untrusted IP when XFF contains multiple untrusted IPs" do
+    expect(
+      request_ip(
+        remote_addr: '4.4.4.4',
+        x_forwarded_for: '3.3.3.3,6.6.6.6,7.7.7.7',
+        trusted_proxies: '4.4.4.0/24'
+      )
+    ).to eq('7.7.7.7')
+  end
+
+  it "returns the right-most untrusted IP when XFF contains some trusted IPs" do
+    expect(
+      request_ip(
+        remote_addr: '4.4.4.4',
+        x_forwarded_for: '3.3.3.3,6.6.6.6,5.5.5.5',
+        trusted_proxies: '4.4.4.0/24,5.5.5.0/24'
+      )
+    ).to eq('6.6.6.6')
+  end
+
+  it "returns the right-most untrusted IP when XFF contains a trusted IP in the middle" do
+    expect(
+      request_ip(
+        remote_addr: '4.4.4.4',
+        x_forwarded_for: '3.3.3.3,5.5.5.5,6.6.6.6,7.7.7.7',
+        trusted_proxies: '4.4.4.0/24,5.5.5.0/24'
+      )
+    ).to eq('7.7.7.7')
+  end
+
+  it "returns the left-most trusted IP when XFF contains all trusted IPs" do
+    expect(
+      request_ip(
+        remote_addr: '4.4.4.4',
+        x_forwarded_for: '5.5.5.5,6.6.6.6',
+        trusted_proxies: '4.4.4.4,5.5.5.5,6.6.6.6'
+      )
+    ).to eq('5.5.5.5')
+  end
+end


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR re-implements the `TRUSTED_PROXIES` Rack IP filter for Rails 5. This replaces the implementation previously provided by the `conjur-rack` gem for Rails 4.

This PR also adds rspec tests that verify the expected `request.ip` with the given scenarios for `REMOTE_ADDR`, `TRUSTED_PROXIES`, and `X-Forwarded-For`.

- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #1689 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation


#### TODO:
- [x] Cleanup fix code
- [x] Add tests for the `request.ip` behavior
- [x] Create issue/PR to remove monkey patch in `conjur-rack` for `trusted_proxy?` 
    Issue: https://github.com/cyberark/conjur-rack/issues/21
- [x] Update CHANGELOG