### PR TITLE
Fixed delimiter validation in resources endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When batch secret requests are sent with an `Accept: base64` header, the secret values in the response will all be
   Base64-encoded. Sending requests with this header allows users to retrieve binary secrets encoded in Base64.
   [cyberark/conjur#1962](https://github.com/cyberark/conjur/issues/1962)
+- Conjur now verifies that the `offset` parameter is a valid integer value.
+  The `GET /resources` request will fail if `offset` is not an integer greater than or equal to 0.
+  [cyberark/conjur#1997](https://github.com/cyberark/conjur/issues/1997)
 
 ### Fixed
 - Requests with empty body and application/json Content-Type Header will now
@@ -36,6 +39,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Attempts to retrieve binary secret data in a batch request without using the `Accept: base64` header now returns a
   message explaining that improper secret encoding is the cause of the 500 response.
   [cyberark/conjur#1962](https://github.com/cyberark/conjur/issues/1962)
+- `GET /resources` request with non-numeric delimiter (limit or offset) now
+  returns `Error 422 Unprocessable Entity` instead of `Error 500`.
+  [cyberark/conjur#1997](https://github.com/cyberark/conjur/issues/1997)
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,9 @@ class ApplicationController < ActionController::API
   class RecordExists < Exceptions::RecordExists
   end
 
+  class UnprocessableEntity < RuntimeError
+  end
+
   rescue_from Exceptions::RecordNotFound, with: :record_not_found
   rescue_from Exceptions::RecordExists, with: :record_exists
   rescue_from Exceptions::Forbidden, with: :forbidden
@@ -57,6 +60,7 @@ class ApplicationController < ActionController::API
   rescue_from Exceptions::InvalidPolicyObject, with: :policy_invalid
   rescue_from ArgumentError, with: :argument_error
   rescue_from ActionController::ParameterMissing, with: :argument_error
+  rescue_from UnprocessableEntity, with: :unprocessable_entity
 
   around_action :run_with_transaction
 
@@ -210,6 +214,16 @@ class ApplicationController < ActionController::API
   def bad_request e
     logger.debug "#{e}\n#{e.backtrace.join "\n"}"
     head :bad_request
+  end
+
+  def unprocessable_entity e
+    logger.debug "#{e}\n#{e.backtrace.join "\n"}"
+    render json: {
+      error: {
+        code: :unprocessable_entity,
+        message: e.message
+      }
+    }, status: :unprocessable_entity
   end
 
   def unauthorized e

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -10,6 +10,8 @@ api: >
   -r cucumber/_authenticators_common/features/support/conjur_token.rb
   -r cucumber/_authenticators_common/features/support/authenticator_helpers.rb
   -r cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
+  -r cucumber/policy/features/step_definitions/error_steps.rb
+  -r cucumber/policy/features/support/policy_helpers.rb
   -r cucumber/api
   cucumber/api
 

--- a/cucumber/api/features/resource_list.feature
+++ b/cucumber/api/features/resource_list.feature
@@ -57,9 +57,55 @@ Feature: List resources with various types of filtering
     When I successfully GET "/resources/cucumber/test-resource?limit=1"
     Then I receive 1 resources
 
+  Scenario: The resource list cannot be limited with non numeric value
+    When I GET "/resources/cucumber/test-resource?limit=abc"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
+
+  Scenario: The resource list cannot be limited with zero
+    When I GET "/resources/cucumber/test-resource?limit=0"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
+
+  Scenario: The resource list cannot be limited with negative integer
+    When I GET "/resources/cucumber/test-resource?limit=-10"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
+
   Scenario: The resource list is retrieved starting from a specific offset.
     When I successfully GET "/resources/cucumber/test-resource?offset=1"
     Then I receive 2 resources
+
+  Scenario: The resource list cannot be retrieved starting from a specific offset with non numeric value
+    When I GET "/resources/cucumber/test-resource?offset=abc"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
+
+  Scenario: The resource list cannot be retrieved starting from a specific offset with negative integer
+    When I GET "/resources/cucumber/test-resource?offset=-10"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
+
+  Scenario: The resource list is retrieved starting from a specific offset and is limited
+    When I successfully GET "/resources/cucumber/test-resource?offset=1&limit=1"
+    Then I receive 1 resources
+
+  Scenario: The resource list cannot be retrieved with non numeric limit delimiter
+    When I GET "/resources/cucumber/test-resource?offset=1&limit=abc"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
+
+  Scenario: The resource list cannot be retrieved with non numeric offset delimiter
+    When I GET "/resources/cucumber/test-resource?offset=abc&limit=1"
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
 
   Scenario: The resource list is counted.
     When I successfully GET "/resources/cucumber/test-resource?count=true"

--- a/cucumber/policy/features/support/policy_helpers.rb
+++ b/cucumber/policy/features/support/policy_helpers.rb
@@ -69,6 +69,8 @@ module PolicyHelpers
       JSON.parse(@result)
     when Conjur::PolicyLoadResult
       JSON.parse(@result.to_json)
+    when Hash
+      @result
     end
   end
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Added delimiter validation to `resources` endpoint
- _Are there relevant screenshots you can add to the PR description?_
![image](https://user-images.githubusercontent.com/31516429/105058646-1b484680-5a7f-11eb-977d-fcdae7e0e399.png)

![image](https://user-images.githubusercontent.com/31516429/105058586-0bc8fd80-5a7f-11eb-9bf7-98d301aa2d1e.png)


### What ticket does this PR close?
Resolves #1997

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
