### PR TITLE
Upgrade to conjur-project-config template system

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,128 @@
+# This is our default .CodeClimate.yml, broken out by language.
+
+version: "2"
+
 plugins:
+
+# ---------------
+# Cross-language plugins. Should always be on.
+
+  duplication: # Looks for similar and identical code blocks
+    enabled: true
+    config:
+      languages:
+        go:
+        java:
+        javascript:
+        php:
+        python:
+          python_version: 3
+        ruby:
+        swift:
+        typescript:
+
+  fixme: # Flags any FIXME, TODO, BUG, XXX, HACK comments so they can be fixed
+    enabled: true
+    issue_override:
+      severity: info # Don't fail PRs for FIXME tags, but still flag them
+    config:
+      strings:
+      - FIXME
+      - TODO
+      - HACK
+      - XXX
+      - BUG
+
+# ---------------
+# Commonly-used languages - run time is minimal and all of these will work
+# whether files of that language are found or not. In general, leave uncommented
+
+  # Markdown
+  markdownlint:
+    enabled: true
+    issue_override:
+      severity: info # Should be redundant as CC says markdownlint defaults to
+                     # info already, but including it here to remind us it's so
+
+  # Go
+  gofmt:
+    enabled: true
+  golint:
+    enabled: true
+  govet:
+    enabled: true
+
+  # Ruby
+  flog:
+    enabled: true
+  reek:
+    enabled: true
   rubocop:
     enabled: true
     channel: rubocop-1-8-1
-  reek:
+  # Shell scripts
+  shellcheck:
+   enabled: true
+
+# ---------------
+# Other languages - will work with or without language files present. Again,
+# runtime is minimal, so OK to leave uncommented.
+
+  # CoffeeScript
+  coffeelint:
     enabled: true
+
+  # CSS
+  csslint:
+    enabled: true
+
+  # Groovy
+  codenarc:
+    enabled: true
+
+  # Java
+  pmd:
+    enabled: true
+  sonar-java:
+    enabled: true
+    config:
+      sonar.java.source: "7"
+
+  # Node.js
+  nodesecurity:
+    enabled: true
+
+  # PHP
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php"
+  phpcodesniffer:
+    enabled: true
+    config:
+      file_extensions: "php,inc,lib"
+      # Using Wordpress standards as our one PHP repo is a Wordpress theme
+      standards: "PSR1,PSR2,WordPress,WordPress-Core,WordPress-Extra"
+  phpmd:
+    enabled: true
+    config:
+      file_extensions: "php,inc,lib"
+      rulesets: "cleancode,codesize,controversial,naming,unusedcode"
+  sonar-php:
+    enabled: true
+
+  # Python
+  bandit:
+    enabled: true
+  pep8:
+    enabled: true
+  radon:
+    enabled: true
+  sonar-python:
+    enabled: true
+  # Ruby - requires presence of Gemfile and Gemfile.lock
   bundler-audit:
     enabled: true
+  # Rails - requires detecting a Rails application
   brakeman:
     enabled: true

--- a/.make_codeclimate
+++ b/.make_codeclimate
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+# Base directory for codeclimate templates
+cc_dir=./conjur-project-config/files/codeclimate
+
+include() {
+  tmpl=$1
+  cat "$cc_dir/$tmpl"
+}
+
+# Default CodeClimate plugins valid for all projects.
+include base.yml
+
+# uncomment for vanilla ruby projects
+include ruby.yml
+
+# uncomment for rails projects
+include rails.yml

--- a/.rubocop_settings.yml
+++ b/.rubocop_settings.yml
@@ -42,7 +42,7 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   IgnoredMethods: [
      # Ruby keywords:
-     gem, require, raise,
+     gem, require, raise, cattr_accessor,
      # Test keywords:
      step, to, to_not, not_to,
      # GLI keywords


### PR DESCRIPTION
This updates conjur to use the new template system we had to introduce
to conjur-project-config.  See that repository for more info.

### What does this PR do?
- _What's changed? Why were these changes made?_

So conjur is up to date with the shared settings repo.

### What ticket does this PR close?
Related to #2075 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
