### PR TITLE
Implement FetchIssuerValue command class

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Authentication
+  module AuthnJwt
+
+    PROVIDER_URI_RESOURCE_NAME = "provider-uri"
+    JWKS_URI_RESOURCE_NAME = "jwks-uri"
+    ISSUER_RESOURCE_NAME = "issuer"
+
+  end
+end
+

--- a/app/domain/authentication/authn_jwt/fetch_issuer_value.rb
+++ b/app/domain/authentication/authn_jwt/fetch_issuer_value.rb
@@ -1,0 +1,131 @@
+require 'uri'
+
+module Authentication
+  module AuthnJwt
+
+    # FetchIssuerValue command class is responsible to fetch the issuer secret value,
+    # in order to validate it later against the JWT token claim
+    FetchIssuerValue ||= CommandClass.new(
+      dependencies: {
+        resource_class: ::Resource,
+        fetch_secrets: ::Conjur::FetchRequiredSecrets.new,
+        logger: Rails.logger
+      },
+      inputs: %i[authenticator_input]
+    ) do
+      extend(Forwardable)
+      def_delegators(:@authenticator_input, :service_id, :authenticator_name,
+                     :account)
+
+      def call
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingIssuerConfigurationValue.new)
+        fetch_issuer_value
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchedIssuerValueFromConfiguration.new)
+
+        @issuer_value
+      end
+
+      private
+
+      def fetch_issuer_value
+        if issuer_resource_exists?
+          @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(ISSUER_RESOURCE_NAME)))
+
+          @issuer_value=issuer_secret
+        else
+          validate_issuer_configuration
+
+          if provider_uri_resource_exists?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(PROVIDER_URI_RESOURCE_NAME)))
+
+            @issuer_value=provider_uri_secret
+          elsif jwks_uri_resource_exists?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(JWKS_URI_RESOURCE_NAME)))
+
+            @issuer_value=fetch_issuer_from_jwks_uri_secret
+          end
+        end
+
+        @logger.debug(LogMessages::Authentication::AuthnJwt::RetrievedIssuerValue.new(@issuer_value))
+        @issuer_value
+      end
+
+      def issuer_resource_exists?
+        !issuer_resource.nil?
+      end
+
+      def issuer_resource
+        @issuer_resource ||= resource(ISSUER_RESOURCE_NAME)
+      end
+
+      def resource(resource_name)
+        @resource_class[resource_id(resource_name)]
+      end
+
+      def resource_id(resource_name)
+        "#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}"
+      end
+
+      def issuer_secret
+        @issuer_secret ||= @fetch_secrets.(resource_ids: [resource_id(ISSUER_RESOURCE_NAME)])
+        @issuer_secret_value ||= @issuer_secret[resource_id(ISSUER_RESOURCE_NAME)]
+      end
+
+      def validate_issuer_configuration
+        if (provider_uri_resource_exists? and jwks_uri_resource_exists?) or
+           (!provider_uri_resource_exists? and !jwks_uri_resource_exists?)
+          raise Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration.new(
+            ISSUER_RESOURCE_NAME,
+            PROVIDER_URI_RESOURCE_NAME,
+            JWKS_URI_RESOURCE_NAME
+          )
+        end
+      end
+
+      def provider_uri_resource_exists?
+        !provider_uri_resource.nil?
+      end
+
+      def jwks_uri_resource_exists?
+        !jwks_uri_resource.nil?
+      end
+
+      def provider_uri_resource
+        @provider_uri_resource ||= resource(PROVIDER_URI_RESOURCE_NAME)
+      end
+
+      def jwks_uri_resource
+        @jwks_uri_resource ||= resource(JWKS_URI_RESOURCE_NAME)
+      end
+
+      def provider_uri_secret
+        @provider_uri_secret ||= @fetch_secrets.(resource_ids: [resource_id(PROVIDER_URI_RESOURCE_NAME)])
+        @provider_uri_secret_value ||= @provider_uri_secret[resource_id(PROVIDER_URI_RESOURCE_NAME)]
+      end
+
+      def fetch_issuer_from_jwks_uri_secret
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingIssuerFromUri.new(jwks_uri_secret))
+
+        begin
+          @issuer_from_jwks_uri_secret ||= URI.parse(jwks_uri_secret).hostname
+        rescue => e
+          raise Errors::Authentication::AuthnJwt::InvalidUriFormat.new(
+            jwks_uri_secret,
+            e.inspect
+          )
+        end
+
+        if @issuer_from_jwks_uri_secret.blank?
+          raise Errors::Authentication::AuthnJwt::FailedToParseHostnameFromUri, jwks_uri_secret
+        end
+
+        @issuer_from_jwks_uri_secret
+      end
+
+      def jwks_uri_secret
+        @jwks_uri_secret ||= @fetch_secrets.(resource_ids: [resource_id(JWKS_URI_RESOURCE_NAME)])
+        @jwks_uri_secret_value ||=@jwks_uri_secret[resource_id(JWKS_URI_RESOURCE_NAME)]
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -365,6 +365,26 @@ module Errors
       )
     end
 
+    module AuthnJwt
+
+      InvalidIssuerConfiguration = ::Util::TrackableErrorClass.new(
+        msg: "Issuer authenticator configuration is invalid. You should configured as authenticator variables: " \
+              "'{0-resource-name}' or one of the following: '{1-resource-name}','{2-resource-name}'",
+        code: "CONJ00070E"
+      )
+
+      FailedToParseHostnameFromUri = ::Util::TrackableErrorClass.new(
+        msg: "Failed to extract hostname from URI '{0}'",
+        code: "CONJ00071E"
+      )
+
+      InvalidUriFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse URI '{0}'. Reason: '{1}'",
+        code: "CONJ00072E"
+      )
+
+    end
+
     module ResourceRestrictions
 
       InvalidResourceRestrictions = ::Util::TrackableErrorClass.new(

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -262,6 +262,35 @@ module LogMessages
       )
 
     end
+
+    module AuthnJwt
+
+      FetchingIssuerConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching issuer authenticator configuration value",
+        code: "CONJ00052D"
+      )
+
+      FetchedIssuerValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched issuer value from authenticator configuration",
+        code: "CONJ00053D"
+      )
+
+      IssuerResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Issuer value will be taken from '{0-resource-id}'",
+        code: "CONJ00054D"
+      )
+
+      RetrievedIssuerValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Retrieved issuer with value '{0}'",
+        code: "CONJ00055D"
+      )
+
+      ParsingIssuerFromUri = ::Util::TrackableLogMessageClass.new(
+        msg: "Parsing issuer value from URI '{0}'",
+        code: "CONJ00056D"
+      )
+
+    end
   end
 
   module Util

--- a/spec/app/domain/authentication/authn-jwt/fetch_issuer_value_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_issuer_value_spec.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::FetchIssuerValue') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:issuer_resource_name) {'issuer'}
+  let(:provider_uri_resource_name) {'provider-uri'}
+  let(:jwks_uri_resource_name) {'jwks-uri'}
+  let(:issuer_secret_value) {'issuer-secret-value'}
+  let(:provider_uri_secret_value) {'provider-uri-secret-value'}
+  let(:jwks_uri_secret_value) {'jwks-uri-secret-value'}
+  let(:jwks_uri_with_bad_uri_format_value) {'=>=>=>////'}
+  let(:jwks_uri_with_bad_uri_hostname_value) {'https://'}
+  let(:jwks_uri_with_valid_hostname_value) {'https://jwt-provider.com/jwks'}
+  let(:valid_hostname_value) {'jwt-provider.com'}
+
+  def mock_resource_id(resource_name:)
+    %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
+  end
+
+  let(:mocked_resource) { double("MockedResource") }
+  let(:mocked_resource_exists_values) { double("MockedResource") }
+  let(:mocked_resource_not_exists_values) { double("MockedResource") }
+  let(:mocked_resource_both_provider_and_jwks_exist_values) { double("MockedResource") }
+  let(:mocked_resource_just_provider_uri_exists_values) { double("MockedResource") }
+  let(:mocked_resource_just_jwks_uri_exists_values) { double("MockedResource") }
+
+  let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values) {  double("MockedFetchSecrets") }
+  let(:mocked_valid_secrets) {  double("MockedValidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value) {  double("MockedInvalidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value) {  double("MockedInvalidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value) {  double("MockedValidSecrets") }
+  let(:mocked_jwks_uri_with_bad_uri_format_secret) {  double("MockedInvalidSecrets") }
+  let(:mocked_jwks_uri_with_bad_uri_hostname_secret) {  double("MockedInvalidSecrets") }
+  let(:mocked_jwks_uri_with_valid_uri_hostname_secret) {  double("MockedValidSecrets") }
+
+  let(:required_secret_missing_error) { "required secret missing error" }
+  let(:invalid_issuer_configuration_error) { "invalid issuer configuration error" }
+
+  before(:each) do
+    allow(mocked_resource_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_not_exists_values).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_fetch_secrets_empty_values).to(
+      receive(:call).and_raise(required_secret_missing_error)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: issuer_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).
+        and_return(issuer_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: provider_uri_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).
+        and_return(provider_uri_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(jwks_uri_resource_name)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_bad_uri_format_secret)
+    )
+
+    allow(mocked_jwks_uri_with_bad_uri_format_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_bad_uri_format_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_bad_uri_hostname_secret)
+    )
+
+    allow(mocked_jwks_uri_with_bad_uri_hostname_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_bad_uri_hostname_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_valid_uri_hostname_secret)
+    )
+
+    allow(mocked_jwks_uri_with_valid_uri_hostname_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_valid_hostname_value)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'issuer' variable is configured in authenticator policy" do
+    context "with empty variable value" do
+      subject do
+        ::Authentication::AuthnJwt::FetchIssuerValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_secrets: mocked_fetch_secrets_empty_values
+        ).call(
+          authenticator_input: authenticator_input
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_secret_missing_error)
+      end
+    end
+
+    context "with valid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::FetchIssuerValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_secrets: mocked_fetch_secrets_exist_values
+        ).call(
+          authenticator_input: authenticator_input
+        )
+      end
+
+      it "returns issuer value" do
+        expect(subject).to eql(issuer_secret_value)
+      end
+    end
+  end
+
+  context "'issuer' variable is not configured in authenticator policy" do
+    context "And both provider-uri and jwks-uri not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchIssuerValue.new(
+          resource_class: mocked_resource_not_exists_values,
+        ).call(
+          authenticator_input: authenticator_input
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration)
+      end
+    end
+
+    context "And both provider-uri and jwks-uri configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchIssuerValue.new(
+          resource_class: mocked_resource_both_provider_and_jwks_exist_values,
+          ).call(
+          authenticator_input: authenticator_input
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration)
+      end
+    end
+
+    context "And just provider-uri configured in authenticator policy" do
+      context "with empty variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_provider_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_empty_values
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(required_secret_missing_error)
+        end 
+      end
+
+      context "with valid variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_provider_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_exist_values
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "returns provider-uri as issuer value" do
+          expect(subject).to eql(provider_uri_secret_value)
+        end
+      end
+    end
+
+    context "And just jwks-uri configured in authenticator policy" do
+      context "with empty variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_empty_values
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(required_secret_missing_error)
+        end
+      end
+
+      context "with bad URI format as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriFormat)
+        end
+      end
+
+      context "with bad URI hostname as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToParseHostnameFromUri)
+        end
+      end
+
+      context "with valid URI hostname as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value
+          ).call(
+            authenticator_input: authenticator_input
+          )
+        end
+
+        it "returns extracted hostname from jwks-uri as issuer value" do
+          expect(subject).to eql(valid_hostname_value)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/app/domain/authentication/authn-jwt/fetch_issuer_value_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_issuer_value_spec.rb
@@ -327,4 +327,3 @@ RSpec.describe('Authentication::AuthnJwt::FetchIssuerValue') do
     end
   end
 end
-


### PR DESCRIPTION
### What does this PR do?
Add fetching issuer value from authenticator configuration base on the following logic:

1. If issuer variable is configured - fetch value
2. Else get the issuer value from 1 of the following variables
2.1. provider-uri
2.2 jwks-uri - extract the hostname from it (from example: https://123.com/jwks --> 123.com)


### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
