### PR TITLE
add REST API response content-type tests

### DIFF
--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -11,6 +11,7 @@ Feature: Exchange a role's API key for a signed authentication token
 
   Scenario: A role's API can be used to authenticate
     Then I can POST "/authn/cucumber/alice/authenticate" with plain text body ":cucumber:user:alice_api_key"
+    And the HTTP response content type is "application/json"
     And there is an audit record matching:
     """
       <86>1 * * conjur * authn

--- a/cucumber/api/features/authn_restricted_to.feature
+++ b/cucumber/api/features/authn_restricted_to.feature
@@ -12,3 +12,4 @@ Feature: User and Host authentication can be network restricted
   Scenario: When the request origin is correct, then access is allowed
     When I authenticate as "bob" with account "cucumber"
     Then the HTTP response status code is 200
+    And the HTTP response content type is "application/json"

--- a/cucumber/api/features/certificate_authority.feature
+++ b/cucumber/api/features/certificate_authority.feature
@@ -51,6 +51,7 @@ Feature: Conjur signs certificates using a configured CA
       privilege: [ sign ]
       resource: !webservice conjur/dining-room/ca
     """
+    And the HTTP response content type is "application/json"
     And I have an intermediate CA "kitchen"
     And I add the "kitchen" intermediate CA private key to the resource "cucumber:variable:conjur/kitchen/ca/private-key"
     And I add the "kitchen" intermediate CA cert chain to the resource "cucumber:variable:conjur/kitchen/ca/cert-chain"
@@ -94,4 +95,5 @@ Feature: Conjur signs certificates using a configured CA
     Given I login as "cucumber:host:table"
     When I send a CSR for "table" to the "dining-room" CA with a ttl of "P6M" and CN of "table"
     Then the HTTP response status code is 201
+    And the HTTP response content type is "application/json; charset=utf-8"
     And the resulting json certificate is valid according to the "dining-room" intermediate CA

--- a/cucumber/api/features/login.feature
+++ b/cucumber/api/features/login.feature
@@ -9,7 +9,8 @@ Feature: Exchange a role's password for its API key
   Scenario: Password can be used to obtain API key
     Given I set the password for "alice" to "My-Password1"
     When I can GET "/authn/cucumber/login" with username "alice" and password "My-Password1"
-    Then the result is the API key for user "alice"
+    Then the HTTP response content type is "text/plain"
+    And the result is the API key for user "alice"
 
   @logged-in
   Scenario: Bearer token cannot be used to login

--- a/cucumber/api/features/policy_load.feature
+++ b/cucumber/api/features/policy_load.feature
@@ -86,3 +86,4 @@ Feature: Updating policies
     When I clear the "Content-Type" header
     And I load a large policy with POST
     Then the HTTP response status code is 201
+    And the HTTP response content type is "application/json"

--- a/cucumber/api/features/resource_visibility.feature
+++ b/cucumber/api/features/resource_visibility.feature
@@ -54,6 +54,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     When I login as "bob"
     And I successfully GET "/resources/cucumber"
+    Then the HTTP response content type is "application/json"
 
     Then the resource list should include the newest resource
 

--- a/cucumber/api/features/rotate_api_key.feature
+++ b/cucumber/api/features/rotate_api_key.feature
@@ -12,6 +12,7 @@ Feature: Rotate the API key of a role
     Given I set the password for "alice" to "My-Password1"
     When I can PUT "/authn/cucumber/api_key" with username "alice" and password "My-Password1"
     Then the result is the API key for user "alice"
+    And the HTTP response content type is "text/plain"
 
   @logged-in
   Scenario: The API key cannot be rotated by foreign role without 'update' privilege
@@ -25,3 +26,4 @@ Feature: Rotate the API key of a role
     And I login as "alice"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the result is the API key for user "bob"
+    And the HTTP response content type is "text/plain"

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -51,6 +51,7 @@ Feature: Adding and fetching secrets
     """
     [ "v-1" ]
     """
+    And the HTTP response content type is "application/json"
 
   Scenario: Secrets can contain any binary data.
 
@@ -73,6 +74,7 @@ Feature: Adding and fetching secrets
     """
     When I successfully GET "/secrets/cucumber/variable/probe"
     Then the binary result is "v-2"
+    And the HTTP response content type is "application/octet-stream"
     And there is an audit record matching:
     """
       <38>1 * * conjur * fetch

--- a/cucumber/authenticators_azure/features/authn_status_azure.feature
+++ b/cucumber/authenticators_azure/features/authn_status_azure.feature
@@ -48,6 +48,7 @@ Feature: Azure Authenticator - Status Check
     And I login as "alice"
     When I GET "/authn-azure/prod/cucumber/status"
     Then the HTTP response status code is 200
+    And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
   Scenario: A non-responsive Azure AD provider returns a 500 response

--- a/cucumber/authenticators_oidc/features/authn_status_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_status_oidc.feature
@@ -53,6 +53,7 @@ Feature: OIDC Authenticator - Status Check
     And I login as "alice"
     When I GET "/authn-oidc/keycloak/cucumber/status"
     Then the HTTP response status code is 200
+    And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
   Scenario: A non-responsive OIDC provider returns a 500 response

--- a/cucumber/rotators/features/expiration.feature
+++ b/cucumber/rotators/features/expiration.feature
@@ -39,4 +39,5 @@ Feature: Manually expiring a rotating variable
     And I save the response as "password_before_expiration"
     And I POST "/secrets/cucumber/variable/db-reports/password?expirations"
     Then the HTTP response status code is 201
+    And the HTTP response content type is "text/html"
     And the password will change from "password_before_expiration"


### PR DESCRIPTION

### What does this PR do?
Adds test that ensure that the correct content-type (as listed in the docs) is returned

### What ticket does this PR close?
Connected to #1544 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
