### PR TITLE
Update base images to use new base image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Conjur images are updated to use pinned versions of the public base images.
+  Users can now determine exactly which dependencies in the
+  [Conjur Base Image](https://github.com/cyberark/conjur-base-image) project
+  are included in their Conjur image.
+  [cyberark/conjur#1974](https://github.com/cyberark/conjur/issues/1974)
+
 ## [1.11.1] - 2020-11-19
 ### Added
 - UBI-based Conjur image to support Conjur server running on OpenShift. Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:20.04-latest
+FROM cyberark/ubuntu-ruby-fips:1.0.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,5 @@
 # Conjur Base Image (UBI)
-FROM cyberark/ubi-ruby-fips:ubi8-latest
+FROM cyberark/ubi-ruby-fips:1.0.0
 
 EXPOSE 8080
 ARG VERSION

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-    FROM cyberark/phusion-ruby-fips:0.11-latest
+FROM cyberark/phusion-ruby-fips:latest
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/gems/policy-parser/Dockerfile.test
+++ b/gems/policy-parser/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:20.04-latest
+FROM cyberark/ubuntu-ruby-fips:latest
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION
### What does this PR do?
In cyberark/conjur-base-image#42 we updated the Conjur Base Image project to
use semantic version-based tags. In this commit, we update the test / dev images
to use the "latest" versions while the Conjur images will be built from a
pinned base image version.

### What ticket does this PR close?
Resolves #1974 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
