### PR TITLE
Remove old link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Accounts can be listed, created, and deleted via the `/accounts` service.
 Permission to use this service is controlled by the built-in resource
 `!:webservice:accounts`. Note that `!` is itself an organization account, and
 therefore privileges on the `!:webservice:accounts` can be managed
-via Conjur [policies](https://developer.conjur.net/policy).
+via Conjur [policies](https://docs.conjur.org/Latest/en/Content/Operations/Policy/policy-overview.htm).
 
 ## Versioning
 


### PR DESCRIPTION
### What does this PR do?
Remove an old developer.conjur.net link in favor of pointing to a docs.conjur.org URL

### What ticket does this PR close?
n/a, but related to #1966 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
