### PR TITLE
Bump base image to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2065](https://github.com/cyberark/conjur/pull/2065)
 - When trying to fetch a missing or empty secret, a proper error message is now returned
   [cyberark/conjur#2023](https://github.com/cyberark/conjur/issues/2023)
+- Conjur base image updated to v1.0.1.
+  [PR cyberark/conjur#2088](https://github.com/cyberark/conjur/pull/2088)
 
 ## [1.11.4] - 2021-03-09
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:1.0.0
+FROM cyberark/ubuntu-ruby-fips:1.0.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,5 @@
 # Conjur Base Image (UBI)
-FROM cyberark/ubi-ruby-fips:1.0.0
+FROM cyberark/ubi-ruby-fips:1.0.1
 
 EXPOSE 8080
 ARG VERSION


### PR DESCRIPTION
### What does this PR do?
The Conjur base image was released with an update to the pg client version (10.16). This PR updates the base image versions in the images produced by this project.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
