### PR TITLE
Add codes to Login and Authentication error messages

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -137,7 +137,7 @@ class AuthenticateController < ApplicationController
   private
 
   def handle_login_error(err)
-    log_error(err, "Login")
+    log_error(err, LogMessages::Authentication::LoginError)
 
     case err
     when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
@@ -151,7 +151,7 @@ class AuthenticateController < ApplicationController
   end
 
   def handle_authentication_error(err)
-    log_error(err, "Authentication")
+    log_error(err, LogMessages::Authentication::AuthenticationError)
 
     case err
     when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
@@ -193,8 +193,8 @@ class AuthenticateController < ApplicationController
     end
   end
 
-  def log_error(err, action)
-    logger.info("#{action} Error: #{err.inspect}")
+  def log_error(err, log_message_class)
+    logger.info(log_message_class.new(err.inspect))
     err.backtrace.each do |line|
       logger.debug(line)
     end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -18,6 +18,16 @@ module LogMessages
 
   module Authentication
 
+    LoginError = ::Util::TrackableErrorClass.new(
+      msg:  "Login Error: {0}",
+      code: "CONJ00047I"
+    )
+
+    AuthenticationError = ::Util::TrackableErrorClass.new(
+      msg:  "Authentication Error: {0}",
+      code: "CONJ00048I"
+    )
+
     OriginValidated = ::Util::TrackableLogMessageClass.new(
       msg:  "Origin validated",
       code: "CONJ00003D"


### PR DESCRIPTION
Connected to #1861

We currently log the login and authentication errors without a `CONJ`
prefix. This commit aligns these log messages to our pattern.

The log message now shows:
```
 INFO 2020/10/18 08:23:22 +0000 [pid=207] [origin=127.0.0.1] [request_id=acdba60b-2578-4308-a73c-bcd7d254679b] [tid=217] CONJ00048I Authentication Error: #<Errors::Authentication::Security::RoleNotFound: CONJ00007E 'not_in_conjur' not found>
```