### PR TITLE
Fix markdown detection regex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     stage('Build and test Conjur') {
       when {
         expression {
-         sh(returnStatus: true, script: 'git diff  origin/master --name-only | grep -v "^*.md$" > /dev/null') == 0
+         sh(returnStatus: true, script: 'git diff  origin/master --name-only | grep -v "^.*\\.md$" > /dev/null') == 0
         }
       }
       stages {


### PR DESCRIPTION
### What does this PR do?
Previously the regex used a quantifier `*` without a quantifiable term, leading to the `*` being matched literally. 


Notice that we get the same result for files ending .md and .py:
```
HughWorkMBPWired:692-secretless-xa-oct hsaunders$ echo "test.md" | grep -v "^*.md$"; echo $?
test.md
0
HughWorkMBPWired:692-secretless-xa-oct hsaunders$ echo "test.py" | grep -v "^*.md$"; echo $?
test.py
0
```

But a file called `*.md` is detected:
```
HughWorkMBPWired:692-secretless-xa-oct hsaunders$ echo "*.md" | grep -v "^*.md$"; echo $?
1
```

This commit adds a `.` before the `*`, to make the `*` work as expected. It also escapes the `.` that is acting as a file extension seperator so that it is interpreted literally rather than matching any character.

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
