### PR TITLE
Add missing shift in CI image push script

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Push the 'conjur' image to various Docker registries
 # Push tagged images on master branch
@@ -11,7 +12,8 @@
 if [[ -z "${TAG_NAME:-}" ]]; then
   echo "Please supply environment variable TAG_NAME."
   echo "If you see this error in Jenkins it means the publish script was run"
-  echo "for a build that wasn't triggered by a tag - please check publish stage conditions."
+  echo "for a build that wasn't triggered by a tag -" \
+    "please check publish stage conditions."
   exit 1
 fi
 
@@ -25,46 +27,52 @@ IMAGE_NAME="cyberark/conjur"
 REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6/conjur"
 
 # both old-style 'conjur' and new-style 'cyberark/conjur'
-INTERNAL_IMAGES=`echo $CONJUR_REGISTRY/{conjur,$IMAGE_NAME}`
+INTERNAL_IMAGES=("$CONJUR_REGISTRY/conjur" "$CONJUR_REGISTRY/$IMAGE_NAME")
 
 function main() {
   # always push VERSION-SHA tags to our registry
-  tag_and_push $TAG $SOURCE_IMAGE $INTERNAL_IMAGES
+  tag_and_push "$TAG" "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
 
   # this script is only auto-triggered on a tag, so it will always publish
   # releases to DockerHub
-  tag_and_push latest $SOURCE_IMAGE $INTERNAL_IMAGES
+  tag_and_push latest "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
 
-  # only do 1-stable and 1.2-stable for 1.2.3-dev
-  # (1.2.3-stable doesn't make sense if there is a released version called 1.2.3)
-  for v in `gen_versions $TAG_NAME`; do
-    tag_and_push $v-stable $SOURCE_IMAGE $INTERNAL_IMAGES
+  # Only do 1-stable and 1.2-stable for 1.2.3-dev.  1.2.3-stable doesn't make
+  # sense if there is a released version called 1.2.3
+  local prefix_versions
+  readarray -t prefix_versions <(gen_versions "$TAG_NAME")
+  for v in "${prefix_versions[@]}"; do
+    tag_and_push "$v-stable" "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
   done
 
-  for v in latest $TAG_NAME `gen_versions $TAG_NAME`; do
-    tag_and_push $v $SOURCE_IMAGE $IMAGE_NAME
+  for v in latest "$TAG_NAME" "${prefix_versions[@]}"; do
+    tag_and_push "$v" "$SOURCE_IMAGE" "$IMAGE_NAME"
   done
 
   # Publish only the tag version to the Redhat Registries
-  if summon bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
-    tag_and_push $VERSION $RH_SOURCE_IMAGE $REDHAT_IMAGE
+  # Note: We want $REDHAT_API_KEY to expand inside bash -c, not here.
+  # shellcheck disable=SC2016
+  if summon bash -c \
+    'docker login scan.connect.redhat.com -u unused -p "$REDHAT_API_KEY"';
+  then
+    tag_and_push "$VERSION" "$RH_SOURCE_IMAGE" "$REDHAT_IMAGE"
   else
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
 }
 
-# tag_and_publish tag image1 image2 ...
+# tag_and_publish tag source image1 image2 ...
 function tag_and_push() {
   local tag="$1"
   local source="$2"
   shift
 
-  for image in $*; do
+  for image in "$@"; do
     local target=$image:$tag
-    echo Tagging and pushing $target...
-    docker tag "$source" $target
-    docker push $target
+    echo "Tagging and pushing $target..."
+    docker tag "$source" "$target"
+    docker push "$target"
   done
 }
 

--- a/push-image.sh
+++ b/push-image.sh
@@ -64,9 +64,8 @@ function main() {
 
 # tag_and_publish tag source image1 image2 ...
 function tag_and_push() {
-  local tag="$1"
-  local source="$2"
-  shift
+  local tag="$1"; shift
+  local source="$1"; shift
 
   for image in "$@"; do
     local target=$image:$tag


### PR DESCRIPTION
In the recent the PR to add a UBI based image (https://github.com/cyberark/conjur/pull/1927) we added a new argument to the `tag_and_push` function in our Docker image push step for CI. However, this addition neglected to shift the remaining arguments. This led the function to interpret the source image in the list of image targets to push to, leading to a malformed image reference.
