### PR TITLE
Update security bulletin change log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - Replaces string comparison with Secure Compare to prevent timing attacks against
   the API authentication endpoint. [Security Bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-c7x2-6g4j-327p)
-- Roles can no longer rotate their own API key using only an access token.
-  [Security Bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-qhjf-g9gm-64jq)
+- Roles must use basic authentication to rotate their own API key, and can no longer
+  rotate their API key using only an access token. [Security Bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-qhjf-g9gm-64jq)
 
 ## [1.8.1] - 2020-07-14
 ### Fixed


### PR DESCRIPTION
### What does this PR do?
The change log message for the changes from this [security bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-qhjf-g9gm-64jq) are not clear enough that you **must** use basic auth to rotate your own API key now. This PR updates the message to be more clear on this point.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
