### PR TITLE
Remove publish AMIs from ToC of CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ For general contribution and community guidelines, please see the [community rep
     - [Update the version and changelog](#update-the-version-and-changelog)
     - [Tag the version](#tag-the-version)
     - [Add a new GitHub release](#add-a-new-github-release)
-    - [Publishing AMIs](#publishing-amis)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 


### PR DESCRIPTION
We removed the `publish AMIs` section but didn't removed it from the ToC

### What does this PR do?
- _What's changed? Why were these changes made?_
Removed the Publish AMIs from ToC as we removed the section itself
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Related to https://github.com/cyberark/conjur/commit/dfebd7a3da536ece3d4ab4e921ed7b9182b1fae9

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
