### PR TITLE
Body parser now raises proper error on invalid request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   are included in their Conjur image.
   [cyberark/conjur#1974](https://github.com/cyberark/conjur/issues/1974)
 
+### Fixed
+- Requests with empty body and application/json Content-Type Header will now
+  return 400 error instead of 500 error.
+  [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)
+
 ## [1.11.1] - 2020-11-19
 ### Added
 - UBI-based Conjur image to support Conjur server running on OpenShift. Image

--- a/app/controllers/concerns/body_parser.rb
+++ b/app/controllers/concerns/body_parser.rb
@@ -19,7 +19,12 @@ module BodyParser
       when nil, 'application/x-www-form-urlencoded'
         decode_form_body
       when 'application/json'
-        JSON.parse request.body.read
+        body = request.body.read
+        begin
+          JSON.parse body
+        rescue JSON::JSONError
+          raise ApplicationController::BadRequest, "Unable to parse request json body: #{body}"
+        end
       else
         {}
       end


### PR DESCRIPTION
Fixes issues where 500 error was raised when application/json
Content-Type header was specified with empty or malformed request body

### What does this PR do?
Adds error handling for malformed JSON body in request which will nicely catch the error then return a 400 error code rather than a 500 error.

### What ticket does this PR close?
Resolves #1968

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
