### PR TITLE
Update logic in image publish script

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -67,6 +67,16 @@ if [[ "${PUBLISH_EDGE}" = true ]]; then
   # This script is running to publish the edge tagged image to DockerHub
   tag_and_push "edge" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}${IMAGE_NAME}"
 
+elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
+
+  # This is not running on a tag-triggered build, and a registry prefix has
+  # been supplied. Publish to the specified registry.
+
+  # Push the VERSION-SHA tagged images to our internal registry
+  tag_and_push "${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
+  tag_and_push "${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
+  tag_and_push "${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"
+
 elif [[ ! -z "${TAG_NAME:-}" ]]; then
 
   # This is running on a tag-triggered build, and public images should be published
@@ -85,16 +95,6 @@ elif [[ ! -z "${TAG_NAME:-}" ]]; then
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
-
-elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
-
-  # This is not running on a tag-triggered build, and a registry prefix has
-  # been supplied. Publish to the specified registry.
-
-  # Push the VERSION-SHA tagged images to our internal registry
-  tag_and_push "${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
-  tag_and_push "${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
-  tag_and_push "${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"
 
 else
 


### PR DESCRIPTION
### What does this PR do?
Check if the `registry-path` prefix is set before checking if it's a tag build,
so that on tag-triggered builds we can still publish internal images (that may
be used by tests) early in the pipeline without triggering an image publish
because `TAG_NAME` is set for the whole pipeline.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
