### PR TITLE
Remove contents of ssl dir but not dir

### DIFF
--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -23,7 +23,7 @@ Before do
         pod_namespace: pod.metadata.namespace,
         pod_name: pod.metadata.name,
         container: container.name,
-        cmds: %w(rm -rf /etc/conjur/ssl)
+        cmds: %w(rm -rf /etc/conjur/ssl/*)
       )
     end
   end


### PR DESCRIPTION
Before each cucumber test of authn-k8s, we delete the cert file
from `/etc/conjur/ssl` so that each test starts with a fresh folder.

However, the current implementation deletes the directory itself instead
of deleting only its content. The directory needs to be present as its permissions
are defined upon its initial creation.