### PR TITLE
Introduce nightly FIPS EE agent parallel tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,19 +6,28 @@ pipeline {
   options {
     timestamps()
     buildDiscarder(logRotator(numToKeepStr: '30'))
-    skipDefaultCheckout()  // see 'Checkout SCM' below, once perms are fixed this is no longer needed
     timeout(time: 1, unit: 'HOURS')
   }
 
   triggers {
-    cron(getDailyCronString())
+    parameterizedCron(getDailyCronString("%NIGHTLY=true"))
+  }
+
+  parameters {
+    booleanParam(name: 'NIGHTLY', defaultValue: false, description: 'Run tests on all agents and environment including: FIPS')
   }
 
   stages {
-    stage('Checkout SCM') {
+    stage('Fetch tags') {
       steps {
-        checkout scm
-        sh 'git fetch' // to pull the tags
+        withCredentials(
+          [usernameColonPassword(credentialsId: 'conjur-jenkins-api', variable: 'GITCREDS')]
+        ) {
+          sh '''
+            git fetch --tags `git remote get-url origin | sed -e "s|https://|https://$GITCREDS@|"`
+            git tag # just print them out to make sure, can remove when this is robust
+          '''
+        }
       }
     }
 
@@ -66,23 +75,93 @@ pipeline {
       }
     }
 
-    stage('Run Tests') {
+    stage('Run environment tests in parallel') {
+      failFast true
       parallel {
-        stage('RSpec') {
-          steps { sh 'ci/test rspec' }
-        }
-        stage('Authenticators Config') {
-          steps { sh 'ci/test cucumber_authenticators_config' }
-        }
-        stage('Authenticators Status') {
-          steps { sh 'ci/test cucumber_authenticators_status' }
-        }
-        stage('LDAP Authenticator') {
-          steps { sh 'ci/test cucumber_authenticators_ldap' }
-        }
-        stage('OIDC Authenticator') {
-          steps { sh 'ci/test cucumber_authenticators_oidc' }
-        }
+          stage('EE FIPS agent tests') {
+            agent { label 'executor-v2-rhel-ee' }
+            when {
+                beforeAgent true
+                expression { params.NIGHTLY }
+            }
+            steps {
+              script {
+                 parallel([
+                    "RSpec - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec'
+                    },
+                    "Authenticators Config - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_config'
+                    },
+                    "Authenticators Status - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_status'
+                    },
+                    "LDAP Authenticator - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_ldap'
+                    },
+                    "OIDC Authenticator - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_oidc'
+                    },
+                    "Policy - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_policy'
+                    },
+                    "API - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_api'
+                    },
+                    "Rotators - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec'
+                    },
+                    "Kubernetes 1.7 in GKE - ${env.STAGE_NAME}": {
+                      sh 'cd ci/authn-k8s && summon ./test.sh gke'
+                    },
+                    "Audit - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec_audit'
+                    }
+                 ])
+              } // script
+              stash name: 'testResultEE', includes: "cucumber/*/*.*,container_logs/*/*,spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/*/features/reports/**/*.xml"
+            } // steps
+          } // EE FIPS agent tests
+
+          stage('Standard agent tests') {
+            steps {
+              script {
+                 parallel([
+                    "RSpec - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec'
+                    },
+                    "Authenticators Config - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_config'
+                    },
+                    "Authenticators Status - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_status'
+                    },
+                    "LDAP Authenticator - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_ldap'
+                    },
+                    "OIDC Authenticator - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_authenticators_oidc'
+                    },
+                    "Policy - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_policy'
+                    },
+                    "API - ${env.STAGE_NAME}": {
+                      sh 'ci/test cucumber_api'
+                    },
+                    "Rotators - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec'
+                    },
+                    "Kubernetes 1.7 in GKE - ${env.STAGE_NAME}": {
+                      sh 'cd ci/authn-k8s && summon ./test.sh gke'
+                    },
+                    "Audit - ${env.STAGE_NAME}": {
+                      sh 'ci/test rspec_audit'
+                    }
+                 ])
+             } // script
+            } // steps
+          } // Standard agent tests
+
         stage('Azure Authenticator') {
           steps {
             script {
@@ -151,23 +230,8 @@ pipeline {
             }
           }
         }
-        stage('Policy') {
-          steps { sh 'ci/test cucumber_policy' }
-        }
-        stage('API') {
-          steps { sh 'ci/test cucumber_api' }
-        }
-        stage('Rotators') {
-          steps { sh 'ci/test cucumber_rotators' }
-        }
-        stage('Kubernetes 1.7 in GKE') {
-          steps { sh 'cd ci/authn-k8s && summon ./test.sh gke' }
-        }
-        stage('Audit') {
-          steps { sh 'ci/test rspec_audit'}
-        }
-      }
-    }
+      } // Parallel
+    } // Stage - Run parallel env tests
 
     stage('Submit Coverage Report'){
       steps{
@@ -184,7 +248,6 @@ pipeline {
     stage('Build Debian package') {
       steps {
         sh './package.sh'
-
         archiveArtifacts artifacts: '*.deb', fingerprint: true
       }
     }
@@ -205,19 +268,42 @@ pipeline {
       }
     }
     always {
+      script {
+          env.nightly_msg = ""
+          if (params.NIGHTLY) {
+            env.nightly_msg = "nightly"
+            dir('ee-test'){
+                 unstash 'testResultEE'
+            }
+            archiveArtifacts artifacts: "ee-test/cucumber/*/*.*", fingerprint: false, allowEmptyArchive: true
+            archiveArtifacts artifacts: "ee-test/container_logs/*/*", fingerprint: false, allowEmptyArchive: true
+
+            publishHTML([reportDir: 'ee-test/cucumber', reportFiles: 'api/cucumber_results.html, 	authenticators_config/cucumber_results.html, \
+                                     authenticators_azure/cucumber_results.html, authenticators_ldap/cucumber_results.html, \
+                                     authenticators_oidc/cucumber_results.html, authenticators_status/cucumber_results.html,\
+                                     policy/cucumber_results.html , rotators/cucumber_results.html',\
+                                     reportName: 'EE Integration reports', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
+
+          }
+      }
       archiveArtifacts artifacts: "container_logs/*/*", fingerprint: false, allowEmptyArchive: true
       archiveArtifacts artifacts: "coverage/.resultset*.json", fingerprint: false, allowEmptyArchive: true
       archiveArtifacts artifacts: "ci/authn-k8s/output/simplecov-resultset-authnk8s-gke.json", fingerprint: false, allowEmptyArchive: true
       archiveArtifacts artifacts: "cucumber/*/*.*", fingerprint: false, allowEmptyArchive: true
+
       publishHTML([reportDir: 'cucumber', reportFiles: 'api/cucumber_results.html, 	authenticators_config/cucumber_results.html, \
                                authenticators_azure/cucumber_results.html, authenticators_ldap/cucumber_results.html, \
                                authenticators_oidc/cucumber_results.html, authenticators_status/cucumber_results.html,\
                                policy/cucumber_results.html , rotators/cucumber_results.html',\
                                reportName: 'Integration reports', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
+
+
       publishHTML([reportDir: 'coverage', reportFiles: 'index.html', reportName: 'Coverage Report', reportTitles: '', allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true])
-      junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/*/features/reports/**/*.xml'
+      junit 'spec/reports/*.xml,spec/reports-audit/*.xml,cucumber/*/features/reports/**/*.xml,ee-test/spec/reports/*.xml,ee-test/spec/reports-audit/*.xml,ee-test/cucumber/*/features/reports/**/*.xml'
       cucumber fileIncludePattern: '**/cucumber_results.json', sortingMethod: 'ALPHABETICAL'
-      cleanupAndNotify(currentBuild.currentResult, '#conjur-core', '', true)
+
+
+      cleanupAndNotify(currentBuild.currentResult, '#conjur-core', "${env.nightly_msg}", true)
     }
   }
 }

--- a/ci/authn-k8s/test.sh
+++ b/ci/authn-k8s/test.sh
@@ -74,11 +74,15 @@ function createNginxCert() {
 
 function buildDockerImages() {
   conjur_version=$(echo "$(< ../../VERSION)-$(git rev-parse --short=8 HEAD)")
+  DOCKER_REGISTRY_PATH="registry.tld/test"
 
-  docker tag conjur:$conjur_version $CONJUR_AUTHN_K8S_TAG
+  docker pull $DOCKER_REGISTRY_PATH/conjur:$conjur_version
+  docker pull $DOCKER_REGISTRY_PATH/conjur-test:$conjur_version
+
+  docker tag $DOCKER_REGISTRY_PATH/conjur:$conjur_version $CONJUR_AUTHN_K8S_TAG
 
   # cukes will be run from this image
-  docker tag conjur-test:$conjur_version $CONJUR_TEST_AUTHN_K8S_TAG
+  docker tag $DOCKER_REGISTRY_PATH/conjur-test:$conjur_version $CONJUR_TEST_AUTHN_K8S_TAG
   
   docker build -t $INVENTORY_TAG -f dev/Dockerfile.inventory dev
 


### PR DESCRIPTION
### What does this PR do?
Introduce **nightly** FIPS EE agent parallel tests run all agents and environment, currently FIPS EE agents, at nightly triggerd job
- [Success Standard build run blue ocean](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/nightly-fips/2/pipeline/)
- [Success EE nightly build run blue ocean](url)
- [Failed EE nightly build run blue ocean](https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--conjur/detail/nightly-fips/6/pipeline/233/)

![image](https://user-images.githubusercontent.com/50704381/95496883-25e83f80-09aa-11eb-8ee6-53e1abc9cca9.png)
![image](https://user-images.githubusercontent.com/50704381/95496912-2f71a780-09aa-11eb-8617-0104a428d5b0.png)



### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
