### PR TITLE
Add dummy class for validate resource restrictions for jwt token

### DIFF
--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -39,10 +39,8 @@ module Authentication
       end
 
       def validate_restrictions
-        @logger.debug(LogMessages::Authentication::AuthnJwt::CHECKING_IDENTITY_FIELD_EXISTS.new)
-        unless @jwt_configuration.validate_restrictions(@authentication_parameters)
-          raise "not matching policy annotations"
-        end
+        @logger.debug(LogMessages::Authentication::AuthnJwt::CALLING_VALIDATE_RESTRICTIONS.new)
+        @jwt_configuration.validate_restrictions(@authentication_parameters)
       end
 
       def new_token

--- a/app/domain/authentication/authn_jwt/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/configuration_jwt_generic_vendor.rb
@@ -8,7 +8,9 @@ module Authentication
       end
 
       def self.validate_restrictions(authentication_parameters)
-        true
+        Authentication::AuthnJwt::ValidateResourceRestrictions.new.call(
+          authentication_parameters: authentication_parameters
+        )
       end
 
       def self.validate_and_decode_token(authentication_parameters)

--- a/app/domain/authentication/authn_jwt/validate_resource_restrictions.rb
+++ b/app/domain/authentication/authn_jwt/validate_resource_restrictions.rb
@@ -1,0 +1,46 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    ValidateResourceRestrictions = CommandClass.new(
+      dependencies: {
+        logger: Rails.logger,
+        # TODO: Dependency for extract_resource_restrictions should be added here
+        # TODO: Dependency for validate_resource_restrictions_configuration should be added here
+        # TODO: Dependency for validate_request_matches_resource_restrictions should be added here
+      },
+      inputs: %i[authentication_parameters]
+    ) do
+      def call
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatingResourceRestrictions.new(@authentication_parameters.jwt_identity))
+
+        extract_resource_restrictions_configuration
+        validate_resource_restrictions_configuration
+        validate_token_matches_resource_restrictions
+
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatedResourceRestrictions.new)
+      end
+
+      private
+
+      def extract_resource_restrictions_configuration
+        # TODO: Code of extraction fo resource restrictions should be inserted here
+        true
+      end
+
+      def validate_resource_restrictions_configuration
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatingResourceRestrictionsConfiguration.new)
+        # TODO: Code of Validate Source Restriction Should be inserted here
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatedResourceRestrictionsConfiguration.new)
+      end
+
+      def validate_token_matches_resource_restrictions
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatingResourceRestrictionsValues.new)
+
+        # TODO: Code responsible of validating jwt token and the restrictions should be inserted here
+
+        @logger.debug(LogMessages::Authentication::ResourceRestrictions::ValidatedResourceRestrictionsValues.new)
+      end
+    end
+  end
+end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -330,8 +330,8 @@ module LogMessages
         code: "CONJ00064D"
       )
 
-      CHECKING_IDENTITY_FIELD_EXISTS = ::Util::TrackableLogMessageClass.new(
-        msg: "Checking if the field exists",
+      CALLING_VALIDATE_RESTRICTIONS = ::Util::TrackableLogMessageClass.new(
+        msg: "Calling JWT validate restrictions",
         code: "CONJ00065D"
       )
 


### PR DESCRIPTION
This is a skeleton command class for the validate resource restrictions in the JWT token.  So we will be able to work in perrarel on different parts of this. 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
