### PR TITLE
Add specific error message for invalid account in audience

### DIFF
--- a/app/domain/authentication/authn_gcp/update_authenticator_input.rb
+++ b/app/domain/authentication/authn_gcp/update_authenticator_input.rb
@@ -63,10 +63,16 @@ module Authentication
 
       def validate_audience
         if audience_parts.length != 3 ||
-            audience_parts[0] != "conjur" ||
-            audience_parts[1] != account
+            audience_parts[0] != "conjur"
           raise Errors::Authentication::AuthnGcp::InvalidAudience, audience
+        elsif audience_parts[1] != account
+          raise Errors::Authentication::AuthnGcp::InvalidAccountInAudienceClaim.new(
+            audience,
+            audience_parts[1],
+            account
+          )
         end
+
       end
 
       def audience_parts

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -365,6 +365,12 @@ module Errors
         msg:  "Role must have at least one of the following constraints: {0-constraints}",
         code: "CONJ00069E"
       )
+
+      InvalidAccountInAudienceClaim = ::Util::TrackableErrorClass.new(
+        msg:  "'audience' token claim '{0}' is invalid. " \
+              "The account in the audience '{1}' does not match the account in the URL request '{2}'",
+        code: "CONJ00071E"
+      )
     end
   end
 

--- a/cucumber/authenticators_gcp/features/authn_gce.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce.feature
@@ -97,9 +97,18 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
-  Scenario: Non-existing account in request is denied
+  Scenario: Non-existing account in token audience claim is denied
     Given I obtain a non_existing_account GCE identity token
     And I save my place in the log file
+    When I authenticate with authn-gcp using obtained GCE token and existing account
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00071E 'audience' token claim .* is invalid. The account in the audience .* does not match the account in the URL request .*
+    """
+
+  Scenario: Non-existing account in URL request is denied
+    Given I save my place in the log file
     When I authenticate with authn-gcp using obtained GCE token and non-existing account
     Then it is unauthorized
     And The following appears in the log after my savepoint:

--- a/spec/app/domain/authentication/authn-gcp/update_authenticator_input_spec.rb
+++ b/spec/app/domain/authentication/authn-gcp/update_authenticator_input_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe 'Authentication::AuthnGcp::UpdateAuthenticatorInput' do
 
             it 'raises an InvalidAudience error' do
               expect { subject }.to raise_error(
-                Errors::Authentication::AuthnGcp::InvalidAudience
+                Errors::Authentication::AuthnGcp::InvalidAccountInAudienceClaim
               )
             end
           end


### PR DESCRIPTION
### What does this PR do?
Improve supportability by adding specific error for invalid account in audience use case  


