### PR TITLE
Ensure resource exists before updating search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Requests with empty body and application/json Content-Type Header will now
   return 400 error instead of 500 error.
   [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)
+- Policy loading no longer fails when attempting to update the annotation
+  search index for a resource that no longer exists.
+  [cyberark/conjur#1948](https://github.com/cyberark/conjur/issues/1948)
 
 ## [1.11.1] - 2020-11-19
 ### Added

--- a/db/migrate/20201119122834_update_annotation_update_textsearch.rb
+++ b/db/migrate/20201119122834_update_annotation_update_textsearch.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# This migration addresses an issue highlight in this post 
+# https://discuss.cyberarkcommons.org/t/database-error-after-backup-restore/474/11.
+# Where a foreign key constraint leads to an internal error
+Sequel.migration do
+  up do
+    run "CREATE OR REPLACE FUNCTION annotation_update_textsearch() RETURNS  trigger
+      -- The loader orchestration logic changes the search path temporarily, which causes
+      -- these triggers to be unable to find the tables and functions they need. Fix this
+      -- by setting the search path from the current schema each time. Added for Conjur OSS.
+      SET search_path FROM CURRENT
+      LANGUAGE plpgsql
+      AS $annotation_update_textsearch$
+        BEGIN
+          IF TG_OP IN ('INSERT', 'UPDATE') THEN
+          UPDATE resources_textsearch rts
+            SET textsearch = (
+              SELECT r.tsvector FROM resources r
+              WHERE r.resource_id = rts.resource_id
+            ) WHERE resource_id = NEW.resource_id;
+          END IF;
+          
+          IF TG_OP IN ('UPDATE', 'DELETE') THEN
+            BEGIN
+              UPDATE resources_textsearch rts
+              SET textsearch = (
+                SELECT r.tsvector FROM resources r
+                WHERE r.resource_id = rts.resource_id
+              ) WHERE resource_id = OLD.resource_id;
+            EXCEPTION WHEN foreign_key_violation THEN
+              /*
+              It's possible when an annotation is deleted that the entire resource
+              has been deleted. When this is the case, attempting to update the
+              search text will raise a foreign key violation on the missing
+              resource_id. 
+              */
+              RAISE WARNING 'Cannot update search text for % because it no longer exists', OLD.resource_id;
+              RETURN NULL;
+            END;
+          END IF;
+
+          RETURN NULL;
+        END
+        $annotation_update_textsearch$"
+  end
+
+  down do
+    run "CREATE FUNCTION OR REPLACE annotation_update_textsearch() RETURNS trigger
+      -- The loader orchestration logic changes the search path temporarily, which causes
+      -- these triggers to be unable to find the tables and functions they need. Fix this
+      -- by setting the search path from the current schema each time. Added for Conjur OSS.
+      SET search_path FROM CURRENT
+      LANGUAGE plpgsql
+      AS $annotation_update_textsearch$
+      BEGIN
+        IF TG_OP IN ('INSERT', 'UPDATE') THEN
+          UPDATE resources_textsearch rts
+          SET textsearch = (
+            SELECT r.tsvector FROM resources r
+            WHERE r.resource_id = rts.resource_id
+          ) WHERE resource_id = NEW.resource_id;
+        END IF;
+        
+        IF TG_OP IN ('UPDATE', 'DELETE') THEN
+          UPDATE resources_textsearch rts
+          SET textsearch = (
+            SELECT r.tsvector FROM resources r
+            WHERE r.resource_id = rts.resource_id
+          ) WHERE resource_id = OLD.resource_id;
+        END IF;
+
+        RETURN NULL;
+      END
+      $annotation_update_textsearch$;"
+  end
+end


### PR DESCRIPTION

Without checking if resource_id existence, queries can fail due to a foreign key constraint.
Related post: https://discuss.cyberarkcommons.org/t/database-error-after-backup-restore/474/11

This PR supersedes https://github.com/cyberark/conjur/pull/1949.

### What does this PR do?
The following SQL function `annotation_update_textsearch` is updated to ensure the `resource_id` exists during update/deletion. If it doesn't an appropriate log message is recorded. This ensures we do not receive the 500 error highlighted in the issue. 

### What ticket does this PR close?
Resolves #1948

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
