### PR TITLE
Remove the ActionDispatch::RemoteIp middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `/whoami` API endpoint for improved supportability and debugging for access
   tokens and client IP address determination. [cyberark/conjur#1697](https://github.com/cyberark/conjur/issues/1697)
 
+### Changed
+- The Conjur server request logs now records the same IP address used by audit
+  logs and network authentication filters with the `restricted_to` attribute.
+  [cyberark/conjur#1719](https://github.com/cyberark/conjur/issues/1719)
+
 ### Fixed
 - The `TRUSTED_PROXIES` environment variable now works correctly again after the
   Rails 5 upgrade. This is to indicate trusted proxy IP addresses when using the

--- a/config/initializers/rack_middleware.rb
+++ b/config/initializers/rack_middleware.rb
@@ -27,4 +27,10 @@ Rails.application.configure do
   # attempts are handled correctly. So we add this middleware
   # to the start of the Rack middleware chain.
   config.middleware.insert_before(0, ::Rack::DefaultContentType)
+
+  # Deleting the RemoteIp middleware means that `request.remote_ip` will
+  # always be the same as `request.ip`. This ensure that the Conjur request log
+  # (using `remote_ip`) and the audit log (using `ip`) will have the same value
+  # for each request.
+  config.middleware.delete ActionDispatch::RemoteIp
 end

--- a/spec/request/request_ip_spec.rb
+++ b/spec/request/request_ip_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "request IP address determination", type: :request do
         x_forwarded_for: '3.3.3.3'
       )
     ).to eq('44.0.0.1')
+    expect(request.remote_ip).to eq('44.0.0.1')
   end
 
   # By default "non-routable" IP addresses are trusted (according to this
@@ -70,6 +71,7 @@ RSpec.describe "request IP address determination", type: :request do
         x_forwarded_for: '3.3.3.3'
       )
     ).to eq('3.3.3.3')
+    expect(request.remote_ip).to eq('3.3.3.3')
   end
 
   it "doesn't trust the remote_addr if not included in TRUSTED_PROXIES" do
@@ -80,6 +82,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.4'
       )
     ).to eq('44.0.0.1')
+    expect(request.remote_ip).to eq('44.0.0.1')
   end
 
   it "trusts 127.0.0.1 for XFF even when not included explicitly with TRUSTED_PROXIES" do
@@ -90,6 +93,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.4'
       )
     ).to eq('3.3.3.3')
+    expect(request.remote_ip).to eq('3.3.3.3')
   end
   
   it "trusts IP ranges for XFF using CIDR notation in TRUSTED_PROXIES" do
@@ -100,6 +104,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '5.5.5.0/24'
       )
     ).to eq('3.3.3.3')
+    expect(request.remote_ip).to eq('3.3.3.3')
   end
 
   it "returns the expected IP when multiple XFF values are included" do
@@ -110,6 +115,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '5.5.5.0/24'
       )
     ).to eq('3.3.3.3')
+    expect(request.remote_ip).to eq('3.3.3.3')
   end
 
   it "returns the expected IP when multiple ranges are included in TRUSTED_PROXIES" do
@@ -120,6 +126,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '5.5.5.0/24,4.4.4.0/24'
       )
     ).to eq('3.3.3.3')
+    expect(request.remote_ip).to eq('3.3.3.3')
   end
 
   it "returns the right-most untrusted IP when XFF contains multiple untrusted IPs" do
@@ -130,6 +137,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.0/24'
       )
     ).to eq('7.7.7.7')
+    expect(request.remote_ip).to eq('7.7.7.7')
   end
 
   it "returns the right-most untrusted IP when XFF contains some trusted IPs" do
@@ -140,6 +148,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.0/24,5.5.5.0/24'
       )
     ).to eq('6.6.6.6')
+    expect(request.remote_ip).to eq('6.6.6.6')
   end
 
   it "returns the right-most untrusted IP when XFF contains a trusted IP in the middle" do
@@ -150,6 +159,7 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.0/24,5.5.5.0/24'
       )
     ).to eq('7.7.7.7')
+    expect(request.remote_ip).to eq('7.7.7.7')
   end
 
   it "returns the left-most trusted IP when XFF contains all trusted IPs" do
@@ -160,5 +170,6 @@ RSpec.describe "request IP address determination", type: :request do
         trusted_proxies: '4.4.4.4,5.5.5.5,6.6.6.6'
       )
     ).to eq('5.5.5.5')
+    expect(request.remote_ip).to eq('5.5.5.5')
   end
 end


### PR DESCRIPTION


### What does this PR do?
- _What's changed? Why were these changes made?_

This PR removes `ActionDispatch::RemoteIP` from the Conjur Rack middleware.This middleware 
provides additional logic for selecting the client IP address in Conjur,
and stores the client IP in `request.remote_ip`. This can sometimes be different than
the client IP determined by Rack in `request.ip`.

We use `request.ip` for audit and CIDR restrictions. However, Rails uses `request.remote_ip` in the request log.

In order to make the request log match the audit log and network restrictions, we remove this middleware. This causes `request.remote_ip` to fallback to the value in `request.ip`.

- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #1719 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
