### PR TITLE
Bug Fix: Pipe instead of logical OR

### DIFF
--- a/ci/authn-gcp/get_gcp_id_tokens.sh
+++ b/ci/authn-gcp/get_gcp_id_tokens.sh
@@ -112,7 +112,7 @@ print_running_gce_instances() {
 }
 
 get_tokens_into_files() {
-  if [ "${INSTANCE_EXISTS}" = "0" ] | [ "${INSTANCE_RUNNING}" = "0" ]; then
+  if [ "${INSTANCE_EXISTS}" = "0" ] || [ "${INSTANCE_RUNNING}" = "0" ]; then
     error_exit "-- Cannot run command, GCE instance '${INSTANCE_NAME}' not in a valid state!"
   fi
 


### PR DESCRIPTION
A bug was reported in this script. Instead of using || logical OR, there was a pipe, which will output a wrong result.

### What does this PR do?
Fixed an if expression that had a pipe instead of logical OR.

### What ticket does this PR close?
Resolves #[relevant GitHub issues, #1888 ]
