### PR TITLE
Delete cert file only from authenticator container

### DIFF
--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -9,13 +9,15 @@ end
 Before do
   # Erase the certificates and keys from each container.
   kubectl_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
-    next unless ready_status = pod.status.conditions.find{|c| c.type == "Ready"}
+    next unless (ready_status = pod.status.conditions.find { |c| c.type == "Ready" })
     next unless ready_status.status == "True"
     next unless pod.metadata.name =~ /inventory\-deployment/
 
     exec = Authentication::AuthnK8s::KubectlExec.new
 
     pod.spec.containers.each do |container|
+      next unless container.name == "authenticator"
+
       exec.execute(
         k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,
         pod_namespace: pod.metadata.namespace,


### PR DESCRIPTION
Before each cucumber test of authn-k8s, we delete the cert file
from `/etc/conjur/ssl` so that each test starts with a fresh folder.

We should delete the file only from the authenticator container, and not
from the application container.
