### PR TITLE
Upgrade dev and CI Postgres version from 9.4 to 10.14

### DIFF
--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -57,7 +57,7 @@ spec:
         app: postgres
     spec:
       containers:
-      - image: postgres:9.4
+      - image: postgres:10.14
         imagePullPolicy: Always
         name: postgres
         env:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   pg:
-    image: postgres:9.4
+    image: postgres:10.14
     environment:
       # To avoid the following error:
       #
@@ -15,13 +15,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   audit:
-    image: postgres:9.4
+    image: postgres:10.14
     environment: 
       # See description on `pg` service for use of POSTGRES_HOST_AUTH_METHOD
       POSTGRES_HOST_AUTH_METHOD: trust
 
   testdb:
-    image: postgres:9.4
+    image: postgres:10.14
     environment:
       # To avoid the following error:
       #

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   pg:
-    image: postgres:9.4
+    image: postgres:10.14
     environment:
       # To avoid the following error:
       #
@@ -15,13 +15,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   audit:
-    image: postgres:9.4
+    image: postgres:10.14
     environment:
       # See description on `pg` service for use of POSTGRES_HOST_AUTH_METHOD
       POSTGRES_HOST_AUTH_METHOD: trust
 
   testdb:
-    image: postgres:9.4
+    image: postgres:10.14
     environment:
       POSTGRES_PASSWORD: postgres_secret
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates the version of Postgres we use in our dev environment, CI tests, and example k8s policy from the EOL version `9.4` to version `10.14`. This moves our dev and CI off of an EOL version and aligns our development with the version of Postgres used in the DAP appliance.


### What ticket does this PR close?
Resolves #1876

### Checklists

#### Changelog
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
