### PR TITLE
Add API Version to status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - File `API_VERSION` containing the current Conjur API Version, which corresponds to a
   release of the [Conjur OpenAPI Spec](https://github.com/cyberark/conjur-openapi-spec).
   [cyberark/conjur#2086](https://github.com/cyberark/conjur/pull/2086)
+- Status page details section now displays the Conjur API version.
+  [cyberark/conjur#2130](https://github.com/cyberark/conjur/issues/2130)
 
 ## [1.11.5] - 2021-04-05
 

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -57,6 +57,7 @@
         <dl>
           <dt>Details:</dt>
           <dd>Version <%= ENV["CONJUR_VERSION_DISPLAY"] %></dd>
+          <dd>API Version <a href="https://github.com/cyberark/conjur-openapi-spec/releases/tag/v<%= ENV["API_VERSION"] %>"><%= ENV["API_VERSION"] %></a>
           <dt>More Info:</dt>
           <dd>
             <ul>

--- a/config/initializers/status.rb
+++ b/config/initializers/status.rb
@@ -3,3 +3,4 @@
 require 'logs'
 
 ENV["CONJUR_VERSION_DISPLAY"] = File.read(File.expand_path("../../VERSION", File.dirname(__FILE__)))
+ENV["API_VERSION"] = File.read(File.expand_path("../../API_VERSION", File.dirname(__FILE__)))


### PR DESCRIPTION
### What does this PR do?
Recently, the `API_VERSION` file was added to track the Conjur OpenAPI Spec release versions.
This PR displays the current API version on the Conjur status page.

![image](https://user-images.githubusercontent.com/54131464/116419842-7078be80-a80b-11eb-98df-1b32dfb7ed1b.png)

### What ticket does this PR close?
Resolves #2130 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
