### PR TITLE
Moved from Accept to Accept-Encoding header in secrets batch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When a user checks permissions of a non-existing role or a non-existing resource, Conjur now audits a failure message.
   [cyberark/conjur#2059](https://github.com/cyberark/conjur/issues/2059)
 
+### Changed
+- The secrets batch retrieval endpoint now refers to the `Accept-Encoding` header rather than `Accept` to determine the response encoding
+  [cyberark/conjur#2065](https://github.com/cyberark/conjur/pull/2065)
+
 ## [1.11.4] - 2021-03-09
 
 ### Security

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -78,8 +78,13 @@ class SecretsController < RestController
     raise Exceptions::RecordNotFound, variable.resource_id unless secret
 
     secret_value = secret.value
-    accepts_base64 = String(request.headers['Accept']).casecmp?('base64')
-    accepts_base64 ? Base64.encode64(secret_value) : secret_value
+    accepts_base64 = String(request.headers['Accept-Encoding']).casecmp?('base64')
+    if accepts_base64
+      response.set_header("Content-Encoding", "base64")
+      Base64.encode64(secret_value)
+    else
+      secret_value
+    end
   end
 
   def audit_fetch resource, version: nil

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -94,13 +94,14 @@ Feature: Batch retrieval of secrets
   Scenario: Returns the correct result for binary secrets
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
-    And I set the "Accept" header to "base64"
+    And I set the "Accept-Encoding" header to "base64"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
     Then the binary data is preserved for "cucumber:variable:secret3"
+    And the content encoding is "base64"
 
   Scenario: Returns the correct result for binary secrets
     Given I create a binary secret value for resource "cucumber:variable:secret3"
-    And I set the "Accept" header to "Base64"
+    And I set the "Accept-Encoding" header to "Base64"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the binary data is preserved for "cucumber:variable:secret3"
 
@@ -115,7 +116,7 @@ Feature: Batch retrieval of secrets
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
     Then the HTTP response status code is 500
 
-  Scenario: Omit the Accept header entirely from batch secrets request
+  Scenario: Omit the Accept-Encoding header entirely from batch secrets request
     Given I add the secret value "v2" to the resource "cucumber:variable:secret2"
     When I GET "/secrets?variable_ids=cucumber:variable:secret2" with no default headers
     Then the JSON should be:

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -58,6 +58,10 @@ Then(/^the binary result is preserved$/) do
   expect(@result).to eq(@value)
 end
 
+Then(/^the content encoding is "([^"]*)"/) do |encoding|
+  expect(@content_encoding).to eq(encoding)
+end
+
 Then(/^the binary data is preserved for "([^"]*)"$/) do |resource_id|
   data = Base64.decode64(@result[resource_id])
   expect(data).to eq(@value)

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -129,6 +129,7 @@ module RestHelpers
     @http_status = result.code
 
     @content_type = result.headers[:content_type]
+    @content_encoding = result.headers[:content_encoding]
     if /^application\/json/.match?(@content_type)
       @result = JSON.parse(result)
       @response_api_key = @result['api_key'] if @result.is_a?(Hash)


### PR DESCRIPTION
### What does this PR do?
When I first implemented this fix I chose to have the batch secrets retrieval endpoint check the `Accept` Header, however after reading [the RFC](https://tools.ietf.org/html/rfc2616#section-14.1) relating to the two headers and putting some thought into it I believe the header should be changed. 

I wanted to address this issue because currently it will be easy to update the integrations which use this header (only the Go client and OpenAPI spec), however left alone it will become an annoying piece of technical debt.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [x] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API

Related [OpenAPI PR](https://github.com/cyberark/conjur-openapi-spec/pull/159)
