### PR TITLE
1883 publish ubi based conjur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- UBI-based Conjur image to support Conjur server running on OpenShift. Image
+  will be published to RedHat Container Registry.
+  [cyberark/conjur#1883](https://github.com/cyberark/conjur/issues/1883)
 - GCP authenticator (`authn-gcp`) supports authenticating from Google Cloud Function (GCF)
   using a GCE instance identity token. See [design](design/authenticators/authn_gcp/authn_gcp_solution_design.md)
   for details. [cyberark/conjur#1804](https://github.com/cyberark/conjur/issues/1804)

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -23,7 +23,6 @@ RUN INSTALL_PKGS="gcc \
                   glibc-devel \
                   libxml2-devel \
                   libxslt-devel \
-                  libzip-devel \
                   make \
                   openldap-clients \
                   redhat-rpm-config \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,22 @@ pipeline {
             scanAndReport("conjur:${TAG}", "NONE", true)
           }
         }
+        stage("Scan UBI-based Docker Image for fixable issues") {
+          steps {
+            script {
+              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short=8 HEAD)')
+            }
+            scanAndReport("conjur-ubi:${TAG}", "HIGH", false)
+          }
+        }
+        stage("Scan UBI-based Docker image for total issues") {
+          steps {
+            script {
+              TAG = sh(returnStdout: true, script: 'echo $(< VERSION)-$(git rev-parse --short=8 HEAD)')
+            }
+            scanAndReport("conjur-ubi:${TAG}", "NONE", true)
+          }
+        }
       }
     }
 

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,10 @@ fi
 if image_needs_building "conjur-ubi:$TAG"; then
   echo "Building image conjur-ubi:$TAG container"
   docker build --build-arg "VERSION=$TAG" -t "conjur-ubi:$TAG" -f Dockerfile.ubi .
+  docker tag "conjur-ubi:$TAG" "$REGISTRY_TEST_PATH/conjur-ubi:$TAG"
+
+  echo "Pushing image $REGISTRY_TEST_PATH/conjur-ubi:$TAG"
+  docker push "$REGISTRY_TEST_PATH/conjur-ubi:$TAG"
 fi
 
 if [[ $jenkins = false ]]; then

--- a/push-image.sh
+++ b/push-image.sh
@@ -18,41 +18,52 @@ fi
 TAG="${1:-$(version_tag)}"
 VERSION="$(< VERSION)"
 SOURCE_IMAGE="conjur:$TAG"
+RH_SOURCE_IMAGE="conjur-ubi:$TAG"
 
-CONJUR_REGISTRY=registry.tld
-IMAGE_NAME=cyberark/conjur
+CONJUR_REGISTRY="registry.tld"
+IMAGE_NAME="cyberark/conjur"
+REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6/conjur"
 
 # both old-style 'conjur' and new-style 'cyberark/conjur'
 INTERNAL_IMAGES=`echo $CONJUR_REGISTRY/{conjur,$IMAGE_NAME}`
 
 function main() {
   # always push VERSION-SHA tags to our registry
-  tag_and_push $TAG $INTERNAL_IMAGES
+  tag_and_push $TAG $SOURCE_IMAGE $INTERNAL_IMAGES
 
   # this script is only auto-triggered on a tag, so it will always publish
   # releases to DockerHub
-  tag_and_push latest $INTERNAL_IMAGES
+  tag_and_push latest $SOURCE_IMAGE $INTERNAL_IMAGES
 
   # only do 1-stable and 1.2-stable for 1.2.3-dev
   # (1.2.3-stable doesn't make sense if there is a released version called 1.2.3)
   for v in `gen_versions $TAG_NAME`; do
-    tag_and_push $v-stable $INTERNAL_IMAGES
+    tag_and_push $v-stable $SOURCE_IMAGE $INTERNAL_IMAGES
   done
 
   for v in latest $TAG_NAME `gen_versions $TAG_NAME`; do
-    tag_and_push $v $IMAGE_NAME
+    tag_and_push $v $SOURCE_IMAGE $IMAGE_NAME
   done
+
+  # Publish only the tag version to the Redhat Registries
+  if summon bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
+    tag_and_push $VERSION $RH_SOURCE_IMAGE $REDHAT_IMAGE
+  else
+    echo 'Failed to log in to scan.connect.redhat.com'
+    exit 1
+  fi
 }
 
 # tag_and_publish tag image1 image2 ...
 function tag_and_push() {
   local tag="$1"
+  local source="$2"
   shift
 
   for image in $*; do
     local target=$image:$tag
     echo Tagging and pushing $target...
-    docker tag "$SOURCE_IMAGE" $target
+    docker tag "$source" $target
     docker push $target
   done
 }


### PR DESCRIPTION
### What does this PR do?
Depends on #1926 (this PR should be fixed up with those changes before this PR is merged)

Adds UBI-based Conjur image scans and publishes the UBI-based Conjur image to the RH container registry. This will enable cyberark/conjur-oss-helm-chart#60 which adds support for deploying Conjur OSS using the helm chart to OCP.

### What ticket does this PR close?
Resolves #1883

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
