### PR TITLE
Generalize performance tests

### DIFF
--- a/cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
+++ b/cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
@@ -36,3 +36,7 @@ Then(/authenticator "([^"]*)" is disabled/) do |resource_id|
   config = AuthenticatorConfig.where(resource_id: resource_id).first
   expect(config&.enabled).to be_falsey
 end
+
+Then(/The (avg|max) authentication request responds in less than (\d+\.?(\d+)?) seconds?/) do |type, threshold|
+  validate_authentication_performance(type, threshold)
+end

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -32,16 +32,16 @@ Feature: Azure Authenticator - Performance tests
   Scenario: successful requests
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
-    Then The "avg" Azure Authentication request responds in less than "0.75" seconds
+    Then The avg authentication request responds in less than 0.75 seconds
 
   Scenario: Unsuccessful requests with an invalid token
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"
-    Then The "avg" Azure Authentication request responds in less than "0.75" seconds
+    Then The avg authentication request responds in less than 0.75 seconds
 
   Scenario: Unsuccessful requests with invalid resource restrictions
     Given I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "no-azure-annotations-app"
-    Then The "avg" Azure Authentication request responds in less than "0.75" seconds
+    Then The avg authentication request responds in less than 0.75 seconds

--- a/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
+++ b/cucumber/authenticators_azure/features/support/authn_azure_helper.rb
@@ -5,6 +5,9 @@
 module AuthnAzureHelper
   include AuthenticatorHelpers
 
+  SERVICE_ID = 'prod'
+  ACCOUNT = 'cucumber'
+
   def create_and_set_azure_provider_uri_variable(value = azure_provider_uri)
     create_and_set_azure_variable("provider-uri", value)
   end

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -40,8 +40,8 @@ Feature: OIDC Authenticator - Performance tests
   Scenario: successful requests
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate 1000 times in 10 threads via OIDC with id token
-    Then The "avg" response time should be less than "0.75" seconds
+    Then The avg authentication request responds in less than 0.75 seconds
 
   Scenario: Unsuccessful requests with an invalid token
     When I authenticate 1000 times in 10 threads via OIDC with invalid id token
-    Then The "avg" response time should be less than "0.75" seconds
+    Then The avg authentication request responds in less than 0.75 seconds

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -5,6 +5,9 @@
 module AuthnOidcHelper
   include AuthenticatorHelpers
 
+  SERVICE_ID = 'keycloak'
+  ACCOUNT = 'cucumber'
+
   def authenticate_id_token_with_oidc(service_id:, account:, id_token: parsed_id_token)
     path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/authenticate"
 


### PR DESCRIPTION
We had the logic for verifying authentication requests performance implemented
in several authenticators. We should have this logic implemented once and used
across them.