### PR TITLE
Trim docker image tag commit sha suffix received from git to explicit 8 chars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
         stage("Scan Docker Image for fixable issues") {
           steps {
             script {
-              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short HEAD)')
+              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short=8 HEAD)')
             }
             scanAndReport("conjur:${TAG}", "HIGH", false)
           }
@@ -49,7 +49,7 @@ pipeline {
         stage("Scan Docker image for total issues") {
           steps {
             script {
-              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short HEAD)')
+              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short=8 HEAD)')
             }
             scanAndReport("conjur:${TAG}", "NONE", true)
           }

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$tag = "$(git rev-parse --short HEAD)"
+$tag = "$(git rev-parse --short=8 HEAD)"
 $run_dev = $true
 
 Write-Host "Building Conjur Docker image"

--- a/ci/authn-k8s/test.sh
+++ b/ci/authn-k8s/test.sh
@@ -73,7 +73,7 @@ function createNginxCert() {
 }
 
 function buildDockerImages() {
-  conjur_version=$(echo "$(< ../../VERSION)-$(git rev-parse --short HEAD)")
+  conjur_version=$(echo "$(< ../../VERSION)-$(git rev-parse --short=8 HEAD)")
 
   docker tag conjur:$conjur_version $CONJUR_AUTHN_K8S_TAG
 

--- a/version_utils.sh
+++ b/version_utils.sh
@@ -3,7 +3,7 @@
 # Functions to generate version numbers for this project
 
 version_tag() {
-  echo "$(< VERSION)-$(git rev-parse --short HEAD)"
+  echo "$(< VERSION)-$(git rev-parse --short=8 HEAD)"
 }
 
 # generate less specific versions, eg. given 1.2.3 will print 1.2 and 1


### PR DESCRIPTION
### What does this PR do?
Trim docker image tag commit sha suffix received from git to explicit 8 chars, can not keep implicit trim - on ubuntu agent 7 is default on other OS it can be 8.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
