### PR TITLE
Add rake task for password strength validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - Upgrade github-pages in docs/Gemfile to resolve CVE-2021-28834 in kramdown dependency [cyberark/conjur#2099](https://github.com/cyberark/conjur/issues/2099)
 
+### Added
+- Rake task for password strength validation. Can be called with `rake password:validate_strength[password]`
+  [cyberark/conjur#2109](https://github.com/cyberark/conjur/issues/2109)
+
 ## [1.11.5] - 2021-04-05
 
 ### Fixed

--- a/app/models/credentials.rb
+++ b/app/models/credentials.rb
@@ -15,13 +15,6 @@ class Credentials < Sequel::Model
   # Bcrypt work factor, minimum recommended work factor is 12
   BCRYPT_COST = 12
 
-  # special characters according to https://www.owasp.org/index.php/Password_special_characters
-  VALID_PASSWORD_REGEX = %r{^(?=.*?[A-Z].*[A-Z])                             # 2 uppercase letters
-                             (?=.*?[a-z].*[a-z])                             # 2 lowercase letters
-                             (?=.*?[0-9])                                    # 1 digit
-                             (?=.*[ !"#$%&'()*+,-./:;<=>?@\[\\\]^_`{|}~]).  # 1 special character
-                             {12,128}$}x.freeze                                     # 12-128 characters
-
   plugin :validation_helpers
 
   unrestrict_primary_key

--- a/lib/tasks/account.rake
+++ b/lib/tasks/account.rake
@@ -27,11 +27,7 @@ namespace :"account" do
 
   desc "Create an account with a preset password"
   task :create_with_password, [ "account", "password" ] => [ "environment" ] do |t,args|
-    unless Conjur::Password.valid?(args[:password])
-      $stderr.puts(::Errors::Conjur::InsufficientPasswordComplexity.new.to_s)
-      exit 1
-    end
-
+    Rake::Task["password:validate_strength"].invoke(args[:password])
     Account.find_or_create_accounts_resource
     begin
       Account.create(args[:account])

--- a/lib/tasks/password.rake
+++ b/lib/tasks/password.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :password do
+  desc "Validate password strength"
+  task :validate_strength, ["password"] => [ "environment" ] do |_, args|
+    unless Conjur::Password.valid?(args[:password])
+      $stderr.puts(::Errors::Conjur::InsufficientPasswordComplexity.new.to_s)
+      exit 1
+    end
+    puts "Password strength validated successfully"
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Adds rake task for password validation.
Can be used with
`rake account:validate_password_strength[examplePasswordToCheck]` from terminal
`Rake::Task["password:validate_password_strength"].invoke(password)` from code

### What ticket does this PR close?
Resolves https://github.com/cyberark/conjur/issues/2109

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
