### PR TITLE
Update upgrade instructions for v1.9.0 release

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,6 +85,13 @@ $ docker-compose logs conjur_server
 
 ## Version Specific Upgrade Instructions
 
+### Version 1.9.0
+
+When upgrading to version `1.9.0` and above, please ensure that you also upgrade your
+[Ruby client library](https://github.com/cyberark/conjur-api-ruby) to at least `v5.3.4`.
+The Ruby client changed to accommodate the changes in the REST API that were made in response to
+this [security bulletin](https://github.com/cyberark/conjur/security/advisories/GHSA-qhjf-g9gm-64jq).
+
 ### Versions 1.8.0 and 1.8.1
 
 #### Affected Upgrades:


### PR DESCRIPTION
### What does this PR do?
Updates the upgrading instructions to include guidance to update Ruby client versions with the v1.9.0 release as well.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
