### PR TITLE
Cleanup in authn_gcp_solution_design.md

### DIFF
--- a/design/authenticators/authn_gcp/authn_gcp_solution_design.md
+++ b/design/authenticators/authn_gcp/authn_gcp_solution_design.md
@@ -16,7 +16,6 @@
   * [Performance](#performance)
   * [Affected Components](#affected-components)
 - [Security](#security)
-- [Test Plan](#test-plan)
 - [Logs](#logs)
   * [Error Log level](#error-log-level)
   * [Debug Log level](#debug-log-level)
@@ -89,7 +88,7 @@ We will support only the following service accounts types:
 * Default service accounts - automatically granted by google
 * User-managed service accounts - created by the user
 
-As mentioned in the [in the this issue](https://github.com/cyberark/conjur/issues/1711), 
+As mentioned [in this issue](https://github.com/cyberark/conjur/issues/1711), 
 before any authentication request is sent to Conjur, the admin will load the authenticator policy:
  
 The YAML snippet below depicts the Google authenticator policy in Conjur:
@@ -347,8 +346,6 @@ and signed by google private keys which are not expose to the apps in contrast t
 
 * **onetime** - Ori suggested to consider a mechanism to allow to each token to be used only once, 
 but in this version we will not implement this capability  
-
-## Test Plan
 
 ## Logs
 


### PR DESCRIPTION
### What does this PR do?
Pretty small cleanup PR that:
Fixes a typo and get rid of dangling "Testing Plan" section from PR #1862 which removed links to confluence

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
