### PR TITLE
Updated how batch secrets are rendered in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#1974](https://github.com/cyberark/conjur/issues/1974)
 - Correct unit tests and integration tests for audit, and correct a couple of issues found with them.
   [cyberark/conjur#1987](https://github.com/cyberark/conjur/issues/1987)
+- When batch secret requests are sent with an `Accept: base64` header, the secret values in the response will all be
+  Base64-encoded. Sending requests with this header allows users to retrieve binary secrets encoded in Base64.
+  [cyberark/conjur#1962](https://github.com/cyberark/conjur/issues/1962)
 
 ### Fixed
 - Requests with empty body and application/json Content-Type Header will now
@@ -30,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Audit engine routing now correctly matches URLs that include a period (`.`)
   in the resource ID.
   [cyberark/conjur#2001](https://github.com/cyberark/conjur/issues/2001)
+- Attempts to retrieve binary secret data in a batch request without using the `Accept: base64` header now returns a
+  message explaining that improper secret encoding is the cause of the 500 response.
+  [cyberark/conjur#1962](https://github.com/cyberark/conjur/issues/1962)
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -25,6 +25,12 @@ module Errors
       code: "CONJ00065E"
     )
 
+    BadSecretEncoding = ::Util::TrackableErrorClass.new(
+      msg:  "Issue encoding secret into JSON format, try including 'Accept: base64' " \
+          "header in request.",
+      code: "CONJ00074E"
+    )
+
   end
 
   module Authentication

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -91,3 +91,26 @@ Feature: Batch retrieval of secrets
     { "cucumber:variable:secret1": "v3", "cucumber:variable:secret2": "v5", "cucumber:variable:secret3": "v6" }
     """
 
+  Scenario: Returns the correct result for binary secrets
+    Given I create a binary secret value for resource "cucumber:variable:secret3"
+    And I add the secret value "v2" to the resource "cucumber:variable:secret2"
+    And I set the "Accept" header to "base64"
+    When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
+    Then the binary data is preserved for "cucumber:variable:secret3"
+
+  Scenario: Returns the correct result for binary secrets
+    Given I create a binary secret value for resource "cucumber:variable:secret3"
+    And I set the "Accept" header to "Base64"
+    When I GET "/secrets?variable_ids=cucumber:variable:secret3"
+    Then the binary data is preserved for "cucumber:variable:secret3"
+
+  Scenario: Returns the correct result for binary secrets
+    Given I create a binary secret value for resource "cucumber:variable:secret3"
+    When I GET "/secrets?variable_ids=cucumber:variable:secret3"
+    Then the HTTP response status code is 500
+
+  Scenario: Raises error on binary secret with no annotation
+    Given I create a binary secret value for resource "cucumber:variable:secret3"
+    And I add the secret value "v2" to the resource "cucumber:variable:secret2"
+    When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
+    Then the HTTP response status code is 500

--- a/cucumber/api/features/step_definitions/authz_steps.rb
+++ b/cucumber/api/features/step_definitions/authz_steps.rb
@@ -86,6 +86,11 @@ Given(/^I create a binary secret value?$/) do
   Secret.create resource_id: @current_resource.id, value: @value
 end
 
+Given(/^I create a binary secret value for resource "([^"]*)"?$/) do |resource_id|
+  @value = Random.new.bytes(16)
+  Secret.create resource_id: resource_id, value: @value
+end
+
 Given(/^I add the secret value(?: "([^"]*)")? to the resource(?: "([^"]*)")?$/) do |value, resource_id|
   Secret.create resource_id: resource_id, value: value
 end

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -57,3 +57,8 @@ Then(/^the binary result is preserved$/) do
   expect(@result.headers[:content_type]).to eq("application/octet-stream")
   expect(@result).to eq(@value)
 end
+
+Then(/^the binary data is preserved for "([^"]*)"$/) do |resource_id|
+  data = Base64.decode64(@result[resource_id])
+  expect(data).to eq(@value)
+end


### PR DESCRIPTION
### What does this PR do?
Changed how binary secrets are rendered in batch requests.

#### Some Details on the Implementation:
Based on feedback in a slack discussion I have moved to a different solution for this issue.

Now on requests to the batch secrets endpoint Conjur will read the `Accept` header from the request. Currently if the header is `base64` it will encode **all** of the secrets in `base64` and return them in the same JSON format we currently use. If the header is set to anything else (or not set at all) the endpoint will act as it has previously, except now returning a 501 with an error message to the user. The up side of this approach is that it will maintain compatibility and is a simple implementation. 

Here is an example of a returned JSON object with the `Accept: base64` header set:
```JSON
{
  "cucumber:variable:secret2": "djI=\n",
  "cucumber:variable:secret3": "+6qohmBo1KyHByGIXejpYQ==\n"
}
```

The original value of secret2 was `"v2"` and secret3 was binary data.

I also included a conversion of the header value to lowercase to avoid issues between `base64` and `Base64` because I know some people prefer one over the other.

### What ticket does this PR close?
Resolves #1962

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
