### PR TITLE
2159 fix conjurctl account create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug where running `conjurctl server` or `conjurctl account create` with
+  passwords that contain `,`s sent via stdin raised an error.
+  [cyberark/conjur#2159](https://github.com/cyberark/conjur/issues/2159)
+
 ### Security
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885 
   [cyberark/conjur#2149](https://github.com/cyberark/conjur/issues/2149)
@@ -14,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix bug where running `conjurctl server` or `conjurctl account create` with
   non-alpha-numeric passwords sent via stdin raised an error.
-  [cyberark/conjur#2083](https://github.com/cyberark/conjur/issues/2083)
+  [cyberark/conjur#2114](https://github.com/cyberark/conjur/issues/2114)
 
 ### Changed
 - The batch secret retrieval endpoint now returns a 406 Not Acceptable instead

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -81,7 +81,10 @@ command :server do |c|
 
     if account
       if options["password-from-stdin"]
-        password = stdin_input
+        # Rake is interpreting raw commas in the password as
+        # delimiting addtional arguments to rake itself. 
+        # Reference: https://github.com/ruby/rake/blob/a842fb2c30cc3ca80803fba903006b1324a62e9a/lib/rake/application.rb#L163
+        password = stdin_input.gsub(',', '\,')
         system("rake 'account:create_with_password[#{account},#{password}]'")\
           or exit $?.exitstatus
       else
@@ -233,7 +236,10 @@ $ conjurctl account create [--password-from-stdin] --name myorg
       connect
 
       if options["password-from-stdin"]
-        password = stdin_input
+        # Rake is interpreting raw commas in the password as
+        # delimiting addtional arguments to rake itself. 
+        # Reference: https://github.com/ruby/rake/blob/a842fb2c30cc3ca80803fba903006b1324a62e9a/lib/rake/application.rb#L163
+        password = stdin_input.gsub(',', '\,')
         exec("rake 'account:create_with_password[#{account},#{password}]'")
       else
         exec("rake 'account:create[#{account}]'")

--- a/cucumber/api/features/account_create.feature
+++ b/cucumber/api/features/account_create.feature
@@ -133,5 +133,5 @@ Feature: Create a new account
 
   @create_account
   Scenario: Creating account with predefined password and login with it
-    Given I create an account with the name "demo" and the password "MySecretP@SS1()!" using conjurctl
-    Then I can GET "/authn/demo/login" with username "admin" and password "MySecretP@SS1()!"
+    Given I create an account with the name "demo" and the password "MySecretP,@SS1()!" using conjurctl
+    Then I can GET "/authn/demo/login" with username "admin" and password "MySecretP,@SS1()!"

--- a/spec/conjurctl/account_spec.rb
+++ b/spec/conjurctl/account_spec.rb
@@ -18,7 +18,7 @@ describe "account" do
       delete_account("demo")
     end
     
-    let(:password) { "MySecretP@SS1()!" }
+    let(:password) { "MySecretP,@SS1()!" }
     let(:create_account_with_password_and_name_flag) do
       "conjurctl account create --name demo --password-from-stdin"
     end

--- a/spec/conjurctl/server_spec.rb
+++ b/spec/conjurctl/server_spec.rb
@@ -40,7 +40,7 @@ describe "conjurctl server" do
     it "with both account and password-from-stdin flags" do
       # Run in background to easily kill process later
       system("
-        echo -n 'MySecretP@SS1()!' | 
+        echo -n 'MySecretP,@SS1()!' | 
         conjurctl server --account demo --password-from-stdin &
       ")
       wait_for_conjur


### PR DESCRIPTION
### What does this PR do?
Passwords provided to `conjurctl account create` and `conjurctl server` now passes when they contain `,`s.

### What ticket does this PR close?
#2159 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
