### PR TITLE
Replace Log Message Level in Test Assertion

### DIFF
--- a/cucumber/authenticators_gce/features/authn_gce_token_errors.feature
+++ b/cucumber/authenticators_gce/features/authn_gce_token_errors.feature
@@ -38,7 +38,7 @@ Feature: GCE Authenticator - Test Token Error Handling
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    CONJ00018D Failed to decode the token with the error '#<JWT::DecodeError: No key id \(kid\) found from token headers>
+    CONJ00035E Failed to decode token \(3rdPartyError ='#<JWT::DecodeError: No key id \(kid\) found from token headers>'\)
     """
 
   Scenario: Authenticate using token with an invalid audience claim is denied


### PR DESCRIPTION
Per @InbalZilberman  request, the `self signed token missing 'kid' header claim` test now expects an error message on log, rather than a debug message. 
