### PR TITLE
GCP authenticator - Conjur integration tests #1737

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -63,6 +63,12 @@ cucumber_authenticators_azure() {
   _run_cucumber_tests authenticators_azure "" "$(_get_azure_env_args)"
 }
 
+cucumber_authenticators_gce() {
+  : DOC - Runs Cucumber GCE Authenticator features
+
+  _run_cucumber_tests authenticators_gce "" "$(_get_gce_env_args)"
+}
+
 cucumber_authenticators_oidc() {
   : DOC - Runs Cucumber OIDC Authenticator features
 
@@ -250,6 +256,18 @@ _get_azure_env_args() {
   azure_env_args="$azure_env_args -e USER_ASSIGNED_IDENTITY_CLIENT_ID=$USER_ASSIGNED_IDENTITY_CLIENT_ID"
   azure_env_args="$azure_env_args -e SYSTEM_ASSIGNED_IDENTITY=$SYSTEM_ASSIGNED_IDENTITY"
   echo "${azure_env_args}"
+}
+
+_get_gce_env_args() {
+  local gce_env_args="-e GCE_INSTANCE_IP=$GCE_INSTANCE_IP"
+  gce_env_args="$gce_env_args -e GCE_INSTANCE_NAME=$GCE_INSTANCE_NAME"
+  gce_env_args="$gce_env_args -e GCE_INSTANCE_USERNAME=$GCE_INSTANCE_USERNAME"
+  gce_env_args="$gce_env_args -e GCE_PRIVATE_KEY_PATH=$GCE_PRIVATE_KEY_PATH"
+  gce_env_args="$gce_env_args -e GCE_SERVICE_ACCOUNT_ID=$GCE_SERVICE_ACCOUNT_ID"
+  gce_env_args="$gce_env_args -e GCE_SERVICE_ACCOUNT_EMAIL=$GCE_SERVICE_ACCOUNT_EMAIL"
+  gce_env_args="$gce_env_args -e GCE_PROJECT_ID=$GCE_PROJECT_ID"
+
+  echo "${gce_env_args}"
 }
 
 _wait_for_keycloak() {

--- a/cucumber/api/features/support/ssh_helpers.rb
+++ b/cucumber/api/features/support/ssh_helpers.rb
@@ -13,7 +13,27 @@ module SshHelpers
   end
 
   def run_command_in_machine_with_private_key(machine_ip:, machine_username:, private_key_path:, command:)
-    ssh = Net::SSH.start(machine_ip, machine_username, :keys => [private_key_path])
+    # The SSH command triggered a warning:
+    # "bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)\ntotal 0\n"
+    # which was included as a prefix of the command output.
+    #
+    # This can be prevented by altering the ssh configuration on the client
+    # (the global file is typically `/etc/ssh/ssh_config`):
+    # comment out / remove the following line:
+    #  SendEnv LANG LC_*
+    #
+    # Alternatively the configuration of the server can be changed, by editing `/etc/ssh/sshd_config` on the remote
+    # machine (note the d in sshd_config):
+    # comment out / remove the following line:
+    #  AcceptEnv LANG LC_*
+    #
+    # Using the Net::SSH.start options
+    # --------------------------------
+    # from: https://www.rubydoc.info/github/net-ssh/net-ssh/Net/SSH
+    # :config => set to true to load the default OpenSSH config files (~/.ssh/config, /etc/ssh_config),
+    # or to false to not load them, or to a file-name (or array of file-names) to load those specific configuration
+    # files. Defaults to true.
+    ssh = Net::SSH.start(machine_ip, machine_username, :keys => [private_key_path], :config => false)
     ssh.exec!(command).tap do
       ssh.close
     end

--- a/cucumber/authenticators_gce/features/authn_gce.feature
+++ b/cucumber/authenticators_gce/features/authn_gce.feature
@@ -1,6 +1,6 @@
 Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
 
-  In this feature we define a Google Cloud Platform authenticator in policy and perform authentication
+  In this feature we define a GCE authenticator in policy and perform authentication
   with Conjur.
   In successful scenarios we will also define a variable and permit the host to
   execute it, to verify not only that the host can authenticate with the GCE
@@ -33,12 +33,41 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     And I set "authn-gce/service-account-email" annotation to host "test-app"
     And I set "authn-gce/project-id" annotation to host "test-app"
     And I set "authn-gce/instance-name" annotation to host "test-app"
-    And I obtain a GCE identity token in "full" format with audience claim value: "conjur/cucumber/host/test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the audit log file
-    When I authenticate with authn-gce using Google identity token
+    When I authenticate with authn-gce using token and account "cucumber"
     Then host "test-app" has been authorized by Conjur
     And I can GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the audit log after my savepoint:
     """
     cucumber:host:test-app successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
+    """
+
+  Scenario: Missing GCE access token is a bad request
+    Given I save my place in the log file
+    When I authenticate with authn-gce using no token and account "cucumber"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+
+
+  Scenario: Empty GCE access token is a bad request
+    Given I save my place in the log file
+    When I authenticate with authn-gce using an empty token and account "cucumber"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+
+  Scenario: Non-existing account in request is denied
+    Given I obtain a GCE identity token in full format with audience claim value: "conjur/non-existing/host/test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using token and account "non-existing"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::AccountNotDefined
     """

--- a/cucumber/authenticators_gce/features/authn_gce.feature
+++ b/cucumber/authenticators_gce/features/authn_gce.feature
@@ -31,7 +31,7 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     And I permit host "test-app" to "execute" it
     And I set all valid GCE annotations to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
-    And I save my place in the audit log file
+    And I save my place in the log file
     When I authenticate with authn-gce using token and existing account
     Then host "test-app" has been authorized by Conjur
     And I can GET "/secrets/cucumber/variable/test-variable" with authorized user

--- a/cucumber/authenticators_gce/features/authn_gce.feature
+++ b/cucumber/authenticators_gce/features/authn_gce.feature
@@ -29,13 +29,10 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     Given I have a "variable" resource called "test-variable"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I permit host "test-app" to "execute" it
-    And I set "authn-gce/service-account-id" annotation to host "test-app"
-    And I set "authn-gce/service-account-email" annotation to host "test-app"
-    And I set "authn-gce/project-id" annotation to host "test-app"
-    And I set "authn-gce/instance-name" annotation to host "test-app"
+    And I set all valid GCE annotations to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the audit log file
-    When I authenticate with authn-gce using token and account "cucumber"
+    When I authenticate with authn-gce using token and existing account
     Then host "test-app" has been authorized by Conjur
     And I can GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the audit log after my savepoint:
@@ -45,7 +42,7 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
 
   Scenario: Missing GCE access token is a bad request
     Given I save my place in the log file
-    When I authenticate with authn-gce using no token and account "cucumber"
+    When I authenticate with authn-gce using no token and existing account
     Then it is a bad request
     And The following appears in the log after my savepoint:
     """
@@ -55,7 +52,7 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
 
   Scenario: Empty GCE access token is a bad request
     Given I save my place in the log file
-    When I authenticate with authn-gce using an empty token and account "cucumber"
+    When I authenticate with authn-gce using empty token and existing account
     Then it is a bad request
     And The following appears in the log after my savepoint:
     """
@@ -65,7 +62,7 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
   Scenario: Non-existing account in request is denied
     Given I obtain a GCE identity token in full format with audience claim value: "conjur/non-existing/host/test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and account "non-existing"
+    When I authenticate with authn-gce using token and non existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """

--- a/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
@@ -1,4 +1,4 @@
-Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
+Feature: GCE Authenticator - Test Malformed Configuration
 
   In this feature we define a GCE authenticator with a malformed configuration.
   Each test will verify a failure of the authentication request in such a case
@@ -16,11 +16,11 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     """
     And I am the super-user
     And I have host "test-app"
-    And I set GCE annotations to host "test-app"
+    And I set all valid GCE annotations to host "test-app"
     And I grant group "conjur/authn-gce/apps" to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the audit log file
-    When I authenticate with authn-gce using token and account "cucumber"
+    When I authenticate with authn-gce using token and existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
@@ -44,11 +44,11 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     """
     And I am the super-user
     And I have host "test-app"
-    And I set GCE annotations to host "test-app"
+    And I set all valid GCE annotations to host "test-app"
     And I grant group "conjur/authn-gce/apps" to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the audit log file
-    When I authenticate with authn-gce using token and account "cucumber"
+    When I authenticate with authn-gce using token and existing account
     Then it is forbidden
     And The following appears in the log after my savepoint:
     """

--- a/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
@@ -19,7 +19,7 @@ Feature: GCE Authenticator - Test Malformed Configuration
     And I set all valid GCE annotations to host "test-app"
     And I grant group "conjur/authn-gce/apps" to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
-    And I save my place in the audit log file
+    And I save my place in the log file
     When I authenticate with authn-gce using token and existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
@@ -47,7 +47,7 @@ Feature: GCE Authenticator - Test Malformed Configuration
     And I set all valid GCE annotations to host "test-app"
     And I grant group "conjur/authn-gce/apps" to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
-    And I save my place in the audit log file
+    And I save my place in the log file
     When I authenticate with authn-gce using token and existing account
     Then it is forbidden
     And The following appears in the log after my savepoint:

--- a/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
@@ -1,0 +1,57 @@
+Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
+
+  In this feature we define a GCE authenticator with a malformed configuration.
+  Each test will verify a failure of the authentication request in such a case
+  and log the relevant error for the user to re-configure the authenticator
+  properly.
+
+  Scenario: Webservice missing in policy is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-gce
+      body:
+
+      - !group apps
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set GCE annotations to host "test-app"
+    And I grant group "conjur/authn-gce/apps" to host "test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    And I save my place in the audit log file
+    When I authenticate with authn-gce using token and account "cucumber"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::WebserviceNotFound
+    """
+
+  Scenario: Webservice with read and no authenticate permission in policy is denied
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-gce
+      body:
+      - !webservice
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read ]
+        resource: !webservice
+    """
+    And I am the super-user
+    And I have host "test-app"
+    And I set GCE annotations to host "test-app"
+    And I grant group "conjur/authn-gce/apps" to host "test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    And I save my place in the audit log file
+    When I authenticate with authn-gce using token and account "cucumber"
+    Then it is forbidden
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotAuthorizedOnResource
+    """
+

--- a/cucumber/authenticators_gce/features/authn_gce_hosts.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_hosts.feature
@@ -1,6 +1,6 @@
-Feature: Azure Authenticator - Different Hosts can authenticate with Azure authenticator
+Feature: GCP Authenticator - Test hosts can authentication scenarios
 
-  In this feature we define GCE authenticator in policy, and test with different
+  In this feature we define GCE authenticator in policy, test with different
   host configurations and perform authentication with Conjur.
 
   Background:
@@ -18,12 +18,11 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
         privilege: [ read, authenticate ]
         resource: !webservice
     """
-    And I am the super-user
 
   Scenario: Non-existing host is denied
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and account "cucumber"
+    When I authenticate with authn-gce using token and existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """

--- a/cucumber/authenticators_gce/features/authn_gce_hosts.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_hosts.feature
@@ -1,0 +1,32 @@
+Feature: Azure Authenticator - Different Hosts can authenticate with Azure authenticator
+
+  In this feature we define GCE authenticator in policy, and test with different
+  host configurations and perform authentication with Conjur.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-gce
+      body:
+      - !webservice
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I am the super-user
+
+  Scenario: Non-existing host is denied
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using token and account "cucumber"
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotFound
+    """
+

--- a/cucumber/authenticators_gce/features/step_definitions/authn_gce_steps.rb
+++ b/cucumber/authenticators_gce/features/step_definitions/authn_gce_steps.rb
@@ -1,3 +1,4 @@
+# Enable selective setting of GCE annotations
 Given(/^I set "authn-gce\/(service-account-id|service-account-email|project-id|instance-name)" annotation (with incorrect value )?to host "([^"]*)"$/) do |annotation_name, incorrect_value, hostname|
   i_have_a_resource "host", hostname
 
@@ -14,19 +15,42 @@ Given(/^I set "authn-gce\/(service-account-id|service-account-email|project-id|i
     raise "Incorrect annotation name: '#{annotation_name}', expected: service-account-id|service-account-email|project-id|instance-name"
   end
 
-  set_annotation_to_resource("#{annotation_name}", annotation_value)
+  set_annotation_to_resource("authn-gce/#{annotation_name}", annotation_value)
 end
 
-Given(/^I obtain a GCE identity token in "([^"]*)" format with audience claim value: "([^"]*)"$/) do | audience, format |
+# Sets all GCE annotations
+Given(/^I set GCE annotations to host "([^"]*)"$/) do | hostname |
+  i_have_a_resource "host", hostname
+
+  set_annotation_to_resource("authn-gce/service-account-id", gce_service_account_id)
+  set_annotation_to_resource("authn-gce/service-account-email", gce_service_account_email)
+  set_annotation_to_resource("authn-gce/project-id", gce_project_id)
+  set_annotation_to_resource("authn-gce/instance-name", gce_instance_name)
+end
+
+# Runs a curl command in a remote machine
+Given(/^I obtain a GCE identity token in (full|standard) format with audience claim value: "([^"]*)"$/) do | format, audience |
   gce_identity_access_token(
     audience: audience,
     token_format: format
   )
 end
 
-Given(/I authenticate with authn-gce using Google identity token/) do
+# Authenticates with Conjur GCE authenticator
+Given(/I authenticate with authn-gce using (no |an empty |invalid )?token and account "([^"]*)"$/) do | token_state, account |
+  token = case token_state
+          when "no "
+            nil
+          when "empty "
+            ""
+          when "invalid "
+            invalid_token
+          else
+            @gce_identity_token
+          end
+
   authenticate_gce_token(
-    account:     'cucumber',
-    gce_token:   @gce_identity_token
+    account:     account,
+    gce_token:   token
   )
 end

--- a/cucumber/authenticators_gce/features/step_definitions/authn_gce_steps.rb
+++ b/cucumber/authenticators_gce/features/step_definitions/authn_gce_steps.rb
@@ -19,7 +19,7 @@ Given(/^I set "authn-gce\/(service-account-id|service-account-email|project-id|i
 end
 
 # Sets all GCE annotations
-Given(/^I set GCE annotations to host "([^"]*)"$/) do | hostname |
+Given(/^I set all valid GCE annotations to host "([^"]*)"$/) do | hostname |
   i_have_a_resource "host", hostname
 
   set_annotation_to_resource("authn-gce/service-account-id", gce_service_account_id)
@@ -37,7 +37,9 @@ Given(/^I obtain a GCE identity token in (full|standard) format with audience cl
 end
 
 # Authenticates with Conjur GCE authenticator
-Given(/I authenticate with authn-gce using (no |an empty |invalid )?token and account "([^"]*)"$/) do | token_state, account |
+Given(/I authenticate with authn-gce using (no |empty |invalid )?token and (non )?existing account/) do | token_state, non_existing_account |
+  account = non_existing_account ? 'non-existing' : 'cucumber'
+
   token = case token_state
           when "no "
             nil

--- a/cucumber/authenticators_gce/features/support/authn_gce_helper.rb
+++ b/cucumber/authenticators_gce/features/support/authn_gce_helper.rb
@@ -8,7 +8,7 @@ module AuthnGceHelper
   # export GCE_INSTANCE_NAME='gcp-authn'
   # export GCE_INSTANCE_USERNAME='gcp-authn'
   # export GCE_PRIVATE_KEY_PATH=./.gcp-authn
-  # export GCE_SERVICE_ACCOUNT_ID='108551114425891493254'
+  # export GCE_SERVICE_ACCOUNT_ID='115072799640778267780'
   # export GCE_SERVICE_ACCOUNT_EMAIL='120811889825-compute@developer.gserviceaccount.com'
   # export GCE_PROJECT_ID='refreshing-mark-284016'
 

--- a/cucumber/authenticators_gce/features/support/authn_gce_helper.rb
+++ b/cucumber/authenticators_gce/features/support/authn_gce_helper.rb
@@ -22,6 +22,10 @@ module AuthnGceHelper
   def gce_identity_access_token(audience:, token_format: 'standard')
     audience = audience.gsub("/", "%2F")
 
+    unless File.exist?(private_key_path)
+      raise "GCE private key credentials file '#{private_key_path}' not found."
+    end
+
     @gce_identity_token = run_command_in_machine_with_private_key(
       machine_ip:        gce_instance_ip,
       machine_username:  gce_instance_user,

--- a/dev/cli
+++ b/dev/cli
@@ -35,6 +35,19 @@ EOF
 exit
 }
 
+function enable_gce() {
+  echo "Setting GCE details as env variables"
+  local gce_env_args="-e GCE_INSTANCE_IP=$GCE_INSTANCE_IP"
+  gce_env_args="$gce_env_args -e GCE_INSTANCE_NAME=$GCE_INSTANCE_NAME"
+  gce_env_args="$gce_env_args -e GCE_INSTANCE_USERNAME=$GCE_INSTANCE_USERNAME"
+  gce_env_args="$gce_env_args -e GCE_PRIVATE_KEY_PATH=$GCE_PRIVATE_KEY_PATH"
+  gce_env_args="$gce_env_args -e GCE_SERVICE_ACCOUNT_ID=$GCE_SERVICE_ACCOUNT_ID"
+  gce_env_args="$gce_env_args -e GCE_SERVICE_ACCOUNT_EMAIL=$GCE_SERVICE_ACCOUNT_EMAIL"
+  gce_env_args="$gce_env_args -e GCE_PROJECT_ID=$GCE_PROJECT_ID"
+
+  env_args="$env_args $gce_env_args"
+}
+
 function enable_oidc() {
   echo "Extracting keycloak variables & setting as env variables"
 
@@ -80,6 +93,7 @@ while true ; do
         -h | --help ) print_exec_help ; shift ;;
         --authn-oidc ) enable_oidc ; shift ;;
         --authn-azure ) enable_azure ; shift ;;
+        --authn-gce ) enable_gce ; shift ;;
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 


### PR DESCRIPTION

Implementation of authn-gce integration tests of **input** validation and **configuration** tests.
Add `--authn-gce` flag support to the following scripts:

- ci/test
- dev/cli

The addition to the scripts sets the GCE authenticator test environment variables.

Connected to #[relevant GitHub issues](https://app.zenhub.com/workspaces/palmtree-5d99d900491c060001c85cba/issues/cyberark/conjur/1737)
