### PR TITLE
Change missing or empty secret error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Secrets batch request with blank variables' names, now returns `Error 422 Unprocessable Entity`
+  [cyberark/conjur#2083](https://github.com/cyberark/conjur/issues/2083)
+
 ### Added
 - `/whoami` API endpoint now produces audit events.
   [cyberark/conjur#2052](https://github.com/cyberark/conjur/issues/2052)
@@ -17,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The secrets batch retrieval endpoint now refers to the `Accept-Encoding` header rather than `Accept` to determine the response encoding
   [cyberark/conjur#2065](https://github.com/cyberark/conjur/pull/2065)
+- When trying to fetch a missing or empty secret, a proper error message is now returned
+  [cyberark/conjur#2023](https://github.com/cyberark/conjur/issues/2023)
 
 ## [1.11.4] - 2021-03-09
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,6 +44,7 @@ class ApplicationController < ActionController::API
   end
 
   rescue_from Exceptions::RecordNotFound, with: :record_not_found
+  rescue_from Errors::Conjur::MissingSecretValue, with: :render_secret_not_found
   rescue_from Exceptions::RecordExists, with: :record_exists
   rescue_from Exceptions::Forbidden, with: :forbidden
   rescue_from BadRequest, with: :bad_request
@@ -273,6 +274,16 @@ class ApplicationController < ActionController::API
   # Gets the value of the :account parameter.
   def account
     @account ||= params[:account]
+  end
+
+  def render_secret_not_found e
+    logger.debug "#{e}\n#{e.backtrace.join "\n"}"
+    render json: {
+      error: {
+        code: "not found",
+        message: e.message
+      }
+    }, status: :not_found
   end
 
   def render_record_not_found e

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -31,6 +31,11 @@ module Errors
       code: "CONJ00074E"
     )
 
+    MissingSecretValue = ::Util::TrackableErrorClass.new(
+      msg:  "Variable {0-variable-id} is empty or not found.",
+      code: "CONJ00076E"
+    )
+
   end
 
   module Authentication

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -26,15 +26,24 @@ Feature: Adding and fetching secrets
     """
     Then the HTTP response status code is 404
 
+  Scenario: Fetching a resource with no name provided return a 404 error.
+
+    When I GET "/secrets/cucumber/variable/"
+    Then the HTTP response status code is 404
+
   Scenario: Fetching a resource with no secret values return a 404 error.
 
     When I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
+    And there is an error
+    And the error message is "CONJ00076E Variable cucumber:variable:probe is empty or not found."
 
   Scenario: Fetching a secret for a nonexistent resource
 
     When I GET "/secrets/cucumber/variable/non-existent"
     Then the HTTP response status code is 404
+    And there is an error
+    And the error message is "CONJ00076E Variable cucumber:variable:non-existent is empty or not found."
 
   Scenario: Update a secret of a nonexistent resource
 

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -53,20 +53,28 @@ Feature: Batch retrieval of secrets
 
   Scenario: Fails with 404 if variable_ids param has some blank items
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,,,cucumber:variable:secret2"
-    Then the HTTP response status code is 404
+    Then the HTTP response status code is 422
+    And there is an error
+    And the error message is "variable_ids"
 
   Scenario: Fails with 404 if a variable_id param is of an incorrect format
     When I GET "/secrets?variable_ids=1,2,3"
     Then the HTTP response status code is 404
+    And there is an error
+    And the error message is "CONJ00076E Variable 1 is empty or not found."
 
   Scenario: Fails with 404 if a resource doesn't exist
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,cucumber:variable:not-a-secret"
     Then the HTTP response status code is 404
+    And there is an error
+    And the error message is "CONJ00076E Variable cucumber:variable:not-a-secret is empty or not found."
 
   Scenario: Fails with 404 if a resource doesn't have a value
     Given I create a new "variable" resource called "secret-no-value"
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,cucumber:variable:secret-no-value"
     Then the HTTP response status code is 404
+    And there is an error
+    And the error message is "CONJ00076E Variable cucumber:variable:secret-no-value is empty or not found."
 
   # This test explicitly tests an error case that was discovered in Conjur v4 where
   # resource IDs were matched with incorrect variable values in the JSON response.


### PR DESCRIPTION
### What does this PR do?
A new error message while fetching missing or empty secret

### What ticket does this PR close?
Resolves #2023 , #2083 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API


![image](https://user-images.githubusercontent.com/31516429/112004050-1dd02680-8b2a-11eb-9965-aedb33a933af.png)

