### PR TITLE
Generalize InvalidResourceRestrictions

### DIFF
--- a/app/domain/authentication/authn_azure/validate_resource_restrictions.rb
+++ b/app/domain/authentication/authn_azure/validate_resource_restrictions.rb
@@ -36,7 +36,7 @@ module Authentication
         resource_restrictions.resources.each do |resource_from_role|
           resource_from_request = resources_from_request.find { |resource| resource == resource_from_role }
           unless resource_from_request
-            raise Errors::Authentication::AuthnAzure::InvalidResourceRestrictions, resource_from_role.type
+            raise Errors::Authentication::Jwt::InvalidResourceRestrictions, resource_from_role.type
           end
         end
         @logger.debug(LogMessages::Authentication::ValidatedResourceRestrictions.new)

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -171,6 +171,12 @@ module Errors
         code: "CONJ00051E"
       )
 
+      InvalidResourceRestrictions = ::Util::TrackableErrorClass.new(
+        msg:  "Resource restriction '{0-resource-restriction-name}' does not match " \
+            "resource in JWT token",
+        code: "CONJ00049E"
+      )
+
     end
 
     module AuthnOidc
@@ -314,12 +320,6 @@ module Errors
     end
 
     module AuthnAzure
-
-      InvalidResourceRestrictions = ::Util::TrackableErrorClass.new(
-        msg:  "Resource restriction '{0-resource-restriction-name}' does not match " \
-            "resource in Azure token",
-        code: "CONJ00049E"
-      )
 
       XmsMiridParseError = ::Util::TrackableErrorClass.new(
         msg:  "Failed to parse xms_mirid {0}. Reason: {1}",

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -109,7 +109,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnAzure::InvalidResourceRestrictions
+    Errors::Authentication::Jwt::InvalidResourceRestrictions
     """
 
   Scenario: Host with incorrect resource-group Azure annotation is denied
@@ -123,7 +123,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnAzure::InvalidResourceRestrictions
+    Errors::Authentication::Jwt::InvalidResourceRestrictions
     """
 
   Scenario: Host with incorrect user-assigned-identity annotation is denied
@@ -138,7 +138,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnAzure::InvalidResourceRestrictions
+    Errors::Authentication::Jwt::InvalidResourceRestrictions
     """
 
   Scenario: Host with incorrect system-assigned-identity annotation is denied
@@ -153,7 +153,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnAzure::InvalidResourceRestrictions
+    Errors::Authentication::Jwt::InvalidResourceRestrictions
     """
 
   Scenario: Non-existing host is denied

--- a/spec/app/domain/authentication/authn-azure/validate_resource_restrictions_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_resource_restrictions_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Authentication::AuthnAzure::ValidateResourceRestrictions' do
 
         it "raises an error" do
           expect { subject }.to raise_error(
-            Errors::Authentication::AuthnAzure::InvalidResourceRestrictions
+            Errors::Authentication::Jwt::InvalidResourceRestrictions
           )
         end
       end


### PR DESCRIPTION
Generalize `InvalidResourceRestrictions` error so it can be used in other authentication methods