### PR TITLE
Pass dockerhub image ref to conjurops build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -525,7 +525,7 @@ pipeline {
             build(
               job:'../conjurinc--conjurops/master',
               parameters:[
-                string(name: 'conjur_oss_source_image', value: "registry2.itci.conjur.net/conjur:${TAG_NAME}")
+                string(name: 'conjur_oss_source_image', value: "cyberark/conjur:${TAG_NAME}")
               ],
               wait: false
             )


### PR DESCRIPTION
### What does this PR do?
The conjur build triggers conjurops so that conjurops staging is always
running the latest tag. Due to a change in the conjurops deployment
mechanism, it now needs a dockerhub image reference rather than an
internal registry image reference.

### What ticket does this PR close?
Related: conjurinc/ops#736

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
