### PR TITLE
Set the puma persistent_timeout higher than nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix bug where running `conjurctl server` or `conjurctl account create` with
   passwords that contain `,`s sent via stdin raised an error.
   [cyberark/conjur#2159](https://github.com/cyberark/conjur/issues/2159)
+- Specify keepalive timeout for puma to be longer than proxy and load balancers
 
 ### Security
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,6 +11,15 @@ threads threads_count, threads_count
 # cause and implement a permanent solution.
 worker_timeout 600
 
+# If the load balancer/proxy/server in front of Conjur has
+# a longer timeout than Conjur, there will be 502s as Conjur will
+# close the connection even if there are pending requests. This
+# can lead to it being marked unavailable, errors returned to the
+# client and performance issues as nginx/load balancer in front of it.
+# Puma defaults to 20 seconds which is substantially lower than
+# other service defaults
+persistent_timeout 80
+
 preload_app!
 
 rackup      DefaultRackup


### PR DESCRIPTION
If the load balancer/proxy/server in front of Conjur has
a longer timeout than Conjur, there will be 502s as Conjur will
close the connection even if there are pending requests.  This
can lead to it being marked unavailable, errors returned to the
client and performance issues as nginx/load balancer in front of it

### What does this PR do?
- _What's changed? Why were these changes made?_ This specifies the puma `persistent_timeout` value that should be higher than any load balancer or proxy in front of Conjur.  The default value is 20 seconds, shorter than nginx and most load balancer default values.

### What ticket does this PR close?
#### Resolves 
- [conjurinc/ops#778 (private)](conjurinc/ops#778)
- [cyberark/conjur-ecs-deploy#28 (private)](cyberark/conjur-ecs-deploy#28)

#### Potentially solves symptoms associated with
- [conjurinc/appliance#1201 (private)](conjurinc/appliance#1201)
- The multitude of retries we have built in to our tests in case of intermittent gateway errors

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API

