### PR TITLE
Fix git submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "conjur-project-config"]
 	path = conjur-project-config
 	url = https://github.com/cyberark/conjur-project-config.git
-	branch = test-updates
+	branch = main


### PR DESCRIPTION
PR fixes branch of conjur-project-config git submodule so build wouldn't fail


#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
