### PR TITLE
[DO NOT MERGE] Include ipv6 loopback address (`::1`) in `TRUSTED_PROXIES`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Conjur server request logs now records the same IP address used by audit
   logs and network authentication filters with the `restricted_to` attribute.
   [cyberark/conjur#1719](https://github.com/cyberark/conjur/issues/1719)
-- Conjur now only trusts `127.0.0.1` to send the `X-Forwarded-For` header by
-  default. Additional trusted IP addresses may be added with the `TRUSTED_PROXIES`
+- Conjur now only trusts `127.0.0.1` and `::1` to send the `X-Forwarded-For` header
+  by default. Additional trusted IP addresses may be added with the `TRUSTED_PROXIES`
   environment variable. [cyberark/conjur#1725](https://github.com/cyberark/conjur/issues/1725)
 
 ### Fixed

--- a/lib/conjur/trusted_proxy_filter.rb
+++ b/lib/conjur/trusted_proxy_filter.rb
@@ -10,6 +10,11 @@ module Conjur
   #
   # Example: TRUSTED_PROXIES=4.4.4.4,192.168.100.0/24
   class TrustedProxyFilter
+    DEFAULT_TRUSTED_IPS = [
+      IPAddr.new('127.0.0.1'),
+      IPAddr.new('::1')
+    ]
+
     def initialize(env: ENV, options: { disable_cache: true })
       @env = env
       @options = options
@@ -34,7 +39,7 @@ module Conjur
 
       # The trusted proxy IPs are `127.0.0.1` plus those defined in the
       # `TRUSTED_PROXIES` environment variable.
-      proxy_ips = [IPAddr.new('127.0.0.1')] + env_trusted_proxies
+      proxy_ips = DEFAULT_TRUSTED_IPS + env_trusted_proxies
       
       # If not disabled, cache the IP address list
       @cached_trusted_proxies = proxy_ips unless @options[:disable_cache]


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR includes the ipv6 loopback address (`::1`) in the list of default trusted IP address in Conjur for the `X-Forwarded-For` header.

- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #1728 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
