### PR TITLE
Make early deletion of SA key on GCP tests pipeline (Security concern)

### DIFF
--- a/ci/authn-gcp/cleanup_function.sh
+++ b/ci/authn-gcp/cleanup_function.sh
@@ -8,7 +8,6 @@ cleanup_function() {
   validate_pre_requisites
   delete_function
   delete_identity_token
-  delete_sa_key_file
   echo "-- Cleanup function done"
 }
 
@@ -41,6 +40,9 @@ delete_function() {
   # NOTE! The script that runs the container with this script provisions the file
   # and this script deletes it.
   gcloud auth activate-service-account --key-file "$GCP_OWNER_SERVICE_KEY"
+
+  # delete key soon after done using - due to security concerns
+  rm -f "$GCP_OWNER_SERVICE_KEY"
 
   # List all functions and filter the $GCF_FUNC_NAME variable
   local func_exists="gcloud functions list --format='value(name)' --filter='name ~ $GCF_FUNC_NAME'"

--- a/ci/authn-gcp/deploy_function.sh
+++ b/ci/authn-gcp/deploy_function.sh
@@ -9,9 +9,9 @@ GCF_SOURCE_FILE="$GCF_SOURCE_DIR/main.py"
 
 main() {
   echo "Deploy function: $GCF_FUNC_NAME in project: $GCP_PROJECT"
-  validate_pre_requisites || exit 1
-  deploy_function || exit 1
-  write_identity_token_to_file || exit 1
+  validate_pre_requisites
+  deploy_function
+  write_identity_token_to_file
   echo "-> Deploying done"
 }
 
@@ -59,12 +59,13 @@ deploy_function() {
   gcloud config set project "$GCP_PROJECT"
 
   # Authenticate using the service account key file
-  # NOTE! The script that runs the container with this script provisions the file
-  # and the cleanup_function.sh script deletes it.
   gcloud auth activate-service-account --key-file "$GCP_OWNER_SERVICE_KEY"
 
+  # delete key soon after done using - due to security concerns
+  rm -f "$GCP_OWNER_SERVICE_KEY"
+
   # Change dir to function source file
-  cd "$GCF_SOURCE_DIR" || exit 1
+  cd "$GCF_SOURCE_DIR"
 
   echo "-- Deploying function: $GCF_FUNC_NAME"
   gcloud functions deploy "$GCF_FUNC_NAME" --runtime python37 --trigger-http --quiet
@@ -80,9 +81,9 @@ write_identity_token_to_file() {
   echo 'write_identity_token_to_file'
   cd ..
   echo "-- Write identity-token to file:'$(pwd)/$IDENTITY_TOKEN_FILE'"
-  echo  "$(gcloud auth print-identity-token)" > "$IDENTITY_TOKEN_FILE" || exit 1
+  echo  "$(gcloud auth print-identity-token)" > "$IDENTITY_TOKEN_FILE"
   echo "Identity token written to file: '$IDENTITY_TOKEN_FILE'."
   echo '-> write_identity_token_to_file done'
 }
 
-main || exit 1
+main

--- a/ci/authn-gcp/run_gcloud.sh
+++ b/ci/authn-gcp/run_gcloud.sh
@@ -5,12 +5,16 @@
 # The name of the script to run in the Google SDK container.
 GCLOUD_SCRIPT=$1
 
+finish() {
+  verify_sa_key_file_deleted
+}
+trap finish EXIT
+
 main() {
   echo "run_gcloud.sh with script: $GCLOUD_SCRIPT"
-  validate_pre_requisites || exit 1
-  write_sa_key_to_file || exit 1
-  run_gcloud_container || exit 1
-  delete_sa_key_file || exit 1
+  validate_pre_requisites
+  write_sa_key_to_file
+  run_gcloud_container
   echo "-> run_gcloud.sh with script: $GCLOUD_SCRIPT done"
 }
 
@@ -82,16 +86,14 @@ run_gcloud_container() {
   echo "-> run_gcloud_container done"
 }
 
-# Deletes the service account key file.
+# Deletes the service account key file if still exists
 # Service account key file is used to authenticate with Google SDK CLI.
 # Google SDK CLI (gcloud) is used to deploy the Google function.
-delete_sa_key_file() {
-  echo 'delete_sa_key_file'
+verify_sa_key_file_deleted() {
   if [ -f "$GCP_OWNER_SERVICE_KEY_FILE" ]; then
-    rm -f echo "$GCP_OWNER_SERVICE_KEY_FILE" || echo "Error cannot delete Service Account key file: \
-    '$GCP_OWNER_SERVICE_KEY_FILE'"
+    echo "Error: Container didn't take care to delete key file after usage"
+    rm -f echo "$GCP_OWNER_SERVICE_KEY_FILE"
   fi
-  echo '-> delete_sa_key_file done'
 }
 
-main || exit 1
+main


### PR DESCRIPTION
### What does this PR do?
- On GCP pipeline, agent Invokes container which now is responsible to delete SA-key as soon as done using it.

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
