### PR TITLE
Refactor KubectlExec to KubeExec

### DIFF
--- a/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
+++ b/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
@@ -8,7 +8,7 @@ module Authentication
 
     CopyTextToFileInContainer ||= CommandClass.new(
       dependencies: {
-        kubectl_exec:      KubectlExec.new,
+        kube_exec:         KubeExec.new,
         k8s_object_lookup: K8sObjectLookup,
         logger:            Rails.logger
       },
@@ -24,7 +24,7 @@ module Authentication
       private
 
       def copy_text_to_file_in_container
-        @kubectl_exec.call(
+        @kube_exec.call(
           k8s_object_lookup: @k8s_object_lookup.new(@webservice),
           pod_namespace:     @pod_namespace,
           pod_name:          @pod_name,

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -12,7 +12,7 @@ module Authentication
         logger:                         Rails.logger,
         resource_class:                 Resource,
         conjur_ca_repo:                 Repos::ConjurCA,
-        kubectl_exec:                   KubectlExec,
+        kube_exec:                      KubeExec,
         copy_text_to_file_in_container: CopyTextToFileInContainer.new,
         validate_pod_request:           ValidatePodRequest.new,
         extract_container_name:         ExtractContainerName.new,

--- a/app/domain/authentication/authn_k8s/kube_exec.rb
+++ b/app/domain/authentication/authn_k8s/kube_exec.rb
@@ -11,7 +11,7 @@ require 'websocket-client-simple'
 module Authentication
   module AuthnK8s
 
-    KubectlExec ||= CommandClass.new(
+    KubeExec ||= CommandClass.new(
       dependencies: {
         env:    ENV,
         logger: Rails.logger
@@ -28,7 +28,7 @@ module Authentication
       extend Forwardable
       def_delegators :@k8s_object_lookup, :kube_client
 
-      DEFAULT_KUBECTL_EXEC_COMMAND_TIMEOUT = 5
+      DEFAULT_KUBE_EXEC_COMMAND_TIMEOUT = 5
 
       def call
         @message_log = MessageLog.new
@@ -126,12 +126,12 @@ module Authentication
       private
 
       def add_websocket_event_handlers(ws_client, body, stdin)
-        kubectl = self
+        kube = self
 
-        ws_client.on(:open) { kubectl.on_open(ws_client, body, stdin) }
-        ws_client.on(:message) { |msg| kubectl.on_message(msg, ws_client) }
-        ws_client.on(:close) { kubectl.on_close }
-        ws_client.on(:error) { |err| kubectl.on_error(err) }
+        ws_client.on(:open) { kube.on_open(ws_client, body, stdin) }
+        ws_client.on(:message) { |msg| kube.on_message(msg, ws_client) }
+        ws_client.on(:close) { kube.on_close }
+        ws_client.on(:error) { |err| kube.on_error(err) }
       end
 
       def wait_for_close_message
@@ -162,15 +162,15 @@ module Authentication
       def timeout
         return @timeout if @timeout
 
-        kube_timeout = @env["KUBECTL_EXEC_COMMAND_TIMEOUT"]
+        kube_timeout = @env["KUBE_EXEC_COMMAND_TIMEOUT"]
         not_provided = kube_timeout.to_s.strip.empty?
-        default = DEFAULT_KUBECTL_EXEC_COMMAND_TIMEOUT
-        # If the value of KUBECTL_EXEC_COMMAND_TIMEOUT is not an integer it will be zero
+        default = DEFAULT_KUBE_EXEC_COMMAND_TIMEOUT
+        # If the value of KUBE_EXEC_COMMAND_TIMEOUT is not an integer it will be zero
         @timeout = not_provided ? default : kube_timeout.to_i
       end
     end
 
-    class KubectlExec
+    class KubeExec
       # This delegates to all the work to the call method created automatically
       # by CommandClass
       #

--- a/app/domain/authentication/authn_k8s/kube_exec.rb
+++ b/app/domain/authentication/authn_k8s/kube_exec.rb
@@ -16,13 +16,7 @@ module Authentication
         env:    ENV,
         logger: Rails.logger
       },
-      inputs: %i( k8s_object_lookup
-                  pod_namespace
-                  pod_name
-                  container
-                  cmds
-                  body
-                  stdin )
+      inputs:       %i(k8s_object_lookup pod_namespace pod_name container cmds body stdin)
     ) do
 
       extend Forwardable
@@ -126,6 +120,9 @@ module Authentication
       private
 
       def add_websocket_event_handlers(ws_client, body, stdin)
+        # We need to set this so the handlers will call this class's methods.
+        # If we use 'self' inside the curly brackets it will be try to use methods
+        # of the class WebSocket::Client::Simple::Client
         kube = self
 
         ws_client.on(:open) { kube.on_open(ws_client, body, stdin) }

--- a/app/domain/authentication/authn_k8s/kube_exec.rb
+++ b/app/domain/authentication/authn_k8s/kube_exec.rb
@@ -25,11 +25,11 @@ module Authentication
       DEFAULT_KUBE_EXEC_COMMAND_TIMEOUT = 5
 
       def call
-        @message_log = MessageLog.new
+        @message_log    = MessageLog.new
         @channel_closed = false
 
-        url = server_url(@cmds, @stdin)
-        headers = kube_client.headers.clone
+        url       = server_url(@cmds, @stdin)
+        headers   = kube_client.headers.clone
         ws_client = WebSocket::Client::Simple.connect(url, headers: headers)
 
         add_websocket_event_handlers(ws_client, @body, @stdin)
@@ -50,7 +50,7 @@ module Authentication
       end
 
       def on_open(ws_client, body, stdin)
-        hs = ws_client.handshake
+        hs       = ws_client.handshake
         hs_error = hs.error
 
         if hs_error
@@ -140,19 +140,19 @@ module Authentication
 
       def query_string(cmds, stdin)
         stdin_part = stdin ? ['stdin=true'] : []
-        cmds_part = cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
+        cmds_part  = cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
         (base_query_string_parts + stdin_part + cmds_part).join("&")
       end
 
       def base_query_string_parts
-        ["container=#{CGI.escape(@container)}", "stderr=true", "stdout=true"]
+        %W(container=#{CGI.escape(@container)} stderr=true stdout=true)
       end
 
       def server_url(cmds, stdin)
-        api_uri = kube_client.api_endpoint
+        api_uri  = kube_client.api_endpoint
         base_url = "wss://#{api_uri.host}:#{api_uri.port}"
-        path = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
-        query = query_string(cmds, stdin)
+        path     = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
+        query    = query_string(cmds, stdin)
         "#{base_url}#{path}?#{query}"
       end
 
@@ -161,7 +161,7 @@ module Authentication
 
         kube_timeout = @env["KUBE_EXEC_COMMAND_TIMEOUT"]
         not_provided = kube_timeout.to_s.strip.empty?
-        default = DEFAULT_KUBE_EXEC_COMMAND_TIMEOUT
+        default      = DEFAULT_KUBE_EXEC_COMMAND_TIMEOUT
         # If the value of KUBE_EXEC_COMMAND_TIMEOUT is not an integer it will be zero
         @timeout = not_provided ? default : kube_timeout.to_i
       end
@@ -173,63 +173,16 @@ module Authentication
       #
       # This is needed because we need these methods to exist on the class,
       # but that class contains only a metaprogramming generated `call()`.
-      def execute(k8s_object_lookup:,
-        pod_namespace:,
-        pod_name:,
-        cmds:,
-        container: 'authenticator',
-        body: "",
-        stdin: false)
+      def execute(k8s_object_lookup:, pod_namespace:, pod_name:, cmds:, container: 'authenticator', body: "", stdin: false)
         call(
           k8s_object_lookup: k8s_object_lookup,
-          pod_namespace: pod_namespace,
-          pod_name: pod_name,
-          container: container,
-          cmds: cmds,
-          body: body,
-          stdin: stdin
+          pod_namespace:     pod_namespace,
+          pod_name:          pod_name,
+          container:         container,
+          cmds:              cmds,
+          body:              body,
+          stdin:             stdin
         )
-      end
-    end
-
-    # Utility class for processing WebSocket messages.
-    class WebSocketMessage
-      class << self
-        def channel_byte(channel_name)
-          channel_number_from_name(channel_name).chr
-        end
-
-        def channel_number_from_name(channel_name)
-          channel_names.index(channel_name)
-        end
-
-        def channel_names
-          %w(stdin stdout stderr error resize)
-        end
-      end
-
-      def initialize(msg)
-        @msg = msg
-      end
-
-      def type
-        @msg.type
-      end
-
-      def data
-        @msg.data[1..-1]
-      end
-
-      def channel_name
-        self.class.channel_names[channel_number]
-      end
-
-      def channel_number
-        unless @msg.respond_to?(:data)
-          return self.class.channel_number_from_name('error')
-        end
-
-        @msg.data[0..0].bytes.first
       end
     end
   end

--- a/app/domain/authentication/authn_k8s/web_socket_message.rb
+++ b/app/domain/authentication/authn_k8s/web_socket_message.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Utility class for processing WebSocket messages.
+module Authentication
+  module AuthnK8s
+    class WebSocketMessage
+      class << self
+        def channel_byte(channel_name)
+          channel_number_from_name(channel_name).chr
+        end
+
+        def channel_number_from_name(channel_name)
+          channel_names.index(channel_name)
+        end
+
+        def channel_names
+          %w(stdin stdout stderr error resize)
+        end
+      end
+
+      def initialize(msg)
+        @msg = msg
+      end
+
+      def type
+        @msg.type
+      end
+
+      def data
+        @msg.data[1..-1]
+      end
+
+      def channel_name
+        self.class.channel_names[channel_number]
+      end
+
+      def channel_number
+        unless @msg.respond_to?(:data)
+          return self.class.channel_number_from_name('error')
+        end
+
+        @msg.data[0..0].bytes.first
+      end
+    end
+  end
+end

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -13,7 +13,7 @@ Before do
     next unless ready_status.status == "True"
     next unless pod.metadata.name =~ /inventory\-deployment/
 
-    exec = Authentication::AuthnK8s::KubectlExec.new
+    exec = Authentication::AuthnK8s::KubeExec.new
 
     pod.spec.containers.each do |container|
       next unless container.name == "authenticator"

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -28,8 +28,8 @@ module AuthnK8sWorld
     pattern
   end
 
-  def kubectl_exec
-    Authentication::AuthnK8s::KubectlExec.new
+  def kube_exec
+    Authentication::AuthnK8s::KubeExec.new
   end
 
   def print_result_errors response
@@ -53,7 +53,7 @@ module AuthnK8sWorld
       puts "Waiting for client cert to be available (Attempt #{count + 1} of #{retries})"
 
       pod_metadata = @pod.metadata
-      response = kubectl_exec.execute(
+      response = kube_exec.execute(
         k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,
         pod_namespace: pod_metadata.namespace,
         pod_name: pod_metadata.name,
@@ -73,7 +73,7 @@ module AuthnK8sWorld
     if !success
       puts "ERROR: Unable to retrieve client certificate for pod #{@pod.metadata.name.inspect}, " \
            "printing logs from the container..."
-      get_cert_injection_logs_response = kubectl_exec.execute(
+      get_cert_injection_logs_response = kube_exec.execute(
         k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,
         pod_namespace: pod_metadata.namespace,
         pod_name: pod_metadata.name,

--- a/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
   let(:content) { "Content" }
   let(:mode) { "Mode" }
 
-  let(:kubectl_exec) { double("KubectlExec") }
+  let(:kube_exec) { double("KubeExec") }
 
   let(:k8s_object_lookup_instance) { double("K8sObjectLookupInstance") }
   let(:k8s_object_lookup) { double("K8sObjectLookup") }
@@ -25,14 +25,14 @@ RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
   end
 
   before(:each) do
-    allow(kubectl_exec)
+    allow(kube_exec)
       .to receive(:call)
   end
 
   context "Calling CopyTextToFileInContainer" do
     subject do
       ::Authentication::AuthnK8s::CopyTextToFileInContainer.new(
-        kubectl_exec:      kubectl_exec,
+        kube_exec:         kube_exec,
         k8s_object_lookup: k8s_object_lookup
       ).call(
         webservice:    webservice,
@@ -62,8 +62,8 @@ RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
                     "}\n\n" \
                     "set_file_content > \"${TMPDIR:-/tmp}/conjur_set_file_content.log\" 2>&1\n"
 
-    it "calls kubectl_exec with expected parameters" do
-      expect(kubectl_exec)
+    it "calls kube_exec with expected parameters" do
+      expect(kube_exec)
         .to receive(:call)
           .with(
             hash_including(


### PR DESCRIPTION
Connected to #1855

This class performs exec commands to the K8s API but it is not
using kubectl, which is the cli client of the K8s API.
Thus, the name is misleading and we should refactor it.