### PR TITLE
authn-gce - integration tests - error handing

### DIFF
--- a/cucumber/authenticators_gce/features/authn_gce.feature
+++ b/cucumber/authenticators_gce/features/authn_gce.feature
@@ -32,7 +32,7 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     And I set all valid GCE annotations to host "test-app"
     And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and existing account
+    When I authenticate with authn-gce using valid token and existing account
     Then host "test-app" has been authorized by Conjur
     And I can GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the audit log after my savepoint:
@@ -40,31 +40,64 @@ Feature: GCE Authenticator - Hosts can authenticate with GCE authenticator
     cucumber:host:test-app successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
     """
 
-  Scenario: Missing GCE access token is a bad request
-    Given I save my place in the log file
-    When I authenticate with authn-gce using no token and existing account
-    Then it is a bad request
-    And The following appears in the log after my savepoint:
+  Scenario: Host can authenticate with only project-id annotation set
+    Given I have host "test-app-project-id-only"
+    And I grant group "conjur/authn-gce/apps" to host "test-app-project-id-only"
+    And I set "authn-gce/project-id" annotation to host "test-app-project-id-only"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app-project-id-only"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then host "test-app-project-id-only" has been authorized by Conjur
+    And The following appears in the audit log after my savepoint:
     """
-    Errors::Authentication::RequestBody::MissingRequestParam
+    cucumber:host:test-app-project-id-only successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
     """
 
-
-  Scenario: Empty GCE access token is a bad request
-    Given I save my place in the log file
-    When I authenticate with authn-gce using empty token and existing account
-    Then it is a bad request
-    And The following appears in the log after my savepoint:
+  Scenario: Host can authenticate with only service-account-id annotation set
+    Given I have host "test-app-sa-id-only"
+    And I grant group "conjur/authn-gce/apps" to host "test-app-sa-id-only"
+    And I set "authn-gce/service-account-id" annotation to host "test-app-sa-id-only"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app-sa-id-only"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then host "test-app-sa-id-only" has been authorized by Conjur
+    And The following appears in the audit log after my savepoint:
     """
-    Errors::Authentication::RequestBody::MissingRequestParam
+    cucumber:host:test-app-sa-id-only successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
+    """
+
+  Scenario: Host can authenticate with only service-account-email annotation set
+    Given I have host "test-app-sa-email-only"
+    And I grant group "conjur/authn-gce/apps" to host "test-app-sa-email-only"
+    And I set "authn-gce/service-account-email" annotation to host "test-app-sa-email-only"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app-sa-email-only"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then host "test-app-sa-email-only" has been authorized by Conjur
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:test-app-sa-email-only successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
+    """
+
+  Scenario: Host can authenticate with only instance-name annotation set
+    Given I have host "test-app-instance-name"
+    And I grant group "conjur/authn-gce/apps" to host "test-app-instance-name"
+    And I set "authn-gce/instance-name" annotation to host "test-app-instance-name"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app-instance-name"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then host "test-app-instance-name" has been authorized by Conjur
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:test-app-instance-name successfully authenticated with authenticator authn-gce service cucumber:webservice:conjur/authn-gce
     """
 
   Scenario: Non-existing account in request is denied
     Given I obtain a GCE identity token in full format with audience claim value: "conjur/non-existing/host/test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and non existing account
+    When I authenticate with authn-gce using valid token and non-existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::AccountNotDefined
+    CONJ00008E Account '.*' is not defined in Conjur
     """

--- a/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_bad_configuration.feature
@@ -5,7 +5,7 @@ Feature: GCE Authenticator - Test Malformed Configuration
   and log the relevant error for the user to re-configure the authenticator
   properly.
 
-  Scenario: Webservice missing in policy is denied
+  Scenario: Webservice is missing in policy gets denied
     Given a policy:
     """
     - !policy
@@ -14,17 +14,16 @@ Feature: GCE Authenticator - Test Malformed Configuration
 
       - !group apps
     """
-    And I am the super-user
-    And I have host "test-app"
-    And I set all valid GCE annotations to host "test-app"
-    And I grant group "conjur/authn-gce/apps" to host "test-app"
-    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    And I have host "missing-web-service-in-policy-test-app"
+    And I set all valid GCE annotations to host "missing-web-service-in-policy-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "missing-web-service-in-policy-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/missing-web-service-in-policy-test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and existing account
+    When I authenticate with authn-gce using valid token and existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::WebserviceNotFound
+    CONJ00005E Webservice 'authn-gce' not found
     """
 
   Scenario: Webservice with read and no authenticate permission in policy is denied
@@ -42,16 +41,15 @@ Feature: GCE Authenticator - Test Malformed Configuration
         privilege: [ read ]
         resource: !webservice
     """
-    And I am the super-user
-    And I have host "test-app"
-    And I set all valid GCE annotations to host "test-app"
-    And I grant group "conjur/authn-gce/apps" to host "test-app"
-    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    And I have host "role-not-authorized-on-resource-test-app"
+    And I set all valid GCE annotations to host "role-not-authorized-on-resource-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "role-not-authorized-on-resource-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/role-not-authorized-on-resource-test-app"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and existing account
+    When I authenticate with authn-gce using valid token and existing account
     Then it is forbidden
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::RoleNotAuthorizedOnResource
+    CONJ00006E .* does not have 'authenticate' privilege on .*>
     """
 

--- a/cucumber/authenticators_gce/features/authn_gce_hosts.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_hosts.feature
@@ -20,12 +20,102 @@ Feature: GCP Authenticator - Test hosts can authentication scenarios
     """
 
   Scenario: Non-existing host is denied
-    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/test-app"
+    Given I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/non-existing-host"
     And I save my place in the log file
-    When I authenticate with authn-gce using token and existing account
+    When I authenticate with authn-gce using valid token and existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::Security::RoleNotFound
+    CONJ00007E 'host/non-existing-host' not found
     """
 
+  # "authn-gce/project-id" annotation is set because at least one of the annotations is expected.
+  Scenario: Host not in permitted group is denied
+    Given I have host "not-permitted-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/not-permitted-test-app"
+    And I set "authn-gce/project-id" annotation to host "not-permitted-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is forbidden
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00006E 'host/not-permitted-test-app' does not have 'authenticate' privilege on cucumber:webservice:conjur/authn-gce
+    """
+
+  Scenario: Host with all valid annotations except for project-id is denied
+    Given I have host "valid-annotations-except-for-project-id-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "valid-annotations-except-for-project-id-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/valid-annotations-except-for-project-id-test-app"
+    And I set invalid "authn-gce/project-id" annotation to host "valid-annotations-except-for-project-id-test-app"
+    And I set "authn-gce/service-account-id" annotation to host "valid-annotations-except-for-project-id-test-app"
+    And I set "authn-gce/service-account-email" annotation to host "valid-annotations-except-for-project-id-test-app"
+    And I set "authn-gce/instance-name" annotation to host "valid-annotations-except-for-project-id-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00049E Resource restriction 'authn-gce/project-id' does not match resource in JWT token
+    """
+
+  Scenario: Host with all valid annotations except for instance-name is denied
+    Given I have host "all-valid-annotations-except-for-instance-name-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "all-valid-annotations-except-for-instance-name-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/all-valid-annotations-except-for-instance-name-test-app"
+    And I set "authn-gce/project-id" annotation to host "all-valid-annotations-except-for-instance-name-test-app"
+    And I set "authn-gce/service-account-id" annotation to host "all-valid-annotations-except-for-instance-name-test-app"
+    And I set "authn-gce/service-account-email" annotation to host "all-valid-annotations-except-for-instance-name-test-app"
+    And I set invalid "authn-gce/instance-name" annotation to host "all-valid-annotations-except-for-instance-name-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00049E Resource restriction 'authn-gce/instance-name' does not match resource in JWT token
+    """
+
+  Scenario: Host with all valid annotations except for service-account-email is denied
+    Given I have host "valid-annotations-except-for-sa-email-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "valid-annotations-except-for-sa-email-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/valid-annotations-except-for-sa-email-test-app"
+    And I set "authn-gce/project-id" annotation to host "valid-annotations-except-for-sa-email-test-app"
+    And I set "authn-gce/service-account-id" annotation to host "valid-annotations-except-for-sa-email-test-app"
+    And I set invalid "authn-gce/service-account-email" annotation to host "valid-annotations-except-for-sa-email-test-app"
+    And I set "authn-gce/instance-name" annotation to host "valid-annotations-except-for-sa-email-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00049E Resource restriction 'authn-gce/service-account-email' does not match resource in JWT token
+    """
+
+  Scenario: Host with all valid annotations except for service-account-id is denied
+    Given I have host "valid-annotations-except-for-sa-id-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "valid-annotations-except-for-sa-id-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/valid-annotations-except-for-sa-id-test-app"
+    And I set "authn-gce/project-id" annotation to host "valid-annotations-except-for-sa-id-test-app"
+    And I set invalid "authn-gce/service-account-id" annotation to host "valid-annotations-except-for-sa-id-test-app"
+    And I set "authn-gce/service-account-email" annotation to host "valid-annotations-except-for-sa-id-test-app"
+    And I set "authn-gce/instance-name" annotation to host "valid-annotations-except-for-sa-id-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00049E Resource restriction 'authn-gce/service-account-id' does not match resource in JWT token
+    """
+
+  Scenario: Host with all valid annotations and an illegal annotation key is denied
+    Given I have host "illegal-annotation-key-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "illegal-annotation-key-test-app"
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/host/illegal-annotation-key-test-app"
+    And I set all valid GCE annotations to host "illegal-annotation-key-test-app"
+    And I set "authn-gce/invalid-key" annotation to host "illegal-annotation-key-test-app"
+    And I save my place in the log file
+    When I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00050E Resource type 'authn-gce/invalid-key' is not a supported resource restriction
+    """

--- a/cucumber/authenticators_gce/features/authn_gce_token_errors.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_token_errors.feature
@@ -1,0 +1,115 @@
+Feature: GCE Authenticator - Test Token Error Handling
+
+  In this feature we test authentication using malformed tokens.
+  Will verify a failure of the authentication request in such a case
+  and log of the relevant error.
+
+  Background:
+    Given a policy:
+    """
+    - !policy
+      id: conjur/authn-gce
+      body:
+      - !webservice
+
+      - !group apps
+
+      - !permit
+        role: !group apps
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+    And I have host "test-app"
+    And I grant group "conjur/authn-gce/apps" to host "test-app"
+    And I set all valid GCE annotations to host "test-app"
+
+  Scenario: Authenticate using a self signed token is denied
+    When I save my place in the log file
+    And I authenticate with authn-gce using self signed token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00035E Failed to decode token \(3rdPartyError ='#<JWT::DecodeError: Could not find public key for kid .*>'
+    """
+
+  Scenario: Authenticate using a self signed token missing 'kid' header claim is denied
+    When I save my place in the log file
+    And I authenticate with authn-gce using no kid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00018D Failed to decode the token with the error '#<JWT::DecodeError: No key id \(kid\) found from token headers>
+    """
+
+  Scenario: Authenticate using token with an invalid audience claim is denied
+    When I save my place in the log file
+    And I obtain a GCE identity token in full format with audience claim value: "invalid-audience"
+    And I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00067E 'audience' token claim invalid-audience is invalid. The format should be 'conjur/<account_name>/<host_id>'
+    """
+
+  Scenario: Authenticate using token with an invalid audience claim format missing 'conjur' part is denied
+    When I save my place in the log file
+    And I obtain a GCE identity token in full format with audience claim value: "cucumber/host/test-app"
+    And I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00067E 'audience' token claim cucumber/host/test-app is invalid
+    """
+
+  Scenario: Authenticate using token with an invalid audience claim format missing 'account' part is denied
+    When I save my place in the log file
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/host/test-app"
+    And I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00067E 'audience' token claim conjur/host/test-app is invalid
+    """
+
+  Scenario: Authenticate using token with an invalid audience claim format missing 'host' part is denied
+    When I save my place in the log file
+    And I obtain a GCE identity token in full format with audience claim value: "conjur/cucumber/test-app"
+    And I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00007E 'test-app' not found
+    """
+
+  Scenario: Missing GCE access token is a bad request
+    Given I save my place in the log file
+    When I authenticate with authn-gce using no token and existing account
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00009E Field 'jwt' is missing or empty in request body
+    """
+
+  Scenario: Empty GCE access token is a bad request
+    Given I save my place in the log file
+    When I authenticate with authn-gce using empty token and existing account
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00009E Field 'jwt' is missing or empty in request body
+    """
+
+  # Only project-id is because at leas one annotation is required and the scenario is testing invalid
+  # token format
+  Scenario: Authenticate using token in standard format is denied
+    When I have host "project-id-only-test-app"
+    And I grant group "conjur/authn-gce/apps" to host "project-id-only-test-app"
+    And I set "authn-gce/project-id" annotation to host "project-id-only-test-app"
+    And I save my place in the log file
+    And I obtain a GCE identity token in standard format with audience claim value: "conjur/cucumber/host/project-id-only-test-app"
+    And I authenticate with authn-gce using valid token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+     CONJ00068E Claim 'google/compute_engine/project_id' not found or empty in token
+    """


### PR DESCRIPTION
This PR covers the error handling tests defined in the test plan of the GCE authenticator feature.

Error handling tests of:
- Hosts
- Malformed tokens
- Resource restrictions

### What does this PR do?
- Adds integration tests and support in feature steps file and the test helper file. 

### What ticket does this PR close?
Connected to #[relevant GitHub issues](https://github.com/cyberark/conjur/issues/1760)

#### Test coverage
- [ ] This PR includes new integration tests

