### PR TITLE
Move email claim to be an optional claim

### DIFF
--- a/app/domain/authentication/authn_gcp/decoded_token.rb
+++ b/app/domain/authentication/authn_gcp/decoded_token.rb
@@ -26,10 +26,10 @@ module Authentication
       def initialize_required_claims
         @audience = required_token_claim_value(AUDIENCE_TOKEN_CLAIM_NAME)
         @service_account_id = required_token_claim_value(SUB_TOKEN_CLAIM_NAME)
-        @service_account_email = required_token_claim_value(EMAIL_TOKEN_CLAIM_NAME)
       end
 
       def initialize_optional_claims
+        @service_account_email = optional_token_claim_value(EMAIL_TOKEN_CLAIM_NAME)
         @project_id = optional_token_claim_value(PROJECT_ID_TOKEN_CLAIM_NAME)
         @instance_name = optional_token_claim_value(INSTANCE_NAME_TOKEN_CLAIM_NAME)
       end
@@ -50,6 +50,7 @@ module Authentication
         optional_token_claim_value = token_claim_value(optional_token_claim)
 
         if optional_token_claim_value.nil? || optional_token_claim_value.empty?
+          optional_token_claim_value = nil
           @logger.debug(LogMessages::Authentication::Jwt::OptionalTokenClaimNotFoundOrEmpty.new(optional_token_claim))
         else
           log_claim_extracted_from_token(optional_token_claim, optional_token_claim_value)

--- a/spec/app/domain/authentication/authn-gcp/decoded_token_spec.rb
+++ b/spec/app/domain/authentication/authn-gcp/decoded_token_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
       <<~EOS
         {
           "aud": "#{sub_value}", 
+          "sub": "", 
           "email": "#{email_value}", 
           "google": {
             "compute_engine": {
@@ -122,7 +123,8 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
     decoded_token_hash(
       <<~EOS
         {
-          "aud": "#{sub_value}", 
+          "aud": "#{sub_value}",
+          "email": "", 
           "sub": "#{sub_value}", 
           "google": {
             "compute_engine": {
@@ -161,6 +163,7 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
           "email": "#{email_value}", 
           "google": {
             "compute_engine": {
+              "instance_name": "", 
               "project_id": "#{project_id_value}"
             }
           }
@@ -195,7 +198,8 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
           "email": "#{email_value}", 
           "google": {
             "compute_engine": {
-              "instance_name": "#{instance_name_value}"
+              "instance_name": "#{instance_name_value}",
+              "project_id": ""
             }
           }
         }
@@ -281,7 +285,9 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
           expect { decoded_token }.to raise_error(Errors::Authentication::Jwt::TokenClaimNotFoundOrEmpty)
         end
       end
+    end
 
+    context "that is missing optional token claims" do
       context "missing email claim" do
         subject(:decoded_token) do
           ::Authentication::AuthnGcp::DecodedToken.new(
@@ -290,8 +296,15 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
           )
         end
 
-        it "raises an error" do
-          expect { decoded_token }.to raise_error(Errors::Authentication::Jwt::TokenClaimNotFoundOrEmpty)
+        it "does not raise an error" do
+          expect { decoded_token }.to_not raise_error
+        end
+
+        it "parses the token expectedly" do
+          expect(decoded_token.project_id).to eq(project_id_value)
+          expect(decoded_token.instance_name).to eq(instance_name_value)
+          expect(decoded_token.service_account_id).to eq(sub_value)
+          expect(decoded_token.service_account_email).to eq(nil)
         end
       end
 
@@ -303,13 +316,18 @@ RSpec.describe 'Authentication::AuthnGcp::DecodedToken' do
           )
         end
 
-        it "raises an error" do
-          expect { decoded_token }.to raise_error(Errors::Authentication::Jwt::TokenClaimNotFoundOrEmpty)
+        it "does not raise an error" do
+          expect { decoded_token }.to_not raise_error
+        end
+
+        it "parses the token expectedly" do
+          expect(decoded_token.project_id).to eq(project_id_value)
+          expect(decoded_token.instance_name).to eq(instance_name_value)
+          expect(decoded_token.service_account_id).to eq(sub_value)
+          expect(decoded_token.service_account_email).to eq(nil)
         end
       end
-    end
 
-    context "that is missing optional token claims" do
       context "missing instance_name claim" do
         subject(:decoded_token) do
           ::Authentication::AuthnGcp::DecodedToken.new(


### PR DESCRIPTION
### What does this PR do?
Move email claim to be an optional claim

In the decoded token stage we will fail the request only if the following claims are missing:
1. Aud - contains the host-id
2. Sub - is the only cliam which shared with GCE and GCF

All other token are optional, and will fail the request only the JWT token validation stage


