### PR TITLE
Turn off on:push for settings updates

### DIFF
--- a/.github/workflows/update_settings.yml
+++ b/.github/workflows/update_settings.yml
@@ -1,6 +1,5 @@
 name: Keep Settings Up To Date
 on:
-  push:
   schedule:
     - cron:  '*/5 * * * *'
 
@@ -33,4 +32,3 @@ jobs:
 
             Please verify that the changes look good and merge this PR to keep
             its settings up to date with Conjur's current best practices.
-


### PR DESCRIPTION
I had originally turned this on to force the cron to stop working, but
we actually only want the cron running, as this will create duplicate
PRs on other branches.  Going to turn it off and hope cron keeps running
-- it only runs on master.