### PR TITLE
Add test for changing restricted_to value

### DIFF
--- a/cucumber/policy/features/cidr_restrictions.feature
+++ b/cucumber/policy/features/cidr_restrictions.feature
@@ -75,3 +75,35 @@ from a particular network, defined by a CIDR in the policy
     Then there is an error
     And the error code is "validation_failed"
     And the error message includes "Invalid IP address or CIDR range '10.0.0.1/24': Value has bits set to right of mask. Did you mean '10.0.0.0/24'"
+
+  Scenario: Change CIDR restriction value
+    Given I load a policy:
+    """
+    - !policy
+      id: servers
+      body:
+      - !host
+        id: server-a
+        restricted_to: 1.2.3.7
+    """
+    When I show the host "servers/server-a"
+    Then the "restricted_to" should be: 
+    """
+      ["1.2.3.7/32"]
+    """
+
+    When I load a policy:
+    """
+    - !policy
+      id: servers
+      body:
+      - !host
+        id: server-a
+        restricted_to: 1.2.3.8
+    """
+    And I show the host "servers/server-a"
+    Then the "restricted_to" should be: 
+    """
+      ["1.2.3.8/32"]
+    """
+


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR adds a test to verify that a host's `restricted_to` value can be modified by reloading the policy that defines it.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
