### PR TITLE
DeploymentConfig kind failed to authenticate on OCP 4.3 testing

### DIFF
--- a/app/domain/authentication/authn_k8s/k8s_resolver.rb
+++ b/app/domain/authentication/authn_k8s/k8s_resolver.rb
@@ -99,23 +99,23 @@ module Authentication
 
       class DeploymentConfig < Base
         def validate_pod
-          replication_resource_ref = pod_owner_refs&.find { |ref| ref.kind == "Replicationresource" }
-          unless replication_resource_ref
+          replication_controller_ref = pod_owner_refs&.find { |ref| ref.kind == "ReplicationController" }
+          unless replication_controller_ref
             raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(
               pod_name,
               'ReplicationController'
             )
           end
 
-          replication_resource = k8s_object_lookup.find_object_by_name(
-            "replication_resource",
-            replication_resource_ref.name,
+          replication_controller = k8s_object_lookup.find_object_by_name(
+            "replication_controller",
+            replication_controller_ref.name,
             namespace
           )
 
-          replication_resource_owner_refs = replication_resource.metadata.ownerReferences
+          replication_controller_owner_refs = replication_controller.metadata.ownerReferences
 
-          deployment_config_ref = replication_resource_owner_refs&.find { |ref| ref.kind == "DeploymentConfig" }
+          deployment_config_ref = replication_controller_owner_refs&.find { |ref| ref.kind == "DeploymentConfig" }
 
           unless deployment_config_ref
             raise Errors::Authentication::AuthnK8s::PodMissingRelationError.new(


### PR DESCRIPTION
**Should wait until @orenbm test it on 3.11!**

### What does this PR do?
 DeploymentConfig kind failed to authenticate on OCP 4.3 testing (could be from earlier version). changing name from Replicationresource to ReplicationController

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
