### PR TITLE
Fill operation field in the audit object for set secret api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Requests with empty body and application/json Content-Type Header will now
   return 400 error instead of 500 error.
   [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)
+- Conjur now properly sets the 'operation' field of a secret update audit message. 
+  Previously the operation field was always empty.
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -23,7 +23,8 @@ class SecretsController < RestController
     update_info = error_info.merge(
       resource: resource, 
       user: @current_user,
-      client_ip: request.ip
+      client_ip: request.ip,
+      operation: "update"
     )
 
     Audit.logger.log(

--- a/app/models/audit/event/update.rb
+++ b/app/models/audit/event/update.rb
@@ -9,12 +9,14 @@ module Audit
         client_ip:,
         resource:,
         success:,
+        operation:,
         error_message: nil
       )
         @user = user
         @client_ip = client_ip
         @resource = resource
         @success = success
+        @operation = operation
         @error_message = error_message
       end
 
@@ -72,6 +74,11 @@ module Audit
         # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
         # is deprecated.
         Syslog::LOG_AUTHPRIV
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
       end
 
       private

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -17,7 +17,16 @@ Feature: Adding and fetching secrets
     Given I am a user named "eve"
     Given I create a new "variable" resource called "probe"
 
-  Scenario: Fetching a resource with no secret values returna a 404 error.
+  Scenario: Update a secret for a resource with no permissions
+
+    When I am a user named "alice"
+    When I POST "/secrets/cucumber/variable/probe" with body:
+    """
+    v-1
+    """
+    Then the HTTP response status code is 404
+
+  Scenario: Fetching a resource with no secret values return a 404 error.
 
     When I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
@@ -25,6 +34,14 @@ Feature: Adding and fetching secrets
   Scenario: Fetching a secret for a nonexistent resource
 
     When I GET "/secrets/cucumber/variable/non-existent"
+    Then the HTTP response status code is 404
+
+  Scenario: Update a secret of a nonexistent resource
+
+    When I POST "/secrets/cucumber/variable/non-existent" with body:
+    """
+    v-1
+    """
     Then the HTTP response status code is 404
 
   Scenario: The 'conjur/mime_type' annotation is used in the value response.
@@ -123,6 +140,15 @@ Feature: Adding and fetching secrets
     """
     """
     Then the HTTP response status code is 422
+    And there is an audit record matching:
+    """
+      <37>1 * * conjur * update
+      [auth@43868 user="cucumber:user:eve"]
+      [subject@43868 resource="cucumber:variable:probe"]
+      [action@43868 operation="update" result="failure"]
+      cucumber:user:eve updated cucumber:variable:probe
+      cucumber:user:eve tried to update cucumber:variable:probe: 'value' may not be empty
+    """
 
   Scenario: Only the last 20 versions of a secret are stored.
   

--- a/spec/models/audit/event/update_spec.rb
+++ b/spec/models/audit/event/update_spec.rb
@@ -14,7 +14,7 @@ describe Audit::Event::Update do
   let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
-
+  let(:operation) { 'update' }
 
   subject do
     Audit::Event::Update.new(
@@ -22,6 +22,7 @@ describe Audit::Event::Update do
       resource: resource,
       client_ip: client_ip,
       success: success,
+      operation: operation,
       error_message: error_message
     )
   end
@@ -43,6 +44,10 @@ describe Audit::Event::Update do
       )
     end
 
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"update", :result=>"success"}})
+    end
+
     it_behaves_like 'structured data includes client IP address'
   end
 
@@ -58,6 +63,10 @@ describe Audit::Event::Update do
 
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"update", :result=>"failure"}})
     end
 
     it_behaves_like 'structured data includes client IP address'


### PR DESCRIPTION
Conjur now properly sets the 'operation' field of set secret api audit message.
For success and failure scenarios the operation field will have 'update' for its value.
Added Unit Tests and Integration Tests for the scenario.

### What does this PR do?
This PR adds unit tests and integration tests for the existing audit events, and corrects a couple of issues found with their addition.

### What ticket does this PR close?
Resolves #1987

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
