### PR TITLE
Add JWT Configuration for dummy vendor

### DIFF
--- a/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor.rb
@@ -1,0 +1,18 @@
+module Authentication
+  module AuthnJwt
+    # Mock JWTConfiguration class to use it to develop other part in the jwt authenticator
+    class JWTConfigurationDummyVendor < JWTConfigurationInterface
+      def get_identity
+        return "cucumber"
+      end
+
+      def validate_restrictions
+        return true
+      end
+
+      def validate_and_decode
+        return true
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/jwt_configuration_interface.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_interface.rb
@@ -1,5 +1,5 @@
 module Authentication
-  module AuthnJWT
+  module AuthnJwt
     # Interface containing JWT configuration functions to be implemented in JWTConfiguration class for a vendor
     class JWTConfigurationInterface
       def get_identity; end;

--- a/spec/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor_spec.rb
+++ b/spec/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'spec_helper'
+RSpec.describe(Authentication::AuthnJwt::JWTConfigurationDummyVendor) do
+
+  it "return cucumber on get_identity" do
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
+    expect(dummy_jwt_configuration.get_identity).to eq "cucumber"
+  end
+
+  it "return true on validate_restrictions" do
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
+    expect(dummy_jwt_configuration.validate_restrictions).to eq true
+  end
+
+  it "return true on validate_and_decode" do
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
+    expect(dummy_jwt_configuration.validate_and_decode).to eq true
+  end
+
+end


### PR DESCRIPTION
### What does this PR do?

Add JWTConfigurationDummyVendor that return dummy values

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x The changes in this PR do not affect the Conjur API
