### PR TITLE
Update project to use tag-triggered builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,7 +317,12 @@ pipeline {
       }
     }
 
-    stage('Push Docker image') {
+    stage('Publish Docker image') {
+      when {
+        // Only run this stage when it's a tag build matching vA.B.C
+        tag pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+\$", comparator: "REGEXP"
+      }
+
       steps {
         sh './push-image.sh'
       }


### PR DESCRIPTION
### What does this PR do?
Instead of using logic to compare the the current commit to the version to
check if the current commit is a matching tag, this commit updates the logic
in the project Jenkinsfile to only run the image publish script when the
project is tagged with a tag matching the syntax `vA.B.C` where A/B/C are
numbers.

A note on testing locally:

It is notoriously hard to test Jenkins pipeline changes that mimic a tag / release locally. Here is what I have done to test this, as best as I am able:
- Test the REGEX using https://www.freeformatter.com/java-regex-tester.html to validate that the tag REGEX will be parsed properly by Jenkins. The full syntax of the `when` conditional is from https://www.jenkins.io/doc/book/pipeline/syntax/.
- Test the `push-image.sh` script by commenting out the `docker push` line, setting `TAG_NAME=v1.10.0` in my terminal, and running the `./build.sh --jenkins` followed by `./push-image.sh` to verify that the proper set of images would be pushed. The output was:
   ```
   Tagging and pushing registry.tld/conjur:1.10.0-3c377563...
   Tagging and pushing registry.tld/cyberark/conjur:1.10.0-3c377563...
   Tagging and pushing registry.tld/conjur:latest...
   Tagging and pushing registry.tld/cyberark/conjur:latest...
   Tagging and pushing registry.tld/conjur:v1.10-stable...
   Tagging and pushing registry.tld/cyberark/conjur:v1.10-stable...
   Tagging and pushing registry.tld/conjur:v1-stable...
   Tagging and pushing registry.tld/cyberark/conjur:v1-stable...
   Tagging and pushing cyberark/conjur:latest...
   Tagging and pushing cyberark/conjur:v1.10.0...
   Tagging and pushing cyberark/conjur:v1.10...
   Tagging and pushing cyberark/conjur:v1...
   ```

### What ticket does this PR close?
Resolves #1912 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
