### PR TITLE
Change exp claim to be mandatory

### DIFF
--- a/app/domain/authentication/authn_jwt/fetch_jwt_claims_to_validate.rb
+++ b/app/domain/authentication/authn_jwt/fetch_jwt_claims_to_validate.rb
@@ -33,9 +33,7 @@ module Authentication
       OPTIONAL_CLAIMS = [ISS_CLAIM_NAME, NBF_CLAIM_NAME, IAT_CLAIM_NAME].freeze
 
       def validate_decoded_token_exists
-        if decoded_token.blank?
-          raise Errors::Authentication::AuthnJwt::MissingToken.new
-        end
+        raise Errors::Authentication::AuthnJwt::MissingToken.new if decoded_token.blank?
       end
 
       def fetch_jwt_claims_to_validate

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -401,6 +401,11 @@ module Errors
               "   with field in the decoded token that contains the identity",
         code: "CONJ00075E"
       )
+
+      MissingToken = ::Util::TrackableErrorClass.new(
+        msg: "Token is empty or not found.",
+        code: "CONJ00077E"
+      )
     end
 
     module ResourceRestrictions

--- a/spec/app/domain/authentication/authn-jwt/fetch_jwt_claims_to_validate_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_jwt_claims_to_validate_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwtClaimsToValidate') do
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
   #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
 
-  context "JWT decided token input" do
+  context "JWT decoded token input" do
     context "with mandatory claims (exp)" do
       context "and with all supported optional claims: (iss, nbf, iat)" do
         context "with valid issuer variable configuration in authenticator policy" do


### PR DESCRIPTION
### What does this PR do?
As results of logic requested change, exp claim is changed from optional to mandatory

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
