### PR TITLE
Conjurctl create account with password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2083](https://github.com/cyberark/conjur/issues/2083)
 
 ### Added
+- `conjurctl server` and `conjurctl account create` allow the operator to specify
+  the admin user's password via STDIN by providing the `--password-from-stdin` switch.
+  [cyberark/conjur#2043](https://github.com/cyberark/conjur/issues/2043)
+- `conjurctl account create` now allows the operator to specify the account name via
+  the `--name` flag. We recommend using this explicit flag when using the `--password-from-stdin`
+  option so that commands are explicit and more readable.
+  [cyberark/conjur#2043](https://github.com/cyberark/conjur/issues/2043)
 - `/whoami` API endpoint now produces audit events.
   [cyberark/conjur#2052](https://github.com/cyberark/conjur/issues/2052)
 - When a user checks permissions of a non-existing role or a non-existing resource, Conjur now audits a failure message.

--- a/app/models/credentials.rb
+++ b/app/models/credentials.rb
@@ -2,6 +2,7 @@
 
 require 'bcrypt'
 require 'util/cidr'
+require 'conjur/password'
 
 # TODO: This is needed because having the same line config/application.rb is
 # not working.  I wasn't able to figure out what precisely was going wrong,
@@ -13,13 +14,6 @@ Sequel::Model.db.extension(:pg_array, :pg_inet)
 class Credentials < Sequel::Model
   # Bcrypt work factor, minimum recommended work factor is 12
   BCRYPT_COST = 12
-
-  # special characters according to https://www.owasp.org/index.php/Password_special_characters
-  VALID_PASSWORD_REGEX = %r{^(?=.*?[A-Z].*[A-Z])                             # 2 uppercase letters
-                             (?=.*?[a-z].*[a-z])                             # 2 lowercase letters
-                             (?=.*?[0-9])                                    # 1 digit
-                             (?=.*[ !"#$%&'()*+,-.\/:;<=>?@\[\\\]^_`{|}~]).  # 1 special character
-                             {12,128}$}x                                     # 12-128 characters
 
   plugin :validation_helpers
 
@@ -80,7 +74,15 @@ class Credentials < Sequel::Model
 
     validates_presence [ :api_key ]
 
-    errors.add(:password, ::Errors::Conjur::InsufficientPasswordComplexity.new.to_s) if @plain_password && (@plain_password.index("\n") || @plain_password !~ VALID_PASSWORD_REGEX)
+    # We intentionally don't validate when there is no password
+    # See flow in Account.create
+    return unless @plain_password
+
+    unless Conjur::Password.valid?(@plain_password)
+      errors.add(
+        :password, ::Errors::Conjur::InsufficientPasswordComplexity.new.to_s
+      )
+    end
   end
 
   def before_validation

--- a/cucumber/api/features/account_create.feature
+++ b/cucumber/api/features/account_create.feature
@@ -130,3 +130,8 @@ Feature: Create a new account
       }
     }
     """
+
+  @create_account
+  Scenario: Creating account with predefined password and login with it
+    Given I create an account with the name "demo" and the password "MySecretP@SS1" using conjurctl
+    Then I can GET "/authn/demo/login" with username "admin" and password "MySecretP@SS1"

--- a/cucumber/api/features/step_definitions/conjurctl_steps.rb
+++ b/cucumber/api/features/step_definitions/conjurctl_steps.rb
@@ -12,3 +12,9 @@ end
 Then(/^the stderr includes the error "([^"]*)"$/) do |error|
   expect(@conjurctl_stderr).to include(error)
 end
+
+Given(/^I create an account with the name "(.*?)" and the password "(.*?)" using conjurctl/) do |name, password|
+  command = "echo -n '#{password}' | \
+    conjurctl account create --password-from-stdin --name #{name}"
+  @conjurctl_stdout, @conjurctl_stderr, = Open3.capture3(command)
+end

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -51,3 +51,7 @@ end
 Before("@logged-in-admin") do
   @current_user = admin_user
 end
+
+After('@create_account') do
+  system("conjurctl account delete demo")
+end

--- a/dev/files/killConjurServer
+++ b/dev/files/killConjurServer
@@ -1,3 +1,15 @@
 #!/bin/sh
 
-kill $(ps aux | grep '[r]uby /usr/local/bin/conjurctl server' | awk '{print $2}')
+# This terminates the process and all of its child processes
+kill_recurse() {
+    for child_pid in $(pgrep -P "$1");
+    do
+        kill_recurse "$child_pid"
+    done
+    kill "$1"
+}
+
+conjur_server_pid=$(pgrep -f 'ruby /usr/local/bin/conjurctl server')
+if [ -n "$conjur_server_pid" ]; then
+  kill_recurse "$conjur_server_pid"
+fi

--- a/lib/conjur/password.rb
+++ b/lib/conjur/password.rb
@@ -1,0 +1,19 @@
+module Conjur
+  # Enable password validation
+  module Password
+    # special characters according to https://www.owasp.org/index.php/Password_special_characters
+    VALID_PASSWORD_REGEX = %r{^(?=.*?[A-Z].*[A-Z]) # 2 uppercase letters
+      (?=.*?[a-z].*[a-z])                                 # 2 lowercase letters
+      (?=.*?[0-9])                                        # 1 digit
+      (?=.*[ !"#$%&'()*+,-.\/:;<=>?@\[\\\]^_`{|}~]).      # 1 special character
+      {12,128}$}x.freeze                                  # 12-128 characters
+
+    def self.valid?(pwd)
+      # If password is nil it will be coerced to be empty string
+      string_pwd = String(pwd)
+      return false if string_pwd.include?("\n")
+      
+      string_pwd.match?(VALID_PASSWORD_REGEX)
+    end
+  end
+end

--- a/spec/conjurctl/account_spec.rb
+++ b/spec/conjurctl/account_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'open3'
+
+describe "account" do
+  def delete_account(name)
+    system("conjurctl account delete #{name}")
+  end
+
+  it "no account name provided" do
+    _, stderr_str, = Open3.capture3(
+      "conjurctl account create"
+    )
+    expect(stderr_str).to include("No account name was provided")
+  end
+
+  context "create with name demo" do
+    after(:each) do
+      delete_account("demo")
+    end
+    
+    let(:password) { "MySecretP@SS1" }
+    let(:create_account_with_password_and_name_flag) do
+      "conjurctl account create --name demo --password-from-stdin"
+    end
+
+    let(:create_account_with_password_flag) do
+      "conjurctl account create --password-from-stdin demo"
+    end
+
+    it "with no flags" do
+      stdout_str, = Open3.capture3("conjurctl account create demo")
+      expect(stdout_str).to include("API key for admin")
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "with the name flag" do
+      stdout_str, = Open3.capture3("conjurctl account create --name demo")
+      expect(stdout_str).to include("API key for admin")
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "with predefined password MySecretP@SS1 and account name flag" do
+      stdout_str, = Open3.capture3(
+        create_account_with_password_and_name_flag, stdin_data: password
+      )
+      expect(stdout_str).to include("Password is set")
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "with predefined password MySecretP@SS1" do
+      stdout_str, = Open3.capture3(
+        create_account_with_password_flag, stdin_data: password
+      )
+      expect(stdout_str).to include("Password is set")
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "with both an account name argument and flag" do
+      system(
+        "conjurctl account create --name demo ingored_account_name"
+      )
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "and with invalid password" do
+      _, stderr_str, = Open3.capture3(
+        create_account_with_password_flag, stdin_data: "invalid"
+      )
+      expect(stderr_str).to include("CONJ00046E")
+      expect(Slosilo["authn:demo"]).not_to be
+      expect(Role["demo:user:admin"]).not_to be
+    end
+  end
+end

--- a/spec/conjurctl/server_spec.rb
+++ b/spec/conjurctl/server_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'open3'
+
+describe "conjurctl server" do
+  def delete_account(name)
+    system("conjurctl account delete #{name}")
+  end
+
+  # Wait for conjur server to be up. 
+  # Exit if it takes longer than 35 seconds
+  def wait_for_conjur
+    system("conjurctl wait --retries 35")
+  end
+
+  context "start server" do
+    after(:each) do
+      delete_account("demo")
+      # Kills the conjur server process if it was started
+      `/src/conjur-server/dev/files/killConjurServer`
+    end
+
+    it "with password-from-stdin flag but no account flag" do
+      _, stderr_str, = Open3.capture3(
+        "conjurctl server --password-from-stdin"
+      )
+      expect(stderr_str).to include("account is required")
+      wait_for_conjur
+      expect(Slosilo["authn:demo"]).not_to be
+      expect(Role["demo:user:admin"]).not_to be
+    end
+
+    it "with account flag" do
+      # Run in background to easily kill process later
+      system("conjurctl server --account demo &")
+      wait_for_conjur
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+
+    it "with both account and password-from-stdin flags" do
+      # Run in background to easily kill process later
+      system("
+        echo -n 'MySecretP@SS1' | 
+        conjurctl server --account demo --password-from-stdin &
+      ")
+      wait_for_conjur
+      expect(Slosilo["authn:demo"]).to be
+      expect(Role["demo:user:admin"]).to be
+    end
+  end
+end

--- a/spec/lib/password_spec.rb
+++ b/spec/lib/password_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Conjur::Password do
+  context "Password" do
+    it "is valid" do
+      expect(Conjur::Password.valid?("MySecretP@SS1")).to be(true)
+    end
+
+    context "is not valid because it is" do
+      it "too short" do
+        expect(Conjur::Password.valid?("SecretP@SS1")).to be(false)
+      end
+      it "missing a digit" do
+        expect(Conjur::Password.valid?("MySecretP@SS")).to be(false)
+      end
+      it "missing a special character" do
+        expect(Conjur::Password.valid?("MySecretPASS1")).to be(false)
+      end
+      it "missing atleast 2 uppercase letters" do
+        expect(Conjur::Password.valid?("mySecretp@ss1")).to be(false)
+        expect(Conjur::Password.valid?("mysecretp@ss1")).to be(false)
+      end
+      it "missing atleast 2 lowercase letters" do
+        expect(Conjur::Password.valid?("MYSECRETP@Ss1")).to be(false)
+        expect(Conjur::Password.valid?("MYSECRETP@SS1")).to be(false)
+      end
+      it "too long" do
+        expect(Conjur::Password.valid?("MySecretP@SS1"*10)).to be(false)
+      end
+      it "is nil" do
+        expect(Conjur::Password.valid?(nil)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
- Enable operators to specify an admin user's password:
   - `conjurctl account create --name demo --password-from-stdin` (STDIN)
   - `conjurctl server --account demo --password-from-stdin` (STDIN)

- How to manually test?
  - cd dev
  - dev: docker-compose up -d --no-deps pg conjur client
  - dev: docker-compose exec conjur bundle
  - dev: docker-compose exec conjur conjurctl db migrate
  - exec into the conjur container and run echo -n "testP@SS1alice" | conjurctl server --account demo --password-file -
  - Attempt to authenticate the admin user with the password set above
  - Also test  echo -n "testP@SS1alice" | conjurctl account create demo1 -
  - Attempt to authenticate the admin user with the password set above
  - Repeat the previous steps but write the password to a file and provide the path instead of utilizing STDIN


### What ticket does this PR close?
Resolves #2043 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
