### PR TITLE
Re-use authenticator_input for authn-oidc

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -75,22 +75,11 @@ class AuthenticateController < ApplicationController
     handle_authentication_error(e)
   end
 
-  def authenticator_input
-    Authentication::AuthenticatorInput.new(
-      authenticator_name: params[:authenticator],
-      service_id:         params[:service_id],
-      account:            params[:account],
-      username:           params[:id],
-      credentials:        request.body.read,
-      client_ip:          request.ip,
-      request:            request
-    )
-  end
-
   # Update the input to have the username from the token and authenticate
   def authenticate_oidc
+    params[:authenticator] = "authn-oidc"
     input = Authentication::AuthnOidc::UpdateInputWithUsernameFromIdToken.new.(
-      authenticator_input: oidc_authenticator_input
+      authenticator_input: authenticator_input
     )
   rescue => e
     handle_authentication_error(e)
@@ -98,12 +87,12 @@ class AuthenticateController < ApplicationController
     authenticate(input)
   end
 
-  def oidc_authenticator_input
+  def authenticator_input
     Authentication::AuthenticatorInput.new(
-      authenticator_name: 'authn-oidc',
+      authenticator_name: params[:authenticator],
       service_id:         params[:service_id],
       account:            params[:account],
-      username:           nil,
+      username:           params[:id],
       credentials:        request.body.read,
       client_ip:          request.ip,
       request:            request


### PR DESCRIPTION
It is best to have only one `authenticator_input` method so that in case
it needs to be changed (e.g add another input parameter) then we don't need
to do the change twice (or maybe miss it).

The only difference between the two is that the authenticator name is not in `params`
and that the `username` is nil. Both are handled in this PR.
