### PR TITLE
Update Ruby version to `2.5.8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   error in case it failed to install the client certificate during authn-k8s.
   [cyberark/conjur#1860](https://github.com/cyberark/conjur/issues/1860)
 
+### Security
+- Bumped Ruby version from 2.5.1 to 2.5.8 to address
+  [CVE-2020-10663](https://nvd.nist.gov/vuln/detail/CVE-2020-10663).
+  [cyberark/conjur#1906](https://github.com/cyberark/conjur/pull/1906)
+
 ## [1.10.0] - 2020-10-16
 ### Added
 - [Documentation](./UPGRADING.md) explaining how to upgrade a Conjur server deployed in a

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ git_source(:github) { |name| "https://github.com/#{name}.git" }
 # nicely with RVM and we should be explicit since Ruby is such a fundamental
 # part of a Rails project. The Ruby version is also locked in place by the
 # Docker base image so it won't be updated with fuzzy matching.
-ruby '2.5.1'
+ruby '2.5.8'
 #ruby-gemset=conjur
 
 gem 'command_class'


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR updates the expected Ruby version to match what is now included in the base image (`2.5.8`).

### What ticket does this PR close?
Connected to https://github.com/cyberark/conjur-base-image/issues/33

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require additional or updated tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
