### PR TITLE
Run rotators tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
                       sh 'ci/test cucumber_api'
                     },
                     "Rotators - ${env.STAGE_NAME}": {
-                      sh 'ci/test rspec'
+                      sh 'ci/test cucumber_rotators'
                     },
                     "Kubernetes 1.7 in GKE - ${env.STAGE_NAME}": {
                       sh 'cd ci/authn-k8s && summon ./test.sh gke'
@@ -148,7 +148,7 @@ pipeline {
                     sh 'ci/test cucumber_api'
                   },
                   "Rotators - ${env.STAGE_NAME}": {
-                    sh 'ci/test rspec'
+                    sh 'ci/test cucumber_rotators'
                   },
                   "Kubernetes 1.7 in GKE - ${env.STAGE_NAME}": {
                     sh 'cd ci/authn-k8s && summon ./test.sh gke'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,14 +323,15 @@ pipeline {
       }
     }
 
-    stage('Build Debian package') {
+    stage('Build Debian and RPM packages') {
       steps {
         sh './package.sh'
         archiveArtifacts artifacts: '*.deb', fingerprint: true
+        archiveArtifacts artifacts: '*.rpm', fingerprint: true
       }
     }
 
-    stage('Publish Debian package'){
+    stage('Publish Debian and RPM packages'){
       steps {
         sh './publish.sh'
       }


### PR DESCRIPTION
A previous commit accidentally replaced the rotators test step
so that it ran rspec tests instead. Thus, the rotators tests didn't
run at all.
