### PR TITLE
Erase cert from every authenticator container

### DIFF
--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -11,7 +11,7 @@ Before do
   kube_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
     next unless (ready_status = pod.status.conditions.find { |c| c.type == "Ready" })
     next unless ready_status.status == "True"
-    next unless pod.metadata.name =~ /inventory\-deployment/
+    next unless pod.metadata.name =~ /inventory\-/
 
     exec = Authentication::AuthnK8s::KubeExec.new
 


### PR DESCRIPTION
Before each cucumber test of authn-k8s, we delete the cert file
from `/etc/conjur/ssl` so that each test starts with a fresh folder.

However, we currently do this only for pods with the name 'inventory-deployment'.
This is not enough as we have different types of pods with the authenticator container
in it. They all have names that start with 'inventory-' so we can use that as the regex.
