### PR TITLE
Use explicit Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,11 @@ source 'https://rubygems.org'
 # make sure to use tls for github
 git_source(:github) { |name| "https://github.com/#{name}.git" }
 
-ruby '~> 2.5.1'
+# Do not use fuzzy version matching (~>) with the Ruby version. It doesn't play
+# nicely with RVM and we should be explicit since Ruby is such a fundamental
+# part of a Rails project. The Ruby version is also locked in place by the
+# Docker base image so it won't be updated with fuzzy matching.
+ruby '2.5.1'
 #ruby-gemset=conjur
 
 gem 'command_class'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,6 +438,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-18
   x86_64-darwin-19
 
 DEPENDENCIES


### PR DESCRIPTION
Fuzzy version matching (~>) for the Ruby version in the Gemfile does not play
nicely with RVM. We should be explicit about our Ruby version since it's such a
fundamental part of a Rails project.