### PR TITLE
Bump cyberark/ubi-ruby-fips from v1.0.1 to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 - Upgrade github-pages in docs/Gemfile to resolve CVE-2021-28834 in kramdown dependency [cyberark/conjur#2099](https://github.com/cyberark/conjur/issues/2099)
+- Bump `cyberark/ubi-ruby-fips` from 1.0.1 to 1.0.2 to address CVE-2021-20305.
+  [cyberark/conjur#2120](https://github.com/cyberark/conjur/issues/2120)
 
 ### Added
 - Rake task for password strength validation. This rake task can be run on the server to verify that a password is

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:1.0.1
+FROM cyberark/ubuntu-ruby-fips:1.0.2
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,5 @@
 # Conjur Base Image (UBI)
-FROM cyberark/ubi-ruby-fips:1.0.1
+FROM cyberark/ubi-ruby-fips:1.0.2
 
 EXPOSE 8080
 ARG VERSION


### PR DESCRIPTION
### What does this PR do?
This bump addresses CVE-2021-20305.

### What ticket does this PR close?
Resolves #2120 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
