### PR TITLE
Publish an edge-tagged image on master builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New `edge`-tagged images are published to DockerHub on every master branch
+  build.
+  [cyberark/conjur#1617](https://github.com/cyberark/conjur/issues/1617)
+
 ### Changed
 - Conjur images are updated to use pinned versions of the public base images.
   Users can now determine exactly which dependencies in the

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,10 @@ set -ex
 # usage: ./build.sh
 
 # shellcheck disable=SC1091
-. version_utils.sh
+. build_utils.sh
 
 TAG="$(version_tag)"
 jenkins=false # Running on Jenkins (vs local dev machine)
-REGISTRY_TEST_PATH="registry.tld/test"
 
 while [[ $# -gt 0 ]]
 do
@@ -55,7 +54,7 @@ function flatten() {
 # 1. Always, when we're developing locally
 # 2. Only if it doesn't already exist, when on Jenkins
 image_needs_building() {
-  [[ $jenkins = true ]] && 
+  [[ $jenkins = true ]] &&
     # doesn't already exist
     [[ "$(docker images -q "$1" 2> /dev/null)" == "" ]]
 }
@@ -64,33 +63,16 @@ if image_needs_building "conjur:$TAG"; then
   echo "Building image conjur:$TAG"
   docker build -t "conjur:$TAG" .
   flatten "conjur:$TAG"
-  docker tag "conjur:$TAG" "$REGISTRY_TEST_PATH/conjur:$TAG"
-
-# Pushing conjur:$TAG and conjur-test:$TAG images to registry at this early stage (before tests)
-# is done to allow image reuse on all agents instead of rebuilding them
-# thus reducing time and using best practice of testing same artifact
-# since conjur-test image is not flatten and based on conjur we are also reusing layers
-# nevertheless, images has "test" prefix to allow future aggregated purging
-  echo "Pushing image $REGISTRY_TEST_PATH/conjur:$TAG"
-  docker push "$REGISTRY_TEST_PATH/conjur:$TAG"
 fi
 
 if image_needs_building "conjur-test:$TAG"; then
   echo "Building image conjur-test:$TAG container"
   docker build --build-arg "VERSION=$TAG" -t "conjur-test:$TAG" -f Dockerfile.test .
-  docker tag "conjur-test:$TAG" "$REGISTRY_TEST_PATH/conjur-test:$TAG"
-
-  echo "Pushing image $REGISTRY_TEST_PATH/conjur-test:$TAG"
-  docker push "$REGISTRY_TEST_PATH/conjur-test:$TAG"
 fi
 
 if image_needs_building "conjur-ubi:$TAG"; then
   echo "Building image conjur-ubi:$TAG container"
   docker build --build-arg "VERSION=$TAG" -t "conjur-ubi:$TAG" -f Dockerfile.ubi .
-  docker tag "conjur-ubi:$TAG" "$REGISTRY_TEST_PATH/conjur-ubi:$TAG"
-
-  echo "Pushing image $REGISTRY_TEST_PATH/conjur-ubi:$TAG"
-  docker push "$REGISTRY_TEST_PATH/conjur-ubi:$TAG"
 fi
 
 if [[ $jenkins = false ]]; then

--- a/build_utils.sh
+++ b/build_utils.sh
@@ -2,17 +2,30 @@
 
 # Functions to generate version numbers for this project
 
-version_tag() {
+function version_tag() {
   echo "$(< VERSION)-$(git rev-parse --short=8 HEAD)"
 }
 
 # generate less specific versions, eg. given 1.2.3 will print 1.2 and 1
 # (note: the argument itself is not printed, append it explicitly if needed)
-gen_versions()
+function gen_versions()
 {
   local version=$1
   while [[ $version = *.* ]]; do
     version=${version%.*}
     echo $version
+  done
+}
+
+# tag_and_publish tag source image1 image2 ...
+function tag_and_push() {
+  local tag="$1"; shift
+  local source="$1"; shift
+
+  for image in "$@"; do
+    local target=$image:$tag
+    echo "Tagging and pushing $target..."
+    docker tag "$source" "$target"
+    docker push "$target"
   done
 }

--- a/ci/authn-k8s/test.sh
+++ b/ci/authn-k8s/test.sh
@@ -75,7 +75,7 @@ function createNginxCert() {
 
 function buildDockerImages() {
   conjur_version=$(echo "$(< ../../VERSION)-$(git rev-parse --short=8 HEAD)")
-  DOCKER_REGISTRY_PATH="registry.tld/test"
+  DOCKER_REGISTRY_PATH="registry.tld"
 
   docker pull $DOCKER_REGISTRY_PATH/conjur:$conjur_version
   docker pull $DOCKER_REGISTRY_PATH/conjur-test:$conjur_version

--- a/ci/test
+++ b/ci/test
@@ -39,7 +39,7 @@ set -e
 # shellcheck disable=SC1091
 source "./ci/shared.sh"
 # shellcheck disable=SC1091
-source "version_utils.sh"
+source "build_utils.sh"
 
 # Create default value if not set: allows compose to run in isolated namespace
 : "${COMPOSE_PROJECT_NAME:=$(openssl rand -hex 3)}"

--- a/push-image.sh
+++ b/push-image.sh
@@ -1,76 +1,106 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-# Push the 'conjur' image to various Docker registries
-# Push tagged images on master branch
-# Release images can be created by passing the desired tag to this script
-# Ex: ./push-image 4.9.5.1
+# Pushes the 'conjur' image to various Docker registries
+# There are essentially three flows this script supports
+# - Pushing images to the internal registry during the early pipeline stage
+# - Pushing an "edge"-tagged image to DockerHub
+# - Publishing images to public registries on new project releases during a
+#   tag-triggered build
+#
+# The default flow when no parameters are supplied is to publish images to
+# public registries. This does require that the TAG_NAME variable is set, which
+# happens automatically in tag-triggered builds.
+#
+# To publish to a (private) internal registry, run the script with the
+# "--registry-prefix=*" flag to supply the registry prefix.
+#
+# To publish an "edge"-tagged release to DockerHub, run the script with the
+# "--edge" flag.
 
 # shellcheck disable=SC1091
-. version_utils.sh
+. build_utils.sh
 
-if [[ -z "${TAG_NAME:-}" ]]; then
-  echo "Please supply environment variable TAG_NAME."
-  echo "If you see this error in Jenkins it means the publish script was run"
-  echo "for a build that wasn't triggered by a tag -" \
-    "please check publish stage conditions."
-  exit 1
-fi
+function print_help() {
+  echo "Usage: $0 [OPTION...]"
+  echo " --registry-prefix=STRING; optional registry prefix to prepend to '/cyberark/conjur'"
+  echo " --edge; optional flag to publish edge-tagged image to DockerHub"
+}
 
-TAG="${1:-$(version_tag)}"
-VERSION="$(< VERSION)"
-SOURCE_IMAGE="conjur:$TAG"
-RH_SOURCE_IMAGE="conjur-ubi:$TAG"
-
-CONJUR_REGISTRY="registry.tld"
+REGISTRY_PREFIX=""
+PUBLISH_EDGE=false
+TAG="$(version_tag)"
+LOCAL_IMAGE="conjur:${TAG}"
+RH_LOCAL_IMAGE="conjur-ubi:${TAG}"
 IMAGE_NAME="cyberark/conjur"
 REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6/conjur"
 
-# both old-style 'conjur' and new-style 'cyberark/conjur'
-INTERNAL_IMAGES=("$CONJUR_REGISTRY/conjur" "$CONJUR_REGISTRY/$IMAGE_NAME")
+for arg in "$@"; do
+  case $arg in
+    --edge )
+      PUBLISH_EDGE=true
+      shift
+      ;;
+    --registry-prefix=* )
+      REGISTRY_PREFIX="${arg#*=}"
+      shift
+      ;;
+    --registry-prefix )
+      echo "This script expects the flag value to be provided as --registry-prefix=STRING"
+      print_help
+      exit 1
+      ;;
+    * )
+      echo "Unknown option: ${arg}"
+      print_help
+      exit 1
+      ;;
+    esac
+done
 
-function main() {
-  # Push the VERSION-SHA tag to our internal registry
-  tag_and_push "$TAG" "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
+if [[ "${PUBLISH_EDGE}" = true ]]; then
 
-  # Push the latest tag to our internal registry
-  tag_and_push latest "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
+  if [[ ! -z "${REGISTRY_PREFIX}" ]]; then
+    REGISTRY_PREFIX="${REGISTRY_PREFIX}/"
+  fi
 
-  # Push 1-stable and 1.x-stable for 1.x.y tag to our internal registry
-  # Strip the "v" prefix from the tag name before computing major / minor
-  # tag versions.
-  local prefix_versions
-  readarray -t prefix_versions < <(gen_versions "${TAG_NAME//"v"}")
-  for v in "${prefix_versions[@]}"; do
-    tag_and_push "$v-stable" "$SOURCE_IMAGE" "${INTERNAL_IMAGES[@]}"
-  done
+  # This script is running to publish the edge tagged image to DockerHub
+  tag_and_push "edge" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}${IMAGE_NAME}"
 
-  # Strip the "v" prefix from the tag name and push
-  # latest, 1.x.y, 1.x, and 1 to DockerHub
-  for v in latest "${TAG_NAME//"v"}" "${prefix_versions[@]}"; do
-    tag_and_push "$v" "$SOURCE_IMAGE" "$IMAGE_NAME"
+elif [[ ! -z "${TAG_NAME:-}" ]]; then
+
+  # This is running on a tag-triggered build, and public images should be published
+  TAG="${TAG_NAME//"v"}"
+
+  # Push latest, 1.x.y, 1.x, and 1 to DockerHub
+  readarray -t prefix_versions < <(gen_versions "${TAG}")
+  for v in latest "${TAG}" "${prefix_versions[@]}"; do
+    tag_and_push "${v}" "${LOCAL_IMAGE}" "${IMAGE_NAME}"
   done
 
   # Publish only the tag version to the Redhat container registry
-  if docker login scan.connect.redhat.com -u unused -p "$REDHAT_API_KEY"; then
-    tag_and_push "${TAG_NAME//"v"}" "$RH_SOURCE_IMAGE" "$REDHAT_IMAGE"
+  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+    tag_and_push "${TAG}" "${RH_LOCAL_IMAGE}" "${REDHAT_IMAGE}"
   else
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
-}
 
-# tag_and_publish tag source image1 image2 ...
-function tag_and_push() {
-  local tag="$1"; shift
-  local source="$1"; shift
+elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
 
-  for image in "$@"; do
-    local target=$image:$tag
-    echo "Tagging and pushing $target..."
-    docker tag "$source" "$target"
-    docker push "$target"
-  done
-}
+  # This is not running on a tag-triggered build, and a registry prefix has
+  # been supplied. Publish to the specified registry.
 
-main
+  # Push the VERSION-SHA tagged images to our internal registry
+  tag_and_push "${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
+  tag_and_push "${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
+  tag_and_push "${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"
+
+else
+
+  echo "This script is not running in a tag-triggered build."
+  echo "Please supply either:"
+  echo " - The registry prefix with the --registry-prefix flag, or"
+  echo " - The --edge flag to publish an edge release to DockerHub."
+  exit 1
+fi


### PR DESCRIPTION
### What does this PR do?
At current, we only publish images to DockerHub on releases. With this commit,
we will begin publishing `edge`-tagged images with every successful master
branch build.

This commit includes other code cleanups, too. In particular:
- The build.sh script no longer publishes images to the internal registry.
  Instead, the publish script is flexible enough to be used in the Jenkins
  pipeline just after the images are built. Importantly, the needed images
  are still published - the publish step just isn't hidden in the "build" script
  anymore.
- The version_utils script now also includes the `tag_and_push` function, so
  it has been renamed "build_utils"
- This project no longer publishes images to a special registry.tld/test prefix,
  but instead just publishes the commit hash-tagged images to registry.tld.
  The image tags include the version, so we should be able to filter to remove
  old images if the registry is unduly overloaded with these images.
- This project no longer publishes "{version}-stable" images to the internal
  registry, since upon review these are not consumed anywhere and the public
  DockerHub images are used instead.

Since the `push-image.sh` script has undergone some major updates in this PR, here is a sample of how it will work:
```
conjur$ ./push-image.sh 
This script is not running in a tag-triggered build.
Please supply either:
 - The registry prefix with the --registry-prefix flag, or
 - The --edge flag to publish an edge release to DockerHub.

conjur$ ./push-image.sh -f
Unknown option: -f
Usage: ./push-image.sh [OPTION...]
 --registry-prefix=STRING; optional registry prefix to prepend to '/cyberark/conjur'
 --edge; optional flag to publish edge-tagged image to DockerHub

conjur$ TAG_NAME=v1.11.3 ./push-image.sh 
Tagging and pushing cyberark/conjur:latest...
Tagging and pushing cyberark/conjur:1.11.3...
Tagging and pushing cyberark/conjur:1.11...
Tagging and pushing cyberark/conjur:1...
./push-image.sh: line 82: REDHAT_API_KEY: unbound variable

conjur$ ./push-image.sh --edge
Tagging and pushing cyberark/conjur:edge...

conjur$ ./push-image.sh --registry-prefix=registry.tld
Tagging and pushing registry.tld/cyberark/conjur:1.11.1-b06ab2ce...
Tagging and pushing registry.tld/conjur-test:1.11.1-b06ab2ce...
Tagging and pushing registry.tld/conjur-ubi:1.11.1-b06ab2ce...

conjur$ ./push-image.sh --registry-prefix=registry.tld --edge
Tagging and pushing registry.tld/cyberark/conjur:edge...

conjur$ ./push-image.sh --registry-prefix registry.tld --edge
This script expects the flag value to be provided as --registry-prefix=STRING
Usage: ./push-image.sh [OPTION...]
 --registry-prefix=STRING; optional registry prefix to prepend to '/cyberark/conjur'
 --edge; optional flag to publish edge-tagged image to DockerHub
```

To produce this sample, I built the images using `./build.sh --jenkins`, commented out the `docker push` line in `build_utils.sh`, and ran through the commands shown.

### What ticket does this PR close?
Resolves #1617 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
