### PR TITLE
Add nginx server to dev env to allow HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/_site/
 docs/.sass-cache
 
 gems/*/Gemfile.lock
+
+# dev nginx certificates
+/dev/conf/tls/nginx.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dev env now includes nginx server to redirect HTTPS connection to conjur
+  and handle mTLS to allow debugging authn-k8s.
+  [cyberark/conjur#1956](https://github.com/cyberark/conjur/issues/1956)
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,12 @@ see [RubyMine IDE Debugging](#rubymine-ide-debugging) or [Visual Studio Code IDE
 The `dev` directory contains a `docker-compose` file which creates a development
 environment with a database container (`pg`, short for *postgres*), and a
 `conjur` server container with source code mounted into the directory
-`/src/conjur-server`.
+`/src/conjur-server`. `conjur` listens on `127.0.0.1:3000`.
+
+Also, there's a `proxy` container that wraps the conjur server with HTTPS
+redirection using nginx. `proxy` listens on `127.0.0.1:8443`.
+It redirects any HTTPS connection, and also supports client certificate
+needed for `authn-k8s`.
 
 To use it:
 
@@ -133,6 +138,27 @@ To use it:
     $ ./stop
     ```
     Running `stop` removes the running Docker Compose containers and the data key.
+
+#### K8s Authentication
+
+To authenticate to conjur using authn-k8s, you will need to have local k8s environment with access to your machine (the host).
+The following example will use k8s from `docker-for-desktop` to authenticate using the authn-k8s in your dev conjur.
+
+```sh-session
+$ cd dev
+$ ./start --authn-k8s
+...
+root@f39015718062:/src/conjur-server#
+```
+
+This example uses the [conjur-authn-k8s-client](https://github.com/cyberark/conjur-authn-k8s-client/)
+repo and follows these docs: [Kubernetes Authenticator Client](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_deployAuthenticatorSidecar.htm).
+
+The `--authn-k8s` flag will:
+* Enable `authn-k8s/dev` authenticator
+* Create a host `test/authn-client-host`
+* Creates a namespace `authn-ns` where all relevant k8s resources are created
+* Create a StatefulSet named `authn-client` with conjur-authn-k8s-client that regularly authenticates using this authenticator
 
 #### LDAP Authentication
 

--- a/dev/conf/default.conf
+++ b/dev/conf/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen              443 ssl;
+    server_name         proxy;
+    access_log          /var/log/nginx/access.log;
+
+    ssl_certificate     /etc/nginx/tls/nginx.crt;
+    ssl_certificate_key /etc/nginx/tls/nginx.key;
+    ssl_verify_client   optional_no_ca;
+
+    proxy_set_header Conjur-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real_IP $remote_Addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-SSL-Client-Certificate $ssl_client_escaped_cert;
+
+    location / {
+      proxy_pass http://conjur:3000;
+    }
+}

--- a/dev/conf/tls/tls.conf
+++ b/dev/conf/tls/tls.conf
@@ -1,0 +1,40 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+x509_extensions = v3_ca # The extentions to add to the self signed cert
+req_extensions  = v3_req
+x509_extensions = usr_cert
+
+[ dn ]
+C=US
+ST=Wisconsin
+L=Madison
+O=CyberArk
+OU=Onyx
+CN=proxy
+
+[ usr_cert ]
+basicConstraints = critical, CA:TRUE
+nsCertType = client, server, email
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+nsComment = "OpenSSL Generated Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid, issuer
+
+[ v3_req ]
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+basicConstraints = critical, CA:TRUE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = proxy
+DNS.3 = host.docker.internal
+IP.1 = 127.0.0.1

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -80,6 +80,23 @@ services:
       - pg
       - testdb
 
+  openssl:
+    image: svagi/openssl:latest
+    entrypoint: ["openssl", "req", "-newkey", "rsa:2048", "-days", "365", "-nodes", "-x509", "-config", "tmp/conf/tls.conf", "-extensions", "v3_ca", "-keyout", "tmp/conf/nginx.key", "-out", "tmp/conf/nginx.crt"]
+    volumes:
+      - ./conf/tls/:/tmp/conf
+
+  proxy:
+    image: nginx:1.13.6-alpine
+    ports:
+      - "8443:443"
+    volumes:
+      - ./conf/:/etc/nginx/conf.d/:ro
+      - ./conf/tls/:/etc/nginx/tls/:ro
+    depends_on:
+      - conjur
+      - openssl
+
   client:
     image: cyberark/conjur-cli:5
     entrypoint: sleep

--- a/dev/files/authn-k8s/init-authn-k8s-ca.sh
+++ b/dev/files/authn-k8s/init-authn-k8s-ca.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+AUTHENTICATOR_ID='dev'
+CONJUR_ACCOUNT='cucumber'
+
+# Generate OpenSSL private key
+openssl genrsa -out ca.key 2048
+
+CONFIG="
+[ req ]
+distinguished_name = dn
+x509_extensions = v3_ca
+[ dn ]
+[ v3_ca ]
+basicConstraints = critical,CA:TRUE
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+"
+
+# Generate root CA certificate
+openssl req -x509 -new -nodes -key ca.key -sha1 -days 3650 -set_serial 0x0 -out ca.cert \
+  -subj "/CN=conjur.authn-k8s.$AUTHENTICATOR_ID/OU=Conjur Kubernetes CA/O=$CONJUR_ACCOUNT" \
+  -config <(echo "$CONFIG")
+
+# Verify cert
+openssl x509 -in ca.cert -text -noout
+
+# Load variable values
+conjur variable values add conjur/authn-k8s/$AUTHENTICATOR_ID/ca/key "$(cat ca.key)"
+conjur variable values add conjur/authn-k8s/$AUTHENTICATOR_ID/ca/cert "$(cat ca.cert)"

--- a/dev/files/authn-k8s/k8s-authn-client-statefulset.yml
+++ b/dev/files/authn-k8s/k8s-authn-client-statefulset.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: authn-client
+  labels:
+    app: test-authn-client
+spec:
+  replicas: 1
+  serviceName: authn-client-service
+  selector:
+    matchLabels:
+      app: authn-client
+  template:
+    metadata:
+      labels:
+        app: authn-client
+    spec:
+      serviceAccountName: authn-sa
+      containers:
+        - image: cyberark/conjur-authn-k8s-client
+          imagePullPolicy: IfNotPresent
+          name: authn-k8s-client
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+
+            - name: CONJUR_APPLIANCE_URL
+              value:  "https://host.docker.internal:8443"
+
+            - name: CONJUR_AUTHN_URL
+              value:  "https://host.docker.internal:8443/authn-k8s/dev"
+
+            - name: CONJUR_ACCOUNT
+              value:  "cucumber"
+
+            - name: CONJUR_SSL_CERTIFICATE
+              valueFrom:
+                configMapKeyRef:
+                  name: "conjur-cert"
+                  key: ssl-certificate
+
+            - name: CONJUR_AUTHN_LOGIN
+              value: "host/test/authn-k8s-host"
+
+            # sidecar prevents this container from shutting down
+            - name: CONTAINER_MODE
+              value: sidecar
+
+            - name: DEBUG
+              value: "true"

--- a/dev/files/authn-k8s/k8s-resources.yml
+++ b/dev/files/authn-k8s/k8s-resources.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authn-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authn-sa
+---

--- a/dev/files/authn-k8s/policy-authn-k8s.yml
+++ b/dev/files/authn-k8s/policy-authn-k8s.yml
@@ -1,0 +1,32 @@
+- !policy
+  id: conjur/authn-k8s/dev
+  annotations:
+    description: Namespace defs for the Conjur cluster in dev
+  body:
+    - !webservice
+      annotations:
+        description: authn service for cluster
+
+    - !variable kubernetes/service-account-token
+    - !variable kubernetes/ca-cert
+    - !variable kubernetes/api-url
+
+    - !group apps
+
+    # CA cert and key for creating client certificates
+    - !policy
+      id: ca
+      body:
+        - !variable
+          id: cert
+          annotations:
+            description: CA cert for Kubernetes Pods.
+        - !variable
+          id: key
+          annotations:
+            description: CA key for Kubernetes Pods.
+
+    - !permit
+      role: !group apps
+      privilege: [ read, authenticate]
+      resource: !webservice

--- a/dev/files/authn-k8s/policy-k8s-host.yml
+++ b/dev/files/authn-k8s/policy-k8s-host.yml
@@ -1,0 +1,13 @@
+- !policy
+  id: test
+  body:
+    - !host
+      id: authn-k8s-host
+      annotations:
+        description: host for demo
+        authn-k8s/namespace: authn-ns
+        kubernetes/authentication-container-name: authn-k8s-client
+
+- !grant
+  member: !host test/authn-k8s-host
+  role: !group conjur/authn-k8s/dev/apps

--- a/dev/start
+++ b/dev/start
@@ -21,6 +21,8 @@ Usage: start [options]
 
     --authn-gcp     Starts with authn-gcp as authenticator
 
+    --authn-k8s     Starts with authn-k8s/dev as authenticator, and conjur-authn-k8s-client as client
+
     --oidc-adfs     Adds to authn-oidc adfs static env configuration
 
     --oidc-okta     Adds to authn-oidc okta static env configuration
@@ -80,6 +82,7 @@ ENABLE_AUTHN_IAM=false
 ENABLE_AUTHN_AZURE=false
 ENABLE_AUTHN_OIDC=false
 ENABLE_AUTHN_GCP=false
+ENABLE_AUTHN_K8S=false
 ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
@@ -90,6 +93,7 @@ while true ; do
     --authn-azure ) ENABLE_AUTHN_AZURE=true ; shift ;;
     --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
     --authn-gcp ) ENABLE_AUTHN_GCP=true ; shift ;;
+    --authn-k8s ) ENABLE_AUTHN_K8S=true ; shift ;;
     --authn-oidc ) ENABLE_AUTHN_OIDC=true ; shift ;;
     --oidc-adfs ) ENABLE_OIDC_ADFS=true ; shift ;;
     --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
@@ -109,7 +113,7 @@ fi
 
 export CONJUR_DATA_KEY="$(cat data_key)"
 
-services="pg conjur client"
+services="pg conjur client openssl proxy"
 
 if [[ $ENABLE_AUDIT = true ]]; then
   services="$services audit"
@@ -170,6 +174,23 @@ fi
 
 if [[ $ENABLE_AUTHN_GCP = true ]]; then
   enabled_authenticators="$enabled_authenticators,authn-gcp"
+fi
+
+if [[ $ENABLE_AUTHN_K8S = true ]]; then
+  enabled_authenticators="$enabled_authenticators,authn-k8s/dev"
+  kubectl apply -f ./files/authn-k8s/k8s-resources.yml
+  docker-compose exec client conjur policy load root /src/conjur-server/dev/files/authn-k8s/policy-authn-k8s.yml
+  docker-compose exec client conjur policy load root /src/conjur-server/dev/files/authn-k8s/policy-k8s-host.yml
+  docker-compose exec client bash /src/conjur-server/dev/files/authn-k8s/init-authn-k8s-ca.sh
+  token_secret_name="$(kubectl get secrets | grep 'authn-ns.*service-account-token' | head -n1 | awk '{print $1}')"
+  k8s_ca_cert="$(kubectl get secret -n authn-ns $token_secret_name -o json | jq -r '.data["ca.crt"]' | base64 --decode)"
+  k8s_sa_token="$(kubectl get secret -n authn-ns $token_secret_name -o json | jq -r .data.token | base64 --decode)"
+  k8s_api_url="$(kubectl config view --minify -o json | jq -r '.clusters[0].cluster.server')"
+  docker-compose exec client conjur variable values add conjur/authn-k8s/dev/kubernetes/ca-cert $k8s_ca_cert
+  docker-compose exec client conjur variable values add conjur/authn-k8s/dev/kubernetes/service-account-token $k8s_sa_token
+  docker-compose exec client conjur variable values add conjur/authn-k8s/dev/kubernetes/api-url $k8s_api_url
+  kubectl create configmap conjur-cert --from-file=ssl-certificate=./conf/tls/nginx.crt --dry-run -o yaml | kubectl apply -f -
+  kubectl apply -f ./files/authn-k8s/k8s-authn-client-statefulset.yml
 fi
 
 if [[ $ENABLE_AUTHN_OIDC = false && ($ENABLE_OIDC_ADFS = true || $ENABLE_OIDC_OKTA = true) ]]; then

--- a/dev/stop
+++ b/dev/stop
@@ -4,4 +4,4 @@ unset COMPOSE_PROJECT_NAME
 
 docker-compose down -v
 
-rm -f data_key
+rm -f data_key conf/tls/nginx.*


### PR DESCRIPTION
authn-k8s relies on HTTPS connection to work, and this cannot be done on
plain HTTP. It also relies on mTLS.
Adding nginx to dev env to allow debugging and running authn-k8s.

### What ticket does this PR close?
Resolves #1956 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
