### PR TITLE
if host does not exist raise RoleNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Conjur now raises a RoleNotFound when trying to authenticate a non-existing host in authn-k8s
+  [conjurinc/appliance#1546]https://github.com/conjurinc/appliance/issues/1546
 
 ## [1.11.2] - 2021-02-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Conjur now raises a RoleNotFound when trying to authenticate a non-existing host in authn-k8s
-  [conjurinc/appliance#1546]https://github.com/conjurinc/appliance/issues/1546
+  [cyberark/conjur#2046](https://github.com/cyberark/conjur/issues/2046)
 
 ## [1.11.2] - 2021-02-02
 ### Added

--- a/app/domain/authentication/authn_k8s/inject_client_cert.rb
+++ b/app/domain/authentication/authn_k8s/inject_client_cert.rb
@@ -187,6 +187,7 @@ module Authentication
           )
         )
       end
+
       # TODO: this logic is taken from app/models/audit/event/authn.rb.
       # We should use that logic here.
       # Masking role if it doesn't exist to avoid audit pollution


### PR DESCRIPTION
### What does this PR do?
 in k8s authenticator, raise RoleNotFound Exception if host does not exist

### What ticket does this PR close?
----

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
