### PR TITLE
Added extra check for Accept header on batch secrets request

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,7 @@
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-0-58
+    channel: rubocop-1-8-1
   reek:
     enabled: true
   bundler-audit:

--- a/.reek.yml
+++ b/.reek.yml
@@ -308,6 +308,7 @@ detectors:
     - CAHelpers::RootCA
 
   TooManyStatements:
+    max_statements: 10
     exclude:
     - initialize
     - RootLoader#load

--- a/.rubocop_settings.yml
+++ b/.rubocop_settings.yml
@@ -2,8 +2,6 @@ AllCops:
   TargetRubyVersion: 2.5
 
 # These non-default settings best reflect our current code style.
-Style/MethodDefParentheses:
-  EnforcedStyle: require_no_parentheses_except_multiline
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%i": ()

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -96,7 +96,7 @@ class PoliciesController < RestController
 
   def actor_roles(roles)
     roles.select do |role|
-      %w(user host).member?(role.kind)
+      %w[user host].member?(role.kind)
     end
   end
 

--- a/app/controllers/public_keys_controller.rb
+++ b/app/controllers/public_keys_controller.rb
@@ -6,7 +6,7 @@ class PublicKeysController < ApplicationController
 
     values = Secret.latest_public_keys account, kind, id
     # For test stability.
-    values.sort! if %w(test development).member?(Rails.env)
+    values.sort! if %w[test development].member?(Rails.env)
     result = values.map(&:strip).join("\n").strip + "\n"
 
     render plain: result, content_type: "text/plain"

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -7,7 +7,7 @@ class ResourcesController < RestController
   def index
     # Rails 5 requires parameters to be explicitly permitted before converting 
     # to Hash.  See: https://stackoverflow.com/a/46029524
-    allowed_params = %i(account kind limit offset search)
+    allowed_params = %i[account kind limit offset search]
     options = params.permit(*allowed_params)
       .slice(*allowed_params).to_h.symbolize_keys
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -135,7 +135,7 @@ class RolesController < RestController
   def render_params
     # Rails 5 requires parameters to be explicitly permitted before converting
     # to Hash.  See: https://stackoverflow.com/a/46029524
-    allowed_params = %i(limit offset)
+    allowed_params = %i[limit offset]
     params.permit(*allowed_params)
       .slice(*allowed_params).to_h.symbolize_keys
   end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -73,19 +73,13 @@ class SecretsController < RestController
     raise Errors::Conjur::BadSecretEncoding, result
   end
 
-  def get_secret_from_variable variable
+  def get_secret_from_variable(variable)
     secret = variable.last_secret
-    unless secret
-      raise Exceptions::RecordNotFound, variable.resource_id
-    end
+    raise Exceptions::RecordNotFound, variable.resource_id unless secret
 
     secret_value = secret.value
-
-    if request.headers['Accept'].casecmp?('base64')
-      Base64.encode64(secret_value)
-    else
-      secret_value
-    end
+    accepts_base64 = String(request.headers['Accept']).casecmp?('base64')
+    accepts_base64 ? Base64.encode64(secret_value) : secret_value
   end
 
   def audit_fetch resource, version: nil

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -12,7 +12,7 @@ module Authentication
       validate_origin:                     ::Authentication::ValidateOrigin.new,
       audit_log:                           ::Audit.logger
     },
-    inputs:       %i(authenticator_input authenticators enabled_authenticators)
+    inputs:       %i[authenticator_input authenticators enabled_authenticators]
   ) do
 
     extend Forwardable

--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -84,7 +84,7 @@ module Authentication
       end
 
       def required_variable_names
-        @required_variable_names ||= %w(provider-uri)
+        @required_variable_names ||= %w[provider-uri]
       end
     end
 

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -6,7 +6,7 @@ module Authentication
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
         discover_identity_provider:  Authentication::OAuth::DiscoverIdentityProvider.new
       },
-      inputs:       %i(account service_id)
+      inputs:       %i[account service_id]
     ) do
 
       def call
@@ -30,7 +30,7 @@ module Authentication
       end
 
       def required_variable_names
-        @required_variable_names ||= %w(provider-uri)
+        @required_variable_names ||= %w[provider-uri]
       end
 
       def validate_provider_is_responsive

--- a/app/domain/authentication/authn_azure/xms_mirid.rb
+++ b/app/domain/authentication/authn_azure/xms_mirid.rb
@@ -3,7 +3,7 @@ module Authentication
 
     class XmsMirid
 
-      REQUIRED_KEYS = %w(subscriptions resourcegroups providers).freeze
+      REQUIRED_KEYS = %w[subscriptions resourcegroups providers].freeze
 
       def initialize(xms_mirid_token_field)
         @xms_mirid_token_field = xms_mirid_token_field

--- a/app/domain/authentication/authn_gcp/validate_status.rb
+++ b/app/domain/authentication/authn_gcp/validate_status.rb
@@ -5,7 +5,7 @@ module Authentication
       dependencies: {
         discover_identity_provider:  Authentication::OAuth::DiscoverIdentityProvider.new
       },
-      inputs:       %i()
+      inputs:       %i[]
     ) do
 
       def call

--- a/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
+++ b/app/domain/authentication/authn_k8s/copy_text_to_file_in_container.rb
@@ -12,7 +12,7 @@ module Authentication
         k8s_object_lookup:            K8sObjectLookup,
         logger:                       Rails.logger
       },
-      inputs:       %i(webservice pod_namespace pod_name container path content mode)
+      inputs:       %i[webservice pod_namespace pod_name container path content mode]
     ) do
 
       LOG_FILE = "${TMPDIR:-/tmp}/conjur_copy_text_output.log"
@@ -29,7 +29,7 @@ module Authentication
           pod_namespace:     @pod_namespace,
           pod_name:          @pod_name,
           container:         @container,
-          cmds:              %w(sh),
+          cmds:              %w[sh],
           body:              bash_script(@path, @content, @mode),
           stdin:             true
         )

--- a/app/domain/authentication/authn_k8s/execute_command_in_container.rb
+++ b/app/domain/authentication/authn_k8s/execute_command_in_container.rb
@@ -21,7 +21,7 @@ module Authentication
         validate_message:              MessageLog::ValidateMessage.new,
         logger:                        Rails.logger
       },
-      inputs:       %i(k8s_object_lookup pod_namespace pod_name container cmds body stdin)
+      inputs:       %i[k8s_object_lookup pod_namespace pod_name container cmds body stdin]
     ) do
 
       DEFAULT_TIMEOUT_SEC = 5
@@ -111,7 +111,7 @@ module Authentication
         base_url = "wss://#{api_uri.host}:#{api_uri.port}"
         path     = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
 
-        base_query_string_parts = %W(container=#{CGI.escape(@container)} stderr=true stdout=true)
+        base_query_string_parts = %W[container=#{CGI.escape(@container)} stderr=true stdout=true]
         stdin_part              = @stdin ? ['stdin=true'] : []
         cmds_part               = @cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
         query_string            = (

--- a/app/domain/authentication/authn_k8s/extract_container_name.rb
+++ b/app/domain/authentication/authn_k8s/extract_container_name.rb
@@ -9,7 +9,7 @@ module Authentication
       dependencies: {
         logger:                 Rails.logger
       },
-      inputs: %i(service_id host_annotations)
+      inputs: %i[service_id host_annotations]
     ) do
 
       DEFAULT_AUTHENTICATION_CONTAINER_NAME = "authenticator"

--- a/app/domain/authentication/authn_k8s/extract_k8s_resource_restrictions.rb
+++ b/app/domain/authentication/authn_k8s/extract_k8s_resource_restrictions.rb
@@ -9,7 +9,7 @@ module Authentication
         resource_restrictions_class:   ResourceRestrictions::ResourceRestrictions,
         logger:                        Rails.logger
       },
-      inputs:   %i(authenticator_name service_id role_name account)
+      inputs:   %i[authenticator_name service_id role_name account]
     ) do
 
       def call

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -15,7 +15,7 @@ module Authentication
         extract_container_name:         ExtractContainerName.new,
         audit_log:                      ::Audit.logger
       },
-      inputs:       %i(conjur_account service_id csr host_id_prefix client_ip)
+      inputs:       %i[conjur_account service_id csr host_id_prefix client_ip]
     ) do
 
       # :reek:TooManyStatements

--- a/app/domain/authentication/authn_k8s/validate_pod_request.rb
+++ b/app/domain/authentication/authn_k8s/validate_pod_request.rb
@@ -21,7 +21,7 @@ module Authentication
         extract_container_name:              ExtractContainerName.new,
         logger:                              Rails.logger
       },
-      inputs:       %i(pod_request)
+      inputs:       %i[pod_request]
     ) do
 
       extend Forwardable

--- a/app/domain/authentication/authn_k8s/web_socket_message.rb
+++ b/app/domain/authentication/authn_k8s/web_socket_message.rb
@@ -14,7 +14,7 @@ module Authentication
         end
 
         def channel_names
-          %w(stdin stdout stderr error resize)
+          %w[stdin stdout stderr error resize]
         end
       end
 

--- a/app/domain/authentication/authn_ldap/configuration.rb
+++ b/app/domain/authentication/authn_ldap/configuration.rb
@@ -92,7 +92,7 @@ module Authentication
       end
 
       def connect_type_secure?
-        %i(ssl tls).include?(connect_type)
+        %i[ssl tls].include?(connect_type)
       end
 
       def uri_connect_type

--- a/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
+++ b/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
@@ -8,7 +8,7 @@ module Authentication
         verify_and_decode_token:             ::Authentication::OAuth::VerifyAndDecodeToken.new,
         logger:                              Rails.logger
       },
-      inputs:       %i(authenticator_input)
+      inputs:       %i[authenticator_input]
     ) do
 
       extend Forwardable
@@ -64,7 +64,7 @@ module Authentication
       end
 
       def required_variable_names
-        @required_variable_names ||= %w(provider-uri id-token-user-property)
+        @required_variable_names ||= %w[provider-uri id-token-user-property]
       end
 
       def validate_conjur_username

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -6,7 +6,7 @@ module Authentication
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
         discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
       },
-      inputs: %i(account service_id)
+      inputs: %i[account service_id]
     ) do
 
       def call
@@ -30,7 +30,7 @@ module Authentication
       end
 
       def required_variable_names
-        @required_variable_names ||= %w(provider-uri id-token-user-property)
+        @required_variable_names ||= %w[provider-uri id-token-user-property]
       end
 
       def validate_provider_is_responsive

--- a/app/domain/authentication/jwt/verify_and_decode_token.rb
+++ b/app/domain/authentication/jwt/verify_and_decode_token.rb
@@ -21,7 +21,7 @@ module Authentication
         jwt_decoder: JWT,
         logger:      Rails.logger
       },
-      inputs:       %i(token_jwt verification_options)
+      inputs:       %i[token_jwt verification_options]
     ) do
 
       def call

--- a/app/domain/authentication/login.rb
+++ b/app/domain/authentication/login.rb
@@ -13,7 +13,7 @@ module Authentication
       audit_log: ::Audit.logger,
       role_cls: ::Role
     },
-    inputs: %i(authenticator_input authenticators enabled_authenticators)
+    inputs: %i[authenticator_input authenticators enabled_authenticators]
   ) do
 
     extend Forwardable

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -6,7 +6,7 @@ module Authentication
         logger:                    Rails.logger,
         open_id_discovery_service: OpenIDConnect::Discovery::Provider::Config
       },
-      inputs:       %i(provider_uri)
+      inputs:       %i[provider_uri]
     ) do
 
       def call

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -8,7 +8,7 @@ module Authentication
         logger:                 Rails.logger,
         discover_identity_provider: DiscoverIdentityProvider.new
       },
-      inputs:       %i(provider_uri)
+      inputs:       %i[provider_uri]
     ) do
 
       def call

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -23,7 +23,7 @@ module Authentication
         verify_and_decode_token: ::Authentication::Jwt::VerifyAndDecodeToken.new,
         logger:                  Rails.logger
       },
-      inputs:       %i(provider_uri token_jwt claims_to_verify)
+      inputs:       %i[provider_uri token_jwt claims_to_verify]
     ) do
 
       def call

--- a/app/domain/authentication/resource_restrictions/extract_resource_restrictions.rb
+++ b/app/domain/authentication/resource_restrictions/extract_resource_restrictions.rb
@@ -10,7 +10,7 @@ module Authentication
         resource_class:              ::Resource,
         logger:                      Rails.logger
       },
-      inputs:   %i(authenticator_name service_id role_name account)
+      inputs:   %i[authenticator_name service_id role_name account]
     ) do
 
       def call

--- a/app/domain/authentication/resource_restrictions/validate_resource_restrictions.rb
+++ b/app/domain/authentication/resource_restrictions/validate_resource_restrictions.rb
@@ -25,7 +25,7 @@ module Authentication
         extract_resource_restrictions: ExtractResourceRestrictions.new,
         logger:                        Rails.logger
       },
-      inputs:   %i(authenticator_name service_id role_name account constraints authentication_request)
+      inputs:   %i[authenticator_name service_id role_name account constraints authentication_request]
     ) do
 
       def call

--- a/app/domain/authentication/security/validate_account_exists.rb
+++ b/app/domain/authentication/security/validate_account_exists.rb
@@ -8,7 +8,7 @@ module Authentication
       dependencies: {
         role_class: ::Role
       },
-      inputs: %i(account)
+      inputs: %i[account]
     ) do
 
       def call

--- a/app/domain/authentication/security/validate_role_can_access_webservice.rb
+++ b/app/domain/authentication/security/validate_role_can_access_webservice.rb
@@ -14,7 +14,7 @@ module Authentication
         validate_account_exists:    ::Authentication::Security::ValidateAccountExists.new,
         logger:                     Rails.logger
       },
-      inputs:       %i(webservice account user_id privilege)
+      inputs:       %i[webservice account user_id privilege]
     ) do
 
       def call

--- a/app/domain/authentication/security/validate_webservice_exists.rb
+++ b/app/domain/authentication/security/validate_webservice_exists.rb
@@ -10,7 +10,7 @@ module Authentication
         resource_class: ::Resource,
         validate_account_exists: ::Authentication::Security::ValidateAccountExists.new
       },
-      inputs: %i(webservice account)
+      inputs: %i[webservice account]
     ) do
 
       def call

--- a/app/domain/authentication/security/validate_webservice_is_authenticator.rb
+++ b/app/domain/authentication/security/validate_webservice_is_authenticator.rb
@@ -6,7 +6,7 @@ module Authentication
       dependencies: {
         installed_authenticators_class: Authentication::InstalledAuthenticators
       },
-      inputs: %i(webservice)
+      inputs: %i[webservice]
     ) do
       
       def call

--- a/app/domain/authentication/security/validate_webservice_is_whitelisted.rb
+++ b/app/domain/authentication/security/validate_webservice_is_whitelisted.rb
@@ -12,7 +12,7 @@ module Authentication
         webservices_class:       ::Authentication::Webservices,
         validate_account_exists: ::Authentication::Security::ValidateAccountExists.new
       },
-      inputs:       %i(webservice account enabled_authenticators)
+      inputs:       %i[webservice account enabled_authenticators]
     ) do
 
       def call

--- a/app/domain/authentication/update_authenticator_config.rb
+++ b/app/domain/authentication/update_authenticator_config.rb
@@ -11,7 +11,7 @@ module Authentication
       validate_webservice_is_authenticator: ::Authentication::Security::ValidateWebserviceIsAuthenticator.new,
       validate_role_can_access_webservice:  ::Authentication::Security::ValidateRoleCanAccessWebservice.new
     },
-    inputs:       %i(account authenticator_name service_id enabled username)
+    inputs:       %i[account authenticator_name service_id enabled username]
   ) do
 
     def call

--- a/app/domain/authentication/util/fetch_authenticator_secrets.rb
+++ b/app/domain/authentication/util/fetch_authenticator_secrets.rb
@@ -8,7 +8,7 @@ module Authentication
       dependencies: {
         fetch_secrets: ::Conjur::FetchRequiredSecrets.new
       },
-      inputs:       %i(conjur_account authenticator_name service_id required_variable_names)
+      inputs:       %i[conjur_account authenticator_name service_id required_variable_names]
     ) do
 
       def call

--- a/app/domain/authentication/validate_origin.rb
+++ b/app/domain/authentication/validate_origin.rb
@@ -7,7 +7,7 @@ module Authentication
       role_cls: ::Role,
       logger:   Rails.logger
     },
-    inputs: %i(account username client_ip)
+    inputs: %i[account username client_ip]
   ) do
 
     def call

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -13,7 +13,7 @@ module Authentication
       implemented_authenticators:          Authentication::InstalledAuthenticators.authenticators(ENV),
       audit_log:                           ::Audit.logger
     },
-    inputs:       %i(authenticator_status_input enabled_authenticators)
+    inputs:       %i[authenticator_status_input enabled_authenticators]
   ) do
 
     extend Forwardable

--- a/app/domain/commands/credentials/change_password.rb
+++ b/app/domain/commands/credentials/change_password.rb
@@ -14,7 +14,7 @@ module Commands
       # dependency that it will use to save the new password.
       # This should be addressed to make the database dependency explicit:
       # https://github.com/cyberark/conjur/issues/1611
-      inputs: %i(role password client_ip)
+      inputs: %i[role password client_ip]
     ) do
 
       def call

--- a/app/domain/commands/credentials/rotate_api_key.rb
+++ b/app/domain/commands/credentials/rotate_api_key.rb
@@ -14,7 +14,7 @@ module Commands
       dependencies: {
         audit_log: ::Audit.logger
       },
-      inputs: %i(role_to_rotate authenticated_role client_ip)
+      inputs: %i[role_to_rotate authenticated_role client_ip]
     ) do
 
       def call

--- a/app/domain/util/fetch_resource.rb
+++ b/app/domain/util/fetch_resource.rb
@@ -3,7 +3,7 @@ module Util
     dependencies: {
       resource_class: ::Resource
     },
-    inputs: %i(resource_id)
+    inputs: %i[resource_id]
   ) do
 
     def call

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -50,7 +50,7 @@ module Loader
 
     attr_reader :policy_version, :create_records, :delete_records, :new_roles, :schemata
 
-    TABLES = %i(roles role_memberships resources permissions annotations)
+    TABLES = %i[roles role_memberships resources permissions annotations]
 
     # Columns to compare across schemata to find exact duplicates.
     TABLE_EQUIVALENCE_COLUMNS = {

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -93,7 +93,7 @@ module Loader
       def create_resource!
         ::Resource.create(resource_id: resourceid, owner_id: find_ownerid).tap do |resource|
           records = Hash(annotations).map { |name, value| [resource.id, name, value.to_s]}
-          resource.annotations_dataset.import(%i(resource_id name value), records)
+          resource.annotations_dataset.import(%i[resource_id name value], records)
         end
       end
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -8,7 +8,7 @@ class Permission < Sequel::Model
 
   def as_json options = {}
     super(options).tap do |response|
-      %w(resource role policy).each do |field|
+      %w[resource role policy].each do |field|
         write_id_to_json response, field
       end
     end

--- a/app/models/policy_log.rb
+++ b/app/models/policy_log.rb
@@ -8,7 +8,7 @@
 Sequel::Model.db.extension(:pg_hstore)
 
 class PolicyLog < Sequel::Model :policy_log
-  many_to_one :policy_version, key: %i(policy_id version)
+  many_to_one :policy_version, key: %i[policy_id version]
 
   def to_audit_event
     Audit::Event::Policy.new(

--- a/app/models/policy_version.rb
+++ b/app/models/policy_version.rb
@@ -29,7 +29,7 @@ class PolicyVersion < Sequel::Model(:policy_versions)
   # The authenticated user who performs the policy load.
   many_to_one :role
 
-  one_to_many :policy_log, key: %i(policy_id version)
+  one_to_many :policy_log, key: %i[policy_id version]
 
   attr_accessor :parse_error, :policy_filename, :delete_permitted
 
@@ -47,7 +47,7 @@ class PolicyVersion < Sequel::Model(:policy_versions)
   def as_json options = {}
     super(options).tap do |response|
       response["id"] = response.delete("resource_id")
-      %w(role).each do |field|
+      %w[role].each do |field|
         write_id_to_json response, field
       end
     end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -26,7 +26,7 @@ class Resource < Sequel::Model
   def as_json options = {}
     super(options).tap do |response|
       response["id"] = response.delete("resource_id")
-      %w(owner policy).each do |field|
+      %w[owner policy].each do |field|
         write_id_to_json response, field
       end
       response["permissions"] = permissions.as_json.map { |h| h.except 'resource' }

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -104,7 +104,7 @@ class Role < Sequel::Model
   def api_key
     unless self.credentials
       _, kind, id = self.id.split(":", 3)
-      allowed_kind = %w(user host deputy).member?(kind)
+      allowed_kind = %w[user host deputy].member?(kind)
       raise "Role #{id} has no credentials" unless allowed_kind
 
       self.credentials = Credentials.create(role: self)

--- a/app/models/role_membership.rb
+++ b/app/models/role_membership.rb
@@ -8,7 +8,7 @@ class RoleMembership < Sequel::Model
   
   def as_json options = {}
     super(options).tap do |response|
-      %w(role member policy).each do |field|
+      %w[role member policy].each do |field|
         write_id_to_json response, field
       end
     end

--- a/config/initializers/authenticator.rb
+++ b/config/initializers/authenticator.rb
@@ -8,7 +8,7 @@ require 'patches/core_ext'
 
 Sequel.extension :migration
 
-if %w(test development cucumber).member?(Rails.env)
+if %w[test development cucumber].member?(Rails.env)
   ENV['CONJUR_DATA_KEY'] ||= '4pSuk1rAQyuHA5uUYaj0X0BsiPCFb9Nc8J03XA6V5/Y='
 end
 

--- a/cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
+++ b/cucumber/_authenticators_common/features/step_definitions/authn_common_steps.rb
@@ -4,7 +4,7 @@ Then(/^(user|host) "(\S+)" has been authorized by Conjur$/) do |role_type, usern
 end
 
 Then(/^login response token is valid$/) do
-  expect(token_for_keys(%w(user_name expiration_time id_token_encrypted), @response_body)).to be
+  expect(token_for_keys(%w[user_name expiration_time id_token_encrypted], @response_body)).to be
 end
 
 Then(/it is a bad request/) do

--- a/cucumber/_authenticators_common/features/support/hooks.rb
+++ b/cucumber/_authenticators_common/features/support/hooks.rb
@@ -17,7 +17,7 @@ Before do
   Credentials.truncate
 
   Slosilo.each do |k, _|
-    unless %w(authn:rspec authn:cucumber).member?(k)
+    unless %w[authn:rspec authn:cucumber].member?(k)
       Slosilo.send(:keystore).adapter.model[k].delete
     end
   end

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -114,3 +114,11 @@ Feature: Batch retrieval of secrets
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
     Then the HTTP response status code is 500
+
+  Scenario: Omit the Accept header entirely from batch secrets request
+    Given I add the secret value "v2" to the resource "cucumber:variable:secret2"
+    When I GET "/secrets?variable_ids=cucumber:variable:secret2" with no default headers
+    Then the JSON should be:
+    """
+    { "cucumber:variable:secret2": "v2" }
+    """

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -19,6 +19,10 @@ When(/^I( (?:can|successfully))? GET "([^"]*)"$/) do |can, path|
   end
 end
 
+When(/^I GET "([^"]*)" with no default headers$/) do |path|
+  get_json_no_default_headers path
+end
+
 When(/^I( (?:can|successfully))? PUT "([^"]*)"$/) do |can, path|
   try_request can do
     put_json path

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -20,7 +20,7 @@ When(/^I( (?:can|successfully))? GET "([^"]*)"$/) do |can, path|
 end
 
 When(/^I GET "([^"]*)" with no default headers$/) do |path|
-  get_json_no_default_headers path
+  get_json_no_accept_header(path)
 end
 
 When(/^I( (?:can|successfully))? PUT "([^"]*)"$/) do |can, path|

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -19,4 +19,4 @@ ENV['CONJUR_APPLIANCE_URL'] ||= Utils.start_local_server
 
 Slosilo["authn:cucumber"] ||= Slosilo::Key.new
 
-JsonSpec.excluded_keys = %w(created_at updated_at)
+JsonSpec.excluded_keys = %w[created_at updated_at]

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -18,7 +18,7 @@ Before do
   Credentials.truncate
 
   Slosilo.each do |k,v|
-    unless %w(authn:rspec authn:cucumber).member?(k)
+    unless %w[authn:rspec authn:cucumber].member?(k)
       Slosilo.send(:keystore).adapter.model[k].delete
     end
   end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -65,7 +65,7 @@ module RestHelpers
     headers.each { |key, value| request[key] = value }
 
     if options[:user] && options[:password]
-      request.basic_auth options[:user], options[:password]
+      request.basic_auth(options[:user], options[:password])
     end
 
     response = http.request(request)
@@ -281,17 +281,17 @@ module RestHelpers
 
   def current_user_credentials
     username = @current_user.login
-    token = Slosilo["authn:#{@current_user.account}"].signed_token username
-    user_credentials username, token
+    token = Slosilo["authn:#{@current_user.account}"].signed_token(username)
+    user_credentials(username, token)
   end
 
-  def user_credentials username, token
+  def user_credentials(username, token)
     token_authorization = "Token token=\"#{Base64.strict_encode64 token.to_json}\""
     headers = { authorization: token_authorization }
     { headers: headers, username: username }
   end
 
-  def current_user_basic_auth password = nil
+  def current_user_basic_auth(password = nil)
     password ||= @current_user.api_key
     { user: @current_user.login, password: password }
   end
@@ -300,8 +300,11 @@ module RestHelpers
     RestClient::Resource.new(Conjur::Authn::API.host, current_user_credentials)
   end
 
-  def basic_auth_request password = nil
-    RestClient::Resource.new(Conjur::Authn::API.host, current_user_basic_auth(password))
+  def basic_auth_request(password = nil)
+    RestClient::Resource.new(
+      Conjur::Authn::API.host,
+      current_user_basic_auth(password)
+    )
   end
 
   def full_conjur_url(path)

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require('net/http')
+require('uri')
+
 # Utility methods for making API requests
 #
 module RestHelpers
@@ -47,6 +50,31 @@ module RestHelpers
     path = denormalize(path)
     result = rest_resource(options)[path].get
     set_result result
+  end
+
+  # Since there is no way to remove the default Accept header from RestClient
+  # we use Net:HTTP here. Otherwise we would not be able to simulate requests
+  # that omit the Accept header in our tests.
+  def get_json_no_accept_header(path, options = {})
+    uri = URI(root_url + denormalize(path))
+    headers = request_opts(options)[:headers]
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Get.new(uri.request_uri)
+
+    request.delete('Accept')
+    headers.each { |key, value| request[key] = value }
+
+    if options[:user] && options[:password]
+      request.basic_auth options[:user], options[:password]
+    end
+
+    response = http.request(request)
+
+    if response.content_type == 'application/json'
+      @result = JSON.parse(response.body)
+    else
+      @result = response.body
+    end
   end
 
   # TODO: Add proper fix for this with real refactor of test code
@@ -327,22 +355,27 @@ module RestHelpers
     str
   end
 
-  def rest_resource options
-    args = [Conjur.configuration.appliance_url]
-    if options[:token]
-      args << user_credentials(options[:token].username, options[:token].token)
-    elsif current_user?
-      args << current_user_credentials
-    end
+  def root_url
+    Conjur.configuration.appliance_url
+  end
 
-    args <<({}) if args.length == 1
-    args.last[:headers] ||= {}
-    args.last[:headers].merge(headers) if headers
-
-    RestClient::Resource.new(*args).tap do |request|
-      headers.each do |key, val|
-        request.headers[key] = val
+  def request_opts(options)
+    creds =
+      if options[:token]
+        user_credentials(options[:token].username, options[:token].token)
+      elsif current_user?
+        current_user_credentials
+      else
+        {}
       end
+
+    creds[:headers] ||= {}
+    creds[:headers].merge!(headers)
+    creds
+  end
+
+  def rest_resource(options)
+    RestClient::Resource.new(root_url, request_opts(options)).tap do |request|
       if options[:user] && options[:password]
         request.options[:user] = denormalize(options[:user])
         request.options[:password] = denormalize(options[:password])

--- a/cucumber/authenticators/features/support/hooks.rb
+++ b/cucumber/authenticators/features/support/hooks.rb
@@ -12,7 +12,7 @@ Before do
   Credentials.truncate
 
   Slosilo.each do |k, _|
-    unless %w(authn:rspec authn:cucumber).member?(k)
+    unless %w[authn:rspec authn:cucumber].member?(k)
       Slosilo.send(:keystore).adapter.model[k].delete
     end
   end

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -16,7 +16,7 @@ Before do
     pod.spec.containers.each do |container|
       next unless container.name == "authenticator"
 
-      cmds = %w(rm -rf /etc/conjur/ssl/* && rm -rf /tmp/*)
+      cmds = %w[rm -rf /etc/conjur/ssl/* && rm -rf /tmp/*]
       puts "Running command '#{cmds.join(' ')}' container #{container.name} in pod #{pod.metadata.name}"
       Authentication::AuthnK8s::ExecuteCommandInContainer.new.call(
         k8s_object_lookup: Authentication::AuthnK8s::K8sObjectLookup.new,

--- a/cucumber/kubernetes/features/support/world.rb
+++ b/cucumber/kubernetes/features/support/world.rb
@@ -55,7 +55,7 @@ module AuthnK8sWorld
           pod_namespace:     pod_metadata.namespace,
           pod_name:          pod_metadata.name,
           container:         "authenticator",
-          cmds:              %w(cat /etc/conjur/ssl/client.pem),
+          cmds:              %w[cat /etc/conjur/ssl/client.pem],
           body:              "",
           stdin:             false
         )
@@ -93,7 +93,7 @@ module AuthnK8sWorld
         pod_namespace:     pod_metadata.namespace,
         pod_name:          pod_metadata.name,
         container:         "authenticator",
-        cmds:              %w(cat /tmp/conjur_copy_text_output.log),
+        cmds:              %w[cat /tmp/conjur_copy_text_output.log],
         body:              "",
         stdin:             false
       )

--- a/cucumber/policy/features/support/hooks.rb
+++ b/cucumber/policy/features/support/hooks.rb
@@ -25,7 +25,7 @@ Before do
   Credentials.truncate
 
   Slosilo.each do |k, v|
-    unless %w(authn:rspec authn:cucumber).member?(k)
+    unless %w[authn:rspec authn:cucumber].member?(k)
       Slosilo.send(:keystore).adapter.model[k].delete
     end
   end

--- a/db/migrate/20160801210433_create_id_functions.rb
+++ b/db/migrate/20160801210433_create_id_functions.rb
@@ -32,7 +32,7 @@ Sequel.migration do
     # Index 'account' and 'kind' functions on the 'roles' and 'resources' tables 
     # Index 'account,kind' on 'roles' and 'resources'
     # Require account, kind NOT NULL
-    %w(roles resources).each do |table|
+    %w[roles resources].each do |table|
       primary_key = Sequel::Model(table.to_sym).primary_key
 
       execute <<-SQL
@@ -43,7 +43,7 @@ Sequel.migration do
       $$;
       SQL
 
-      %w(account kind).each do |func|
+      %w[account kind].each do |func|
         execute <<-SQL
         CREATE OR REPLACE FUNCTION #{func}(record #{table}) RETURNS text
         LANGUAGE sql IMMUTABLE
@@ -74,9 +74,9 @@ Sequel.migration do
   down do
     execute "DROP INDEX IF EXISTS secrets_account_kind_identifier_idx"
 
-    %w(roles resources).each do |t|
+    %w[roles resources].each do |t|
       execute "DROP FUNCTION IF EXISTS identifier(#{t})"
-      %w(account kind).each do |f|
+      %w[account kind].each do |f|
         execute "DROP FUNCTION IF EXISTS #{f}(#{t})"
         execute "DROP INDEX #{t}_#{f}_idx"
         execute "ALTER TABLE #{t} DROP CONSTRAINT has_#{f}"

--- a/db/migrate/20160815131521_add_policy_column.rb
+++ b/db/migrate/20160815131521_add_policy_column.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  TABLES = %w(roles resources role_memberships permissions annotations)
+  TABLES = %w[roles resources role_memberships permissions annotations]
 
   up do
     TABLES.each do |table|

--- a/db/migrate/20180410092453_policy_log.rb
+++ b/db/migrate/20180410092453_policy_log.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  tables = %i(roles role_memberships resources permissions annotations)
+  tables = %i[roles role_memberships resources permissions annotations]
 
   up do
     execute """
@@ -10,7 +10,7 @@ Sequel.migration do
       CREATE EXTENSION IF NOT EXISTS hstore;
     """
 
-    key = %i(policy_id version)
+    key = %i[policy_id version]
     create_table :policy_log do
       String :policy_id, null: false
       Integer :version, null: false
@@ -82,7 +82,7 @@ Sequel.migration do
 
     drop_table :policy_log
 
-    %w(op kind).each do |t|
+    %w[op kind].each do |t|
       execute "DROP TYPE policy_log_#{t}"
     end
   end

--- a/db/migrate/201808131137612_policy_log_trigger_bypass.rb
+++ b/db/migrate/201808131137612_policy_log_trigger_bypass.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sequel.migration do
-  tables = %i(roles role_memberships resources permissions annotations)
+  tables = %i[roles role_memberships resources permissions annotations]
   
   up do
     # `policy_log_record` is a custom type to record the column

--- a/db/migrate/20190307154241_change_permissions_primary_key.rb
+++ b/db/migrate/20190307154241_change_permissions_primary_key.rb
@@ -9,14 +9,14 @@ Sequel.migration do
   up do
     alter_table :permissions do
       drop_constraint :permissions_pkey
-      add_primary_key %i(resource_id role_id privilege)
+      add_primary_key %i[resource_id role_id privilege]
     end
   end
 
   down do
     alter_table :permissions do
       drop_constraint :permissions_pkey
-      add_primary_key %i(privilege resource_id role_id)
+      add_primary_key %i[privilege resource_id role_id]
     end
   end
 end

--- a/engines/conjur_audit/app/controllers/conjur_audit/messages_controller.rb
+++ b/engines/conjur_audit/app/controllers/conjur_audit/messages_controller.rb
@@ -10,9 +10,9 @@ module ConjurAudit
 
     private
 
-    DIRECT_FIELDS = %i(facility severity hostname appname procid msgid).freeze
+    DIRECT_FIELDS = %i[facility severity hostname appname procid msgid].freeze
 
-    PAGING_FIELDS = %i(limit offset).freeze
+    PAGING_FIELDS = %i[limit offset].freeze
     
     def query
       @query ||= request.query_parameters

--- a/engines/conjur_audit/contrib/gen_log.rb
+++ b/engines/conjur_audit/contrib/gen_log.rb
@@ -48,7 +48,7 @@ class Generator
       # policy messages are rare, ignore
       update: 10
 
-  COLUMNS = %i(facility timestamp msgid hostname appname severity sdata procid message).freeze
+  COLUMNS = %i[facility timestamp msgid hostname appname severity sdata procid message].freeze
 
   def each
     COUNT.times.lazy.each { yield generate.join("\t") + "\n" }

--- a/gems/policy-parser/conjur-policy-parser.gemspec
+++ b/gems/policy-parser/conjur-policy-parser.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors        = ["Cyberark R&D"]
   spec.summary        = 'Parse the Conjur policy YAML format.'
   # spec.files          = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.files          = Dir.glob("lib/**/*") + %w(README.md)
+  spec.files          = Dir.glob("lib/**/*") + %w[README.md]
   spec.require_paths  = ["lib"]
 
   spec.add_dependency "activesupport", ">= 4.2"

--- a/gems/policy-parser/lib/conjur/policy/yaml/handler.rb
+++ b/gems/policy-parser/lib/conjur/policy/yaml/handler.rb
@@ -355,7 +355,7 @@ module Conjur
         def start_mapping *args
           log {"#{indent}start mapping #{args}"}
           anchor, tag, _ = args
-          tag = "!automatic-role" if %w(!managed-role !managed_role).include?(tag)
+          tag = "!automatic-role" if %w[!managed-role !managed_role].include?(tag)
           handler.start_mapping tag, anchor
         end
         

--- a/gems/policy-parser/spec/types/resource_op_base_spec.rb
+++ b/gems/policy-parser/spec/types/resource_op_base_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 describe Conjur::PolicyParser::Types::ResourceOpBase do
   context "with multiple resources" do
-    let(:resource) { %w(a b).map { |id| Types::Resource.new 'crispy', id } }
+    let(:resource) { %w[a b].map { |id| Types::Resource.new 'crispy', id } }
     describe '#subject_id' do
       it "returns an array of resource ids" do
-        expect(op.subject_id).to eq %w(a b)
+        expect(op.subject_id).to eq %w[a b]
       end
     end
   end

--- a/lib/root_loader.rb
+++ b/lib/root_loader.rb
@@ -65,7 +65,7 @@ class RootLoader
       policy_action = Loader::ReplacePolicy.from_policy(policy_version)
       policy_action.call
       policy_action.new_roles.select do |role|
-        %w(user host).member?(role.kind)
+        %w[user host].member?(role.kind)
       end
     end
 

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe 'Authentication::AuthnAzure::Authenticator' do
 
   include_context "security mocks"
-  include_context "fetch secrets", %w(provider-uri)
+  include_context "fetch secrets", %w[provider-uri]
 
   let(:account) { "my-acct" }
   let(:authenticator_name) { "authn-azure" }

--- a/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/validate_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Authentication::AuthnAzure::ValidateStatus do
   let(:account) { "my-acct" }
   let(:service) { "my-service" }
 
-  include_context "fetch secrets", %w(provider-uri)
+  include_context "fetch secrets", %w[provider-uri]
 
   let(:test_azure_discovery_error) { "test-azure-discovery-error" }
 

--- a/spec/app/domain/authentication/authn-oidc/update_input_with_username_from_id_token_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/update_input_with_username_from_id_token_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 
 RSpec.describe Authentication::AuthnOidc::UpdateInputWithUsernameFromIdToken do
 
-  include_context "fetch secrets", %w(provider-uri id-token-user-property)
+  include_context "fetch secrets", %w[provider-uri id-token-user-property]
   include_context "security mocks"
   include_context "oidc setup"
 

--- a/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Authentication::AuthnOidc::ValidateStatus do
   let(:account) { "my-acct" }
   let(:service) { "my-service" }
 
-  include_context "fetch secrets", %w(provider-uri id-token-user-property)
+  include_context "fetch secrets", %w[provider-uri id-token-user-property]
 
   let(:test_oidc_discovery_error) { "test-oidc-discovery-error" }
 

--- a/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/copy_text_to_file_in_container_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Authentication::AuthnK8s::CopyTextToFileInContainer' do
               pod_namespace:     pod_namespace,
               pod_name:          pod_name,
               container:         container,
-              cmds:              %w(sh),
+              cmds:              %w[sh],
               body:              expected_body,
               stdin:             true
             )

--- a/spec/app/domain/authentication/authn_k8s/execute_command_in_container_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/execute_command_in_container_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Authentication::AuthnK8s::ExecuteCommandInContainer' do
   let(:pod_namespace) { "PodNamespace" }
   let(:pod_name) { "PodName" }
   let(:container) { "Container" }
-  let(:cmds) { %w(command1 command2) }
+  let(:cmds) { %w[command1 command2] }
   let(:body) { "Body" }
 
   # This is used in test code to verify that all the client listeners are ready.

--- a/spec/app/domain/authentication/constraints/any_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/any_constraint_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Authentication::Constraints::AnyConstraint do
   end
 
   context "Given AnyConstraint initialized with 2 restrictions" do
-    let(:any_two_restrictions) { %w(required_first required_second) }
+    let(:any_two_restrictions) { %w[required_first required_second] }
     let(:not_required_restriction) { "not-required" }
     let(:raised_error) { ::Errors::Authentication::Constraints::RoleMissingRequiredConstraints }
     let(:expected_error_message) { /#{Regexp.escape(any_two_restrictions.to_s)}/ }

--- a/spec/app/domain/authentication/constraints/exclusive_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/exclusive_constraint_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Authentication::Constraints::ExclusiveConstraint do
   context "Given ExclusiveConstraint initialized with 3 restriction" do
-    let(:exclusive_three_restriction) { %w(exclusive_one exclusive_two exclusive_three) }
+    let(:exclusive_three_restriction) { %w[exclusive_one exclusive_two exclusive_three] }
     let(:additional_restriction) { "additional-required" }
     let(:raised_error) { ::Errors::Authentication::Constraints::IllegalConstraintCombinations }
 

--- a/spec/app/domain/authentication/constraints/multiple_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/multiple_constraint_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Authentication::Constraints::MultipleConstraint do
   context "Given MultipleConstraint initialized with 1 constraint" do
     let(:inner_constraint) { double("InnerConstraint") }
-    let(:resource_restrictions) { %w(restriction_first restriction_second) }
+    let(:resource_restrictions) { %w[restriction_first restriction_second] }
 
     subject(:constraint) do
       Authentication::Constraints::MultipleConstraint.new(inner_constraint)
@@ -22,7 +22,7 @@ RSpec.describe Authentication::Constraints::MultipleConstraint do
   context "Given MultipleConstraint initialized with 2 constraints" do
     let(:inner_constraint_first) { double("InnerConstraint") }
     let(:inner_constraint_second) { double("InnerConstraint") }
-    let(:resource_restrictions) { %w(restriction_first restriction_second) }
+    let(:resource_restrictions) { %w[restriction_first restriction_second] }
 
     subject(:constraint) do
       Authentication::Constraints::MultipleConstraint.new(inner_constraint_first, inner_constraint_second)

--- a/spec/app/domain/authentication/constraints/permitted_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/permitted_constraint_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Authentication::Constraints::PermittedConstraint do
   context "Given PermittedConstraint initialized with 1 restriction" do
     let(:permitted_restriction) { ["permitted"] }
-    let(:not_permitted_restrictions) { %w(not_permitted_first not_permitted_second) }
+    let(:not_permitted_restrictions) { %w[not_permitted_first not_permitted_second] }
     let(:raised_error) { ::Errors::Authentication::Constraints::ConstraintNotSupported }
     let(:expected_error_message) { /'#{Regexp.escape(not_permitted_restrictions.to_s)}'.*#{Regexp.escape(permitted_restriction.to_s)}/ }
 
@@ -55,8 +55,8 @@ RSpec.describe Authentication::Constraints::PermittedConstraint do
   end
 
   context "Given PermittedConstraint initialized with 2 restrictions" do
-    let(:permitted_two_restrictions) { %w(permitted_first permitted_second) }
-    let(:not_permitted_restrictions) { %w(not_permitted_first not_permitted_second) }
+    let(:permitted_two_restrictions) { %w[permitted_first permitted_second] }
+    let(:not_permitted_restrictions) { %w[not_permitted_first not_permitted_second] }
     let(:raised_error) { ::Errors::Authentication::Constraints::ConstraintNotSupported }
     let(:expected_error_message) { /'#{Regexp.escape(not_permitted_restrictions.to_s)}'.*#{Regexp.escape(permitted_two_restrictions.to_s)}/ }
 

--- a/spec/app/domain/authentication/constraints/required_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/required_constraint_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Authentication::Constraints::RequiredConstraint do
   context "Given RequiredConstraint initialized with 1 restriction" do
     let(:required_restriction) { ["required"] }
-    let(:not_required_restrictions) { %w(not_required_first not_required_second) }
+    let(:not_required_restrictions) { %w[not_required_first not_required_second] }
     let(:raised_error) { ::Errors::Authentication::Constraints::RoleMissingConstraints }
     let(:expected_error_message) { /#{Regexp.escape(required_restriction.to_s)}/ }
 
@@ -55,8 +55,8 @@ RSpec.describe Authentication::Constraints::RequiredConstraint do
   end
 
   context "Given RequiredConstraint initialized with 2 restrictions" do
-    let(:required_two_restrictions) { %w(required_first required_second) }
-    let(:not_required_restrictions) { %w(not_required_first not_required_second) }
+    let(:required_two_restrictions) { %w[required_first required_second] }
+    let(:not_required_restrictions) { %w[not_required_first not_required_second] }
     let(:raised_error) { ::Errors::Authentication::Constraints::RoleMissingConstraints }
 
     subject(:constraint) do

--- a/spec/app/domain/util/log_message_spec.rb
+++ b/spec/app/domain/util/log_message_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Util::LogMessageClass' do
     end
 
     it 'works for arrays' do
-      expect(log_message_class.new(%w(aA bB)).to_s).to eq('Variable is ["aA", "bB"].')
+      expect(log_message_class.new(%w[aA bB]).to_s).to eq('Variable is ["aA", "bB"].')
     end
 
     it 'handles overflow args' do

--- a/spec/models/schemata_spec.rb
+++ b/spec/models/schemata_spec.rb
@@ -19,7 +19,7 @@ describe Schemata do
   let(:schemata) { Schemata.new }
 
   describe "with search path $user, publc" do
-    let(:search_path) { %i($user public) }
+    let(:search_path) { %i[$user public] }
     describe "search_path" do
       specify { expect(schemata.search_path).to eq(search_path) }
     end


### PR DESCRIPTION
This check makes sure that the header exists before
attempting to check its value in order to prevent errors

### What does this PR do?

Added an extra check to make sure the `Accept` header is actually included in a request before trying to compare its value to anything. If the header is totally absent Conjur will throw a 500 error. The reason that tests have not found this issue yet is because Ruby's `RestClient::` [implicitly adds](https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L588) an `Accept: */*` header to all requests if another value is not specified. However other languages do not do this.

After some digging it does not seem like there is an easy way to override the default headers set in `RestClient::` and `Net::` so testing this functionality might be difficult. Due to the impending OSS suite release I think this change should be pulled in and a ticket opened to write a new test for this edge case.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
