### PR TITLE
Handle cert injection properly for authn-k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   if the environment variable is not present, rather than attempting to use the empty string value. [cyberark/conjur#1841](https://github.com/cyberark/conjur/issues/1841)
 
 ### Changed
+- The "inject_client_cert" request now returns 202 Accepted instead of 200 OK to
+  indicate that the cert injection has started but not necessarily completed.
+  [cyberark/conjur#1848](https://github.com/cyberark/conjur/issues/1848)
 - The Conjur server request logs now records the same IP address used by audit
   logs and network authentication filters with the `restricted_to` attribute.
   [cyberark/conjur#1719](https://github.com/cyberark/conjur/issues/1719)

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -129,7 +129,7 @@ class AuthenticateController < ApplicationController
       # and the prefix is in the header. This is done to maintain backwards-compatibility
       host_id_prefix:   request.headers["Host-Id-Prefix"]
     )
-    head :ok
+    head :accepted
   rescue => e
     handle_authentication_error(e)
   end

--- a/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
+++ b/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
@@ -6,7 +6,7 @@ require 'command_class'
 module Authentication
   module AuthnK8s
 
-    SetFileContentInContainer ||= CommandClass.new(
+    CopyTextToFileInContainer ||= CommandClass.new(
       dependencies: {
         kubectl_exec:      KubectlExec.new,
         k8s_object_lookup: K8sObjectLookup,
@@ -18,12 +18,12 @@ module Authentication
       LOG_FILE = "${TMPDIR:-/tmp}/conjur_set_file_content.log"
 
       def call
-        set_file_content_in_container
+        copy_text_to_file_in_container
       end
 
       private
 
-      def set_file_content_in_container
+      def copy_text_to_file_in_container
         @kubectl_exec.call(
           k8s_object_lookup: @k8s_object_lookup.new(@webservice),
           pod_namespace:     @pod_namespace,

--- a/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
+++ b/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
@@ -12,7 +12,7 @@ module Authentication
         k8s_object_lookup: K8sObjectLookup,
         logger:            Rails.logger
       },
-      inputs: %i(webservice pod_namespace pod_name path content mode container)
+      inputs: %i(webservice pod_namespace pod_name container path content mode)
     ) do
 
       LOG_FILE = "${TMPDIR:-/tmp}/conjur_set_file_content.log"

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -86,10 +86,10 @@ module Authentication
           container: container_name,
           path: cert_file_path,
           content: cert_to_install.to_pem,
-          mode: 0o644
+          mode: "644"
         )
         validate_cert_installation(resp)
-        @logger.debug(LogMessages::Authentication::AuthnK8s::CopySSLToPodSuccess.new)
+        @logger.debug(LogMessages::Authentication::AuthnK8s::InitializeCopySSLToPodSuccess.new)
       end
 
       def validate_cert_installation(resp)

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -9,14 +9,14 @@ module Authentication
 
     InjectClientCert ||= CommandClass.new(
       dependencies: {
-        logger:                        Rails.logger,
-        resource_class:                Resource,
-        conjur_ca_repo:                Repos::ConjurCA,
-        kubectl_exec:                  KubectlExec,
-        set_file_content_in_container: SetFileContentInContainer.new,
-        validate_pod_request:          ValidatePodRequest.new,
-        extract_container_name:        ExtractContainerName.new,
-        audit_log:                     ::Audit.logger
+        logger:                         Rails.logger,
+        resource_class:                 Resource,
+        conjur_ca_repo:                 Repos::ConjurCA,
+        kubectl_exec:                   KubectlExec,
+        copy_text_to_file_in_container: CopyTextToFileInContainer.new,
+        validate_pod_request:           ValidatePodRequest.new,
+        extract_container_name:         ExtractContainerName.new,
+        audit_log:                      ::Audit.logger
       },
       inputs: %i(conjur_account service_id csr host_id_prefix client_ip)
     ) do
@@ -80,7 +80,7 @@ module Authentication
           pod_name
         ))
 
-        resp = @set_file_content_in_container.call(
+        resp = @copy_text_to_file_in_container.call(
           webservice: webservice,
           pod_namespace: pod_namespace,
           pod_name: pod_name,

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -9,13 +9,14 @@ module Authentication
 
     InjectClientCert ||= CommandClass.new(
       dependencies: {
-        logger:                 Rails.logger,
-        resource_class:         Resource,
-        conjur_ca_repo:         Repos::ConjurCA,
-        kubectl_exec:           KubectlExec,
-        validate_pod_request:   ValidatePodRequest.new,
-        extract_container_name: ExtractContainerName.new,
-        audit_log:              ::Audit.logger
+        logger:                        Rails.logger,
+        resource_class:                Resource,
+        conjur_ca_repo:                Repos::ConjurCA,
+        kubectl_exec:                  KubectlExec,
+        set_file_content_in_container: SetFileContentInContainer.new,
+        validate_pod_request:          ValidatePodRequest.new,
+        extract_container_name:        ExtractContainerName.new,
+        audit_log:                     ::Audit.logger
       },
       inputs: %i(conjur_account service_id csr host_id_prefix client_ip)
     ) do
@@ -79,8 +80,8 @@ module Authentication
           pod_name
         ))
 
-        resp = @kubectl_exec.new.copy(
-          k8s_object_lookup: k8s_object_lookup,
+        resp = @set_file_content_in_container.call(
+          webservice: webservice,
           pod_namespace: pod_namespace,
           pod_name: pod_name,
           container: container_name,
@@ -88,6 +89,7 @@ module Authentication
           content: cert_to_install.to_pem,
           mode: "644"
         )
+
         validate_cert_installation(resp)
         @logger.debug(LogMessages::Authentication::AuthnK8s::InitializeCopySSLToPodSuccess.new)
       end
@@ -121,12 +123,6 @@ module Authentication
 
       def spiffe_id
         @spiffe_id ||= SpiffeId.new(smart_csr.spiffe_id)
-      end
-
-      def pod
-        @pod ||= k8s_object_lookup.pod_by_name(
-          spiffe_id.name, spiffe_id.namespace
-        )
       end
 
       def host
@@ -168,10 +164,6 @@ module Authentication
           smart_csr,
           subject_altnames: [spiffe_id.to_altname]
         )
-      end
-
-      def k8s_object_lookup
-        @k8s_object_lookup ||= K8sObjectLookup.new(webservice)
       end
 
       def container_name

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -68,7 +68,7 @@ module Authentication
       end
 
       # Gets the client object to the /api v1 endpoint.
-      def kubectl_client
+      def kube_client
         KubeClientFactory.client(host_url: api_url, options: options)
       end
 
@@ -149,7 +149,7 @@ module Authentication
       # List them in the order that you want them to be searched for methods.
       def k8s_clients
         @clients ||= [
-          kubectl_client,
+          kube_client,
           KubeClientFactory.client(
             api: 'apis/apps', version: 'v1', host_url: api_url,
             options: options

--- a/app/domain/authentication/authn_k8s/kubectl_exec.rb
+++ b/app/domain/authentication/authn_k8s/kubectl_exec.rb
@@ -23,7 +23,7 @@ module Authentication
     ) do
 
       extend Forwardable
-      def_delegators :@k8s_object_lookup, :kubectl_client
+      def_delegators :@k8s_object_lookup, :kube_client
 
       DEFAULT_KUBECTL_EXEC_COMMAND_TIMEOUT = 5
 
@@ -32,7 +32,7 @@ module Authentication
         @channel_closed = false
 
         url = server_url(@cmds, @stdin)
-        headers = kubectl_client.headers.clone
+        headers = kube_client.headers.clone
         ws_client = WebSocket::Client::Simple.connect(url, headers: headers)
 
         add_websocket_event_handlers(ws_client, @body, @stdin)
@@ -149,7 +149,7 @@ module Authentication
       end
 
       def server_url(cmds, stdin)
-        api_uri = kubectl_client.api_endpoint
+        api_uri = kube_client.api_endpoint
         base_url = "wss://#{api_uri.host}:#{api_uri.port}"
         path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
         query = query_string(cmds, stdin)

--- a/app/domain/authentication/authn_k8s/set_file_content_in_container.rb
+++ b/app/domain/authentication/authn_k8s/set_file_content_in_container.rb
@@ -49,7 +49,7 @@ module Authentication
 set -e
 
 cleanup() {
- rm -rf \"#{tmp_cert}\"
+ rm -f \"#{tmp_cert}\"
 }
 trap cleanup EXIT
 

--- a/app/domain/authentication/authn_k8s/set_file_content_in_container.rb
+++ b/app/domain/authentication/authn_k8s/set_file_content_in_container.rb
@@ -2,6 +2,7 @@
 
 require 'command_class'
 
+# SetFileContentInContainer is used to set some text into a file inside a container
 module Authentication
   module AuthnK8s
 
@@ -49,7 +50,7 @@ module Authentication
 set -e
 
 cleanup() {
- rm -f \"#{tmp_cert}\"
+  rm -f \"#{tmp_cert}\"
 }
 trap cleanup EXIT
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -263,7 +263,7 @@ module Errors
       )
 
       CommandTimedOut = ::Util::TrackableErrorClass.new(
-        msg:  "Command timed out in container '{0}' of pod '{1}'",
+        msg:  "Command timed out after {0} seconds in container '{1}' of pod '{2}'",
         code: "CONJ00033E"
       )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -149,13 +149,13 @@ module LogMessages
       )
 
       CopySSLToPod = ::Util::TrackableLogMessageClass.new(
-        msg:  "Copying SSL certificate to {0-container-name}:{1-cert-file-path} " \
+        msg:  "Copying client certificate to {0-container-name}:{1-cert-file-path} " \
             "in {2-pod-namespace}/{3-pod-name}",
         code: "CONJ00015D"
       )
 
       InitializeCopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
-        msg:  "Initialized SSL certificate copy successfully",
+        msg:  "Started copying the client certificate successfully",
         code: "CONJ00037D"
       )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -139,7 +139,7 @@ module LogMessages
       )
 
       PodMessageData = ::Util::TrackableLogMessageClass.new(
-        msg:  "Pod: '{0-pod-name}', message: '{1-message-type}', data: '{2-message-data}'",
+        msg:  "Pod '{0-pod-name}': message: '{1-message-type}', data: '{2-message-data}'",
         code: "CONJ00013D"
       )
 
@@ -154,8 +154,8 @@ module LogMessages
         code: "CONJ00015D"
       )
 
-      CopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
-        msg:  "Copied SSL certificate successfully",
+      InitializeCopySSLToPodSuccess = ::Util::TrackableLogMessageClass.new(
+        msg:  "Initialized SSL certificate copy successfully",
         code: "CONJ00037D"
       )
 

--- a/cucumber/kubernetes/features/step_definitions/login_steps.rb
+++ b/cucumber/kubernetes/features/step_definitions/login_steps.rb
@@ -36,7 +36,8 @@ end
 def login_with_username request_ip, username, success, headers = {}
   begin
     @pkey = OpenSSL::PKey::RSA.new 2048
-    login(username, request_ip, authn_k8s_host, @pkey, headers)
+    response = login(username, request_ip, authn_k8s_host, @pkey, headers)
+    expect(response.code).to be(202)
   rescue
     raise if success
     @error = $!

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -8,7 +8,7 @@ end
 
 Before do
   # Erase the certificates and keys from each container.
-  kubectl_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
+  kube_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
     next unless (ready_status = pod.status.conditions.find { |c| c.type == "Ready" })
     next unless ready_status.status == "True"
     next unless pod.metadata.name =~ /inventory\-deployment/

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -9,8 +9,8 @@ module AuthnK8sWorld
     @k8s_object_lookup ||= Authentication::AuthnK8s::K8sObjectLookup.new
   end
 
-  def kubectl_client
-    k8s_object_lookup.kubectl_client
+  def kube_client
+    k8s_object_lookup.kube_client
   end
 
   def authn_k8s_host
@@ -112,7 +112,7 @@ module AuthnK8sWorld
     controller = k8s_object_lookup.find_object_by_name controller_type, id, namespace
     raise "#{objectid.inspect} not found" unless controller
 
-    @pod = pod = kubectl_client.get_pods(namespace: namespace).find do |pod|
+    @pod = pod = kube_client.get_pods(namespace: namespace).find do |pod|
       resolver = Authentication::AuthnK8s::K8sResolver.for_resource(controller_type).new(controller, pod, k8s_object_lookup)
       begin
         resolver.validate_pod

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -77,7 +77,7 @@ module AuthnK8sWorld
         k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,
         pod_namespace: pod_metadata.namespace,
         pod_name: pod_metadata.name,
-        cmds: [ "cat", "/tmp/conjur_copy_file.log" ]
+        cmds: [ "cat", "/tmp/conjur_set_file_content.log" ]
       )
 
       if !get_cert_injection_logs_response.nil? &&

--- a/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
@@ -29,11 +29,6 @@ RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
       .to receive(:call)
   end
 
-  #  ____  _   _  ____    ____  ____  ___  ____  ___
-  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
-  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
-  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
-
   context "Calling CopyTextToFileInContainer" do
     subject do
       ::Authentication::AuthnK8s::CopyTextToFileInContainer.new(

--- a/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
+
+  let(:webservice) { double("Webservice") }
+  let(:pod_namespace) { "PodNamespace" }
+  let(:pod_name) { "PodName" }
+  let(:container) { "Container" }
+  let(:path) { "path/to/file" }
+  let(:content) { "Content" }
+  let(:mode) { "Mode" }
+
+  let(:kubectl_exec) { double("KubectlExec") }
+
+  let(:k8s_object_lookup_instance) { double("K8sObjectLookupInstance") }
+  let(:k8s_object_lookup) { double("K8sObjectLookup") }
+  let(:k8s_object_lookup) do
+    double('k8s_object_lookup').tap do |k8s_object_lookup|
+      allow(k8s_object_lookup).to receive(:new)
+        .with(webservice)
+        .and_return(k8s_object_lookup_instance)
+    end
+  end
+
+  before(:each) do
+    allow(kubectl_exec)
+      .to receive(:call)
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "Calling CopyTextToFileInContainer" do
+    subject do
+      ::Authentication::AuthnK8s::CopyTextToFileInContainer.new(
+        kubectl_exec:      kubectl_exec,
+        k8s_object_lookup: k8s_object_lookup
+      ).call(
+        webservice:    webservice,
+        pod_namespace: pod_namespace,
+        pod_name:      pod_name,
+        container:     container,
+        path:          path,
+        content:       content,
+        mode:          mode
+      )
+    end
+
+    it "does not raise an error" do
+      expect { subject }.to_not raise_error
+    end
+
+    expected_body = "\n#!/bin/sh\n" \
+                    "set -e\n\n" \
+                    "cleanup() {\n" \
+                    "  rm -f \"path/to/file.tmp\"\n" \
+                    "}\n" \
+                    "trap cleanup EXIT\n\n" \
+                    "set_file_content() {\n" \
+                    "  cat > \"path/to/file.tmp\" <<EOF\nContent\nEOF\n\n" \
+                    "  chmod \"Mode\" \"path/to/file.tmp\"\n" \
+                    "  mv \"path/to/file.tmp\" \"path/to/file\"\n" \
+                    "}\n\n" \
+                    "set_file_content > \"${TMPDIR:-/tmp}/conjur_set_file_content.log\" 2>&1\n"
+
+    it "calls kubectl_exec with expected parameters" do
+      expect(kubectl_exec)
+        .to receive(:call)
+          .with(
+            hash_including(
+              k8s_object_lookup: k8s_object_lookup_instance,
+              pod_namespace:     pod_namespace,
+              pod_name:          pod_name,
+              container:         container,
+              cmds:              %w(sh),
+              body:              expected_body,
+              stdin:             true
+            )
+          )
+      subject
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
             container: 'authenticator',
             path: "/etc/conjur/ssl/client.pem",
             content: webservice_signed_cert_pem,
-            mode: 0o644))
+            mode: "644"))
           .and_return(copy_response)
       end
 
@@ -243,7 +243,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
               pod_name: spiffe_name,
               path: "/etc/conjur/ssl/client.pem",
               content: webservice_signed_cert_pem,
-              mode: 0o644))
+              mode: "644"))
             .and_raise(RuntimeError.new(expected_error_text))
 
           expect { injector.(conjur_account: account,
@@ -330,7 +330,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
               container: overridden_container_name,
               path: "/etc/conjur/ssl/client.pem",
               content: webservice_signed_cert_pem,
-              mode: 0o644))
+              mode: "644"))
           .and_return(copy_response)
 
           expect { injector.(conjur_account: account,

--- a/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/inject_client_cert_spec.rb
@@ -91,16 +91,16 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
 
   let(:validate_pod_request) { double("ValidatePodRequest") }
 
-  let(:set_file_content_in_container) { double("SetFileContentInContainer") }
+  let(:copy_text_to_file_in_container) { double("SetFileContentInContainer") }
 
   let(:dependencies) {
     {
-      resource_class: resource_class,
-      conjur_ca_repo: conjur_ca_repo,
-      kubectl_exec: kubectl_exec,
-      set_file_content_in_container: set_file_content_in_container,
-      validate_pod_request: validate_pod_request,
-      audit_log: mocked_audit_logger
+      resource_class:                 resource_class,
+      conjur_ca_repo:                 conjur_ca_repo,
+      kubectl_exec:                   kubectl_exec,
+      copy_text_to_file_in_container: copy_text_to_file_in_container,
+      validate_pod_request:           validate_pod_request,
+      audit_log:                      mocked_audit_logger
     }
   }
 
@@ -227,7 +227,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
           .with(:error)
           .and_return(nil)
 
-        allow(set_file_content_in_container)
+        allow(copy_text_to_file_in_container)
           .to receive(:call)
           .with(
             hash_including(
@@ -249,7 +249,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
         it "rethrows" do
           expected_error_text = "ExpectedCopyError"
 
-          allow(set_file_content_in_container).to receive(:call)
+          allow(copy_text_to_file_in_container).to receive(:call)
             .with(
               hash_including(
                 webservice: webservice,
@@ -339,7 +339,7 @@ RSpec.describe Authentication::AuthnK8s::InjectClientCert do
             .with(:value)
             .and_return(overridden_container_name)
 
-          allow(set_file_content_in_container).to receive(:call)
+          allow(copy_text_to_file_in_container).to receive(:call)
             .with(
               hash_including(
                 webservice: webservice,


### PR DESCRIPTION
Connected to #1807 

Currently, we close the WebSocket connection after we send
the injection request to kubectl. This is not correct as this
way we do not wait for kubectl to send its response.

This has 2 implications:
1. If the injection request has succeeded we will return a 200 OK response
   to the 'inject_client_cert' request even if the cert has not finished to
   be written to the pod. This can lead to a race-condition where the client
   will try to read the cert before it is there.
2. If the injection request has failed in the k8s API, we will not
   write the error to the Conjur logs, and we will falsely return a 200
   OK response to the 'inject_client_cert' request

There is also [an issue](https://github.com/kubernetes/kubernetes/issues/89899)
in k8s where messages that are sent via WebSockets to Kubectl Exec are
left hanging without returning a response when using STDIN. This happens because
the `tar` command that we use to copy the file into the container is waiting for the STDIN
to end. 

The solution to the issue above is to inject the cert by running a bash script that exits explicitly.
This way we don't have the hanging issue, and the K8s API will close the socket
upon cert injection success/failure.

Additionally, to overcome the issue that we don't log the error if it occurs, we now redirect
the stdout and stderr into a file inside the client container. This will help is troubleshooting
errors in the cert injection. 

*Logs*
Let's see the Conjur server logs, and the client container logs, in cases where the cert injection succeeds and fails. 
Note: we show the logs of the secrets-provider that uses the authn-client as it's easier to deploy.

**Success**

Conjur server:
```
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] Started POST "/authn-k8s/authn-dev-env/inject_client_cert" for 10.1.3.190 at 2020-09-30 09:37:54 +0000
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00028D Setting common name to host.conjur.authn-k8s.authn-dev-env.apps.local-secrets-provider.*.*
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00026D Validating host id ["local-secrets-provider", "*", "*"]
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00030D Resource restrictions validated
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00015D Copying client certificate to cyberark-secrets-provider-for-k8s:/etc/conjur/ssl/client.pem in local-secrets-provider/test-env-6b7b4b57c6-rh9c4
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
CONJ00010D Pod 'test-env-6b7b4b57c6-rh9c4' : channel open
CONJ00012D Pod 'test-env-6b7b4b57c6-rh9c4', channel 'stdout':
CONJ00013D Pod 'test-env-6b7b4b57c6-rh9c4': message: 'close', data: 'nil'
CONJ00011D Pod 'test-env-6b7b4b57c6-rh9c4' : channel closed
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00037D Started copying the client certificate successfully
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] Completed 202 Accepted in 157ms
```

Secrets-provider:
```
INFO: 2020/09/30 11:56:59 main.go:23: CSPFK008I CyberArk Secrets Provider for Kubernetes v1.1.0-dev starting up
DEBUG: 2020/09/30 11:56:59 main.go:115: CSPFK001D Debug mode is enabled
INFO: 2020/09/30 11:56:59 main.go:81: CSPFK001I Authenticating as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 11:56:59.850083 authenticator.go:201: CAKC005I Trying to login Conjur...
INFO:  2020/09/30 11:56:59.850101 authenticator.go:116: CAKC007I Logging in as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 11:56:59.850929 requests.go:23: CAKC011I Login request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/inject_client_cert
INFO:  2020/09/30 11:57:00.030877 authenticator.go:163: CAKC015I Loaded client certificate successfully from /etc/conjur/ssl/client.pem
INFO:  2020/09/30 11:57:00.031065 authenticator.go:175: CAKC016I Deleted client certificate from memory
INFO:  2020/09/30 11:57:00.031098 authenticator.go:207: CAKC002I Logged in
INFO:  2020/09/30 11:57:00.031114 authenticator.go:190: CAKC008I Cert expires: 2020-10-03 11:56:59 +0000 UTC
INFO:  2020/09/30 11:57:00.031120 authenticator.go:191: CAKC009I Current date: 2020-09-30 11:57:00.031107326 +0000 UTC
INFO:  2020/09/30 11:57:00.031129 authenticator.go:192: CAKC010I Buffer time:  30s
INFO:  2020/09/30 11:57:00.031374 requests.go:47: CAKC012I Authn request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/cucumber/host%2Fconjur%2Fauthn-k8s%2Fauthn-dev-env%2Fapps%2Flocal-secrets-provider%2F%2A%2F%2A/authenticate
INFO:  2020/09/30 11:57:00.085173 authenticator.go:270: CAKC001I Successfully authenticated
INFO: 2020/09/30 11:57:00 k8s_secrets_client.go:54: CSPFK004I Creating Kubernetes client
INFO: 2020/09/30 11:57:00 k8s_secrets_client.go:19: CSPFK005I Retrieving Kubernetes secret 'test-k8s-secret' from namespace 'local-secrets-provider'
DEBUG: 2020/09/30 11:57:00 provide_conjur_secrets.go:127: CSPFK009D Processing 'conjur-map' data entry value of Kubernetes Secret 'test-k8s-secret'
INFO: 2020/09/30 11:57:00 conjur_secrets_retriever.go:11: CSPFK003I Retrieving following secrets from DAP/Conjur: [secrets/test_secret secrets/var with spaces secrets/var+with+pluses]
INFO: 2020/09/30 11:57:00 conjur_client.go:21: CSPFK002I Creating DAP/Conjur client
INFO: 2020/09/30 11:57:00 k8s_secrets_client.go:54: CSPFK004I Creating Kubernetes client
INFO: 2020/09/30 11:57:00 k8s_secrets_client.go:38: CSPFK006I Updating Kubernetes secret 'test-k8s-secret' in namespace 'local-secrets-provider'
INFO: 2020/09/30 11:57:00 main.go:102: CSPFK009I DAP/Conjur Secrets updated in Kubernetes successfully
```

**Failure**
We have 2 kinds of failure:

***The Conjur server fails the handshake with the k8s api***

Conjur server:
```
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] Started POST "/authn-k8s/authn-dev-env/inject_client_cert" for 10.1.3.225 at 2020-09-30 11:48:51 +0000
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00028D Setting common name to host.conjur.authn-k8s.authn-dev-env.apps.local-secrets-provider.*.*
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00026D Validating host id ["local-secrets-provider", "*", "*"]
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00030D Resource restrictions validated
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00015D Copying client certificate to cyberark-secrets-provider-for-k8s:/etc/conjur/ssl/client.pem in local-secrets-provider/test-env-6b7b4b57c6-czdqj
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
CONJ00014D Pod 'test-env-6b7b4b57c6-czdqj' error : '"Websocket handshake error: :invalid_status_code"'
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* failed to inject client certificate with authenticator authn-k8s service cucumber:webservice:conjur/authn-k8s/authn-dev-env: CONJ00027E Certificate could not be copied to pod: ["\"Websocket handshake error: :invalid_status_code\""]
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] Authentication Error: #<Errors::Authentication::AuthnK8s::CertInstallationError: CONJ00027E Certificate could not be copied to pod: ["\"Websocket handshake error: :invalid_status_code\""]>
[origin=10.1.3.225] [request_id=4f449bc0-712a-4ef0-86c4-a07ddf80272b] [tid=36] Completed 401 Unauthorized in 157ms
```

secrets-provider:
```
INFO: 2020/09/30 11:49:03 main.go:23: CSPFK008I CyberArk Secrets Provider for Kubernetes v1.1.0-dev starting up
DEBUG: 2020/09/30 11:49:03 main.go:115: CSPFK001D Debug mode is enabled
INFO: 2020/09/30 11:49:03 main.go:81: CSPFK001I Authenticating as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 11:49:03.738016 authenticator.go:201: CAKC005I Trying to login Conjur...
INFO:  2020/09/30 11:49:03.738036 authenticator.go:116: CAKC007I Logging in as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 11:49:03.739488 requests.go:23: CAKC011I Login request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/inject_client_cert
ERROR: 2020/09/30 11:49:03.897870 authenticator.go:136: CAKC029E Received invalid response to certificate signing request. Reason: status code 401,
ERROR: 2020/09/30 11:49:03.897919 authenticator.go:204: CAKC015E Login failed
```

***The k8s api fails to inject the cert into the container***

The Conjur server log will not indicate a failure:
```
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] Started POST "/authn-k8s/authn-dev-env/inject_client_cert" for 10.1.3.190 at 2020-09-30 09:37:54 +0000
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00028D Setting common name to host.conjur.authn-k8s.authn-dev-env.apps.local-secrets-provider.*.*
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00026D Validating host id ["local-secrets-provider", "*", "*"]
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00030D Resource restrictions validated
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00027D Host id cucumber:host:conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/* extracted from CSR common name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00015D Copying client certificate to cyberark-secrets-provider-for-k8s:/etc/conjur/ssl/client.pem in local-secrets-provider/test-env-6b7b4b57c6-rh9c4
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00024D Retrieved value of annotation kubernetes/authentication-container-name
CONJ00010D Pod 'test-env-6b7b4b57c6-rh9c4' : channel open
CONJ00012D Pod 'test-env-6b7b4b57c6-rh9c4', channel 'stdout':
CONJ00013D Pod 'test-env-6b7b4b57c6-rh9c4': message: 'close', data: 'nil'
CONJ00011D Pod 'test-env-6b7b4b57c6-rh9c4' : channel closed
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] CONJ00037D Started copying the client certificate successfully
[origin=10.1.3.190] [request_id=f80c9d90-6100-4ca4-9e7b-c1c54d9d2e60] [tid=45] Completed 202 Accepted in 157ms
```

However, the client logs will show the error:
```
INFO: 2020/09/30 09:43:47 main.go:23: CSPFK008I CyberArk Secrets Provider for Kubernetes v1.1.0-dev starting up
DEBUG: 2020/09/30 09:43:47 main.go:115: CSPFK001D Debug mode is enabled
INFO: 2020/09/30 09:43:47 main.go:81: CSPFK001I Authenticating as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 09:43:47.752617 authenticator.go:201: CAKC005I Trying to login Conjur...
INFO:  2020/09/30 09:43:47.752639 authenticator.go:116: CAKC007I Logging in as user 'host/conjur/authn-k8s/authn-dev-env/apps/local-secrets-provider/*/*'
INFO:  2020/09/30 09:43:47.753632 requests.go:23: CAKC011I Login request to: https://conjur-oss.local-conjur.svc.cluster.local/authn-k8s/authn-dev-env/inject_client_cert
INFO:  2020/09/30 09:43:48.931582 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:49.932103 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:50.932975 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:51.933315 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:52.934947 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:53.936669 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:54.937943 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:55.940030 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:56.940431 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
INFO:  2020/09/30 09:43:57.940838 file.go:35: CAKC017I Waiting for file /etc/conjur/ssl/client.pem to become available...
ERROR: 2020/09/30 09:43:57.941025 file.go:42: CAKC033E Timed out after waiting for 10 seconds for file to exist: /etc/conjur/ssl/client.pem
ERROR: 2020/09/30 09:43:57.941518 authenticator.go:149: CAKC036E Cert injection failed with the following error:
sh: can't create /etc/conjur/ssl/client.pem.tmp: Permission denied
ERROR: 2020/09/30 09:43:57.941586 authenticator.go:204: CAKC015E Login failed
ERROR: 2020/09/30 09:43:57 main.go:84: CSPFK010E Failed to authenticate
```