### PR TITLE
Get html cucumber tests results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,12 @@ pipeline {
       archiveArtifacts artifacts: "container_logs/*/*", fingerprint: false, allowEmptyArchive: true
       archiveArtifacts artifacts: "coverage/.resultset*.json", fingerprint: false, allowEmptyArchive: true
       archiveArtifacts artifacts: "ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json", fingerprint: false, allowEmptyArchive: true
+      archiveArtifacts artifacts: "cucumber/*/*.*", fingerprint: false, allowEmptyArchive: true
+      publishHTML([reportDir: 'cucumber', reportFiles: 'api/cucumber_results.html, 	authenticators_config/cucumber_results.html, \
+                               authenticators_azure/cucumber_results.html, authenticators_ldap/cucumber_results.html, \
+                               authenticators_oidc/cucumber_results.html, authenticators_status/cucumber_results.html,\
+                               policy/cucumber_results.html , rotators/cucumber_results.html',\
+                               reportName: 'Integration reports', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
       publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
       junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/*/features/reports/**/*.xml'
       cucumber fileIncludePattern: '**/cucumber_results.json', sortingMethod: 'ALPHABETICAL'

--- a/ci/test
+++ b/ci/test
@@ -383,6 +383,7 @@ _run_cucumber_tests() {
      --strict \
      -p $profile \
      --format json --out cucumber/$profile/cucumber_results.json \
+     --format html --out cucumber/$profile/cucumber_results.html \
      --format junit --out cucumber/$profile/features/reports"
 
   # Simplecov writes its report using an at_exit ruby hook. If the container


### PR DESCRIPTION
### What does this PR do?
- json and html files saved as artifacts for any use.
- All the integration tests that written in cucumber can be seen in one place (Integration reports)
- Example can be found [here](https://jenkins.conjur.net/job/cyberark--conjur/job/get_tests_json_file/28/Integration_20reports/)
<img width="1520" alt="Screen Shot 2020-08-02 at 7 41 00" src="https://user-images.githubusercontent.com/59792097/89115654-913a0080-d493-11ea-984f-9e2135001ca6.png">


### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
