### PR TITLE
Rotating the API key of an nonexistent role returns Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   error in case it failed to install the client certificate during authn-k8s.
   [cyberark/conjur#1860](https://github.com/cyberark/conjur/issues/1860)
 
+### Fixed
+- Conjur now raises an Unauthorized error when a user attempts to rotate the API key of a
+  nonexistent role. Previously, the operation would result in a successful rotation of the
+  existing user's API key, with no indication that the target of the operation had changed.
+  [cybeark/conjur#1914](https://github.com/cyberark/conjur/issues/1914)
+
 ### Security
 - Bumped Ruby version from 2.5.1 to 2.5.8 to address
   [CVE-2020-10663](https://nvd.nist.gov/vuln/detail/CVE-2020-10663).

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -77,7 +77,10 @@ class CredentialsController < ApplicationController
 
   # Accept params[:role]. Later it will be ignored if it refers to the same user as the token auth.
   def accept_id_parameter
-    authentication.selected_role = Role[Role.make_full_id(params[:role], account)] if params[:role]
+    if params[:role]
+      authentication.selected_role = Role[Role.make_full_id(params[:role], account)]
+      raise Unauthorized, "Operation attempted against invalid target" unless authentication.selected_role
+    end
     true
   end
 

--- a/cucumber/api/features/rotate_api_key.feature
+++ b/cucumber/api/features/rotate_api_key.feature
@@ -89,7 +89,7 @@ Feature: Rotate the API key of a role
 
   Scenario: User without permissions CAN NOT rotate Bob's API key using an access token
     Given I login as "unprivileged_user"
-    When I PUT "/authn/cucumber/api_key?role=user:carl"
+    When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 
   # A user with update permission rotating Bob's API key
@@ -135,7 +135,7 @@ Feature: Rotate the API key of a role
     And the result is the API key for user "bob"
 
   Scenario: A Host with update privilege CAN NOT rotate Bob's API key with their own API key
-    When I PUT "/authn/cucumber/api_key?role=user:carl" with username "host/host1" and password ":cucucmber:host:host1_api_key"
+    When I PUT "/authn/cucumber/api_key?role=user:bob" with username "host/privileged_host" and password ":cucumber:host:privileged_host_api_key"
     Then the HTTP response status code is 401
 
   # A host without update permission rotating Bob's API key
@@ -147,4 +147,24 @@ Feature: Rotate the API key of a role
 
   Scenario: A Host without update privilege CAN NOT rotate a user's API key with their own API key
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "host/unprivileged_host" and password ":cucumber:host:unprivileged_host_api_key"
+    Then the HTTP response status code is 401
+
+  # Test rotation against nonexistent user
+
+  Scenario: Bob CAN NOT rotate a nonexistent user's API key using basic auth and an API key, RESULTS IN 401
+    When I PUT "/authn/cucumber/api_key?role=user:does_not_exist" with username "bob" and password ":cucumber:user:bob_api_key"
+    Then the HTTP response status code is 401
+
+  Scenario: Bob CAN NOT rotate a nonexistent user's API key using basic auth and a password, RESULTS IN 401
+    Given I set the password for "bob" to "Passw0rd-Bob"
+    When I PUT "/authn/cucumber/api_key?role=user:does_not_exist" with username "bob" and password "Passw0rd-Bob"
+    Then the HTTP response status code is 401
+
+  Scenario: Bob CAN NOT rotate a nonexistent user's API key using an access token, RESULTS IN 401
+    Given I login as "bob"
+    When I PUT "/authn/cucumber/api_key?role=user:does_not_exist"
+    Then the HTTP response status code is 401
+
+  Scenario: Bob CAN NOT rotate API key for user in nonexistent account, RESULTS IN 401
+    When I PUT "/authn/cucumber/api_key?role=nonexistent_account:user:bob" with username "bob" and password ":cucumber:user:bob_api_key"
     Then the HTTP response status code is 401


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where a user rotating a nonexistent role's API key with basic auth would
receive a successful status code implying that the nonexistent role's key was rotated. In
reality, the user was rotating their own API key. The action of rotating a nonexistent user's
API key is now rejected with a 401 Unauthorized status code. Adds test cases to confirm.

### What ticket does this PR close?
Resolves #1914 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
