### PR TITLE
Add failure scenarios audit for check permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `/whoami` API endpoint now produces audit events.
   [cyberark/conjur#2052](https://github.com/cyberark/conjur/issues/2052)
+- When a user checks permissions of a non-existing role or a non-existing resource, Conjur now audits a failure message.
+  [cyberark/conjur#2059](https://github.com/cyberark/conjur/issues/2059)
 
 ## [1.11.4] - 2021-03-09
 

--- a/app/controllers/concerns/find_resource.rb
+++ b/app/controllers/concerns/find_resource.rb
@@ -2,12 +2,12 @@
 
 module FindResource
   extend ActiveSupport::Concern
-  
-  protected
-  
+
   def resource_id
     [ params[:account], params[:kind], params[:identifier] ].join(":")
   end
+
+  protected
 
   def resource!
     @resource ||= Resource[resource_id]

--- a/app/models/audit/event/check.rb
+++ b/app/models/audit/event/check.rb
@@ -14,11 +14,12 @@ module Audit
       )
         @user = user
         @client_ip = client_ip
-        @resource = resource
         @privilege = privilege
         @role = role
         @operation = operation
         @success = success
+        @resource_id = resource.try(:id) || resource
+        @role_id = role.try(:id) || role
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -40,7 +41,7 @@ module Audit
 
       def message
         "#{@user.id} checked if #{role_text} can #{@privilege} " \
-          "#{@resource.id} (#{success_text})"
+          "#{@resource_id} (#{success_text})"
       end
 
       def message_id
@@ -51,8 +52,8 @@ module Audit
         {
           SDID::AUTH => { user: @user.id },
           SDID::SUBJECT => {
-            resource: @resource.id,
-            role: @role.id,
+            resource: @resource_id,
+            role: @role_id,
             privilege: @privilege
           },
           SDID::CLIENT => { ip: @client_ip }
@@ -84,7 +85,7 @@ module Audit
       end
 
       def role_text
-        @user == @role ? 'they' : @role.id
+        @user == @role ? 'they' : @role_id
       end
 
       def success_text

--- a/app/models/audit/event/check.rb
+++ b/app/models/audit/event/check.rb
@@ -6,20 +6,21 @@ module Audit
       def initialize(
         user:,
         client_ip:,
-        resource:,
+        resource_id:,
         privilege:,
-        role:,
+        role_id:,
         operation:,
-        success:
+        success:,
+        error_message: nil
       )
         @user = user
         @client_ip = client_ip
+        @resource_id = resource_id
         @privilege = privilege
-        @role = role
+        @role_id = role_id
         @operation = operation
         @success = success
-        @resource_id = resource.try(:id) || resource
-        @role_id = role.try(:id) || role
+        @error_message = error_message
       end
 
       # Note: We want this class to be responsible for providing `progname`.
@@ -40,8 +41,8 @@ module Audit
       end
 
       def message
-        "#{@user.id} checked if #{role_text} can #{@privilege} " \
-          "#{@resource_id} (#{success_text})"
+        "#{@user.id} #{result_text} if #{role_text} can #{@privilege} " \
+          "#{@resource_id} #{error_message_text}"
       end
 
       def message_id
@@ -85,13 +86,16 @@ module Audit
       end
 
       def role_text
-        @user == @role ? 'they' : @role_id
+        @user.id == @role_id ? 'they' : @role_id
       end
 
-      def success_text
-        attempted_action.success_text
+      def result_text
+        @success ? "successfully checked" : "failed to check"
       end
 
+      def error_message_text
+        @error_message ? ": #{@error_message}" : ""
+      end
     end
   end
 end

--- a/spec/models/audit/event/check_spec.rb
+++ b/spec/models/audit/event/check_spec.rb
@@ -68,4 +68,32 @@ describe Audit::Event::Check do
 
     it_behaves_like 'structured data includes client IP address'
   end
+
+  context 'when the resource does not exist and a failure occurs' do
+    let(:success) { false }
+    let(:resource) { 'rspec:variable:non_existing_var' }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user checked if rspec:host:my_host can execute ' \
+        'rspec:variable:non_existing_var (failure)'
+                                 )
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when the role does not exist and a failure occurs' do
+    let(:success) { false }
+    let(:role) { 'rspec:host:my_non_existing_host' }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user checked if rspec:host:my_non_existing_host can execute ' \
+        'rspec:variable:my_var (failure)'
+                                 )
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
 end

--- a/spec/models/audit/event/check_spec.rb
+++ b/spec/models/audit/event/check_spec.rb
@@ -3,31 +3,33 @@ require 'spec_helper'
 describe Audit::Event::Check do
 
   let(:user) { double('my-user', id: 'rspec:user:my_user') }
-  let(:resource) { double('my-resource', id: 'rspec:variable:my_var') }
+  let(:resource_id)  {'rspec:variable:my_var'}
   let(:privilege) { 'execute' }
-  let(:role) { double('my-host', id: 'rspec:host:my_host') }
+  let(:role_id) { 'rspec:host:my_host' }
   let(:client_ip) { 'my-client-ip' }
   let(:success) { true }
   let(:operation) { 'check' }
+  let(:error_message) { nil }
 
   subject do
     Audit::Event::Check.new(
       user: user,
-      resource: resource,
+      resource_id: resource_id,
       privilege: privilege,
-      role: role,
+      role_id: role_id,
       client_ip: client_ip,
       operation: operation,
-      success: success
+      success: success,
+      error_message: error_message
     )
   end
 
   context 'when successful' do
     it 'produces the expected message' do
       expect(subject.message).to eq(
-        'rspec:user:my_user checked if rspec:host:my_host can execute ' \
-        'rspec:variable:my_var (success)'
-      )
+        'rspec:user:my_user successfully checked if rspec:host:my_host can execute ' \
+        'rspec:variable:my_var '
+                                 )
     end
 
     it 'uses the INFO log level' do
@@ -36,9 +38,9 @@ describe Audit::Event::Check do
 
     it 'renders to string correctly' do
       expect(subject.to_s).to eq(
-        'rspec:user:my_user checked if rspec:host:my_host can execute ' \
-        'rspec:variable:my_var (success)'
-      )
+        'rspec:user:my_user successfully checked if rspec:host:my_host can execute ' \
+        'rspec:variable:my_var '
+                              )
     end
 
     it 'produces the expected action_sd' do
@@ -53,9 +55,9 @@ describe Audit::Event::Check do
 
     it 'produces the expected message' do
       expect(subject.message).to eq(
-        'rspec:user:my_user checked if rspec:host:my_host can execute ' \
-        'rspec:variable:my_var (failure)'
-      )
+        'rspec:user:my_user failed to check if rspec:host:my_host can execute ' \
+        'rspec:variable:my_var '
+                                 )
     end
 
     it 'uses the WARNING log level' do
@@ -71,12 +73,13 @@ describe Audit::Event::Check do
 
   context 'when the resource does not exist and a failure occurs' do
     let(:success) { false }
-    let(:resource) { 'rspec:variable:non_existing_var' }
+    let(:resource_id) { 'rspec:variable:non_existing_var' }
+    let(:error_message) { 'Variable \'non-existing-var\' not found in account \'CyberArk\''}
 
     it 'produces the expected message' do
       expect(subject.message).to eq(
-                                   'rspec:user:my_user checked if rspec:host:my_host can execute ' \
-        'rspec:variable:non_existing_var (failure)'
+        'rspec:user:my_user failed to check if rspec:host:my_host can execute ' \
+        'rspec:variable:non_existing_var : Variable \'non-existing-var\' not found in account \'CyberArk\''
                                  )
     end
 
@@ -85,12 +88,13 @@ describe Audit::Event::Check do
 
   context 'when the role does not exist and a failure occurs' do
     let(:success) { false }
-    let(:role) { 'rspec:host:my_non_existing_host' }
+    let(:role_id) { 'rspec:host:my_non_existing_host' }
+    let(:error_message) { 'Forbidden' }
 
     it 'produces the expected message' do
       expect(subject.message).to eq(
-                                   'rspec:user:my_user checked if rspec:host:my_non_existing_host can execute ' \
-        'rspec:variable:my_var (failure)'
+        'rspec:user:my_user failed to check if rspec:host:my_non_existing_host can execute ' \
+        'rspec:variable:my_var : Forbidden'
                                  )
     end
 


### PR DESCRIPTION
### What does this PR do?
- Added missing audits for failure scenarios on check permission

### What ticket does this PR close?
Resolves ״Some failure scenarios don't produce audit events #1551״

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
