### PR TITLE
Fix the code string of secret not found error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -280,7 +280,7 @@ class ApplicationController < ActionController::API
     logger.debug "#{e}\n#{e.backtrace.join "\n"}"
     render json: {
       error: {
-        code: "not found",
+        code: "not_found",
         message: e.message
       }
     }, status: :not_found


### PR DESCRIPTION
### What does this PR do?
Align the fetching empty or missing secret code string with the rest of the API.

This is a fix to go with the changes from #2023 

