### PR TITLE
Add support of GCF to `dev/start` script

### DIFF
--- a/ci/authn-gcp/get_func_tokens_to_files.sh
+++ b/ci/authn-gcp/get_func_tokens_to_files.sh
@@ -11,7 +11,7 @@ main() {
   # Read the identity token file
   IDENTITY_TOKEN=$(cat $IDENTITY_TOKEN_FILE)
 
-  test_token_function "conjur/cucumber/host/test-app" || exit 1
+  sh ./validate_gcf_url_accessible.sh "$GCP_FUNC_URL" "conjur/cucumber/host/test-app" "$IDENTITY_TOKEN" || exit 1
   get_tokens_to_files || exit 1
   echo '-> get_func_tokens_to_file done'
 }
@@ -44,22 +44,6 @@ validate_pre_requisites() {
     mkdir tokens || exit 1
   fi
   echo '-> validate_pre_requisites done'
-}
-
-# Invokes the function once to test if the function is accessible.
-test_token_function() {
-  echo 'test_token_function'
-  local audience="$1"
-  local status_code=$(curl -o /dev/null -s -w "%{http_code}\n" \
-    -H "Authorization: bearer $IDENTITY_TOKEN" \
-    -H 'Metadata-Flavor: Google' "$GCP_FUNC_URL?audience=${audience}")
-
-  if [ ! "$status_code" = "200" ]; then
-    echo "-- Function returned error, HTTP Status: '${status_code}', \
-    cannot obtain token from URL: $GCP_FUNC_URL?audience=${audience}"
-    exit 1
-  fi
-  echo '-> test_token_function done'
 }
 
 # Invokes the function with different audience

--- a/ci/authn-gcp/get_gcp_id_tokens.sh
+++ b/ci/authn-gcp/get_gcp_id_tokens.sh
@@ -20,9 +20,9 @@ INSTANCE_EXISTS=0
 INSTANCE_RUNNING=0
 
 main() {
-  echo "-- ------------------------------------------ --"
-  echo "-- Generate Google Cloud GCP Identity tokens --"
-  echo "-- ------------------------------------------ --"
+  echo "-- ----------------------------------------------------------- --"
+  echo "-- Generate Google Cloud GCP Identity tokens from GCE instance --"
+  echo "-- ----------------------------------------------------------- --"
 
   echo "-- Verifying 'gcloud' is installed..."
   ensure_gcloud_is_installed

--- a/ci/authn-gcp/validate_gcf_url_accessible.sh
+++ b/ci/authn-gcp/validate_gcf_url_accessible.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# Invokes the function once to test if the function is accessible.
+echo "validate_gcf_url_accessible"
+gcp_func_url=$1
+audience=$2
+optional_identity_token=$3
+
+status_code=$(curl -o /dev/null -s -w "%{http_code}\n" \
+  -H "Authorization: bearer $optional_identity_token" \
+  -H 'Metadata-Flavor: Google' "$gcp_func_url?audience=${audience}")
+
+if [ ! "$status_code" = "200" ]; then
+  echo "-- Function returned error, HTTP Status: '${status_code}', \
+  cannot obtain token from URL: $gcp_func_url?audience=${audience}"
+  exit 1
+fi
+
+echo "-> validate_gcf_url_accessible done"

--- a/dev/cli
+++ b/dev/cli
@@ -36,14 +36,89 @@ EOF
 exit
 }
 
-function enable_gcp() {
-  local gce_instance_name="$1"
+function print_gcp_help() {
+  cat << EOF
+NAME
+    --authn-gcp - Enables GCP features, in order to run local tests.
 
-  if [ -z "$gce_instance_name" ]; then
-    echo "--authn-gcp mode requires a GCE instance name argument."
-    echo "Usage ./cli exec --authn-gcp [GCE_INSTANCE_NAME]"
+SYNOPSIS
+    --authn-gcp [command options] [arguments...]
+GLOBAL OPTIONS
+    --help                                    - Show this message
+COMMANDS
+    -gce     Google compute engine instance name
+    -gcf     Google cloud function URL (Predefine ci/authn-gcp/function/main.py code as GCF)
+USAGE
+    ./cli exec --authn-gcp -gce [GCE_INSTANCE_NAME] -gcf [GCF_URL]
+EOF
+exit
+}
+
+function handle_gcp() {
+  local gcp_params="${@:1:4}"
+  validate_gcp_options_and_args $gcp_params
+  enable_gcp $gcp_params
+}
+
+function validate_gcp_options_and_args() {
+  if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    print_gcp_help
+    exit 1
+  elif [ -z "$1" ];  then
+    echo "-gce,-gcf required command options are missing"
+    print_gcp_help
     exit 1
   fi
+
+  local params_count=$#
+  while [ $params_count -gt 0 ]
+  do
+     local option=$1
+     local option_arg=$2
+     validate_gcp_option $option $option_arg
+
+     shift 2
+     params_count=$(( $params_count - 2 ))
+  done
+}
+
+function validate_gcp_option() {
+  local option=$1
+  local option_arg=$2
+  case "$option" in
+    -gce | -gcf ) validate_gcp_arguments_exist $option $option_arg ;;
+    * ) echo "$option is not a valid option"; print_gcp_help; exit 1;;
+  esac
+}
+
+function validate_gcp_arguments_exist() {
+  local option=$1
+  local option_arg=$2
+  if [ -z "$option_arg" ]; then
+    echo "argument is missing for $option option"
+    exit 1
+  fi
+}
+
+function enable_gcp() {
+  local params_count=$#
+  while [ $params_count -gt 0 ]
+  do
+    local option=$1
+    local option_arg=$2
+
+    case "$option" in
+      -gce ) fetch_gce_tokens $option_arg ;;
+      -gcf ) fetch_gcf_tokens $option_arg ;;
+    esac
+
+     shift 2
+     params_count=$(( $params_count - 2 ))
+  done
+}
+
+function fetch_gce_tokens() {
+  local gce_instance_name="$1"
 
  "../ci/authn-gcp/get_gcp_id_tokens.sh" "$gce_instance_name"
 
@@ -81,6 +156,31 @@ _get_gcp_token_payload() {
   decoded_gcp_token_payload=$(decode_jwt_payload "$gcp_token")
 
   echo "$decoded_gcp_token_payload"
+}
+
+function fetch_gcf_tokens() {
+  echo "-- ------------------------------------------------------ --"
+  echo "-- Generate Google Cloud GCP Identity tokens from GCF URL --"
+  echo "-- ------------------------------------------------------ --"
+
+  local gcp_func_url=$1
+  local token_prefix="tokens/gcf_"
+
+  validate_gcf_url_accessible "$gcp_func_url"
+
+  cd ../ci/authn-gcp/
+  sh ./get_tokens_to_files.sh "$gcp_func_url" "$token_prefix" || exit 1
+  cd -
+
+  echo "Finished obtaining and writing tokens to file"
+}
+
+function validate_gcf_url_accessible() {
+  echo "Validating google cloud function is accessible"
+  local gcp_func_url=$1
+  local audience="dummy_host"
+
+  sh ../ci/authn-gcp/validate_gcf_url_accessible.sh "$gcp_func_url" "$audience" || exit 1
 }
 
 function enable_oidc() {
@@ -127,7 +227,7 @@ while true ; do
         -h | --help ) print_exec_help ; shift ;;
         --authn-oidc ) enable_oidc ; shift ;;
         --authn-azure ) enable_azure ; shift ;;
-        --authn-gcp ) enable_gcp "$3"; shift 2;;
+        --authn-gcp ) handle_gcp "${@:3:4}"; shift 5;;
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 


### PR DESCRIPTION
### What does this PR do?
Add support of generating google cloud function tokens as part of `dev/start` script, 
in order to be able to run the automation tests in a local environmnet 

### What ticket does this PR close?
Connected to #1812 

### Checklists
