### PR TITLE
Adds support for Feature Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Feature Flags allow experimental or in-progress features to be enabled via
+  environment variable. Read the [Feature Flag docs](design/feature_flags.md)
+  for more details.
+
 ## [1.11.6] - 2021-04-28
 
 ### Fixed

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,25 @@
+Rails.application.configure do
+  # Loads Feature Flag configuration.
+  #
+  # The `feature_flags` arguement is an array of valid feature flags (as Ruby
+  # Symbols) used in Conjur to limit or prevent access to a new feature.
+  #
+  # By default, all feature flags are toggled "Off".  A feature can be enabled
+  # by setting an environment variable of the following form:
+  #
+  # CONJUR_FEATURE_<feature_name>_ENABLED=true
+  #
+  # <feature_name> must match the flag provide in the `feature_flags` arguement.
+  #
+  # The feature flag is available for using the following form:
+  #
+  # Rails.configuration.feature_flags.enabled?(:feature_name)
+
+  feature_flags = [] # Array of feature flags as Ruby symbols, ex. [:telemetry]
+
+  config.feature_flags = Conjur::FeatureFlags::Features.new(
+    logger: Rails.logger,
+    environment_settings: ENV,
+    feature_flags: feature_flags
+  )
+end

--- a/design/feature_flags.md
+++ b/design/feature_flags.md
@@ -1,0 +1,38 @@
+# Feature Flags
+
+Feature flags enable partially completed or experimental features to be available in the official Conjur releases. [Martin Fowler](https://martinfowler.com/articles/feature-toggles.html) has an excellent article outlining various approaches to leveraging feature flags.
+
+## Functional Overview
+
+For our initial Feature Flag implementation only supports setting flags via environment variables. In the future, we should support feature flags through file-based as well.
+
+### Define a new feature flag
+
+To create a new feature flag, add the feature name to the `feature_flags` array in `config/initializers/feature_flags.rb`.  For example, to create a feature flag for a feature called `Telemetry Endpoint`, add the following:
+
+```ruby
+feature_flags = [
+  :telemetry_endpoint
+]
+```
+and restart Conjur.
+
+### Gate a feature
+
+After a new flag has been added to the `feature_flags` array, the Telemetry Endpoint is now a valid feature flag. Functionality can be gated with the following:
+
+```ruby
+if Rails.configuration.feature_flags.enabled?(:telemetry_endpoint)
+  ... # Gated code here
+end
+```
+
+### Enable a feature
+
+To enable the Telemetry Endpoint feature, set the feature environment variable flag:
+
+```sh
+CONJUR_FEATURE_TELEMETRY_ENDPOINT_ENABLED=true
+```
+
+and restart Conjur to pick up the new flag setting.

--- a/lib/conjur/feature_flags/features.rb
+++ b/lib/conjur/feature_flags/features.rb
@@ -28,9 +28,10 @@ module Conjur
         @logger.debug("Conjur::FeatureFlags::Features#enabled? - feature flag name: '#{feature_name.inspect}'")
         raise InvalidArguement unless feature_name.is_a?(Symbol)
 
-        symbolized_feature_name = feature_name.downcase
-        result = @enabled_features.key?(symbolized_feature_name) &&
-          @enabled_features[symbolized_feature_name]
+        result =
+          @enabled_features.key?(feature_name) &&
+          @enabled_features[feature_name]
+
         @logger.debug("Conjur::FeatureFlags::Features#enabled? result: '#{result}'")
         result
       end

--- a/lib/conjur/feature_flags/features.rb
+++ b/lib/conjur/feature_flags/features.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Conjur
+  module FeatureFlags
+    # Provides feature flagging support
+    class Features
+      # Instantiates a new Conjur::FeatureFlags::Features object
+      #
+      # @param logger [Logger] the logger used for output
+      # @param environment_settings [Hash] the environment variable has (typically ENV)
+      # @param feature_flags [Array<Symbol>] the list of valid feature flags
+      #
+      # @return [Conjur::FeatureFlags::Features]
+      def initialize(logger:, environment_settings:, feature_flags: [])
+        @logger = logger
+        @enabled_features = merge_with_environment_variable_flags(
+          features: feature_flags,
+          env: environment_settings
+        )
+      end
+
+      # Check to see if a feature flag has been enabled
+      #
+      # @param feature_name [Symbol] the feature flag we want to check
+      #
+      # @return [Boolean]
+      def enabled?(feature_name)
+        @logger.debug("Conjur::FeatureFlags::Features#enabled? - feature flag name: '#{feature_name.inspect}'")
+        raise InvalidArguement unless feature_name.is_a?(Symbol)
+
+        symbolized_feature_name = feature_name.downcase
+        result = @enabled_features.key?(symbolized_feature_name) &&
+          @enabled_features[symbolized_feature_name]
+        @logger.debug("Conjur::FeatureFlags::Features#enabled? result: '#{result}'")
+        result
+      end
+
+      private
+
+      # Builds a hash of the feature flags whether they should be toggled on or
+      # off. Environment variable flags are set with the following format:
+      #   CONJUR_FEATURE_<feature_name>_ENABLED
+      #
+      # @param features [Array<Symbol>] list of feature flags
+      # @param environment [Hash] the environment variables and their values
+      #
+      # @return [Hash<Symbol>:<Boolean>] hash of feature names and their enabled state (true/false)
+      def merge_with_environment_variable_flags(features:, env:)
+        features.map do |f|
+          enabled = env["CONJUR_FEATURE_#{f.upcase}_ENABLED"].to_s == 'true'
+          log_reason_enabled(f) if enabled
+          [f, enabled]
+        end.to_h
+      end
+
+      def log_reason_enabled(feature)
+        @logger.debug(
+          "Feature '#{feature}' enabled via CONJUR_FEATURE_#{feature.upcase}_ENABLED"
+        )
+      end
+    end
+
+    # Provides an error for when an invalid argement is passed to the `enabled?`
+    # method. Only Symbols are currently accepted.
+    class InvalidArguement < StandardError
+      def message
+        'Feature name must be a symbol'
+      end
+    end
+  end
+end

--- a/spec/conjur/feature_flags/features_spec.rb
+++ b/spec/conjur/feature_flags/features_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'logger'
+require './lib/conjur/feature_flags/features'
+
+describe Conjur::FeatureFlags::Features do
+  describe '#enabled?' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+
+    let(:features) do
+      Conjur::FeatureFlags::Features.new(
+        logger: logger,
+        environment_settings: {
+          'FOO' => 'true',
+          'CONJUR_FEATURE_BAR_ENABLED' => 'true',
+          'CONJUR_FEATURE_BLANK_ENABLED' => 'true'
+        },
+        feature_flags: %i[foo bar baz]
+      )
+    end
+
+    it 'returns false when a feature is not declared' do
+      expect(features.enabled?(:bing)).to be(false)
+    end
+
+    it 'returns true when a feature is declared and enabled' do
+      expect(features.enabled?(:bar)).to be(true)
+    end
+
+    it 'logs the environment variable when a feature is enabled' do
+      features
+      expect(log_output.string).to include('DEBUG')
+      expect(log_output.string).to include('CONJUR_FEATURE_BAR_ENABLED')
+    end
+
+    it 'returns false when a feature is enabled but not declared' do
+      expect(features.enabled?(:bing)).to be(false)
+    end
+
+    it 'returns an error unless arguement is a symbol' do
+      expect { features.enabled?('bar') }.to raise_error(
+        Conjur::FeatureFlags::InvalidArguement
+      )
+    end
+
+    it 'returns false when a feature is enabled with a value other than `true`' do
+      expect(Conjur::FeatureFlags::Features.new(
+        logger: logger,
+        environment_settings: {
+          'CONJUR_FEATURE_BLANK_ENABLED' => 'false'
+        },
+        feature_flags: %i[blank]
+      ).enabled?(:blank)).to be(false)
+
+      expect(Conjur::FeatureFlags::Features.new(
+        logger: logger,
+        environment_settings: {
+          'CONJUR_FEATURE_BLANK_ENABLED' => 'Truthy'
+        },
+        feature_flags: %i[blank]
+      ).enabled?(:blank)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
    This change adds simple Feature Flag support.  Features can be toggled on/off via environment variables. This change is intended to allow teams to push features that are not of GA quality. This will allow for early feature preview and feedback.
- _How should the reviewer approach this PR, especially if manual tests are required?_
    - Review: `lib/conjur/feature_flags/features.rb` as it holds most of the key functionality.
    - Review: `config/initializers/feature_flags.rb` to understand how Feature Flags are loaded and accessed.
- _Are there relevant screenshots you can add to the PR description?_
    N/A

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
