### PR TITLE
UBI based image support

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,79 @@
+# Conjur Base Image (UBI)
+FROM cyberark/ubi-ruby-fips:ubi8-latest
+
+EXPOSE 8080
+ARG VERSION
+
+ENV PORT=8080 \
+    LOG_DIR=/opt/conjur-server/log \
+    TMP_DIR=/opt/conjur-server/tmp \
+    SSL_CERT_DIRECTORY=/opt/conjur/etc/ssl \
+    RAILS_ENV=production
+
+LABEL name="conjur-ubi" \
+      vendor="CyberArk" \
+      version="$VERSION" \
+      release="$VERSION" \
+      summary="Conjur UBI-based image" \
+      description="Conjur provides secrets management and machine identity for modern infrastructure."
+
+RUN INSTALL_PKGS="gcc \
+                  gcc-c++ \
+                  git \
+                  glibc-devel \
+                  libxml2-devel \
+                  libxslt-devel \
+                  libzip-devel \
+                  make \
+                  openldap-clients \
+                  redhat-rpm-config \
+                  tzdata" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+# Create conjur user with one that has known gid / uid.
+RUN groupadd -r conjur \
+             -g 777 && \
+    useradd -c "conjur runner account" \
+            -g conjur \
+            -d "$HOME" \
+            -r \
+            -m \
+            -s /bin/bash \
+            -u 777 conjur
+
+WORKDIR /opt/conjur-server
+
+# Ensure few required GID0-owned folders to run as a random UID (OpenShift requirement)
+RUN mkdir -p "$TMP_DIR" \
+             "$LOG_DIR" \
+             "$SSL_CERT_DIRECTORY/ca" \
+             "$SSL_CERT_DIRECTORY/cert" \
+             /run/authn-local && \
+    # Use GID of 0 since that is what OpenShift will want to be able to read things
+    chown conjur:0 "$LOG_DIR" \
+                   "$TMP_DIR" \
+                   "$SSL_CERT_DIRECTORY" \
+                   /run/authn-local && \
+    # We need open group permissions in these directories since OpenShift won't
+    # match our UID when we try to write files to them
+    chmod 770 "$LOG_DIR" \
+              "$TMP_DIR" \
+              "$SSL_CERT_DIRECTORY" \
+              /run/authn-local
+
+COPY Gemfile \
+     Gemfile.lock ./
+
+RUN bundle --without test development
+
+COPY . .
+
+RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
+
+COPY LICENSE.md /licenses/
+
+USER conjur
+
+ENTRYPOINT ["conjurctl"]

--- a/build.sh
+++ b/build.sh
@@ -82,6 +82,11 @@ if image_needs_building "conjur-test:$TAG"; then
   docker push "$REGISTRY_TEST_PATH/conjur-test:$TAG"
 fi
 
+if image_needs_building "conjur-ubi:$TAG"; then
+  echo "Building image conjur-ubi:$TAG container"
+  docker build --build-arg "VERSION=$TAG" -t "conjur-ubi:$TAG" -f Dockerfile.ubi .
+fi
+
 if [[ $jenkins = false ]]; then
   echo "Building image conjur-dev"
   docker build -t conjur-dev -f dev/Dockerfile.dev .


### PR DESCRIPTION
### What does this PR do?
Adds a  Dockerfile.ubi with relevant packages and permissions to build a UBI-based Conjur image. This will be published to RH container registry in #1883. The image is built during the image build step in the pipeline.

Note: the UBI-based image is not expected to be FIPS-compliant. We may address that in future work.

### What ticket does this PR close?
Resolves #1871 
Duplicates #1870 from my fork

### Checklists
- [x] Add LICENSE file to the main repo project
- [x] Add `COPY LICENSE /licenses` to the Dockerfile.ubi
- [x] Change relevant description and summary on the Dockerfile.ubi labels section 
- [x] Adding a build step for the new image to the Jenkinsfile

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
