### PR TITLE
Add constraint for validating at least one annotation is in the policy

### DIFF
--- a/app/domain/authentication/constraints/not_empty_constraint.rb
+++ b/app/domain/authentication/constraints/not_empty_constraint.rb
@@ -1,0 +1,12 @@
+module Authentication
+  module Constraints
+
+    # This constraint returns true if the resource restriction contains at least one restriction. Otherwise it raises
+    # EmptyAnnotationsListConfigured exception
+    class NotEmptyConstraint
+      def validate(resource_restrictions:)
+        raise Errors::Authentication::Constraints::RoleMissingAnyConstraints if resource_restrictions.empty?
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -449,6 +449,11 @@ module Errors
         code: "CONJ00069E"
       )
 
+      RoleMissingAnyConstraints =  ::Util::TrackableErrorClass.new(
+        msg: "Role must have at least one constraint",
+        code: "CONJ00070E"
+      )
+
     end
   end
 

--- a/spec/app/domain/authentication/constraints/not_empty_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/not_empty_constraint_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::Constraints::NotEmptyConstraint) do
+  let(:right_email) { "admin@example.com" }
+  let(:username) { "admin" }
+
+  let(:no_restrictinos){ [] }
+
+  let(:one_restriction) {
+    [
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: right_email)
+    ]
+  }
+
+  let(:two_restrictions) {
+    [
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: right_email),
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "username", value: username)
+    ]
+  }
+
+  context "NotEmptyConstraint" do
+    subject do
+      ::Authentication::Constraints::NotEmptyConstraint.new
+    end
+
+    it "validate runs successfully for one restriction" do
+      expect { subject.validate(resource_restrictions: one_restriction) }.to_not raise_error
+    end
+
+    it "validate runs successfully for two restrictions" do
+      expect { subject.validate(resource_restrictions: two_restrictions) }.to_not raise_error
+    end
+
+    it "validate raises EmptyAnnotationsListConfigured when there are not annotations" do
+      expect { subject.validate(resource_restrictions: no_restrictinos) }.to raise_error(Errors::Authentication::Constraints::RoleMissingAnyConstraints)
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Added constraint to check at least one annotation is given in the policy

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
