### PR TITLE
add migration step that recalculates fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Rails 5 upgrade. This is to indicate trusted proxy IP addresses when using the
   `X-Forwarded-For` HTTP header to identity the true client IP address of a request.
   [cyberark/conjur#1689](https://github.com/cyberark/conjur/issues/1689)
+- A new database migration step updates the fingerprints in slosilo. The FIPS compliance
+  update in `v1.8.0` caused the previous fingerprints to be invalid.
+  [cyberark/conjur#1584](https://github.com/cyberark/conjur/issues/1584)
 
 ## [1.8.1] - 2020-07-14
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,7 +396,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slosilo (2.2.1)
+    slosilo (2.2.2)
     spring (2.1.0)
     spring-commands-cucumber (1.0.1)
       spring (>= 0.9.1)

--- a/db/migrate/20200811181056_reset_fingerprint_column.rb
+++ b/db/migrate/20200811181056_reset_fingerprint_column.rb
@@ -1,0 +1,12 @@
+require 'rake'
+
+# Upgrading to FIPs complaint hashing caused us to update the fingerprint
+# hash to utilize SHA256 instead of MD5: (https://github.com/cyberark/slosilo/pull/15).
+# The following rake task recalculates the fingerprint hashes
+
+# This is a one-way migration
+Sequel.migration do
+  up do
+    Rake::Task['slosilo:recalculate_fingerprints'].execute
+  end
+end


### PR DESCRIPTION
This migration is needed to ensure fingerprints are updated to use SHA256 hashing. This is a FIPS requirement

### What does this PR do?
Updates slosilo to `v2.2.2` and includes a new migration step. This ensures that the fingerprints are rehashed when upgrading to a post-FIPS version. This solves the authentication issues found when upgrading images. 

### What ticket does this PR close?
[appliane#1359](https://github.com/conjurinc/appliance/issues/1359)
[dap-support#134](https://github.com/conjurinc/dap-support/issues/134)

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

TODO: #1607 
