### PR TITLE
Fill operation field in the Fetch audit object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Requests with empty body and application/json Content-Type Header will now
   return 400 error instead of 500 error.
   [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)
-- Conjur now audit Fetch secret events with the fetch operation.Previously, the operation for this event was empty.
+- Conjur now properly sets the 'operation' field of a secret fetch audit message.
+  Previously the operation field was always empty.
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Requests with empty body and application/json Content-Type Header will now
   return 400 error instead of 500 error.
   [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)
+- Conjur now audit Fetch secret events with the fetch operation.Previously, the operation for this event was empty.
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -81,7 +81,8 @@ class SecretsController < RestController
       resource: resource,
       version: version,
       user: current_user,
-      client_ip: request.ip
+      client_ip: request.ip,
+      operation: "fetch"
     )
 
     Audit.logger.log(

--- a/app/models/audit/event/fetch.rb
+++ b/app/models/audit/event/fetch.rb
@@ -9,6 +9,7 @@ module Audit
         resource:,
         success:,
         version:,
+        operation:,
         error_message: nil
       )
         @user = user
@@ -17,6 +18,7 @@ module Audit
         @success = success
         @error_message = error_message
         @version = version
+        @operation = operation
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -26,6 +28,11 @@ module Audit
       # :reek:UtilityFunction
       def progname
         Event.progname
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
       end
 
       def severity

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -17,7 +17,7 @@ Feature: Adding and fetching secrets
     Given I am a user named "eve"
     Given I create a new "variable" resource called "probe"
 
-  Scenario: Fetching a resource with no secret values returna a 404 error.
+  Scenario: Fetching a resource with no secret values return a a 404 error.
 
     When I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
@@ -25,6 +25,16 @@ Feature: Adding and fetching secrets
   Scenario: Fetching a secret for a nonexistent resource
 
     When I GET "/secrets/cucumber/variable/non-existent"
+    Then the HTTP response status code is 404
+
+  Scenario: Fetching a secret for a resource with no permissions
+
+    When I POST "/secrets/cucumber/variable/probe" with body:
+    """
+    v-1
+    """
+    And I am a user named "alice"
+    And I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
 
   Scenario: The 'conjur/mime_type' annotation is used in the value response.

--- a/spec/models/audit/event/fetch_spec.rb
+++ b/spec/models/audit/event/fetch_spec.rb
@@ -8,7 +8,7 @@ describe Audit::Event::Fetch do
   let(:success) { true }
   let(:version) { 1 }
   let(:error_message) { nil }
-
+  let(:operation) { 'fetch' }
 
   subject do
     Audit::Event::Fetch.new(
@@ -17,6 +17,7 @@ describe Audit::Event::Fetch do
       version: version,
       client_ip: client_ip,
       success: success,
+      operation: operation,
       error_message: error_message
     )
   end
@@ -38,6 +39,11 @@ describe Audit::Event::Fetch do
       )
     end
 
+    it 'produces the expected action_sd' do
+      puts subject.action_sd
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"fetch", :result=>"success"}})
+    end
+
     it_behaves_like 'structured data includes client IP address'
   end
 
@@ -54,6 +60,11 @@ describe Audit::Event::Fetch do
 
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      puts subject.action_sd
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"fetch", :result=>"failure"}})
     end
 
     it_behaves_like 'structured data includes client IP address'

--- a/spec/models/audit/event/fetch_spec.rb
+++ b/spec/models/audit/event/fetch_spec.rb
@@ -40,7 +40,6 @@ describe Audit::Event::Fetch do
     end
 
     it 'produces the expected action_sd' do
-      puts subject.action_sd
       expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"fetch", :result=>"success"}})
     end
 


### PR DESCRIPTION
Conjur now properly sets the 'operation' field of fetch secret audit message.
For both Host and User, and for success and failure scenarios the operation field will have 'fetch' for its value.
Added Unit Tests and Integration Tests for the scenario.

### What does this PR do?
This PR adds unit tests and integration tests for the existing audit events, and corrects a couple of issues found with their addition.

### What ticket does this PR close?
Resolves #1987

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
