### PR TITLE
Change return code on fail to encode batch secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   non-alpha-numeric passwords sent via stdin raised an error.
   [cyberark/conjur#2083](https://github.com/cyberark/conjur/issues/2083)
 
+### Changed
+- The batch secret retrieval endpoint now returns a 406 Not Acceptable instead
+  of a 500 error when a secret with incompatible encoding is requested.
+  [cyberark/conjur#2124](https://github.com/cyberark/conjur/pull/2124)
+
 ### Security
 - Upgrade github-pages in docs/Gemfile to resolve CVE-2021-28834 in kramdown dependency [cyberark/conjur#2099](https://github.com/cyberark/conjur/issues/2099)
 - Bump `cyberark/ubi-ruby-fips` from 1.0.1 to 1.0.2 to address CVE-2021-20305.

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -26,7 +26,7 @@ module Errors
     )
 
     BadSecretEncoding = ::Util::TrackableErrorClass.new(
-      msg: "Issue encoding secret into JSON format, try including 'Accept: base64' " \
+      msg: "Issue encoding secret into JSON format, try including 'Accept-Encoding: base64' " \
           "header in request.",
       code: "CONJ00074E"
     )

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -119,13 +119,13 @@ Feature: Batch retrieval of secrets
   Scenario: Returns the correct result for binary secrets
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
-    Then the HTTP response status code is 500
+    Then the HTTP response status code is 406
 
   Scenario: Raises error on binary secret with no annotation
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
-    Then the HTTP response status code is 500
+    Then the HTTP response status code is 406
 
   Scenario: Omit the Accept-Encoding header entirely from batch secrets request
     Given I add the secret value "v2" to the resource "cucumber:variable:secret2"


### PR DESCRIPTION
### What does this PR do?
Now when Conjur attempts to encode a batch secrets
response into JSON format and encounters an encoding
error it will return a 406 status code to the user.
This indicates that The given `Accept-Encoding` header
is not valid for the retrieved values.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [x] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
