### PR TITLE
Require service-id param for authn-oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#1997](https://github.com/cyberark/conjur/issues/1997)
 
 ### Fixed
+- Conjur now raises a proper error if the `service-id` param is missing in an 
+  authentication request for the OIDC authenticator.
+  [cyberark/conjur#2004](https://github.com/cyberark/conjur/issues/2004)
 - Requests with empty body and application/json Content-Type Header will now
   return 400 error instead of 500 error.
   [cyberark/conjur#1968](https://github.com/cyberark/conjur/issues/1968)

--- a/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
+++ b/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
@@ -18,6 +18,7 @@ module Authentication
 
       def call
         validate_account_exists
+        validate_service_id_exists
         validate_credentials_include_id_token
         verify_and_decode_token
         validate_conjur_username
@@ -30,6 +31,10 @@ module Authentication
         @validate_account_exists.(
           account: account
         )
+      end
+
+      def validate_service_id_exists
+        raise Errors::Authentication::AuthnOidc::ServiceIdMissing unless service_id
       end
 
       def validate_credentials_include_id_token

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -10,11 +10,16 @@ module Authentication
     ) do
 
       def call
+        validate_service_id_exists
         validate_secrets
         validate_provider_is_responsive
       end
 
       private
+
+      def validate_service_id_exists
+        raise Errors::Authentication::AuthnOidc::ServiceIdMissing unless @service_id
+      end
 
       def validate_secrets
         oidc_authenticator_secrets

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -171,6 +171,11 @@ module Errors
         code: "CONJ00013E"
       )
 
+      ServiceIdMissing = ::Util::TrackableErrorClass.new(
+        msg:  "Service id is required when authenticating with authn-oidc",
+        code: "CONJ00075E"
+      )
+
     end
 
     module AuthnIam

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       RAILS_ENV:
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-config/env,authn-azure/prod,authn-gcp
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-config/env,authn-azure/prod,authn-gcp
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - DB_VENDOR=H2
       - KEYCLOAK_CLIENT_ID=conjurClient
       - KEYCLOAK_REDIRECT_URI=http://locallhost.com/
-      - KEYCLOAK_CLIENT_SECRET=d7047915-9029-45b8-9bd6-7ec5c2f75e5b
+      - KEYCLOAK_CLIENT_SECRET=1234
       - KEYCLOAK_SCOPE=openid
     ports:
       - "7777:8080"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,10 +27,11 @@ Rails.application.routes.draw do
         patch '/:authenticator/:service_id/:account' => 'authenticate#update_config'
 
         get '/:authenticator(/:service_id)/:account/login' => 'authenticate#login'
-        # authn-oidc login & authenticate are currently for future use only
-        #post '/authn-oidc(/:service_id)/:account/login' => 'authenticate#login_oidc'
 
-        # authn-oidc has to be first as it can be ambgiuous with the optional :service_id & :id
+        # authn-oidc has to be first as it can be ambiguous with the optional :service_id in
+        # the common authn request and the fact that authn-oidc doesn't have an 'id' param.
+        # i.e the request 'authn-oidc/:service_id/:account/authenticate' can be interpreted as
+        # ':authenticator/:account/:id/authenticate'
         post '/authn-oidc(/:service_id)/:account/authenticate' => 'authenticate#authenticate_oidc'
         post '/authn-gcp/:account/authenticate' => 'authenticate#authenticate_gcp'
         post '/:authenticator(/:service_id)/:account/:id/authenticate' => 'authenticate#authenticate'

--- a/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
@@ -150,3 +150,41 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     """
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
+
+  Scenario: An authenticator without a service id
+    Given I load a policy:
+    """
+    - !policy
+      id: conjur/authn-oidc
+      body:
+      - !webservice
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: id-token-user-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !user alice
+
+    - !grant
+      role: !group conjur/authn-oidc/users
+      member: !user alice
+    """
+    And I am the super-user
+    And I successfully set OIDC variables without a service-id
+    Given I fetch an ID Token for username "alice" and password "alice"
+    And I save my place in the log file
+    When I authenticate via OIDC with id token and without a service-id
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnOidc::ServiceIdMissing
+    """

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -12,6 +12,11 @@ Given(/^I successfully set OIDC variables$/) do
   set_id_token_user_property_variable
 end
 
+Given(/^I successfully set OIDC variables without a service-id$/) do
+  set_provider_uri_variable_without_service_id
+  set_id_token_user_property_variable_without_service_id
+end
+
 Given(/^I successfully set provider-uri variable$/) do
   set_provider_uri_variable
 end
@@ -26,6 +31,10 @@ end
 
 When(/^I authenticate via OIDC with id token$/) do
   authenticate_id_token_with_oidc(service_id: AuthnOidcHelper::SERVICE_ID, account: AuthnOidcHelper::ACCOUNT)
+end
+
+When(/^I authenticate via OIDC with id token and without a service-id$/) do
+  authenticate_id_token_with_oidc(service_id: nil, account: AuthnOidcHelper::ACCOUNT)
 end
 
 When(/^I authenticate via OIDC with id token and account "([^"]*)"$/) do |account|

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -8,45 +8,62 @@ Given(/I fetch an ID Token for username "([^"]*)" and password "([^"]*)"/) do |u
 end
 
 Given(/^I successfully set OIDC variables$/) do
-  set_provider_uri_variable
-  set_id_token_user_property_variable
+  create_oidc_secret("provider-uri", oidc_provider_uri)
+  create_oidc_secret("id-token-user-property", oidc_id_token_user_property)
 end
 
 Given(/^I successfully set OIDC variables without a service-id$/) do
-  set_provider_uri_variable_without_service_id
-  set_id_token_user_property_variable_without_service_id
+  create_oidc_secret("provider-uri", oidc_provider_uri, "")
+  create_oidc_secret("id-token-user-property", oidc_id_token_user_property, "")
 end
 
 Given(/^I successfully set provider-uri variable$/) do
-  set_provider_uri_variable
+  create_oidc_secret("provider-uri", oidc_provider_uri)
 end
 
 Given(/^I successfully set provider-uri variable to value "([^"]*)"$/) do |provider_uri|
-  set_provider_uri_variable(provider_uri)
+  create_oidc_secret("provider-uri", provider_uri)
 end
 
 Given(/^I successfully set id-token-user-property variable$/) do
-  set_id_token_user_property_variable
+  create_oidc_secret("id-token-user-property", oidc_id_token_user_property)
 end
 
 When(/^I authenticate via OIDC with id token$/) do
-  authenticate_id_token_with_oidc(service_id: AuthnOidcHelper::SERVICE_ID, account: AuthnOidcHelper::ACCOUNT)
+  authenticate_id_token_with_oidc(
+    service_id: AuthnOidcHelper::SERVICE_ID,
+    account: AuthnOidcHelper::ACCOUNT
+  )
 end
 
 When(/^I authenticate via OIDC with id token and without a service-id$/) do
-  authenticate_id_token_with_oidc(service_id: nil, account: AuthnOidcHelper::ACCOUNT)
+  authenticate_id_token_with_oidc(
+    service_id: nil,
+    account: AuthnOidcHelper::ACCOUNT
+  )
 end
 
 When(/^I authenticate via OIDC with id token and account "([^"]*)"$/) do |account|
-  authenticate_id_token_with_oidc(service_id: AuthnOidcHelper::SERVICE_ID, account: account)
+  authenticate_id_token_with_oidc(
+    service_id: AuthnOidcHelper::SERVICE_ID,
+    account: account
+  )
 end
 
 When(/^I authenticate via OIDC with no id token$/) do
-  authenticate_id_token_with_oidc(service_id: AuthnOidcHelper::SERVICE_ID, account: AuthnOidcHelper::ACCOUNT, id_token: nil)
+  authenticate_id_token_with_oidc(
+    service_id: AuthnOidcHelper::SERVICE_ID,
+    account: AuthnOidcHelper::ACCOUNT,
+    id_token: nil
+  )
 end
 
 When(/^I authenticate via OIDC with empty id token$/) do
-  authenticate_id_token_with_oidc(service_id: AuthnOidcHelper::SERVICE_ID, account: AuthnOidcHelper::ACCOUNT, id_token: "")
+  authenticate_id_token_with_oidc(
+    service_id: AuthnOidcHelper::SERVICE_ID,
+    account: AuthnOidcHelper::ACCOUNT,
+    id_token: ""
+  )
 end
 
 When(/^I authenticate (\d+) times? in (\d+) threads? via OIDC with( invalid)? id token$/) do |num_requests, num_threads, is_invalid|

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -20,23 +20,7 @@ module AuthnOidcHelper
     post(path, payload)
   end
 
-  def set_provider_uri_variable(value = oidc_provider_uri)
-    set_oidc_variable("provider-uri", value)
-  end
-
-  def set_id_token_user_property_variable
-    set_oidc_variable("id-token-user-property", oidc_id_token_user_property)
-  end
-
-  def set_provider_uri_variable_without_service_id(value = oidc_provider_uri)
-    set_oidc_variable("provider-uri", value, "")
-  end
-
-  def set_id_token_user_property_variable_without_service_id
-    set_oidc_variable("id-token-user-property", oidc_id_token_user_property, "")
-  end
-
-  def set_oidc_variable(variable_name, value, service_id_suffix = "/keycloak")
+  def create_oidc_secret(variable_name, value, service_id_suffix = "/keycloak")
     path = "cucumber:variable:conjur/authn-oidc#{service_id_suffix}"
     Secret.create(resource_id: "#{path}/#{variable_name}", value: value)
   end

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -9,7 +9,8 @@ module AuthnOidcHelper
   ACCOUNT = 'cucumber'
 
   def authenticate_id_token_with_oidc(service_id:, account:, id_token: parsed_id_token)
-    path = "#{conjur_hostname}/authn-oidc/#{service_id}/#{account}/authenticate"
+    service_id_part = service_id ? "/#{service_id}" : ""
+    path = "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}/authenticate"
 
     payload = {}
     unless id_token.nil?
@@ -27,8 +28,16 @@ module AuthnOidcHelper
     set_oidc_variable("id-token-user-property", oidc_id_token_user_property)
   end
 
-  def set_oidc_variable(variable_name, value)
-    path = "cucumber:variable:conjur/authn-oidc/keycloak"
+  def set_provider_uri_variable_without_service_id(value = oidc_provider_uri)
+    set_oidc_variable("provider-uri", value, "")
+  end
+
+  def set_id_token_user_property_variable_without_service_id
+    set_oidc_variable("id-token-user-property", oidc_id_token_user_property, "")
+  end
+
+  def set_oidc_variable(variable_name, value, service_id_suffix = "/keycloak")
+    path = "cucumber:variable:conjur/authn-oidc#{service_id_suffix}"
     Secret.create(resource_id: "#{path}/#{variable_name}", value: value)
   end
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     - ../../conjur-policy-parser:/src/conjur-policy-parser
     - authn-local:/run/authn-local
     - ../ci/ldap-certs:/ldap-certs:ro
+    # TODO: authenticators_oidc/test has a dep on this
+    - ../ci/test_suites/authenticators_oidc/keycloak:/authn-oidc/keycloak/scripts
     links:
     - pg:pg
     - ldap-server
@@ -132,8 +134,9 @@ services:
     ports:
       - "7777:8080"
     volumes:
-      - ../ci/authn-oidc/keycloak/standalone.xml:/opt/jboss/keycloak/standalone/configuration/standalone.xml
-      - ../ci/authn-oidc/keycloak:/authn-oidc/keycloak/scripts
+      # TODO: authenticators_oidc/test has a dep on this
+      - ../ci/test_suites/authenticators_oidc/keycloak:/scripts
+      - ../ci/test_suites/authenticators_oidc/keycloak/standalone.xml:/opt/jboss/keycloak/standalone/configuration/standalone.xml
 
   okta-ldap-agent:
     image: weareenvoy/okta-ldap-agent

--- a/dev/start
+++ b/dev/start
@@ -158,7 +158,7 @@ if [[ $ENABLE_AUTHN_AZURE = true ]]; then
 
   ../ci/authn-azure/check_dependencies.sh
 
-  docker-compose exec client conjur policy load root /src/conjur-server/ci/authn-azure/policies/policy.yml
+  docker-compose exec client conjur policy load root /src/conjur-server/ci/test_suites/authenticators_azure/policies/policy.yml
   docker-compose exec client conjur variable values add conjur/authn-azure/prod/provider-uri "https://sts.windows.net/$AZURE_TENANT_ID/"
 
   sed "s#{{ AZURE_SUBSCRIPTION_ID }}#$AZURE_SUBSCRIPTION_ID#g" ../ci/authn-azure/policies/azure-hosts.template.yml |
@@ -193,7 +193,7 @@ if [[ $ENABLE_AUTHN_OIDC = true ]]; then
   keycloak_isready?
 
   echo "Initialize keycloak certificate in conjur server"
-  docker-compose exec conjur /src/conjur-server/ci/authn-oidc/keycloak/fetchCertificate
+  docker-compose exec -T conjur /authn-oidc/keycloak/scripts/fetchCertificate
 
   if [[ $ENABLE_OIDC_OKTA = true ]]; then
     echo "Configuring OKTA as OpenID provider for manual testing"
@@ -209,7 +209,7 @@ if [[ $ENABLE_AUTHN_OIDC = true ]]; then
 
   # add variables' values for keycloak
   echo "Setting keycloak variables values in conjur"
-  docker-compose exec client conjur policy load root /src/conjur-server/ci/authn-oidc/policy.yml
+  docker-compose exec client conjur policy load root /src/conjur-server/ci/test_suites/authenticators_oidc/policy.yml
   docker-compose exec client conjur variable values add conjur/authn-oidc/keycloak/provider-uri "https://keycloak:8443/auth/realms/master"
   docker-compose exec client conjur variable values add conjur/authn-oidc/keycloak/id-token-user-property "preferred_username"
 
@@ -228,17 +228,17 @@ if [[ $ENABLE_AUTHN_OIDC = true ]]; then
   fi
 
   echo "Creating OpenID client in keycloack OpenID provider"
-  docker-compose exec oidc-keycloak /authn-oidc/keycloak/scripts/create_client
+  docker-compose exec oidc-keycloak /scripts/create_client
   echo "keycloak admin console url: http://0.0.0.0:7777/auth/admin"
 
   echo "Creating user 'alice' in Keycloak"
-  docker-compose exec oidc-keycloak bash -c '/authn-oidc/keycloak/scripts/create_user "$KEYCLOAK_APP_USER" "$KEYCLOAK_APP_USER_PASSWORD" "$KEYCLOAK_APP_USER_EMAIL"'
+  docker-compose exec oidc-keycloak bash -c '/scripts/create_user "$KEYCLOAK_APP_USER" "$KEYCLOAK_APP_USER_PASSWORD" "$KEYCLOAK_APP_USER_EMAIL"'
 
   echo "Creating second user 'bob' in Keycloak"
-  docker-compose exec oidc-keycloak bash -c '/authn-oidc/keycloak/scripts/create_user "$KEYCLOAK_SECOND_APP_USER" "$KEYCLOAK_SECOND_APP_USER_PASSWORD" "$KEYCLOAK_SECOND_APP_USER_EMAIL"'
+  docker-compose exec oidc-keycloak bash -c '/scripts/create_user "$KEYCLOAK_SECOND_APP_USER" "$KEYCLOAK_SECOND_APP_USER_PASSWORD" "$KEYCLOAK_SECOND_APP_USER_EMAIL"'
 
   echo "Creating user in Keycloak that will not exist in conjur"
-  docker-compose exec oidc-keycloak bash -c '/authn-oidc/keycloak/scripts/create_user "$KEYCLOAK_NON_CONJUR_APP_USER" "$KEYCLOAK_NON_CONJUR_APP_USER_PASSWORD" "$KEYCLOAK_NON_CONJUR_APP_USER_EMAIL"'
+  docker-compose exec oidc-keycloak bash -c '/scripts/create_user "$KEYCLOAK_NON_CONJUR_APP_USER" "$KEYCLOAK_NON_CONJUR_APP_USER_PASSWORD" "$KEYCLOAK_NON_CONJUR_APP_USER_EMAIL"'
 
   if [[ $ENABLE_AUTHN_LDAP = true && $ENABLE_OIDC_OKTA = true ]]; then
     echo "Building & configuring Okta-LDAP agent"

--- a/dev/start
+++ b/dev/start
@@ -182,7 +182,8 @@ if [[ $ENABLE_AUTHN_OIDC = true ]]; then
   docker-compose up -d --no-deps $services
 
   echo "Configuring Keycloak as OpenID provider for automatic testing"
-  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak"
+  # We enable an OIDC authenticator without a service-id to test that it's invalid
+  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak,authn-oidc"
 
   # Start conjur again, since it is recreating by docker-compose because of dependency with keycloak
   echo "Starting Conjur server"


### PR DESCRIPTION
### What does this PR do?
We do not have a scenario in which an OIDC authenticator
will be initialized without a service id. Thus, we should make
the `service-id` request param required.

### What ticket does this PR close?
Resolves #2004

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes

#### Documentation
- [x] This PR does not require updating any documentation
