### PR TITLE
Test different host prefixes for k8s authn

### DIFF
--- a/ci/authn-k8s/dev/policies/policy.template.yml
+++ b/ci/authn-k8s/dev/policies/policy.template.yml
@@ -239,6 +239,20 @@
     role: !layer
     members: *some-policy-hosts
 
+  - !policy
+    id: second-layer
+    body:
+    - !host
+      id: test-app-pod
+      annotations:
+        authn-k8s/namespace: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}
+        authn-k8s/pod: inventory-pod
+        authn-k8s/authentication-container-name: authenticator
+
+  - !grant
+    role: !layer
+    member: !host second-layer/test-app-pod
+
 # Permit the host above to authenticate with authn-k8s
 - !grant
   role: !group conjur/authn-k8s/minikube/clients

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -5,6 +5,18 @@ Feature: A permitted Conjur host can login with a valid resource restrictions
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-pod" with prefix "host/some-policy"
 
+  Scenario: Authenticate as a Pod with long host prefix.
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy/second-layer"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-pod" with prefix "host/some-policy/second-layer"
+
+  Scenario: Authenticate as a Pod with medium host prefix.
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "second-layer/test-app-pod" with prefix "host/some-policy"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "second-layer/test-app-pod" with prefix "host/some-policy"
+
+  Scenario: Authenticate as a Pod with short host prefix.
+    Given I login to pod matching "app=inventory-pod" to authn-k8s as "some-policy/second-layer/test-app-pod" with prefix "host"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "some-policy/second-layer/test-app-pod" with prefix "host"
+
   Scenario: Authenticate as a Namespace.
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-namespace" with prefix "host/some-policy"


### PR DESCRIPTION
### What does this PR do?
The Kubernetes authenticator client has a structured method for determining
where to split the fully qualified host ID path of a Kubernetes host into a
"prefix" and "suffix", but the server actually doesn't care where the client
splits this value, since it concatenates the prefix and suffix to make up the
full host ID.

This commit adds tests to show that short or long prefixes all work; what's
important is that put together they comprise the host ID of the app.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
