### PR TITLE
Obtain GCE ID Tokens

### DIFF
--- a/ci/authn-gcp/get_gcp_id_tokens.sh
+++ b/ci/authn-gcp/get_gcp_id_tokens.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+#	---------------------------------------------------------------------------------------------------------------------
+# This script obtains all of the GCP identity tokens required by authn-gcp cucumber tests
+# The scripts accepts the GCE instance name as an argument.
+# The script does the following:
+# 1. Validates gcloud is installed (requires a GCP account)
+#   To install gcloud goto: https://cloud.google.com/sdk/docs, download and install the SDK by running:
+#   ./google-cloud-sdk/install.sh
+#   ./google-cloud-sdk/bin/gcloud init
+# 2. Verifies the GCE instance exists and is running
+# 3. Executes a ssh curl command and write the output token with the appropriate token name to '../ci/authn-gcp/tokens'.
+#	---------------------------------------------------------------------------------------------------------------------
+
+PROGNAME=$(basename "$0")
+INSTANCE_ZONE=""
+TOKENS_OUT_DIR_PATH=../ci/authn-gcp/tokens
+TOKEN_FILE_NAME_PREFIX=gcp_token_
+INSTANCE_EXISTS=0
+INSTANCE_RUNNING=0
+
+main() {
+  echo "-- ------------------------------------------ --"
+  echo "-- Generate Google Cloud GCP Identity tokens --"
+  echo "-- ------------------------------------------ --"
+
+  echo "-- Verifying 'gcloud' is installed..."
+  ensure_gcloud_is_installed
+  echo "-- Verifying GCE instance name..."
+  check_instance_name_arg "$1"
+  echo "-- Checking if GCE instance: '${INSTANCE_NAME}' exists..."
+  ensure_instance_exists_and_running "$INSTANCE_NAME"
+  echo "-- Deleting stale token files..."
+  rm -rf ${TOKENS_OUT_DIR_PATH}/${TOKEN_FILE_NAME_PREFIX}*
+  echo "-- Generate tokens and writing to files under '${TOKENS_OUT_DIR_PATH}'..."
+  get_tokens_into_files
+  echo "-- Finished obtaining and writing tokens to files."
+}
+
+ensure_gcloud_is_installed() {
+  COMMAND=gcloud
+
+  if ! command -v $COMMAND &> /dev/null; then
+    error_exit "-- ${COMMAND} could not be found."
+  fi
+  echo "-- ${COMMAND} command exists"
+}
+
+check_instance_name_arg() {
+  if [ -z "$1" ]; then
+    echo "-- GCE instance name is required. Usage: ./${PROGNAME} [GCE_INSTANCE_NAME]"
+    print_running_gce_instances
+    error_exit "GCE instance name is required!"
+  else
+    INSTANCE_NAME=$1
+    echo "-- GCE instance name is set to: '${INSTANCE_NAME}'."
+  fi
+}
+
+#	----------------------------------------------------------------
+# Checks if the given instance name argument exist and in RUNNING
+# status, extracts the instance zone for later use;
+# exit the script with error otherwise.
+#	----------------------------------------------------------------
+ensure_instance_exists_and_running() {
+  local instance_name="$1"
+  # 'gcloud' response format: 'instance-zone;STATUS', (e.g. europe-west3-c;RUNNING).
+  local format="value[separator=';'](zone.basename(),status)"
+
+  # Get list of GCE instances in all zones filtered by exact match regex '$instance_name'.
+  # Returns 'instance-zone;STATUS'
+  # if the instance exists; empty string otherwise.
+  local instance_info=$(gcloud compute instances list --filter="name ~ ^$instance_name$" --format="$format")
+
+  if [[ "$instance_info" != "" ]]; then
+    INSTANCE_EXISTS=1
+    #	----------------------------------------------------------------
+    # The $instance_info output is in the form of 'instance-zone;STATUS',
+    # (e.g. europe-west3-c;RUNNING).
+    # Below we extract the following:
+    # - instance zone: used in the 'gcloud compute ssh' command.
+    # - instance status: used to validate that the instance is running.
+    #	----------------------------------------------------------------
+    set_instance_zone "$instance_info"
+    local instance_status=$(echo "$instance_info" | cut -f2 -d ';')
+
+    if [ "$instance_status" = "RUNNING" ]; then
+      echo "-- GCE instance '${instance_name}', zone: '$INSTANCE_ZONE', status: '$instance_status'."
+      INSTANCE_RUNNING=1
+    else
+      echo "-- GCE instance '${instance_name}', zone: '$INSTANCE_ZONE', NOT RUNNING!, status: '$instance_status'."
+      print_running_gce_instances
+      error_exit "GCE instance '${instance_name}', zone: '$INSTANCE_ZONE' is not running, status: '$instance_status'."
+    fi
+  else
+    echo "-- GCE instance '${instance_name}' NOT FOUND!"
+    print_running_gce_instances
+    error_exit "GCE instance '${instance_name}' not found."
+  fi
+}
+
+set_instance_zone() {
+  local instance_info="$1"
+  INSTANCE_ZONE=$(echo "$instance_info" | cut -f1 -d ';')
+}
+
+print_running_gce_instances() {
+  echo "-- Retrieving running instances..."
+  gcloud compute instances list --limit=50\
+    --format="table[box,title='Running Compute Instances'](name,machine_type.basename(),status)" \
+    --filter="STATUS=RUNNING"
+}
+
+get_tokens_into_files() {
+  if [ "${INSTANCE_EXISTS}" = "0" ] | [ "${INSTANCE_RUNNING}" = "0" ]; then
+    error_exit "-- Cannot run command, GCE instance '${INSTANCE_NAME}' not in a valid state!"
+  fi
+
+  get_token_into_file "full" "conjur/cucumber/host/test-app" "valid"
+  get_token_into_file "full" "conjur/cucumber/host/non-existing" "non_existing_host"
+  get_token_into_file "full" "conjur/cucumber/host/non-rooted/test-app" "non_rooted_host"
+  get_token_into_file "full" "conjur/cucumber/test-app" "user"
+  get_token_into_file "full" "conjur/non-existing/host/test-app" "non_existing_account"
+  get_token_into_file "full" "invalid_audience" "invalid_audience"
+  get_token_into_file "standard" "conjur/cucumber/host/test-app" "standard_format"
+  wait
+}
+
+get_token_into_file() {
+  local token_format="$1"
+  local audience="$2"
+  local filename="$3"
+  local token_file="${TOKENS_OUT_DIR_PATH}/${TOKEN_FILE_NAME_PREFIX}${filename}"
+  local curl_cmd="curl -s -G -H 'Metadata-Flavor: Google' \
+  --data-urlencode 'format=${token_format}' \
+  --data-urlencode 'audience=${audience}' \
+  'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity'"
+
+  echo "-- Obtain an ID token in '${token_format}' format, audience: '${audience}' and persist to: '${token_file}'"
+
+  gcloud compute ssh "$INSTANCE_NAME" --zone="${INSTANCE_ZONE}" --command "${curl_cmd}" > "${token_file}" &
+}
+
+error_exit() {
+  #	----------------------------------------------------------------
+  #	Function for exit due to fatal program error
+  #		Accepts 1 argument:
+  #			string containing descriptive error message
+  #	----------------------------------------------------------------
+
+  echo "${PROGNAME}:${LINENO}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+main "$1"

--- a/dev/cli
+++ b/dev/cli
@@ -29,14 +29,24 @@ SYNOPSIS
 GLOBAL OPTIONS
     --help                                    - Show this message
 COMMANDS
-    --authn-oidc    Enables OIDC features
-    --authn-azure   Enables Azure features
-    --authn-gcp     Enables GCP features
+    --authn-oidc                     Enables OIDC features
+    --authn-azure                    Enables Azure features
+    --authn-gcp [GCE_INSTANCE_NAME]  Enables GCP features
 EOF
 exit
 }
 
 function enable_gcp() {
+  local gce_instance_name="$1"
+
+  if [ -z "$gce_instance_name" ]; then
+    echo "--authn-gcp mode requires a GCE instance name argument."
+    echo "Usage ./cli exec --authn-gcp [GCE_INSTANCE_NAME]"
+    exit 1
+  fi
+
+  '../ci/authn-gcp/get_gcp_id_tokens.sh' "$gce_instance_name"
+
   gcp_token_file="../ci/authn-gcp/tokens/gcp_token_valid"
   if ! [ -f "$gcp_token_file" ]; then
     echo "GCP token file $gcp_token_file does not exist."
@@ -45,11 +55,25 @@ function enable_gcp() {
 
   decoded_gcp_token_payload=$(_get_gcp_token_payload "$gcp_token_file")
 
-  echo "Setting GCP details as env variables"
+  echo "-- Setting GCP details as env variables"
   GCP_PROJECT_ID="$(echo "$decoded_gcp_token_payload" | jq -r '.google.compute_engine.project_id')"
   GCP_INSTANCE_NAME="$(echo "$decoded_gcp_token_payload" | jq -r '.google.compute_engine.instance_name')"
   GCP_SERVICE_ACCOUNT_ID="$(echo "$decoded_gcp_token_payload" | jq -r '.sub')"
   GCP_SERVICE_ACCOUNT_EMAIL="$(echo "$decoded_gcp_token_payload" | jq -r '.email')"
+
+  if [ -z "$GCP_SERVICE_ACCOUNT_ID" ]; then
+    echo "Failed to extract 'sub' claim from token, value is empty"
+    echo "Verify that the token file: '$gcp_token_file' is a valid JWT token."
+    exit 1
+  fi
+
+  echo "-- GCP_PROJECT_ID=$GCP_PROJECT_ID"
+  echo "-- GCP_INSTANCE_NAME=$GCP_INSTANCE_NAME"
+  echo "-- GCP_SERVICE_ACCOUNT_ID=$GCP_SERVICE_ACCOUNT_ID"
+  echo "-- GCP_SERVICE_ACCOUNT_EMAIL=$GCP_SERVICE_ACCOUNT_EMAIL"
+  echo "-- GCP env variables are set"
+
+
 
   local gcp_env_args="-e GCP_INSTANCE_NAME=$GCP_INSTANCE_NAME \
                       -e GCP_SERVICE_ACCOUNT_ID=$GCP_SERVICE_ACCOUNT_ID \
@@ -116,7 +140,7 @@ while true ; do
         -h | --help ) print_exec_help ; shift ;;
         --authn-oidc ) enable_oidc ; shift ;;
         --authn-azure ) enable_azure ; shift ;;
-        --authn-gcp ) enable_gcp ; shift ;;
+        --authn-gcp ) enable_gcp "$3"; shift 2 ;;
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 


### PR DESCRIPTION
The `get_gce_id_tokens.sh` script uses `gcloud` cli to obtain all of the GCE identity tokens from within a running GCE VM, required by `authn-gce` cucumber tests.

The script accepts the GCE instance name as an argument and an optional GCP zone (default is `us-central1-a`).

The script does the following:
1. Validates `gcloud` is installed (`gcloud` **requires a GCP account to execute commands**)
To install `gcloud` goto: [https://cloud.google.com/sdk/docs](https://cloud.google.com/sdk/docs), download and install the SDK by running:
```  
  ./google-cloud-sdk/install.sh
  ./google-cloud-sdk/bin/gcloud init
```
2. Verifies the GCE instance exists and is in **RUNNING** state.
3. Executes a curl command via ssh and writes the output tokens with the appropriate token name (e.g. `gce_token_valid`) to '../ci/authn-gce/tokens'.

### What does this PR do?
New script added  to enable `/dev/cli `to obtain and write GCP ID tokens for the cucumber tests to run properly while in `--authn-gce` mode. `/dev/cli` also extracts claim values from the valid GCE token and sets them as env variables which later are consumed by cucumber feature tests.  

Connected to #[relevant GitHub issues](https://github.com/cyberark/conjur/issues/1741)

