### PR TITLE
Add `/whoami` API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   API request (e.g. `[client@43868 ip="172.24.0.5"]`)
   ([cyberark/conjur#1550](https://github.com/cyberark/conjur/issues/1550))
 - Print Conjur server FIPS mode status. [cyberark/conjur#1654](https://github.com/cyberark/conjur/issues/1654)
+- Add `/whoami` API endpoint for improved supportability and debugging for access
+  tokens and client IP address determination. [cyberark/conjur#1697](https://github.com/cyberark/conjur/issues/1697)
 
 ## [1.7.4] - 2020-06-17
 

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,8 +1,26 @@
 # frozen_string_literal: true
 
+require 'date'
+
 class StatusController < ApplicationController
+  include TokenUser
+
   def index
     render 'index', layout: false
   end
 
+  # /whoami returns basic information about the request client and access token
+  # that Conjur receives.
+  #
+  # This is useful for troubleshooting authentication with access tokens and
+  # configuring proxies or load balancers.
+  def whoami
+    render json: { 
+      client_ip: request.ip,
+      user_agent: request.user_agent,
+      account: token_user.account,
+      username: token_user.login,
+      token_issued_at: Time.at(token_user.token.claims["iat"])
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ end
 Rails.application.routes.draw do
   scope format: false do
     get '/' => 'status#index'
+    get '/whoami' => 'status#whoami'
     get '/authenticators' => 'authenticate#index'
 
     constraints id: /[^\/\?]+/ do

--- a/cucumber/api/features/step_definitions/policy_load_steps.rb
+++ b/cucumber/api/features/step_definitions/policy_load_steps.rb
@@ -1,4 +1,4 @@
-# Let's you reference the global variables such as `$?` using less 
+# This allows to you reference some global variables such as `$?` using less 
 # cryptic names like `$CHILD_STATUS`
 require 'English'
 

--- a/spec/request/whoami_spec.rb
+++ b/spec/request/whoami_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe StatusController, type: :request do
+  describe "GET #whoami" do
+    it "responds with unauthorized when no access token is provided" do
+      get '/whomai'
+      expect(response.status).to equal(401)
+    end
+
+    it "returns the client information" do
+      request_env = {
+        'HTTP_AUTHORIZATION' => access_token_for('alice'),
+        'REMOTE_ADDR' => '4.4.4.4'
+      }
+      
+      get('/whoami', env: request_env)
+
+      response_json = JSON.parse(response.body)
+      expect(response_json).to include({
+        'client_ip' => '4.4.4.4',
+        'account' => 'rspec',
+        'username' => 'alice'
+      })
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This allows to you reference some global variables such as `$?` using less 
+# cryptic names like `$CHILD_STATUS`
+require 'English'
+
 require 'simplecov'
 
 SimpleCov.command_name "SimpleCov #{rand(1000000)}"
@@ -14,7 +18,7 @@ require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each {|f| require f}
 
 ENV['CONJUR_ACCOUNT'] = 'rspec'
 ENV.delete('CONJUR_ADMIN_PASSWORD')
@@ -49,7 +53,7 @@ def secret_logged?(secret)
   #
   # We use backticks because we want the exit code for detailed error messages.
   `grep --quiet '#{secret}' '#{log_file}'`
-  exit_status = ($?).exitstatus
+  exit_status = $CHILD_STATUS.exitstatus
 
   # Grep exit codes:
   # 0   - match

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,5 +69,13 @@ def secret_logged?(secret)
   secret_found
 end
 
+# Creates valid access token for the given username.
+# :reek:UtilityFunction
+def access_token_for(user, account: 'rspec')
+  # Configure Slosilo to produce valid access tokens
+  slosilo = Slosilo["authn:#{account}"] ||= Slosilo::Key.new
+  bearer_token = slosilo.issue_jwt(sub: user)
+  "Token token=\"#{Base64.strict_encode64 bearer_token.to_json}\""
+end
 
 require 'stringio'


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR adds a new API endpoint:
```log
GET /whoami
```

This endpoint optionally accepts an `Authorization` header with a Conjur access token, and returns the following JSON structure:

```json
{
    "client_ip": "192.168.192.1",
    "user_agent": "PostmanRuntime/7.26.1",
    "account": "cucumber",
    "login": "admin",
    "token_issued_at": "2020-07-17T21:11:56.000+00:00"
}
```

When no access token, or an invalid access token, is provided the response is:
```
401 Unauthorized

Unauthorized: Invalid token
```

- _How should the reviewer approach this PR, especially if manual tests are required?_

### What ticket does this PR close?
Connected to #1697 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

Issue for API docs is: https://github.com/cyberark/dap-wiki/issues/90
