### PR TITLE
Add test for invalid CIDR string in policy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Conjur now only trusts `127.0.0.1` to send the `X-Forwarded-For` header by
   default. Additional trusted IP addresses may be added with the `TRUSTED_PROXIES`
   environment variable. [cyberark/conjur#1725](https://github.com/cyberark/conjur/issues/1725)
+- Invalid CIDR notation in `restricted_to` now returns a policy validation
+  error, rather than an internal server error.
+  [cyberark/conjur#1763](https://github.com/cyberark/conjur/issues/1763)
 
 ### Fixed
 - The `TRUSTED_PROXIES` environment variable now works correctly again after the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/conjur-policy-parser.git
-  revision: 2f958c88e59671e72368bf5dbe2845cc56c77c3b
+  revision: 5da02adc64a13292c5158896d2a5903bbe0bba2d
   branch: master
   specs:
     conjur-policy-parser (3.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/cyberark/conjur-policy-parser.git
-  revision: 5da02adc64a13292c5158896d2a5903bbe0bba2d
+  revision: 7a8ad23ef2278fb2083994c0fd92fc2973560bac
   branch: master
   specs:
     conjur-policy-parser (3.0.4)

--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -6,7 +6,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
   properly
 
   Scenario: provider-uri variable missing in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -36,7 +36,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
   # TODO: add this test when issue #1085 is done
   @skip
   Scenario: provider-uri variable without value is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -67,7 +67,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: webservice missing in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -93,7 +93,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: Webservice with read and no authenticate permission in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -125,7 +125,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: Bad Gateway is raised in case of an invalid ID Provider hostname
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -7,7 +7,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
   Authenticator, but that it can retrieve a secret using the Conjur access token.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -4,7 +4,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
   hosts and perform authentication with Conjur.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -6,7 +6,7 @@ Feature: Azure Authenticator - Performance tests
   We test both successful requests and unsuccessful requests.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod

--- a/cucumber/authenticators_azure/features/authn_status_azure.feature
+++ b/cucumber/authenticators_azure/features/authn_status_azure.feature
@@ -1,7 +1,7 @@
 Feature: Azure Authenticator - Status Check
 
   Scenario: A properly configured Azure authenticator returns a successful response
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -52,7 +52,7 @@ Feature: Azure Authenticator - Status Check
     And the authenticator status check succeeds
 
   Scenario: A non-responsive Azure AD provider returns a 500 response
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-azure/prod
@@ -102,7 +102,7 @@ Feature: Azure Authenticator - Status Check
     And the authenticator status check fails with error "ProviderDiscoveryFailed: CONJ00011E"
 
   Scenario: provider-uri variable is missing and a 500 error response is returned
-    Given a policy:
+    Given I load a policy:
      """
     - !policy
       id: conjur/authn-azure/prod

--- a/cucumber/authenticators_config/features/authn_config.feature
+++ b/cucumber/authenticators_config/features/authn_config.feature
@@ -3,7 +3,7 @@ Feature: Authenticator configuration
   Background:
     Given I have user "authn-viewer"
     And I have user "authn-updater"
-    And a policy:
+    And I load a policy:
     """
     # authn-config/env is enabled in CONJUR_AUTHENTICATORS and used in tests to
     # ensure that the env value continues to be used even when DB config exists.

--- a/cucumber/authenticators_config/features/available_authn.feature
+++ b/cucumber/authenticators_config/features/available_authn.feature
@@ -2,7 +2,7 @@ Feature: The list of available authentication providers is discoverable
   through the API.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !user alice
     - !user bob

--- a/cucumber/authenticators_ldap/features/authn_ldap.feature
+++ b/cucumber/authenticators_ldap/features/authn_ldap.feature
@@ -1,7 +1,7 @@
 Feature: Users can login with LDAP credentials from an authorized LDAP server
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !user alice
     - !user bob
@@ -96,7 +96,7 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
 
     #TODO Add an "is denied" for alice added to conjur but not entitled
   Scenario: An LDAP user in Conjur but without authorization can't login
-    Given a policy:
+    Given I load a policy:
     """
     - !user alice
 

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -6,7 +6,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
   Authenticator, but that it can retrieve a secret using the Conjur access token.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
@@ -6,7 +6,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
   properly
 
   Scenario: id-token-user-property variable missing in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -43,7 +43,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: provider-uri variable missing in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -80,7 +80,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: webservice missing in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -112,7 +112,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     """
 
   Scenario: webservice with read and no authenticate permission in policy is denied
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -6,7 +6,7 @@ Feature: OIDC Authenticator - Performance tests
   We test both successful requests and unsuccessful requests.
 
   Background:
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
@@ -6,7 +6,7 @@ Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authentica
 
   Background:
     # Configure OIDC authenticator
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/authenticators_oidc/features/authn_status_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_status_oidc.feature
@@ -1,7 +1,7 @@
 Feature: OIDC Authenticator - Status Check
 
   Scenario: A properly configured OIDC authenticator returns a successful response
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -57,7 +57,7 @@ Feature: OIDC Authenticator - Status Check
     And the authenticator status check succeeds
 
   Scenario: A non-responsive OIDC provider returns a 500 response
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -113,7 +113,7 @@ Feature: OIDC Authenticator - Status Check
     And the authenticator status check fails with error "ProviderDiscoveryFailed: CONJ00011E"
 
   Scenario: provider-uri variable is missing and a 500 error response is returned
-    Given a policy:
+    Given I load a policy:
      """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -165,7 +165,7 @@ Feature: OIDC Authenticator - Status Check
     And the authenticator status check fails with error "RequiredResourceMissing: CONJ00036E"
 
   Scenario: id-token-user-property variable is missing and a 500 error response is returned
-    Given a policy:
+    Given I load a policy:
      """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/authenticators_status/features/authn_status.feature
+++ b/cucumber/authenticators_status/features/authn_status.feature
@@ -15,7 +15,7 @@ Feature: Authenticator status check
   not require a running OIDC Provider in order to run.
 
   Scenario: An unauthorized user is responded with 403
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -65,7 +65,7 @@ Feature: Authenticator status check
     And the authenticator status check fails with error "RoleNotAuthorizedOnResource: CONJ00006E"
 
   Scenario: An authenticator without an implemented status check returns 501
-    Given a policy:
+    Given I load a policy:
     """
     - !user alice
     """
@@ -75,7 +75,7 @@ Feature: Authenticator status check
     And the authenticator status check fails with error "StatusNotImplemented: CONJ00056E"
 
   Scenario: A non-existing authenticator status check returns 404
-    Given a policy:
+    Given I load a policy:
     """
     - !user alice
     """
@@ -85,7 +85,7 @@ Feature: Authenticator status check
     And the authenticator status check fails with error "AuthenticatorNotFound: CONJ00001E"
 
   Scenario: A missing status webservice returns 500
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -124,7 +124,7 @@ Feature: Authenticator status check
     And the authenticator status check fails with error "WebserviceNotFound: CONJ00005E"
 
   Scenario: A non-existing account name in the status request returns 500
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak
@@ -178,7 +178,7 @@ Feature: Authenticator status check
     And the authenticator status check fails with error "AccountNotDefined: CONJ00008E"
 
   Scenario: An authenticator webservice doesn't exist in policy
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-oidc/keycloak

--- a/cucumber/policy/features/bulk_actions.feature
+++ b/cucumber/policy/features/bulk_actions.feature
@@ -8,7 +8,7 @@ Feature: YAML anchors can be used for bulk actions
     policy shorter and easier to update. If the 'rundeck' layer needs fetch
     access to another variable, it can simply be added to the variables list.
 
-    Given a policy:
+    Given I load a policy:
     """
     - &variables
       - !variable aws_access_key_id

--- a/cucumber/policy/features/cidr_restrictions.feature
+++ b/cucumber/policy/features/cidr_restrictions.feature
@@ -37,3 +37,41 @@ from a particular network, defined by a CIDR in the policy
     """
        ["192.168.0.1/32", "192.168.1.10/32"]
     """
+
+  Scenario: Invalid CIDR restriction string
+
+    When I load a policy:
+    """
+    - !host
+      id: serviceA
+      restricted_to: an_invalid_cidr_string
+    """
+    Then there is an error
+    And the error code is "validation_failed"
+    And the error message includes "Invalid IP address or CIDR range 'an_invalid_cidr_string'"
+    
+
+  Scenario: Domain name as CIDR restriction string
+
+    When I load a policy:
+    """
+    - !host
+      id: serviceA
+      restricted_to: dap.my-company.net
+    """
+    Then there is an error
+    And the error code is "validation_failed"
+    And the error message includes "Invalid IP address or CIDR range 'dap.my-company.net'"
+
+  Scenario: Load policy with invalid CIDR (Bits to the right of the mask)
+  Conjur strips the extra bits before storing the CIDR in the database.
+
+    Given I load a policy:
+    """
+    - !host
+      id: serviceA
+      restricted_to: 10.0.0.1/24
+    """
+    Then there is an error
+    And the error code is "validation_failed"
+    And the error message includes "Invalid IP address or CIDR range '10.0.0.1/24': Value has bits set to right of mask. Did you mean '10.0.0.0/24'"

--- a/cucumber/policy/features/cidr_restrictions.feature
+++ b/cucumber/policy/features/cidr_restrictions.feature
@@ -5,7 +5,7 @@ from a particular network, defined by a CIDR in the policy
 
   Scenario: Loading users and hosts with CIDR restrictions
 
-    Given a policy:
+    Given I load a policy:
     """
     - !user
       id: alice

--- a/cucumber/policy/features/deletion.feature
+++ b/cucumber/policy/features/deletion.feature
@@ -4,7 +4,7 @@ Feature: Deleting objects and relationships.
   !revoke, and !deny statements.
 
   Scenario: The !delete statement can be used to delete an object.
-    Given a policy:
+    Given I load a policy:
     """
     - !group developers
     """
@@ -17,7 +17,7 @@ Feature: Deleting objects and relationships.
     Then group "developers" does not exist
 
   Scenario: The !revoke statement can be used to revoke a role grant.
-    Given a policy:
+    Given I load a policy:
     """
     - !group developers
     - !group employees
@@ -38,7 +38,7 @@ Feature: Deleting objects and relationships.
 
 
   Scenario: The !deny statement can be used to revoke a permission.
-    Given a policy:
+    Given I load a policy:
     """
     - !variable db/password
     - !host host-01

--- a/cucumber/policy/features/group_members.feature
+++ b/cucumber/policy/features/group_members.feature
@@ -7,7 +7,7 @@ Feature: Users and groups can be added to groups
     and `operations` to the `employees` group. They are granted all privileges
     of the `employees` group.
     
-    Given a policy:
+    Given I load a policy:
     """
     # First create the groups
     - !group employees
@@ -42,7 +42,7 @@ Feature: Users and groups can be added to groups
     using the same name prepended with a `*`. Aliasing also allows you to group
     records together under a single symbolic name.
     
-    Given a policy:
+    Given I load a policy:
     """
     - !group ci
     

--- a/cucumber/policy/features/host_factory.feature
+++ b/cucumber/policy/features/host_factory.feature
@@ -5,7 +5,7 @@ Feature: Host Factories can be managed through policies.
     The layer is added to the "layers" field.
     The "tokens" field is empty.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !layer
       id: myapp
@@ -48,7 +48,7 @@ Feature: Host Factories can be managed through policies.
     Scenario: The host factory can be defined in a separate policy load event from the creation
       of the layer.
       
-      Given a policy:
+      Given I load a policy:
       """
       - !layer
         id: myapp
@@ -69,7 +69,7 @@ Feature: Host Factories can be managed through policies.
       """
 
     Scenario: Load a Host Factory with no layers
-      Given a policy:
+      Given I load a policy:
         """ 
         - !policy
           id: another-app

--- a/cucumber/policy/features/ownership.feature
+++ b/cucumber/policy/features/ownership.feature
@@ -8,7 +8,7 @@ Feature: Custom ownership can be assigned to a policy object.
   policy.
 
   Scenario: The default owner of a policy-scoped object is the policy.
-    Given a policy:
+    Given I load a policy:
     """
     - !user bob
 
@@ -21,7 +21,7 @@ Feature: Custom ownership can be assigned to a policy object.
     And  the owner of variable "db/password" is policy "db"
 
   Scenario: The owner of a policy-scoped object can be changed.
-    Given a policy:
+    Given I load a policy:
     """
     - !group secrets-managers
 

--- a/cucumber/policy/features/policy_delegation.feature
+++ b/cucumber/policy/features/policy_delegation.feature
@@ -2,7 +2,7 @@ Feature: Policies can be organized into hierarchies with specific update permiss
 
   Scenario: Define a root policy with sub-policies
   
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: teams

--- a/cucumber/policy/features/policy_reference.feature
+++ b/cucumber/policy/features/policy_reference.feature
@@ -9,7 +9,7 @@ Feature: Policies can refer to each other by relative path.
     enclosing policy. So, the expression `../frontend` used in a policy `prod/database`
     is resolved to the path `prod/frontend`. 
   
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: prod
@@ -41,7 +41,7 @@ Feature: Policies can refer to each other by relative path.
     Then I can fetch a secret from variable resource "prod/database/password"
 
   Scenario: Policy references can be used across policy loader invocations.
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: prod

--- a/cucumber/policy/features/policy_scoping.feature
+++ b/cucumber/policy/features/policy_scoping.feature
@@ -13,7 +13,7 @@ Feature: Policies can be used to scope records by name and ownership.
     - The full name of the created variable will be `jenkins/v1/private-key`.
     - The owner of the variable will be be the role `<account>:policy:jenkins/v1`.
       
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: jenkins/v1

--- a/cucumber/policy/features/public_keys.feature
+++ b/cucumber/policy/features/public_keys.feature
@@ -11,7 +11,7 @@ Feature: Public keys can be associated with user records.
     
     The comment is required, so that multiple public keys can be distinguished from each other.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !user
       id: alice
@@ -36,7 +36,7 @@ Feature: Public keys can be associated with user records.
     
     In the case that a key is loaded multiple times with the same comment, the last public key loaded is the one returned by the pubkeys API.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !user
       id: alice

--- a/cucumber/policy/features/replace.feature
+++ b/cucumber/policy/features/replace.feature
@@ -4,7 +4,7 @@ A policy can be reloaded using the --replace flag
 
   Scenario: A multifile policy with one modified file fails on reload
 
-    Given a policy:
+    Given I load a policy:
     """
     - !group
       id: security-admin
@@ -51,7 +51,7 @@ A policy can be reloaded using the --replace flag
 
   Scenario: Policy reload fails when group isn't defined in new policy
 
-    Given a policy:
+    Given I load a policy:
     """
     - !group
       id: security-admin
@@ -87,7 +87,7 @@ A policy can be reloaded using the --replace flag
 
   Scenario: A multifile policy successfully reloads when files are concatenated
 
-    Given a policy:
+    Given I load a policy:
     """
     - !group
       id: security-admin

--- a/cucumber/policy/features/secrets.feature
+++ b/cucumber/policy/features/secrets.feature
@@ -17,7 +17,7 @@ Feature: Secrets can be managed through policies.
     Because the owner of a resource has all privileges on the resource, the owner of a resource
     can both add and fetch secret values.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !group secrets-managers
 
@@ -44,7 +44,7 @@ Feature: Secrets can be managed through policies.
     `execute` privilege convays the right to fetch a secret. Having `update` privilege
     does not give the privilege to `execute`, the permissions are managed separately.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !group secrets-fetchers
 
@@ -91,7 +91,7 @@ Feature: Secrets can be managed through policies.
     given `read` and `execute` permission on the variable, and a `secrets-managers` group is typically
     created which has all privileges on the variable.
 
-    Given a policy:
+    Given I load a policy:
     """
     - !policy
       id: myapp

--- a/cucumber/policy/features/step_definitions/error_steps.rb
+++ b/cucumber/policy/features/step_definitions/error_steps.rb
@@ -8,6 +8,10 @@ Then(/^the error message is "([^"]*)"$/) do |message|
   expect(@error['message']).to eq(message)
 end
 
+Then(/^the error message includes "([^"]*)"$/) do |message|
+  expect(@error['message']).to include(message)
+end
+
 Then(/^there is an error$/) do
   json = json_result
   expect(json).to have_key('error')

--- a/cucumber/policy/features/step_definitions/policy_steps.rb
+++ b/cucumber/policy/features/step_definitions/policy_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given(/^a policy:$/) do |policy|
+Given(/^I load a policy:$/) do |policy|
   invoke do
     load_root_policy policy
   end


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR adds tests for the existing behavior of attempting to load policy with an invalid `restricted_to` attribute on a host.

### What ticket does this PR close?
Connected to #1761 
Connected to #1763

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
