### PR TITLE
Add dummy jwt authenticator and configuration factory

### DIFF
--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -1,0 +1,47 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    # Generic JWT authenticator that receive JWT vendor configuration and uses to validate that the authentication
+    # request is valid, and return conjur authn token accordingly
+    JwtAuthenticate ||= CommandClass.new(
+      dependencies: {
+        token_factory: TokenFactory.new
+      },
+      inputs: %i[jwt_configuration account username]
+    ) do
+      def call
+        validate_and_decode
+        get_identity
+        validate_restrictions
+        get_token
+      end
+
+      def get_identity
+        # Will be changed when real get identity implemented
+        unless @jwt_configuration.get_identity == "cucumber"
+          raise "wrong identity"
+        end
+      end
+
+      def validate_and_decode
+        unless @jwt_configuration.validate_and_decode
+          raise "validate and decode failed"
+        end
+      end
+
+      def validate_restrictions
+        unless @jwt_configuration.validate_restrictions
+          raise "not matching policy annotations"
+        end
+      end
+
+      def get_token
+        @token_factory.signed_token(
+          account: @account,
+          username: @username
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -4,30 +4,32 @@ module Authentication
   module AuthnJwt
     # Generic JWT authenticator that receive JWT vendor configuration and uses to validate that the authentication
     # request is valid, and return conjur authn token accordingly
-    JwtAuthenticate ||= CommandClass.new(
+    Authenticate = CommandClass.new(
       dependencies: {
         token_factory: TokenFactory.new
       },
-      inputs: %i[jwt_configuration account username]
+      inputs: %i[jwt_configuration authenticator_input]
     ) do
+
       def call
-        validate_and_decode
-        get_identity
+        validate_and_decode_token
+        conjur_id
         validate_restrictions
-        get_token
+        new_token
       end
 
-      def get_identity
-        # Will be changed when real get identity implemented
-        unless @jwt_configuration.get_identity == "cucumber"
-          raise "wrong identity"
-        end
-      end
+      private
 
-      def validate_and_decode
-        unless @jwt_configuration.validate_and_decode
+      def validate_and_decode_token
+        #TODO : Need to decide how the token is going to be given and parsed and change this line according to this
+        unless @jwt_configuration.validate_and_decode_token(jwt_token: @authenticator_input.credentials)
           raise "validate and decode failed"
         end
+      end
+
+      def conjur_id
+        # Will be changed when real get identity implemented
+        @jwt_configuration.conjur_id
       end
 
       def validate_restrictions
@@ -36,10 +38,10 @@ module Authentication
         end
       end
 
-      def get_token
+      def new_token
         @token_factory.signed_token(
-          account: @account,
-          username: @username
+          account: @authenticator_input.account,
+          username: @authenticator_input.username
         )
       end
     end

--- a/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor.rb
@@ -2,16 +2,16 @@ module Authentication
   module AuthnJwt
     # Mock JWTConfiguration class to use it to develop other part in the jwt authenticator
     class JWTConfigurationDummyVendor < JWTConfigurationInterface
-      def get_identity
-        return "cucumber"
+      def self.conjur_id
+        "cucumber"
       end
 
-      def validate_restrictions
-        return true
+      def self.validate_restrictions
+        true
       end
 
-      def validate_and_decode
-        return true
+      def self.validate_and_decode_token(jwt_token)
+        true
       end
     end
   end

--- a/app/domain/authentication/authn_jwt/jwt_configuration_factory.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_factory.rb
@@ -1,16 +1,13 @@
 module Authentication
   module AuthnJwt
-    # Factory that receives vendor name and returns appropriate JWT vendor configuration class
+    # Factory that receives a vendor name and returns the appropriate JWT vendor configuration class
     class JwtConfigurationFactory
       VENDORS = {
         "dummy" => JWTConfigurationDummyVendor
       }
 
-      def get_jwt_configuration(vendor)
-        unless VENDORS.key?(vendor)
-          raise "Vendor #{vendor} not implemented yet."
-        end
-        (VENDORS[vendor]).new
+      def create_jwt_configuration(vendor)
+        VENDORS[vendor] || raise("Vendor #{vendor} not implemented yet.")
       end
     end
   end

--- a/app/domain/authentication/authn_jwt/jwt_configuration_factory.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_factory.rb
@@ -1,0 +1,17 @@
+module Authentication
+  module AuthnJwt
+    # Factory that receives vendor name and returns appropriate JWT vendor configuration class
+    class JwtConfigurationFactory
+      VENDORS = {
+        "dummy" => JWTConfigurationDummyVendor
+      }
+
+      def get_jwt_configuration(vendor)
+        unless VENDORS.key?(vendor)
+          raise "Vendor #{vendor} not implemented yet."
+        end
+        (VENDORS[vendor]).new
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/jwt_configuration_interface.rb
+++ b/app/domain/authentication/authn_jwt/jwt_configuration_interface.rb
@@ -2,9 +2,9 @@ module Authentication
   module AuthnJwt
     # Interface containing JWT configuration functions to be implemented in JWTConfiguration class for a vendor
     class JWTConfigurationInterface
-      def get_identity; end;
-      def validate_restrictions; end;
-      def validate_and_decode; end;
+      def self.conjur_id; end
+      def self.validate_restrictions; end
+      def self.validate_and_decode_token(jwt_token); end
     end
   end
 end

--- a/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
@@ -6,7 +6,7 @@ module Authentication
 
     OrchestrateJwtAuthentication ||= CommandClass.new(
       dependencies: {
-        token_factory: TokenFactory.new
+        jwt_configuration_factory: JwtConfigurationFactory.new
       },
       inputs: %i[authenticator_input]
     ) do
@@ -16,13 +16,18 @@ module Authentication
       )
 
       def call
-        authenticate
+        authenticate_jwt
       end
 
       private
 
-      def authenticate
-        @token_factory.signed_token(
+      def get_vendor
+        "dummy"
+      end
+
+      def authenticate_jwt
+        JwtAuthenticate.new.(
+          jwt_configuration: @jwt_configuration_factory.get_jwt_configuration(get_vendor),
           account: account,
           username: username
         )

--- a/spec/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor_spec.rb
+++ b/spec/app/domain/authentication/authn_jwt/jwt_configuration_dummy_vendor_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 RSpec.describe(Authentication::AuthnJwt::JWTConfigurationDummyVendor) do
 
   it "return cucumber on get_identity" do
-    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
-    expect(dummy_jwt_configuration.get_identity).to eq "cucumber"
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor
+    expect(dummy_jwt_configuration.conjur_id).to eq "cucumber"
   end
 
   it "return true on validate_restrictions" do
-    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor
     expect(dummy_jwt_configuration.validate_restrictions).to eq true
   end
 
-  it "return true on validate_and_decode" do
-    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor.new
-    expect(dummy_jwt_configuration.validate_and_decode).to eq true
+  it "return true on validate_and_decode_token" do
+    dummy_jwt_configuration = ::Authentication::AuthnJwt::JWTConfigurationDummyVendor
+    expect(dummy_jwt_configuration.validate_and_decode_token("DummyToken")).to eq true
   end
 
 end


### PR DESCRIPTION
End2end dummy JWT flow

1. Authentication request being sent
2. JWT Orchestrator recives it
3. Function to extract vendor is called. Currently is dummy and returns "dummy" vendor
4. The vendor value is passed to JWTConfiguration Factory that currently knows to return only JWTConfigurationDummyVendor
5. This configuration is passed to generic JWT authenticator that calles this functions in this order: validate_and_decode, get_identity, validate_restrictions. If they all pass get_token is called and returned to the sender of the request

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
