### PR TITLE
Remove OCP 3.7 secrets since only GKE is used

### DIFF
--- a/ci/authn-k8s/secrets.yml
+++ b/ci/authn-k8s/secrets.yml
@@ -2,11 +2,3 @@ GCLOUD_CLUSTER_NAME: !var ci/google-container-engine-testbed/gcloud-cluster-name
 GCLOUD_ZONE: !var ci/google-container-engine-testbed/gcloud-zone
 GCLOUD_PROJECT_NAME: !var ci/google-container-engine-testbed/gcloud-project-name
 GCLOUD_SERVICE_KEY: !var:file ci/google-container-engine-testbed/gcloud-service-key
-
-openshift37:
-  K8S_VERSION: '1.7'
-  OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.7.2/openshift-origin-client-tools-v3.7.2-282e43f-linux-64bit.tar.gz
-  OPENSHIFT_URL: master.openshift37.itci.conjur.net:8443
-  OPENSHIFT_USERNAME: admin
-  OPENSHIFT_PASSWORD: !var ci/openshift37/users/admin/password
-  OPENSHIFT_REGISTRY_URL: docker-registry-default.apps.openshift37.itci.conjur.net


### PR DESCRIPTION
As it seems CI is only tested against GKE and not OCP 3.7, to avoid confusion and harden secrets exposure we remove OCP secrets

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
