### PR TITLE
1714 x request id is tested

### DIFF
--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -20,6 +20,19 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  Scenario: X-Request-Id is set and visible in the audit record
+    Given I set the "X-Request-Id" header to "TestMyApp"
+    Then I can POST "/authn/cucumber/alice/authenticate" with plain text body ":cucumber:user:alice_api_key"
+    And the HTTP response content type is "application/json"
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur TestMyApp authn
+      [auth@43868 authenticator="authn"]
+      [subject@43868 role="cucumber:user:alice"]
+      [action@43868 operation="authenticate" result="success"]
+      cucumber:user:alice successfully authenticated with authenticator authn
+    """
+
   Scenario: Authenticate response should be encoded if Accept-Encoding equals base64
     When I successfully authenticate Alice with Accept-Encoding header "base64"
     Then the HTTP response content type is "text/plain"

--- a/spec/rack/middleware_spec.rb
+++ b/spec/rack/middleware_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/remember_uuid'
+
+describe Rack::RememberUuid do
+  let(:app) { ->(env){ } }
+  subject(:middleware) { described_class.new(app) }
+
+  # Reset the thread's `request_id`
+  after(:each) do
+    Thread.current[:request_id] = nil
+  end
+
+  # If the `X-Request-Id` header is set, then the thread's request_id
+  # will be set to the header value. Otherwise it will be a Uuid set
+  # by the function `action_dispatch.request_id`.
+  context "when called with a GET request" do
+    let(:request) { Rack::MockRequest.new(app) }
+
+    context "with no x-request-id set" do
+      let(:env) { { "action_dispatch.request_id"=> "mocked-uuid" } }
+
+      it "default rails uuuid is passed on to Thread.current" do
+        middleware.call(env)
+        expect(Thread.current[:request_id]).to eq("mocked-uuid")
+      end
+    end
+
+    context "with x-request-id set" do
+      let(:env) { { "action_dispatch.request_id"=> "x-request-id-header" } }
+      it "it copies the value to Thread.current" do
+        middleware.call(env)
+        expect(Thread.current[:request_id]).to eq("x-request-id-header")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Adds tests to ensure that when the `X-Request-Id` header is set during a REST API call. The header appears in the audit record

### What ticket does this PR close?
#1714

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
