### PR TITLE
Fill operation field in the audit object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [Conjur Base Image](https://github.com/cyberark/conjur-base-image) project
   are included in their Conjur image.
   [cyberark/conjur#1974](https://github.com/cyberark/conjur/issues/1974)
+- Correct unit tests and integration tests for audit, and correct a couple of issues found with them.
+  [cyberark/conjur#1987](https://github.com/cyberark/conjur/issues/1987)
 
 ### Fixed
 - Requests with empty body and application/json Content-Type Header will now

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -62,6 +62,7 @@ class ResourcesController < RestController
         resource: resource,
         privilege: privilege,
         role: assumed_role,
+        operation: "check",
         success: result
       )
     )

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -23,7 +23,8 @@ class SecretsController < RestController
     update_info = error_info.merge(
       resource: resource, 
       user: @current_user,
-      client_ip: request.ip
+      client_ip: request.ip,
+      operation: "update"
     )
 
     Audit.logger.log(
@@ -81,7 +82,8 @@ class SecretsController < RestController
       resource: resource,
       version: version,
       user: current_user,
-      client_ip: request.ip
+      client_ip: request.ip,
+      operation: "fetch"
     )
 
     Audit.logger.log(

--- a/app/models/audit/event/check.rb
+++ b/app/models/audit/event/check.rb
@@ -9,6 +9,7 @@ module Audit
         resource:,
         privilege:,
         role:,
+        operation:,
         success:
       )
         @user = user
@@ -16,6 +17,7 @@ module Audit
         @resource = resource
         @privilege = privilege
         @role = role
+        @operation = operation
         @success = success
       end
 
@@ -57,6 +59,11 @@ module Audit
         }.merge(
           attempted_action.action_sd
         )
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
       end
 
       def facility

--- a/app/models/audit/event/fetch.rb
+++ b/app/models/audit/event/fetch.rb
@@ -9,6 +9,7 @@ module Audit
         resource:,
         success:,
         version:,
+        operation:,
         error_message: nil
       )
         @user = user
@@ -17,6 +18,7 @@ module Audit
         @success = success
         @error_message = error_message
         @version = version
+        @operation = operation
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -26,6 +28,11 @@ module Audit
       # :reek:UtilityFunction
       def progname
         Event.progname
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
       end
 
       def severity

--- a/app/models/audit/event/update.rb
+++ b/app/models/audit/event/update.rb
@@ -9,12 +9,14 @@ module Audit
         client_ip:,
         resource:,
         success:,
+        operation:,
         error_message: nil
       )
         @user = user
         @client_ip = client_ip
         @resource = resource
         @success = success
+        @operation = operation
         @error_message = error_message
       end
 
@@ -72,6 +74,11 @@ module Audit
         # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
         # is deprecated.
         Syslog::LOG_AUTHPRIV
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
       end
 
       private

--- a/spec/models/audit/event/check_spec.rb
+++ b/spec/models/audit/event/check_spec.rb
@@ -8,6 +8,7 @@ describe Audit::Event::Check do
   let(:role) { double('my-host', id: 'rspec:host:my_host') }
   let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
+  let(:operation) { 'check' }
 
   subject do
     Audit::Event::Check.new(
@@ -16,6 +17,7 @@ describe Audit::Event::Check do
       privilege: privilege,
       role: role,
       client_ip: client_ip,
+      operation: operation,
       success: success
     )
   end
@@ -39,6 +41,10 @@ describe Audit::Event::Check do
       )
     end
 
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"check", :result=>"success"}})
+    end
+
     it_behaves_like 'structured data includes client IP address'
   end
 
@@ -54,6 +60,10 @@ describe Audit::Event::Check do
 
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"check", :result=>"failure"}})
     end
 
     it_behaves_like 'structured data includes client IP address'

--- a/spec/models/audit/event/fetch_spec.rb
+++ b/spec/models/audit/event/fetch_spec.rb
@@ -8,7 +8,7 @@ describe Audit::Event::Fetch do
   let(:success) { true }
   let(:version) { 1 }
   let(:error_message) { nil }
-
+  let(:operation) { 'fetch' }
 
   subject do
     Audit::Event::Fetch.new(
@@ -17,6 +17,7 @@ describe Audit::Event::Fetch do
       version: version,
       client_ip: client_ip,
       success: success,
+      operation: operation,
       error_message: error_message
     )
   end
@@ -38,6 +39,10 @@ describe Audit::Event::Fetch do
       )
     end
 
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"fetch", :result=>"success"}})
+    end
+
     it_behaves_like 'structured data includes client IP address'
   end
 
@@ -54,6 +59,11 @@ describe Audit::Event::Fetch do
 
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      puts subject.action_sd
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"fetch", :result=>"failure"}})
     end
 
     it_behaves_like 'structured data includes client IP address'

--- a/spec/models/audit/event/update_spec.rb
+++ b/spec/models/audit/event/update_spec.rb
@@ -14,7 +14,7 @@ describe Audit::Event::Update do
   let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:error_message) { nil }
-
+  let(:operation) { 'update' }
 
   subject do
     Audit::Event::Update.new(
@@ -22,6 +22,7 @@ describe Audit::Event::Update do
       resource: resource,
       client_ip: client_ip,
       success: success,
+      operation: operation,
       error_message: error_message
     )
   end
@@ -43,6 +44,10 @@ describe Audit::Event::Update do
       )
     end
 
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"update", :result=>"success"}})
+    end
+
     it_behaves_like 'structured data includes client IP address'
   end
 
@@ -58,6 +63,10 @@ describe Audit::Event::Update do
 
     it 'uses the WARNING log level' do
       expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({:"action@43868"=>{:operation=>"update", :result=>"failure"}})
     end
 
     it_behaves_like 'structured data includes client IP address'


### PR DESCRIPTION
Conjur now properly sets the 'operation' field of check permission audit message.
For success and failure scenarios the operation field will have 'check' for its value.
Added Unit Tests and Integration Tests for the scenario.

### What does this PR do?
This PR adds unit tests and integration tests for the existing audit events, and corrects a couple of issues found with their addition.

### What ticket does this PR close?
Resolves #1987

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation