### PR TITLE
Fix regex to skip pipeline build for .md files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     stage('Build and test Conjur') {
       when {
         expression {
-         sh(returnStatus: true, script: 'git diff  origin/master --name-only | grep -v "^*.md$" > /dev/null') == 0
+         sh(returnStatus: true, script: 'git diff  origin/master --name-only | grep -v "[.]md$" > /dev/null') == 0
         }
       }
       stages {


### PR DESCRIPTION
Current regex does not match `.md` files

### What does this PR do?
Fix `.md` files exclusion regex to cirrectly skip pipeline for `.md` files PR.

### What ticket does this PR close?
Resolves #1940 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
