### PR TITLE
Add audit query index to audit engine migrations

### DIFF
--- a/engines/conjur_audit/db/migrate/20210125101831_add_activity_index.rb
+++ b/engines/conjur_audit/db/migrate/20210125101831_add_activity_index.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  # Adding a new index to the messages audit database table allows queries
+  # filtering on these values to potentially leverage the index rather than
+  # depend on sequential table scans.
+  #
+  # The fields included are based on the queries defined in the audit engine here:
+  # https://github.com/cyberark/conjur/blob/master/engines/conjur_audit/app/models/conjur_audit/message.rb#L27
+  #
+  # NOTE: Due to the statistical nature of the Postgres query planner and the
+  # storage characteristics of JSON column data, the impact of this index isn't
+  # predictable or guaranteed to consistently improve the query performance for
+  # all audit queries.
+  up do
+    execute(<<~SQL)
+      CREATE INDEX messages_timestamp_sdata_entity_idx on messages (
+        -- Entity queries are always sorted by descending timestamp to retrieve
+        -- the most recent audit events.
+        timestamp desc,
+      
+        -- Index the structured data fields that are used to store Resources IDs
+        (sdata #>> '{subject@43868, resource}'),
+        (sdata #>> '{auth@43868, service}'),
+        (sdata #>> '{policy@43868, policy}'),
+        
+        -- Index the structured data fields that are used to Role IDs
+        (sdata #>> '{subject@43868, role}'),
+        (sdata #>> '{subject@43868, member}'),
+        (sdata #>> '{auth@43868, user}')
+      );
+    SQL
+  end
+
+  down do
+    execute(<<~SQL)
+      DROP INDEX IF EXISTS messages_timestamp_sdata_entity_idx;
+    SQL
+  end
+end


### PR DESCRIPTION
### What does this PR do?
This PR adds a new index to the `messages` audit database table that
allows queries filtering on these values to potentially leverage the index
rather than depend on sequential table scans.

This change is further verified in the appliance tests including the index here: https://jenkins.conjur.net/blue/organizations/jenkins/conjurinc--appliance/activity?branch=2005-audit-query-index

### What ticket does this PR close?
Resolves #2005

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

> I decided against a CHANGELOG entry for two reasons:
> 
> 1. There's no change for `cyberark/conjur` OSS users, since the audit database is only configured in the appliance.
> 2. The impact for the user would be more performant audit queries, but it's not a guaranteed improvement. So this change, without other enterprise changes, doesn't appreciably impact the user.

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
