### PR TITLE
Testing expanded for API Key rotation

### DIFF
--- a/cucumber/api/features/rotate_api_key.feature
+++ b/cucumber/api/features/rotate_api_key.feature
@@ -5,40 +5,146 @@ Feature: Rotate the API key of a role
   A role can rotate its own API key using the password or current API key. A role can also
   rotate the API key of another role if it has `update` privilege on the role.
 
+  In these test cases, API key rotation is performed against Bob.
+  API key rotation is executed by 5 roles:
+    - Bob himself
+    - a user with update permission, "privileged_user"
+    - a user without update permission, "unprivileged_user"
+    - a host belonging to a layer with update permission, "privileged_host"
+    - a host without update permission, "unprivileged_host"
+  These roles attempt to rotate Bob's API key with all authentication methods
+  available to them.
+
+  The host with update permission will also attempt to rotate his own key,
+  to validate behavior for each authentication method.
+
   Background:
-    Given I create a new user "alice"
+    Given I create a new user "bob"
+    And I create a new user "privileged_user"
+    And I create a new user "unprivileged_user"
+    And I have host "privileged_host"
+    And I have host "unprivileged_host"
+    And I am the super-user
+    And I successfully PUT "/policies/cucumber/policy/root" with body:
+    """
+    - !user bob
+    - !user privileged_user
+    - !layer host_layer
+    - !host privileged_host
 
-  Scenario: Password can be used to rotate API key
-    Given I set the password for "alice" to "My-Password1"
-    When I can PUT "/authn/cucumber/api_key" with username "alice" and password "My-Password1"
-    Then the result is the API key for user "alice"
-    And the HTTP response content type is "text/plain"
+    # give privileged_user update permissions over user bob
+    - !permit
+      role: !user privileged_user
+      privilege: [ update ]
+      resource: !user bob
 
-  Scenario: API key can be used to rotate API key
-    When I can PUT "/authn/cucumber/api_key" with username "alice" and password ":cucumber:user:alice_api_key"
-    Then the result is the API key for user "alice"
-    And the HTTP response content type is "text/plain"
+    # assign privileged_host as a member of host_layer
+    - !grant
+      role: !layer host_layer
+      member: !host privileged_host
 
-  Scenario: Access token can not be used to rotate API key
-    Given I login as "alice"
+    # give host_layer,
+    # and by extension privileged_host,
+    # update permissions over bob
+    - !permit
+      role: !layer host_layer
+      privilege: [ update ]
+      resource: !user bob
+    """
+    And I log out
+
+  # Bob rotating his own API key
+
+  Scenario: Bob's password CAN be used to rotate own API key
+    Given I set the password for "bob" to "My-Password1"
+    When I can PUT "/authn/cucumber/api_key?role=user:bob" with username "bob" and password "My-Password1"
+    Then the HTTP response status code is 200
+    And the result is the API key for user "bob"
+
+  Scenario: Bob's API key CAN be used to rotate own API key
+    When I can PUT "/authn/cucumber/api_key" with username "bob" and password ":cucumber:user:bob_api_key"
+    Then the HTTP response status code is 200
+    And the result is the API key for user "bob"
+
+  Scenario: Bob's access token CAN NOT be used to rotate own API key
+    Given I login as "bob"
     When I PUT "/authn/cucumber/api_key"
     Then the HTTP response status code is 401
 
-  Scenario: Access token can not be used to rotate API key using role parameter with self role value
-    Given I login as "alice"
-    When I PUT "/authn/cucumber/api_key?role=user:alice"
-    Then the HTTP response status code is 401
-
-  @logged-in
-  Scenario: The API key cannot be rotated by foreign role without 'update' privilege
-    Given I create a new admin-owned user "bob"
+  Scenario: Bob's access token CAN NOT be used to rotate own API key using role parameter with self role value
+    Given I login as "bob"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 
-  Scenario: The API key can be rotated by foreign role when it has 'update' privilege
-    Given I create a new user "bob"
-    And I permit user "alice" to "update" user "bob"
-    And I login as "alice"
+  # A user without update permission rotating Bob's API key
+
+  Scenario: User without permissions CAN NOT rotate Bob's API key using their own API key
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "unprivileged_user" and password ":cucumber:user:unprivileged_user_api_key"
+    Then the HTTP response status code is 401
+
+  Scenario: User without permissions CAN NOT rotate Bob's API key using their password
+    Given I set the password for "unprivileged_user" to "Passw0rd-Unprivileged"
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "unprivileged_user" and password "Passw0rd-Unprivileged"
+    Then the HTTP response status code is 401
+
+  Scenario: User without permissions CAN NOT rotate Bob's API key using an access token
+    Given I login as "unprivileged_user"
+    When I PUT "/authn/cucumber/api_key?role=user:carl"
+    Then the HTTP response status code is 401
+
+  # A user with update permission rotating Bob's API key
+
+  Scenario: A User with update privilege CAN rotate Bob's API key using an access token
+    Given I login as "privileged_user"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
-    Then the result is the API key for user "bob"
-    And the HTTP response content type is "text/plain"
+    Then the HTTP response status code is 200
+    And the result is the API key for user "bob"
+
+  Scenario: A User with update privilege CAN NOT rotate another user's API key using their own API key
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "privileged_user" and password ":cucumber:user:privileged_user_api_key"
+    Then the HTTP response status code is 401
+
+  Scenario: A User with update privilege CAN NOT rotate another user's API key using their password
+    Given I set the password for "privileged_user" to "Passw0rd-Privileged"
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "privileged_user" and password "Passw0rd-Privileged"
+    Then the HTTP response status code is 401
+
+  # A host rotating their own API key
+
+  Scenario: A Host CAN rotate their own API key using their API key
+    When I PUT "/authn/cucumber/api_key?role=host:privileged_host" with username "host/privileged_host" and password ":cucumber:host:privileged_host_api_key"
+    Then the HTTP response status code is 200
+    And the result is the API key for host "privileged_host"
+
+  Scenario: A Host CAN NOT rotate their own API key using an access token
+    Given I login as "host/privileged_host"
+    When I PUT "/authn/cucumber/api_key"
+    Then the HTTP response status code is 401
+
+  Scenario: A Host CAN NOT rotate their own API key using an access token and a role parameter with self role value
+    Given I login as "host/privileged_host"
+    When I PUT "/authn/cucumber/api_key?role=host:privileged_host"
+    Then the HTTP response status code is 401
+
+  # A host with update permission rotating Bob's API key
+
+  Scenario: A Host with update privilege CAN rotate Bob's API key with an access token
+    Given I login as "host/privileged_host"
+    When I PUT "/authn/cucumber/api_key?role=user:bob"
+    Then the HTTP response status code is 200
+    And the result is the API key for user "bob"
+
+  Scenario: A Host with update privilege CAN NOT rotate Bob's API key with their own API key
+    When I PUT "/authn/cucumber/api_key?role=user:carl" with username "host/host1" and password ":cucucmber:host:host1_api_key"
+    Then the HTTP response status code is 401
+
+  # A host without update permission rotating Bob's API key
+
+  Scenario: A Host without update privilege CAN NOT rotate Bob's API key with an access token
+    Given I login as "host/unprivileged_host"
+    When I PUT "/authn/cucumber/api_key?role=user:bob"
+    Then the HTTP response status code is 401
+
+  Scenario: A Host without update privilege CAN NOT rotate a user's API key with their own API key
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "host/unprivileged_host" and password ":cucumber:host:unprivileged_host_api_key"
+    Then the HTTP response status code is 401

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -160,11 +160,19 @@ Then(/^the result is an API key$/) do
   expect(@result).to match(/^[a-z0-9]+$/)
 end
 
-Then(/^the result is the API key for user "([^"]*)"$/) do |login|
-  user = lookup_user(login)
-  user.reload
-  expect(user.credentials).to be
-  expect(@result).to eq(user.credentials.api_key)
+Then(/^the result is the API key for ([^"]*) "([^"]*)"$/) do |kind, login|
+  case kind
+  when "user"
+    role = lookup_user(login)
+  when "host"
+    role = lookup_host(login)
+  else
+    raise ArgumentError, "Invalid role kind. Function accepts 'host' or 'user'"
+  end
+
+  role.reload
+  expect(role.credentials).to be
+  expect(@result).to eq(role.credentials.api_key)
 end
 
 Then(/^it's confirmed$/) do

--- a/cucumber/api/features/step_definitions/user_steps.rb
+++ b/cucumber/api/features/step_definitions/user_steps.rb
@@ -34,7 +34,13 @@ Given('I create a new user {string} in account {string}') do |login, account|
 end
 
 Given("I login as {string}") do |login|
-  roleid = (login.include?(":") ? login : "cucumber:user:#{login}")
+  if login.match? %r{host\/[^:\/]+}
+    loginid = login.split('/')[1]
+    roleid = (login.include?(":") ? login : "cucumber:host:#{loginid}")
+  else
+    roleid = (login.include?(":") ? login : "cucumber:user:#{login}")
+  end
+
   @current_user = Role.with_pk!(roleid)
   Credentials.new(role: @current_user).save unless @current_user.credentials
 end
@@ -44,7 +50,7 @@ Given("I log out") do
   # TODO: investigate smell
   headers.delete(:authorization) if headers.key?(:authorization)
 end
-  
+
 Given("I set the password for {string} to {string}") do |login, password|
   # TODO: investigate smell
   user = lookup_user(login)


### PR DESCRIPTION
### What does this PR do?
This PR adds test cases to confirm API Key rotation for different relationships and authentication methods.
Validates behavior for a user or host rotating their own or another user's API key, using all forms of authentication, 
both with and without ownership or update privilege.

### What ticket does this PR close?
Resolves #1907 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
