### PR TITLE
Add encoded optional param to authenticate request

### DIFF
--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -54,6 +54,11 @@ module LogMessages
       code: "CONJ00030D"
     )
 
+    EncodedJWTResponse = ::Util::TrackableLogMessageClass.new(
+      msg:  "Responding with a base64 encoded access token",
+      code: "CONJ00039D"
+    )
+
     module OAuth
 
       IdentityProviderUri = ::Util::TrackableLogMessageClass.new(

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -7,6 +7,9 @@ api: >
   --format pretty
   -r cucumber/api/features/support/logs_helpers.rb
   -r cucumber/api/features/step_definitions/logs_steps.rb
+  -r cucumber/_authenticators_common/features/support/conjur_token.rb
+  -r cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+  -r cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
   -r cucumber/api
   cucumber/api
 

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -103,10 +103,6 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice failed to authenticate with authenticator authn
     """
 
-  Scenario: successful encoded requests in limited time
-    When I can authenticate Alice 1000 times in 10 threads with Accept-Encoding header "base64"
-    Then The avg authentication request responds in less than 0.75 seconds
-
   Scenario: User cannot login as a same-named user in a different account
 
     User logins are scoped per account. Conjur cannot be tricked into authenticating a user

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -21,6 +21,20 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  Scenario: Authenticate response should be encoded if asked
+    When I POST "/authn/cucumber/alice/authenticate?encoded=true" with plain text body ":cucumber:user:alice_api_key"
+    Then the HTTP response content type is "text/plain"
+    And the HTTP response is base64 encoded
+    And user "alice" has been authorized by Conjur
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
+
   Scenario: Authenticating with no Content-Type header succeeds without writing API key to the logs
     And I save my place in the log file
     And I can authenticate Alice with no Content-Type header

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -5,7 +5,6 @@ Feature: Exchange a role's API key for a signed authentication token
   The token is a signed JSON structure that contains the role id. The 
   token can be sent as the `Authorization` header to other Conjur REST
   functions as proof of authentication.
-
   Background:
     Given I create a new user "alice"
 
@@ -21,11 +20,51 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
-  Scenario: Authenticate response should be encoded if asked
-    When I POST "/authn/cucumber/alice/authenticate?encoded=true" with plain text body ":cucumber:user:alice_api_key"
+  Scenario: Authenticate response should be encoded if Accept-Encoding equals base64
+    When I successfully authenticate Alice with Accept-Encoding header "base64"
     Then the HTTP response content type is "text/plain"
     And the HTTP response is base64 encoded
     And user "alice" has been authorized by Conjur
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
+
+  Scenario: Authenticate response should be encoded if Accept-Encoding includes base64
+    When I successfully authenticate Alice with Accept-Encoding header "base64,gzip,defalte,br"
+    Then the HTTP response content type is "text/plain"
+    And the HTTP response is base64 encoded
+    And user "alice" has been authorized by Conjur
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
+
+  Scenario: Authenticate response should be encoded if Accept-Encoding includes base64 with mixed case and spaces
+    When I successfully authenticate Alice with Accept-Encoding header "gzip      ,  bASe64 ,defalte,br"
+    Then the HTTP response content type is "text/plain"
+    And the HTTP response is base64 encoded
+    And user "alice" has been authorized by Conjur
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
+
+  Scenario: Authenticate response should be json if Accept-Encoding doesn't include base64
+    When I successfully authenticate Alice with Accept-Encoding header "gzip,defalte,br"
+    Then the HTTP response content type is "application/json"
     And there is an audit record matching:
     """
       <86>1 * * conjur * authn
@@ -51,6 +90,22 @@ Feature: Exchange a role's API key for a signed authentication token
       [action@43868 operation="authenticate" result="failure"]
       cucumber:user:alice failed to authenticate with authenticator authn
     """
+
+  Scenario: Attempting to use an invalid API key to authenticate with Accept-Encoding base64 result in 401 error
+    When I authenticate Alice with Accept-Encoding header "base64" with plain text body "wrong-api-key"
+    Then the HTTP response status code is 401
+    And there is an audit record matching:
+    """
+      <84>1 * * conjur * authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="failure"]
+      cucumber:user:alice failed to authenticate with authenticator authn
+    """
+
+  Scenario: successful encoded requests in limited time
+    When I can authenticate Alice 1000 times in 10 threads with Accept-Encoding header "base64"
+    Then The avg authentication request responds in less than 0.75 seconds
 
   Scenario: User cannot login as a same-named user in a different account
 

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -162,6 +162,12 @@ Then(/^the HTTP response content type is "([^"]*)"$/) do |content_type|
   expect(@content_type).to match(content_type)
 end
 
+Then(/^the HTTP response is base64 encoded$/) do
+  # Override encoded response with decode one to use other helpers
+  @result = @response_body = Base64.strict_decode64(@result)
+  expect(JSON.parse(@result).is_a?(Hash)).to be true
+end
+
 Then(/^the result is true$/) do
   expect(@result).to be true
 end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -99,6 +99,10 @@ module RestHelpers
   def set_result result
     @response_api_key = nil
     @status = result.code
+
+    # Authenticators helpers using http_status
+    @http_status = result.code
+
     @content_type = result.headers[:content_type]
     if /^application\/json/.match?(@content_type)
       @result = JSON.parse(result)

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -54,7 +54,7 @@ module RestHelpers
   # NOTE: The way this works is tricky.  We are relying on a behavior of
   # RestClient, which will automatically add a Basic Auth header to your
   # request, if you've set the user and password fields on its Request object:
-  # 
+  #
   # See: https://github.com/rest-client/rest-client/blob/f450a0f086f1cd1049abbef2a2c66166a1a9ba71/spec/unit/request_spec.rb#L442
   #
   # However, it will only do this IF the request does not already have its
@@ -98,9 +98,6 @@ module RestHelpers
 
   def set_result result
     @response_api_key = nil
-    @status = result.code
-
-    # Authenticators helpers using http_status
     @http_status = result.code
 
     @content_type = result.headers[:content_type]
@@ -145,6 +142,13 @@ module RestHelpers
     UNIXSocket.open socket_file do |sock|
       sock.puts command
       sock.read
+    end
+  end
+
+  def authn_request(url:, api_key:, encoding:, can:)
+    headers["Accept-Encoding"] = encoding
+    try_request can do
+      post_json(url, api_key)
     end
   end
 
@@ -281,7 +285,7 @@ module RestHelpers
   rescue RestClient::Exception
     puts $ERROR_INFO
     @exception = $ERROR_INFO
-    @status = $ERROR_INFO.http_code
+    @http_status = $ERROR_INFO.http_code
     raise if can
     set_result @exception.response  
   end

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -34,6 +34,11 @@ Feature: Azure Authenticator - Performance tests
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
     Then The avg authentication request responds in less than 0.75 seconds
 
+  Scenario: successful requests with Accept-Encoding base64
+    And I fetch a non-assigned-identity Azure access token from inside machine
+    When I authenticate 1000 times in 10 threads via Azure with token as host "test-app" with Accept-Encoding header "base64"
+    Then The avg authentication request responds in less than 0.75 seconds
+
   Scenario: Unsuccessful requests with an invalid token
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"

--- a/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
+++ b/cucumber/authenticators_azure/features/step_definitions/authn_azure_steps.rb
@@ -19,7 +19,7 @@ Given(/I fetch a (non|system|user)-assigned-identity Azure access token from ins
   end
 end
 
-Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |empty |invalid )?token as (user|host) "([^"]*)"/) do |num_requests, num_threads, token_state, role_type, username|
+Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |empty |invalid )?token as (user|host) "([^"]*)"(?: with Accept-Encoding header "([^"]*)")?/) do |num_requests, num_threads, token_state, role_type, username, header|
   username = role_type == "user" ? username : "host/#{username}"
 
   token = case token_state
@@ -41,10 +41,11 @@ Given(/I authenticate (?:(\d+) times? in (\d+) threads? )?via Azure with (no |em
     num_threads,
     authentication_func: :authenticate_azure_token,
     authentication_func_params: {
-      service_id:  AuthnAzureHelper::SERVICE_ID,
-      account:     AuthnAzureHelper::ACCOUNT,
-      username:    username,
-      azure_token: token
+      service_id:             AuthnAzureHelper::SERVICE_ID,
+      account:                AuthnAzureHelper::ACCOUNT,
+      username:               username,
+      azure_token:            token,
+      accept_encoding_header: header
     }
   )
 end

--- a/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
+++ b/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
@@ -35,12 +35,14 @@ module AuthnAzureHelper
     raise "Failed to fetch azure token with reason: #{err}"
   end
 
-  def authenticate_azure_token(service_id:, account:, username:, azure_token:)
+  def authenticate_azure_token(service_id:, account:, username:, azure_token:, accept_encoding_header:)
     username = username.gsub("/", "%2F")
     path = "#{conjur_hostname}/authn-azure/#{service_id}/#{account}/#{username}/authenticate"
 
     payload = {}
     payload["jwt"] = azure_token
+
+    headers["Accept-Encoding"] = accept_encoding_header
 
     post(path, payload)
   end


### PR DESCRIPTION
### What does this PR do?
Added optional parameter to 'authenticate' request which instruct the server to encode with base64 its response

### What ticket does this PR close?
Connected to #151 
Connected to #1050 

#### Test coverage
- A UT should be added 
