### PR TITLE
Fetch Jwt signing key from provider

### DIFF
--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -28,7 +28,6 @@ module Authentication
       end
 
       def validate_and_decode_token
-        Authentication::AuthnJwt::CreateSigningKeyInterface.new.(authentication_parameters: @authentication_parameters).fetch_signing_key
         @logger.debug(LogMessages::Authentication::AuthnJwt::VALIDATE_AND_DECODE_TOKEN.new)
         @authentication_parameters.decoded_token = @jwt_configuration.validate_and_decode_token(@authentication_parameters)
       end

--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -28,6 +28,7 @@ module Authentication
       end
 
       def validate_and_decode_token
+        Authentication::AuthnJwt::CreateSigningKeyInterface.new.(authentication_parameters: @authentication_parameters).fetch_signing_key
         @logger.debug(LogMessages::Authentication::AuthnJwt::VALIDATE_AND_DECODE_TOKEN.new)
         @authentication_parameters.decoded_token = @jwt_configuration.validate_and_decode_token(@authentication_parameters)
       end

--- a/app/domain/authentication/authn_jwt/create_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/create_signing_key_interface.rb
@@ -1,0 +1,63 @@
+module Authentication
+  module AuthnJwt
+    # Factory that returns the interface implementation of FetchSigningKey
+    CreateSigningKeyInterface ||= CommandClass.new(
+      dependencies: {
+        fetch_provider_uri: Authentication::AuthnJwt::FetchProviderUriSigningKey,
+        fetch_jwks_uri: Authentication::AuthnJwt::FetchJwksUriSigningKey
+      },
+      inputs: %i[authenticator_parameters]
+    ) do
+
+      def call
+        create
+      end
+
+      private
+
+      def create
+        validate_key_configuration
+
+        if provider_uri_has_valid_configuration?
+          fetch_provider_uri_signing_key
+        elsif jwks_uri_has_valid_configuration?
+          fetch_jwks_uri_signing_key
+        end
+      end
+
+      def validate_key_configuration
+        if (provider_uri_has_valid_configuration? and jwks_uri_has_valid_configuration?) or
+          (!provider_uri_has_valid_configuration? and !jwks_uri_has_valid_configuration?)
+          raise Errors::Authentication::AuthnJwt::InvalidUriConfiguration.new(
+            PROVIDER_URI_RESOURCE_NAME,
+            JWKS_URI_RESOURCE_NAME
+          )
+        end
+      end
+
+      def provider_uri_has_valid_configuration?
+        @provider_uri_has_valid_configuration ||= fetch_provider_uri_signing_key.has_valid_configuration?
+      end
+
+      def jwks_uri_has_valid_configuration?
+        @jwks_uri_has_valid_configuration ||= fetch_jwks_uri_signing_key.has_valid_configuration?
+      end
+
+      def fetch_provider_uri_signing_key
+        @fetch_provider_uri_signing_key ||= @fetch_provider_uri.new(@authenticator_parameters,
+                                                                    Rails.logger,
+                                                                    Conjur::FetchRequiredSecrets.new,
+                                                                    ::Resource,
+                                                                    Authentication::OAuth::DiscoverIdentityProvider.new)
+      end
+
+      def fetch_jwks_uri_signing_key
+        @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri.new(@authenticator_parameters,
+                                                            Rails.logger,
+                                                            Conjur::FetchRequiredSecrets.new,
+                                                            ::Resource,
+                                                            Net::HTTP)
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/create_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/create_signing_key_interface.rb
@@ -7,7 +7,7 @@ module Authentication
         fetch_jwks_uri: Authentication::AuthnJwt::FetchJwksUriSigningKey,
         logger: Rails.logger
       },
-      inputs: %i[authenticator_parameters]
+      inputs: %i[authentication_parameters]
     ) do
 
       def call
@@ -48,7 +48,7 @@ module Authentication
       end
 
       def fetch_provider_uri_signing_key
-        @fetch_provider_uri_signing_key ||= @fetch_provider_uri.new(authenticator_parameters: @authenticator_parameters,
+        @fetch_provider_uri_signing_key ||= @fetch_provider_uri.new(authentication_parameters: @authentication_parameters,
                                                                     logger: Rails.logger,
                                                                     fetch_required_secrets: Conjur::FetchRequiredSecrets.new,
                                                                     resource_class: ::Resource,
@@ -56,7 +56,7 @@ module Authentication
       end
 
       def fetch_jwks_uri_signing_key
-        @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri.new(authenticator_parameters: @authenticator_parameters,
+        @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri.new(authentication_parameters: @authentication_parameters,
                                                             logger: Rails.logger,
                                                             fetch_required_secrets: Conjur::FetchRequiredSecrets.new,
                                                             resource_class: ::Resource,

--- a/app/domain/authentication/authn_jwt/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/fetch_jwks_uri_signing_key.rb
@@ -1,0 +1,75 @@
+require 'uri'
+require 'net/http'
+
+module Authentication
+  module AuthnJwt
+    # This class is responsible for fetching JWK Set from JWKS-uri
+    class FetchJwksUriSigningKey < FetchSigningKeyInterface
+
+      def initialize(authenticator_parameters,
+                     logger,
+                     fetch_required_secrets,
+                     resource_class,
+                     http)
+        @logger = logger
+        @resource_id = authenticator_parameters.authenticator_resource_id
+        @fetch_required_secrets = fetch_required_secrets
+        @resource_class = resource_class
+        @http = http
+      end
+
+      def has_valid_configuration?
+        @jwks_uri_resource_exists ||= jwks_uri_resource_exists?
+      end
+
+      def fetch_signing_key
+        fetch_jwks_uri
+        fetch_jwks_keys
+      end
+
+      private
+
+      def jwks_uri_resource_exists?
+        !jwks_uri_resource.nil?
+      end
+
+      def jwks_uri_resource
+        @jwks_uri_resource ||= resource
+      end
+
+      def resource
+        @resource_class[jwks_uri_resource_id]
+      end
+
+      def fetch_jwks_uri
+        @logger.debug(LogMessages::Authentication::AuthnJwt::JwksUriResourceNameConfiguration.new(jwks_uri_resource_id))
+        jwks_uri
+      end
+
+      def jwks_uri
+        @jwks_uri ||= jwks_uri_secret[jwks_uri_resource_id]
+      end
+
+      def jwks_uri_secret
+        @jwks_uri_secret ||= @fetch_required_secrets.(resource_ids: [jwks_uri_resource_id])
+      end
+
+      def jwks_uri_resource_id
+        "#{@resource_id}/#{JWKS_URI_RESOURCE_NAME}"
+      end
+
+      def fetch_jwks_keys
+        uri = URI(jwks_uri)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwksFromJwksUri.new)
+        response = @http.get_response(uri)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchJwksUriKeysSuccess.new)
+        JSON.parse(response.body)['keys']
+      rescue => e
+        raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(
+          jwks_uri,
+          e.inspect
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
@@ -3,11 +3,11 @@ module Authentication
     # This class is responsible for fetching JWK Set from provider-uri
     class FetchProviderUriSigningKey < FetchSigningKeyInterface
 
-      def initialize(authenticator_parameters,
-                     logger,
-                     fetch_required_secrets,
-                     resource_class,
-                     discover_identity_provider)
+      def initialize(authenticator_parameters:,
+                     logger:,
+                     fetch_required_secrets:,
+                     resource_class:,
+                     discover_identity_provider:)
         @logger = logger
         @resource_id = authenticator_parameters.authenticator_resource_id
         @fetch_required_secrets = fetch_required_secrets
@@ -35,11 +35,11 @@ module Authentication
       end
 
       def resource
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwtConfigurationValue.new(provider_uri_resource_id))
         @resource_class[provider_uri_resource_id]
       end
 
       def provider_uri
-        @logger.debug(LogMessages::Authentication::AuthnJwt::ProviderUriResourceNameConfiguration.new(provider_uri_resource_id))
         @provider_uri ||= provider_uri_secret[provider_uri_resource_id]
       end
 
@@ -56,6 +56,7 @@ module Authentication
       end
 
       def discovered_provider
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(provider_uri))
         @discovered_provider ||= @discover_identity_provider.(
           provider_uri: provider_uri
         )

--- a/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
@@ -3,13 +3,13 @@ module Authentication
     # This class is responsible for fetching JWK Set from provider-uri
     class FetchProviderUriSigningKey < FetchSigningKeyInterface
 
-      def initialize(authenticator_parameters:,
+      def initialize(authentication_parameters:,
                      logger:,
                      fetch_required_secrets:,
                      resource_class:,
                      discover_identity_provider:)
         @logger = logger
-        @resource_id = authenticator_parameters.authenticator_resource_id
+        @resource_id = authentication_parameters.authenticator_resource_id
         @fetch_required_secrets = fetch_required_secrets
         @resource_class = resource_class
         @discover_identity_provider = discover_identity_provider

--- a/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/fetch_provider_uri_signing_key.rb
@@ -1,0 +1,75 @@
+module Authentication
+  module AuthnJwt
+    # This class is responsible for fetching JWK Set from provider-uri
+    class FetchProviderUriSigningKey < FetchSigningKeyInterface
+
+      def initialize(authenticator_parameters,
+                     logger,
+                     fetch_required_secrets,
+                     resource_class,
+                     discover_identity_provider)
+        @logger = logger
+        @resource_id = authenticator_parameters.authenticator_resource_id
+        @fetch_required_secrets = fetch_required_secrets
+        @resource_class = resource_class
+        @discover_identity_provider = discover_identity_provider
+      end
+
+      def has_valid_configuration?
+        @provier_uri_resource_exists ||= provider_uri_resource_exists?
+      end
+
+      def fetch_signing_key
+        discover_provider
+        fetch_provider_keys
+      end
+
+      private
+
+      def provider_uri_resource_exists?
+        !provider_uri_resource.nil?
+      end
+
+      def provider_uri_resource
+        @provider_uri_resource ||= resource
+      end
+
+      def resource
+        @resource_class[provider_uri_resource_id]
+      end
+
+      def provider_uri
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ProviderUriResourceNameConfiguration.new(provider_uri_resource_id))
+        @provider_uri ||= provider_uri_secret[provider_uri_resource_id]
+      end
+
+      def provider_uri_secret
+        @provider_uri_secret ||= @fetch_required_secrets.(resource_ids: [provider_uri_resource_id])
+      end
+
+      def provider_uri_resource_id
+        "#{@resource_id}/#{PROVIDER_URI_RESOURCE_NAME}"
+      end
+
+      def discover_provider
+        discovered_provider
+      end
+
+      def discovered_provider
+        @discovered_provider ||= @discover_identity_provider.(
+          provider_uri: provider_uri
+        )
+      end
+
+      def fetch_provider_keys
+        @logger.debug(LogMessages::Authentication::OAuth::FetchProviderKeysSuccess.new)
+        @discovered_provider.jwks
+      rescue => e
+        raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(
+          @provider_uri,
+          e.inspect
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/fetch_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/fetch_signing_key_interface.rb
@@ -1,0 +1,8 @@
+module Authentication
+  module AuthnJwt
+    class FetchSigningKeyInterface
+      def create; end
+      def has_valid_configuration?; end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -411,8 +411,26 @@ module Errors
 
       MissingToken = ::Util::TrackableErrorClass.new(
         msg: "Token is empty or not found.",
-        code: "CONJ00077E"
+        code: "CONJ00177E"
       )
+
+      InvalidUriConfiguration = ::Util::TrackableErrorClass.new(
+        msg: "Uri authenticator configuration is invalid. It should configured as authenticator variables: " \
+              "one of the following: '{0-resource-name}','{1-resource-name}'",
+        code: "CONJ00178E"
+      )
+
+      InvalidUriConfiguration = ::Util::TrackableErrorClass.new(
+        msg: "Uri authenticator configuration is invalid. It should configured as authenticator variables: " \
+              "one of the following: '{0-resource-name}','{1-resource-name}'",
+        code: "CONJ00179E"
+      )
+
+      FetchJwksKeysFailed = ::Util::TrackableErrorClass.new(
+        msg: "Failed to fetch keys from Jwks Uri (JWKS URI: '{0}'). Reason: '{1}'",
+        code: "CONJ00180E"
+      )
+
     end
 
     module ResourceRestrictions
@@ -447,11 +465,6 @@ module Errors
       RoleMissingRequiredConstraints = ::Util::TrackableErrorClass.new(
         msg: "Role must have at least one of the following constraints: {0-constraints}",
         code: "CONJ00069E"
-      )
-
-      RoleMissingAnyConstraints =  ::Util::TrackableErrorClass.new(
-        msg: "Role must have at least one constraint",
-        code: "CONJ00070E"
       )
 
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -415,20 +415,25 @@ module Errors
       )
 
       InvalidUriConfiguration = ::Util::TrackableErrorClass.new(
-        msg: "Uri authenticator configuration is invalid. It should configured as authenticator variables: " \
+        msg: "Signing key uri authenticator configuration is invalid. It should configured as authenticator variables: " \
               "one of the following: '{0-resource-name}','{1-resource-name}'",
         code: "CONJ00178E"
       )
 
       InvalidUriConfiguration = ::Util::TrackableErrorClass.new(
-        msg: "Uri authenticator configuration is invalid. It should configured as authenticator variables: " \
+        msg: "Signing key uri authenticator configuration is invalid. It should configured as authenticator variables: " \
               "one of the following: '{0-resource-name}','{1-resource-name}'",
         code: "CONJ00179E"
       )
 
       FetchJwksKeysFailed = ::Util::TrackableErrorClass.new(
-        msg: "Failed to fetch keys from Jwks Uri (JWKS URI: '{0}'). Reason: '{1}'",
+        msg: "Failed to fetch jwks from '{0-uri}'. Reason: '{1}'",
         code: "CONJ00180E"
+      )
+
+      FetchJwksUriKeysNotFound = ::Util::TrackableErrorClass.new(
+        msg: "Fetched jwks not found in response: {0}",
+        code: "CONJ00181E"
       )
 
     end
@@ -467,6 +472,10 @@ module Errors
         code: "CONJ00069E"
       )
 
+      RoleMissingAnyConstraints =  ::Util::TrackableErrorClass.new(
+        msg: "Role must have at least one constraint",
+        code: "CONJ00070E"
+      )
     end
   end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -360,6 +360,50 @@ module LogMessages
         code: "CONJ00070D"
       )
 
+      FetchingJwksUriConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwks-uri authenticator configuration value",
+        code: "CONJ00071D"
+      )
+
+      FetchedJwksUriValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched jwks-uri value from authenticator configuration",
+        code: "CONJ00072D"
+      )
+
+      FetchingProviderUriConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching provider-uri authenticator configuration value",
+        code: "CONJ00073D"
+      )
+
+      FetchedProviderUriValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched provider-uri value from authenticator configuration",
+        code: "CONJ00074D"
+      )
+
+      JwksUriResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Jwks-uri value will be taken from '{0-resource-id}'",
+        code: "CONJ00075D"
+      )
+
+      ProviderUriResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Provider-uri value will be taken from '{0-resource-id}'",
+        code: "CONJ00076D"
+      )
+
+      FetchProviderUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched Identity Provider keys from provider successfully'",
+        code: "CONJ00077D"
+      )
+
+      FetchingJwksFromJwksUri = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwks from jwks-uri",
+        code: "CONJ00078D"
+      )
+
+      FetchJwksUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched jwks keys from jwks-uri successfully'",
+        code: "CONJ00079D"
+      )
     end
   end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -360,49 +360,34 @@ module LogMessages
         code: "CONJ00070D"
       )
 
-      FetchingJwksUriConfigurationValue = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetching jwks-uri authenticator configuration value",
+      FetchingJwtConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwt signing key uri from '{0-resource-id}'",
         code: "CONJ00071D"
       )
 
-      FetchedJwksUriValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetched jwks-uri value from authenticator configuration",
+      FetchingJwksFromProvider = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwks from '{0-uri}'",
         code: "CONJ00072D"
       )
 
-      FetchingProviderUriConfigurationValue = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetching provider-uri authenticator configuration value",
+      FetchJwtUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched jwks successfully",
         code: "CONJ00073D"
       )
 
-      FetchedProviderUriValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetched provider-uri value from authenticator configuration",
+      ValidatingJwtSigningKeyConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating Jwt signing key uri configuration",
         code: "CONJ00074D"
       )
 
-      JwksUriResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
-        msg: "Jwks-uri value will be taken from '{0-resource-id}'",
+      FetchingProviderUriSigningKey = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching provider-uri signing key",
         code: "CONJ00075D"
       )
 
-      ProviderUriResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
-        msg: "Provider-uri value will be taken from '{0-resource-id}'",
+      FetchingJwksUriSigningKey = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwks-uri signing key",
         code: "CONJ00076D"
-      )
-
-      FetchProviderUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetched Identity Provider keys from provider successfully'",
-        code: "CONJ00077D"
-      )
-
-      FetchingJwksFromJwksUri = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetching jwks from jwks-uri",
-        code: "CONJ00078D"
-      )
-
-      FetchJwksUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetched jwks keys from jwks-uri successfully'",
-        code: "CONJ00079D"
       )
     end
   end

--- a/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
           fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
           logger: mocked_logger
         ).call(
-          authenticator_parameters: authentication_parameters
+          authentication_parameters: authentication_parameters
         )
       end
 
@@ -90,7 +90,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
           fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
           logger: mocked_logger
         ).call(
-          authenticator_parameters: authentication_parameters
+          authentication_parameters: authentication_parameters
         )
       end
 
@@ -107,7 +107,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
           fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
           logger: mocked_logger
         ).call(
-          authenticator_parameters: authentication_parameters
+          authentication_parameters: authentication_parameters
         )
       end
 
@@ -124,7 +124,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
           fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
           logger: mocked_logger
         ).call(
-          authenticator_parameters: authentication_parameters
+          authentication_parameters: authentication_parameters
         )
       end
 

--- a/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
   let(:mocked_fetch_non_exists_jwks_uri) { double("Mocked fetch with non-existing jwks-uri")  }
   let(:mocked_exists_has_valid_configuration) { double("Mocked valid configuration")  }
   let(:mocked_non_exists_has_valid_configuration) { double("Mocked invalid configuration")  }
+  let(:mocked_logger) { double("Mocked logger")  }
 
   before(:each) do
     allow(mocked_fetch_exists_provider_uri).to(
@@ -52,6 +53,10 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
       receive(:has_valid_configuration?).and_return(false)
     )
 
+    allow(mocked_logger).to(
+      receive(:debug).and_return(nil)
+    )
+
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
@@ -65,7 +70,8 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
       subject do
         ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
           fetch_provider_uri: mocked_fetch_exists_provider_uri,
-          fetch_jwks_uri: mocked_fetch_exists_jwks_uri
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
+          logger: mocked_logger
         ).call(
           authenticator_parameters: authentication_parameters
         )
@@ -81,7 +87,8 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
       subject do
         ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
           fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
-          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
+          logger: mocked_logger
         ).call(
           authenticator_parameters: authentication_parameters
         )
@@ -97,7 +104,8 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
       subject do
         ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
           fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
-          fetch_jwks_uri: mocked_fetch_exists_jwks_uri
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
+          logger: mocked_logger
         ).call(
           authenticator_parameters: authentication_parameters
         )
@@ -113,7 +121,8 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
       subject do
         ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
           fetch_provider_uri: mocked_fetch_exists_provider_uri,
-          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
+          logger: mocked_logger
         ).call(
           authenticator_parameters: authentication_parameters
         )

--- a/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy_identity",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    ))
+  }
+
+  let(:mocked_fetch_exists_provider_uri) { double("Mocked fetch with existing provider-uri")  }
+  let(:mocked_fetch_non_exists_provider_uri) { double("Mocked fetch with non-existing provider-uri")  }
+  let(:mocked_fetch_exists_jwks_uri) { double("Mocked fetch with existing jwks-uri")  }
+  let(:mocked_fetch_non_exists_jwks_uri) { double("Mocked fetch with non-existing jwks-uri")  }
+  let(:mocked_exists_has_valid_configuration) { double("Mocked valid configuration")  }
+  let(:mocked_non_exists_has_valid_configuration) { double("Mocked invalid configuration")  }
+
+  before(:each) do
+    allow(mocked_fetch_exists_provider_uri).to(
+      receive(:new).and_return(mocked_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_non_exists_provider_uri).to(
+      receive(:new).and_return(mocked_non_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_exists_jwks_uri).to(
+      receive(:new).and_return(mocked_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_non_exists_jwks_uri).to(
+      receive(:new).and_return(mocked_non_exists_has_valid_configuration)
+    )
+
+    allow(mocked_exists_has_valid_configuration).to(
+      receive(:has_valid_configuration?).and_return(true)
+    )
+
+    allow(mocked_non_exists_has_valid_configuration).to(
+      receive(:has_valid_configuration?).and_return(false)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "CreateSigningKeyInterface " do
+    context "'jwks-uri' and 'provider-uri' exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri
+        ).call(
+          authenticator_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+    context "'jwks-uri' and 'provider-uri' does not exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri
+        ).call(
+          authenticator_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+    context "'jwks-uri' does not exits and 'provider-uri' exists" do
+
+      subject do
+        ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri
+        ).call(
+          authenticator_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to_not raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+    context "'jwks-uri' exists and 'provider-uri' does not exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri
+        ).call(
+          authenticator_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to_not raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_jwks_signing_key_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
 
   let(:required_jwks_uri_configuration_error) { "required jwks_uri configuration missing error" }
   let(:mocked_logger) { double("Mocked Logger")  }
-  let(:mocked_authenticator_params) { double("mocked authenticator params")  }
+  let(:mocked_authentication_parameters) { double("mocked authenticator params")  }
   let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
   let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
   let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
@@ -32,7 +32,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
       receive(:debug).and_return(true)
     )
 
-    allow(mocked_authenticator_params).to(
+    allow(mocked_authentication_parameters).to(
       receive(:authenticator_resource_id).and_return('resource_id')
     )
 
@@ -81,7 +81,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
   context "FetchJwksUriSigningKey has_valid_configuration " do
     context "'jwks-uri' variable is not configured in authenticator policy" do
       subject do
-        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                logger: mocked_logger,
                                                                fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                resource_class: mocked_resource_value_not_exists,
@@ -95,7 +95,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
 
     context "'jwks-uri' variable is configured in authenticator policy" do
       subject do
-        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                logger: mocked_logger,
                                                                fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                resource_class: mocked_resource_value_exists,
@@ -111,7 +111,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
   context "FetchJwksUriSigningKey fetch_signing_key " do
     context "'jwks-uri' secret is not valid" do
       subject do
-        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                logger: mocked_logger,
                                                                fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                resource_class: mocked_resource_value_exists,
@@ -125,7 +125,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
 
     context "'jwks-uri' secret is valid" do
       subject do
-        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                logger: mocked_logger,
                                                                fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                resource_class: mocked_resource_value_exists,

--- a/spec/app/domain/authentication/authn-jwt/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_jwks_signing_key_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe('Authentication::AuthnJwt::FetchJwksUriSigningKey') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:required_jwks_uri_configuration_error) { "required jwks_uri configuration missing error" }
+  let(:mocked_logger) { double("Mocked Logger")  }
+  let(:mocked_authenticator_params) { double("mocked authenticator params")  }
+  let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
+  let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
+  let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
+  let(:mocked_resource_value_exists) { double("Mocked resource value exists")  }
+  let(:mocked_http) { double("Mocked http")  }
+  let(:mocked) { double("Mocked http")  }
+
+  before(:each) do
+    allow(mocked_logger).to(
+      receive(:call).and_return(true)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(true)
+    )
+
+    allow(mocked_authenticator_params).to(
+      receive(:authenticator_resource_id).and_return('resource_id')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:call).and_return('resource_id/jwks-uri' => 'https://jwks-uri.com/jwks')
+    )
+
+    allow(mocked_fetch_required_empty_secret).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_value_not_exists).to(
+      receive(:[]).and_raise(required_jwks_uri_configuration_error)
+    )
+
+    allow(mocked_resource_value_exists).to(
+      receive(:[]).and_return("resource")
+    )
+
+    allow(mocked_http).to(
+      receive(:get_response).and_return(mocked)
+    )
+
+    allow(mocked).to(
+      receive(:body).and_return('{"keys":[{"kty":"RSA","kid":"FirstKid","e":"AQAB","n":"FirstJwtToken","use":"sig","alg":"RS256"},{"kty":"RSA","kid":"secondKid","e":"AQAB","n":"SecondJwtToken","use":"sig","alg":"RS256"}]}'.to_json)
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "FetchJwksUriSigningKey has_valid_configuration " do
+    context "'jwks-uri' variable is not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(mocked_authenticator_params,
+                                                               mocked_logger,
+                                                               mocked_fetch_required_existing_secret,
+                                                               mocked_resource_value_not_exists,
+                                                               mocked_http).has_valid_configuration?
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_jwks_uri_configuration_error)
+      end
+    end
+
+    context "'jwks-uri' variable is configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(mocked_authenticator_params,
+                                                               mocked_logger,
+                                                               mocked_fetch_required_existing_secret,
+                                                               mocked_resource_value_exists,
+                                                               mocked_http).has_valid_configuration?
+      end
+
+      it "does not raise error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+  context "FetchJwksUriSigningKey fetch_signing_key " do
+    context "'jwks-uri' secret is valid" do
+      subject do
+        ::Authentication::AuthnJwt::FetchJwksUriSigningKey.new(mocked_authenticator_params,
+                                                               mocked_logger,
+                                                               mocked_fetch_required_existing_secret,
+                                                               mocked_resource_value_exists,
+                                                               mocked_http).fetch_signing_key
+      end
+
+      it "does not raise error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/fetch_provider_uri_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_provider_uri_signing_key_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:required_provider_uri_configuration_error) { "required provider_uri configuration missing error" }
+  let(:mocked_logger) { double("Mocked Logger")  }
+  let(:mocked_authenticator_params) { double("mocked authenticator params")  }
+  let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
+  let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
+  let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
+  let(:mocked_resource_value_exists) { double("Mocked resource value exists")  }
+  let(:mocked_discover_identity_provider) { double("Mocked discover identity provider")  }
+  let(:mocked_provider_uri) { double("Mocked provider uri")  }
+
+  before(:each) do
+    allow(mocked_logger).to(
+      receive(:call).and_return(true)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(true)
+    )
+
+    allow(mocked_authenticator_params).to(
+      receive(:authenticator_resource_id).and_return('resource_id')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:[]).and_return('resource_id/provider-uri' => 'https://provider-uri.com/provider')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:call).and_return('resource_id/provider-uri' => 'https://provider-uri.com/provider')
+    )
+
+    allow(mocked_fetch_required_empty_secret).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_value_not_exists).to(
+      receive(:[]).and_raise(required_provider_uri_configuration_error)
+    )
+
+    allow(mocked_resource_value_exists).to(
+      receive(:[]).and_return("resource")
+    )
+
+    allow(mocked_discover_identity_provider).to(
+      receive(:call).and_return(mocked_provider_uri)
+    )
+
+    allow(mocked_provider_uri).to(
+      receive(:jwks).and_return("Some Jwks")
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "FetchproviderUriSigningKey has_valid_configuration " do
+    context "'provider-uri' variable is not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(mocked_authenticator_params,
+                                                                   mocked_logger,
+                                                                   mocked_fetch_required_existing_secret,
+                                                                   mocked_resource_value_not_exists,
+                                                                   mocked_discover_identity_provider).has_valid_configuration?
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_provider_uri_configuration_error)
+      end
+    end
+
+    context "'provider-uri' variable is configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(mocked_authenticator_params,
+                                                                   mocked_logger,
+                                                                   mocked_fetch_required_existing_secret,
+                                                                   mocked_resource_value_exists,
+                                                                   mocked_discover_identity_provider).has_valid_configuration?
+      end
+
+      it "does not raise error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/fetch_provider_uri_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/fetch_provider_uri_signing_key_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
   let(:required_discover_identity_error) { "Provider uri identity error" }
 
   let(:mocked_logger) { double("Mocked Logger")  }
-  let(:mocked_authenticator_params) { double("mocked authenticator params")  }
+  let(:mocked_authentication_parameters) { double("mocked authenticator params")  }
   let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
   let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
   let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
@@ -32,7 +32,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
       receive(:debug).and_return(true)
     )
 
-    allow(mocked_authenticator_params).to(
+    allow(mocked_authentication_parameters).to(
       receive(:authenticator_resource_id).and_return('resource_id')
     )
 
@@ -77,7 +77,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
   context "FetchProviderUriSigningKey has_valid_configuration " do
     context "'provider-uri' variable is not configured in authenticator policy" do
       subject do
-        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                    logger: mocked_logger,
                                                                    fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                    resource_class: mocked_resource_value_not_exists,
@@ -91,7 +91,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
 
     context "'provider-uri' value is valid" do
       subject do
-        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+        ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                    logger: mocked_logger,
                                                                    fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                    resource_class: mocked_resource_value_exists,
@@ -108,7 +108,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
     context "'provider-uri' variable is configured in authenticator policy" do
       context "'provider-uri' value is invalid" do
         subject do
-          ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+          ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                      logger: mocked_logger,
                                                                      fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                      resource_class: mocked_resource_value_exists,
@@ -122,7 +122,7 @@ RSpec.describe('Authentication::AuthnJwt::FetchProviderUriSigningKey') do
 
       context "'provider-uri' value is valid" do
         subject do
-          ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authenticator_parameters: mocked_authenticator_params,
+          ::Authentication::AuthnJwt::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
                                                                      logger: mocked_logger,
                                                                      fetch_required_secrets: mocked_fetch_required_existing_secret,
                                                                      resource_class: mocked_resource_value_exists,


### PR DESCRIPTION
### What does this PR do?
- _Added fetch sign in key logic to jwt including a factory for different vendor configurations

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
