### PR TITLE
Run full pipeline on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
       when {
         // Run tests only when ANY of the following is true:
         // 1. A non-markdown file has changed.
-        // 2. It's the nightly build.
+        // 2. It's running on the master branch (which includes nightly builds).
         // 3. It's a tag-triggered build.
         anyOf {
           // Note: You cannot use "when"'s changeset condition here because it's
@@ -72,8 +72,8 @@ pipeline {
             )
           }
 
-          // Always run the full pipeline on nightly builds
-          expression { params.NIGHTLY }
+          // Always run the full pipeline on the master branch (which includes nightly builds)
+          branch "master"
 
           // Always run the full pipeline on tags of the form v*
           tag "v*"


### PR DESCRIPTION
### What does this PR do?
In recent changes we updated the pipeline to run a limited set of stages when the only changes on the branch are MD files, but it has the apparently unintended consequence of not running the full pipeline on non-nightly master builds.

Some history:
- I don’t see from here that we intended to skip master builds: https://github.com/cyberark/conjur/pull/1939
- This commit message talks about enabling nightly builds: https://github.com/cyberark/conjur/commit/9edce0e03abbbd99b649fbb2d712d94d21bd3bd4#diff-e6ffa5dc854b843b3ee3c3c28f[…]36c2df2b1ca299cca1fa5982e390cf8
- This commit message implies it should only skip this when it’s a branch: https://github.com/cyberark/conjur/commit/22959ab5d1b234297a988600d33f128f353041e4#diff-e6ffa5dc854b843b3ee3c3c28f[…]36c2df2b1ca299cca1fa5982e390cf8

This PR updates the pipeline to run on master.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
