### PR TITLE
Obtain GCP Identity Token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,8 @@ group :development, :test do
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'
   gem 'table_print'
+  gem 'ed25519'
+  gem 'bcrypt_pbkdf'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     base32-crockford (0.1.0)
     base58 (0.2.3)
     bcrypt (3.1.13)
+    bcrypt_pbkdf (1.0.1)
     bindata (2.4.7)
     builder (3.2.4)
     byebug (11.1.1)
@@ -179,6 +180,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.4, >= 0.4.2)
       inflecto (~> 0.0.0, >= 0.0.2)
+    ed25519 (1.2.4)
     erubi (1.9.0)
     event_emitter (0.2.6)
     excon (0.73.0)
@@ -452,6 +454,7 @@ DEPENDENCIES
   base32-crockford
   base58
   bcrypt (~> 3.1.2)
+  bcrypt_pbkdf
   ci_reporter_rspec
   command_class
   conjur-api!
@@ -466,6 +469,7 @@ DEPENDENCIES
   debase
   dry-struct (~> 0.4.0)
   dry-types (~> 0.12.2)
+  ed25519
   ffi (>= 1.9.24)
   gli
   haikunator (~> 1)

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -83,6 +83,7 @@ authenticators_gcp: >
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
+  -r cucumber/api/features/support/ssh_helpers.rb
   -r cucumber/api/features/step_definitions/request_steps.rb
   -r cucumber/api/features/step_definitions/user_steps.rb
   -r cucumber/api/features/support/logs_helpers.rb

--- a/cucumber/api/features/support/ssh_helpers.rb
+++ b/cucumber/api/features/support/ssh_helpers.rb
@@ -11,6 +11,14 @@ module SshHelpers
       ssh.close
     end
   end
+
+  def run_command_in_machine_with_private_key(machine_ip:, machine_username:, private_key_path:, command:)
+    ssh = Net::SSH.start(machine_ip, machine_username, :keys => [private_key_path])
+    ssh.exec!(command).tap do
+      ssh.close
+    end
+  end
+
 end
 
 World(SshHelpers)

--- a/cucumber/authenticators_gcp/features/authn_gcp.feature
+++ b/cucumber/authenticators_gcp/features/authn_gcp.feature
@@ -1,0 +1,44 @@
+Feature: GCP Authenticator - Hosts can authenticate with GCP authenticator
+
+  In this feature we define a Google Cloud Platform authenticator in policy and perform authentication
+  with Conjur.
+  In successful scenarios we will also define a variable and permit the host to
+  execute it, to verify not only that the host can authenticate with the GCP
+  Authenticator, but that it can retrieve a secret using the Conjur access token.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-gcp
+      body:
+      - !webservice
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I grant group "conjur/authn-gcp/apps" to host "test-app"
+
+  Scenario: Hosts can authenticate with GCP authenticator and fetch secret
+    Given I have a "variable" resource called "test-variable"
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I permit host "test-app" to "execute" it
+    And I set authn-gcp/service-account-id annotation to host "test-app"
+    And I set authn-gcp/service-account-email annotation to host "test-app"
+    And I set authn-gcp/project-id annotation to host "test-app"
+    And I set authn-gcp/instance-name annotation to host "test-app"
+    And I obtain a GCE identity token in "full" format with audience claim value: "conjur/cucumber/host/test-app"
+    And I save my place in the audit log file
+    When I authenticate with authn-gcp using GCP identity token
+    Then host "test-app" has been authorized by Conjur
+    And I can GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
+    """

--- a/cucumber/authenticators_gcp/features/step_definitions/authn_gcp_steps.rb
+++ b/cucumber/authenticators_gcp/features/step_definitions/authn_gcp_steps.rb
@@ -1,0 +1,32 @@
+Given(/^I set authn-gcp\/(service-account-id|service-account-email|project-id|instance-name) annotation (with incorrect value )?to host "([^"]*)"$/) do |annotation_name, incorrect_value, hostname|
+  i_have_a_resource "host", hostname
+
+  case annotation_name
+  when "service-account-id"
+    annotation_value = gcp_service_account_id
+  when "service-account-email"
+    annotation_value = gcp_service_account_email
+  when "project-id"
+    annotation_value = gcp_project_id
+  when "instance-name"
+    annotation_value = gce_instance_name
+  else
+    raise "Incorrect annotation name: '#{annotation_name}', expected: service-account-id|service-account-email|project-id|instance-name"
+  end
+
+  set_annotation_to_resource("#{annotation_name}", annotation_value)
+end
+
+Given(/^I obtain a GCE identity token in "([^"]*)" format with audience claim value: "([^"]*)"$/) do | audience, format |
+  gce_identity_access_token(
+    audience: audience,
+    token_format: format
+  )
+end
+
+Given(/I authenticate with authn-gcp using GCP identity token/) do
+  authenticate_gcp_token(
+    account:     'cucumber',
+    gcp_token:   @gce_identity_token
+  )
+end

--- a/cucumber/authenticators_gcp/features/support/authn_gcp_helper.rb
+++ b/cucumber/authenticators_gcp/features/support/authn_gcp_helper.rb
@@ -1,0 +1,77 @@
+module AuthnGcpHelper
+  include AuthenticatorHelpers
+
+  # @todo Remove the env variables we the the vars will be injected
+  # The ENV variables that are expected (temporary this will be injected)
+  #
+  # export GCE_INSTANCE_IP='104.198.201.199'
+  # export GCE_INSTANCE_NAME='gcp-authn'
+  # export GCE_INSTANCE_USERNAME='gcp-authn'
+  # export GCE_PRIVATE_KEY_PATH=./.gcp-authn
+  # export GCP_SERVICE_ACCOUNT_ID='108551114425891493254'
+  # export GCP_SERVICE_ACCOUNT_EMAIL='120811889825-compute@developer.gserviceaccount.com'
+  # export GCP_PROJECT_ID='refreshing-mark-284016'
+
+  # Obtains a GCE identity token by running a curl command inside a GCE instance using ssh.
+  # The above ENV variables are assumed to be set.
+  # token_format; default="standard"
+  # Specify whether or not the project and instance details are included in the identity token payload.
+  # This flag only applies to Google Compute Engine instance identity tokens.
+  # See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#token_format
+  # for more details on token format. TOKEN_FORMAT must be one of: standard, full.
+  def gce_identity_access_token(audience:, token_format: 'standard')
+    audience = audience.gsub("/", "%2F")
+
+    @gce_identity_token = run_command_in_machine_with_private_key(
+      machine_ip:        gce_instance_ip,
+      machine_username:  gce_instance_user,
+      private_key_path:  private_key_path,
+      command:           identity_token_curl_cmd(audience, token_format))
+  end
+
+  def gce_instance_ip
+    @gce_machine_ip ||= validated_env_var('GCE_INSTANCE_IP')
+  end
+
+  def gce_instance_name
+    @gce_machine_name ||= validated_env_var('GCE_INSTANCE_NAME')
+  end
+
+  def gce_instance_user
+    @gce_instance_user ||= validated_env_var('GCE_INSTANCE_USERNAME')
+  end
+
+  def private_key_path
+    @private_key_path ||= validated_env_var('GCE_PRIVATE_KEY_PATH')
+  end
+
+  def gcp_service_account_email
+    @gcp_service_account_email ||= validated_env_var('GCP_SERVICE_ACCOUNT_EMAIL')
+  end
+
+  def gcp_project_id
+    @gcp_project_id ||= validated_env_var('GCP_PROJECT_ID')
+  end
+
+  def gcp_service_account_id
+    @gcp_service_account_id ||= validated_env_var('GCP_SERVICE_ACCOUNT_ID')
+  end
+
+  def identity_token_curl_cmd(audience, token_format)
+    header = 'Metadata-Flavor: Google'
+    url = 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity'
+    query_string = "audience=#{audience}&format=#{token_format}"
+    "curl -s -H '#{header}' '#{url}?#{query_string}'"
+  end
+
+  def authenticate_gcp_token(account:, gcp_token:)
+    path_uri = "#{conjur_hostname}/authn-gcp/#{account}/authenticate"
+
+    payload = {}
+    payload["jwt"] = gcp_token
+
+    post(path_uri, payload)
+  end
+end
+
+World(AuthnGcpHelper)


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
GCP Authenticator cucumber tests skeleton has been added.
A new step that obtains a GCE identity token using ssh and curl has been added.
- _How should the reviewer approach this PR, especially if manual tests are required?_
In order to run the test locally the following ENV params need to be set:
```
export GCE_INSTANCE_IP='104.198.201.199'
export GCE_INSTANCE_USERNAME='gcp-authn'
export GCE_PRIVATE_KEY_PATH=<path to the private key file>
export GCP_SERVICE_ACCOUNT_ID='108551114425891493254'
```
Make sure the machine is up and running.
Run in `dev` folder:
1. `./start`
2. Type `exit`
3. Run `./cli exec`
4. Run `cucumber -p authenticators_gcp cucumber/authenticators_gcp/features/authn_gcp_basic_host.feature`
The test will run to the point that it attempts to authenticate with `gcp-authn`, there it will fail.

### What ticket does this PR close?
Connected to #[relevant GitHub issues, #1743 ]


