### PR TITLE
Publish edge tag to local registry as we do on dockerhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -534,9 +534,17 @@ pipeline {
 
         stage('On a master build') {
           when { branch "master" }
-
           steps {
-            sh './push-image.sh --edge'
+            script {
+              def tasks = [:]
+              tasks["Publish edge to local registry"] = {
+                sh './push-image.sh --edge --registry-prefix=registry.tld'
+              }
+              tasks["Publish edge to DockerHub"] = {
+                sh './push-image.sh --edge'
+              }
+              parallel tasks
+            }
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
For security, performance & early debugging reasons we want `edge` tag to be present and stored at out local Docker registry as it is at DockerHub.
See [Slack Thread](https://conjurhq.slack.com/archives/C8BNMU0KV/p1617353627026700) for additional details

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
