### PR TITLE
Add new environment with default logger

### DIFF
--- a/config/environments/audit.rb
+++ b/config/environments/audit.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+load File.expand_path '../production.rb', __FILE__
+require 'syslog/logger'
+
+Rails.application.configure do
+  config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new('conjur-possum'))
+  config.log_level = ENV['CONJUR_LOG_LEVEL'] || :info
+  config.audit_socket = '/run/conjur/audit.socket'
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,3 +12,7 @@ appliance:
   # Conjur doesn't use HTTP cookies or Rails key generation,
   # so we set secret_key_base to a random value on application startup.
   secret_key_base: <%= SecureRandom.hex(64) %>
+audit:
+  # Conjur doesn't use HTTP cookies or Rails key generation,
+  # so we set secret_key_base to a random value on application startup.
+  secret_key_base: <%= SecureRandom.hex(64) %>


### PR DESCRIPTION
### What does this PR do?
Adding new rails profile that is controlled by `RAILS_ENV` environment variable in order to allow streaming logs by default

### What ticket does this PR close?
None

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
