### PR TITLE
Remove cert file from correct pod

### DIFF
--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -11,7 +11,7 @@ Before do
   kubectl_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
     next unless ready_status = pod.status.conditions.find{|c| c.type == "Ready"}
     next unless ready_status.status == "True"
-    next if pod.metadata.name =~ /conjur\-authn\-k8s/
+    next unless pod.metadata.name =~ /inventory\-deployment/
 
     exec = Authentication::AuthnK8s::KubectlExec.new
 


### PR DESCRIPTION
Before each cucumber test of authn-k8s, we delete the cert file
from `/etc/conjur/ssl` so that each test starts with a fresh folder.

For some reason we skipped the pod if its name started with `conjur-authn-k8s`
(which is the pod of the Conjur server) and performed the erase from pods that
do not start with this prefix. However, we need to erase the cert only from the
pod that performs the authentication which has the `inventory-deployment` prefix

This causes the k8s tests to be flakey as sometimes we get a timeout while trying to
delete the cert from the `cli` or `cucumber` containers, which is redundant.