### PR TITLE
Only trust `127.0.0.1` by default for sending the `X-Forwarded-For` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `/whoami` API endpoint for improved supportability and debugging for access
   tokens and client IP address determination. [cyberark/conjur#1697](https://github.com/cyberark/conjur/issues/1697)
+- `TRUSTED_PROXIES` is validated at Conjur startup to ensure that it contains
+  valid IP addresses and/or address ranges in CIDR notation.
+  [cyberark/conjur#1727](https://github.com/cyberark/conjur/issues/1727)
 
 ### Changed
 - The Conjur server request logs now records the same IP address used by audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Conjur server request logs now records the same IP address used by audit
   logs and network authentication filters with the `restricted_to` attribute.
   [cyberark/conjur#1719](https://github.com/cyberark/conjur/issues/1719)
+- Conjur now only trusts `127.0.0.1` to send the `X-Forwarded-For` header by
+  default. Additional trusted IP addresses may be added with the `TRUSTED_PROXIES`
+  environment variable. [cyberark/conjur#1725](https://github.com/cyberark/conjur/issues/1725)
 
 ### Fixed
 - The `TRUSTED_PROXIES` environment variable now works correctly again after the

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -20,6 +20,11 @@ module Errors
       code: "CONJ00046E"
     )
 
+    InvalidTrustedProxies = ::Util::TrackableErrorClass.new(
+      msg:  "Invalid IP address or CIDR address range in TRUSTED_PROXIES: {0-cidr}",
+      code: "CONJ00065E"
+    )
+
   end
 
   module Authentication

--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  # Save the original ip_filter to use as a fallback if TRUSTED_PROXIES
-  # is not set.
-  default_ip_filter = Rack::Request.ip_filter
-
   # Only disable the trusted proxies cache if the config attribute exists and is
   # truthy.
   disable_cache = config.respond_to?(:conjur_disable_trusted_proxies_cache) &&
     config.conjur_disable_trusted_proxies_cache
 
   Rack::Request.ip_filter = Conjur::TrustedProxyFilter.new(
-    default_ip_filter,
     options: {
       disable_cache: disable_cache
     }

--- a/spec/conjur/trusted_proxy_filter_spec.rb
+++ b/spec/conjur/trusted_proxy_filter_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Conjur::TrustedProxyFilter do
+  it "raises an exception when created with invalid IP addresses" do
+    env = { 'TRUSTED_PROXIES' => 'invalid-ip' }
+
+    expect {
+      Conjur::TrustedProxyFilter.new(env: env)
+    }.to raise_error(Errors::Conjur::InvalidTrustedProxies)
+  end
+
+  it "does not raise an exception when created with valid IP addresses" do
+    env = { 'TRUSTED_PROXIES' => '127.0.0.1' }
+
+    expect {
+      Conjur::TrustedProxyFilter.new(env: env)
+    }.not_to raise_error
+  end
+end

--- a/spec/request/request_ip_spec.rb
+++ b/spec/request/request_ip_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "request IP address determination", type: :request do
   end
 
   def request_ip(remote_addr:, x_forwarded_for: nil, trusted_proxies: nil)
-    ENV['TRUSTED_PROXIES'] = trusted_proxies if trusted_proxies
-  
+    ENV['TRUSTED_PROXIES'] = trusted_proxies
+
     headers = {}
     headers['X-Forwarded-For'] = x_forwarded_for if x_forwarded_for
   

--- a/spec/request/request_ip_spec.rb
+++ b/spec/request/request_ip_spec.rb
@@ -60,9 +60,6 @@ RSpec.describe "request IP address determination", type: :request do
     expect(request.remote_ip).to eq('44.0.0.1')
   end
 
-  # By default "non-routable" IP addresses are trusted (according to this
-  # regular expression: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L19)
-  #
   # `127.0.0.1` is important as the address of the nginx proxy when used in DAP
   it 'trusts the loopback address by default to provide XFF' do
     expect(
@@ -72,6 +69,16 @@ RSpec.describe "request IP address determination", type: :request do
       )
     ).to eq('3.3.3.3')
     expect(request.remote_ip).to eq('3.3.3.3')
+  end
+
+  it 'does not trust other non-routable addresses by default to provide XFF' do
+    expect(
+      request_ip(
+        remote_addr: '192.168.1.1',
+        x_forwarded_for: '3.3.3.3'
+      )
+    ).to eq('192.168.1.1')
+    expect(request.remote_ip).to eq('192.168.1.1')
   end
 
   it "doesn't trust the remote_addr if not included in TRUSTED_PROXIES" do


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

Previously, if `TRUSTED_PROXIES` was not configured, Conjur would fallback to
the default Rack behavior for which IP addresses to trust to send the
`X-Forwarded-For` HTTP header. This used a regular expression to determine
whether an IP address was routable or not. Any IP address considered non-routable
according to this regex was trusted.

This commit modifies this behavior to only trust `127.0.0.1` by default, effectively
locking down the `X-Forwarded-For` header, unless explicitly trusted with the
`TRUSTED_PROXIES` environment variable.

### What ticket does this PR close?
Connected to #1725, #1727 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
