### PR TITLE
Authn jwt status new api

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -31,6 +31,16 @@ class AuthenticateController < ApplicationController
     render(status_failure_response(e))
   end
 
+  def authn_jwt_status
+    Authentication::AuthnJwt::ValidateStatus.new.call(
+      authenticator_status_input: status_input("authn-jwt")
+    )
+    render(json: { status: "ok" })
+  rescue => e
+    log_backtrace(e)
+    render(status_failure_response(e))
+  end
+
   def update_config
     body_params = Rack::Utils.parse_nested_query(request.body.read)
 
@@ -47,9 +57,9 @@ class AuthenticateController < ApplicationController
     handle_authentication_error(e)
   end
 
-  def status_input
+  def status_input(authenticator_name = params[:authenticator])
     Authentication::AuthenticatorStatusInput.new(
-      authenticator_name: params[:authenticator],
+      authenticator_name: authenticator_name,
       service_id: params[:service_id],
       account: params[:account],
       username: ::Role.username_from_roleid(current_user.role_id),

--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -4,7 +4,7 @@ module Authentication
   module AuthnJwt
     # Generic JWT authenticator that receive JWT vendor configuration and uses to validate that the authentication
     # request is valid, and return conjur authn token accordingly
-    Authenticate = CommandClass.new(
+    Authenticator = CommandClass.new(
       dependencies: {
         token_factory: TokenFactory.new,
         logger: Rails.logger

--- a/app/domain/authentication/authn_jwt/identity_from_decoded_token_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_from_decoded_token_provider.rb
@@ -29,6 +29,12 @@ module Authentication
 
       private
 
+      # This method is for the authenticator status check, unlike 'identity_available?' it checks if the
+      # secret value is not empty too
+      def identity_configured_properly?
+        raise Errors::Authentication::AuthnJwt::IdentitySecretIsEmpty.new if fetch_token_field_name.blank?
+      end
+
       def identity_field_variable
         @resource_class[token_id_field_resource_id]
       end

--- a/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
@@ -8,7 +8,7 @@ module Authentication
       dependencies: {
         validate_uri_based_parameters: Authentication::AuthnJwt::ValidateUriBasedParameters.new,
         jwt_configuration_factory: ConfigurationFactory.new,
-        jwt_authenticator: Authentication::AuthnJwt::Authenticate.new,
+        jwt_authenticator: Authentication::AuthnJwt::Authenticator.new,
         logger: Rails.logger
       },
       inputs: %i[authenticator_input enabled_authenticators]

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -1,0 +1,120 @@
+module Authentication
+  module AuthnJwt
+
+    ValidateStatus = CommandClass.new(
+      dependencies: {
+        create_signing_key: Authentication::AuthnJwt::CreateSigningKeyInterface.new,
+        fetch_issuer_value: Authentication::AuthnJwt::FetchIssuerValue.new,
+        fetch_identity_from_token: Authentication::AuthnJwt::IdentityFromDecodedTokenProvider,
+        validate_webservice_is_whitelisted: ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,
+        validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
+        validate_webservice_exists: ::Authentication::Security::ValidateWebserviceExists.new,
+        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV),
+        validate_account_exists: ::Authentication::Security::ValidateAccountExists.new,
+        logger: Rails.logger
+      },
+      inputs: %i[authenticator_status_input]
+    ) do
+      extend(Forwardable)
+      def_delegators(:@authenticator_status_input, :authenticator_name, :account,
+                     :username, :status_webservice, :service_id, :client_ip)
+
+      def call
+        validate_generic_status_validations
+        validate_secrets
+      end
+
+      private
+
+      def validate_generic_status_validations
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingJwtStatusConfiguration.new)
+        validate_account_exists
+        validate_service_id_exists
+        validate_user_has_access_to_status_webservice
+        validate_authenticator_webservice_exists
+        validate_webservice_is_whitelisted
+      end
+
+      def validate_user_has_access_to_status_webservice
+        @validate_role_can_access_webservice.(
+          webservice: status_webservice,
+            account: account,
+            user_id: username,
+            privilege: 'read'
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedUserHasAccessToStatusWebservice.new)
+      end
+
+      def validate_webservice_is_whitelisted
+        @validate_webservice_is_whitelisted.(
+          webservice: webservice,
+            account: account,
+            enabled_authenticators: @enabled_authenticators
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedStatusWebserviceIsWhitelisted.new)
+      end
+
+      def validate_authenticator_webservice_exists
+        @validate_webservice_exists.(
+          webservice: webservice,
+            account: account
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedAuthenticatorWebServiceExists.new)
+      end
+
+      def validate_service_id_exists
+        raise Errors::Authentication::AuthnJwt::ServiceIdMissing.new unless service_id
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedStatusServiceIdExists.new)
+      end
+
+      def validate_account_exists
+        @validate_account_exists.(
+          account: account
+        )
+      end
+
+      def validate_secrets
+        validate_signing_key_secrets
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedSigningKeyConfiguration.new)
+        validate_issuer
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedIssuerConfiguration.new)
+        validate_identity_secrets
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedIdentityConfiguration.new)
+      end
+
+      def validate_signing_key_secrets
+        @create_signing_key.call(authentication_parameters: authentication_parameters)
+      end
+
+      def validate_issuer
+        @fetch_issuer_value.call(authentication_parameters: authentication_parameters)
+      end
+
+      def validate_identity_secrets
+        @fetch_identity_from_token.new(authentication_parameters).identity_configured_properly?
+      end
+
+      def authentication_parameters
+        @authentication_parameters ||= Authentication::AuthnJwt::AuthenticationParameters.new(
+          Authentication::AuthenticatorInput.new(
+            authenticator_name: authenticator_name,
+            service_id: service_id,
+            account: account,
+            username: username,
+            client_ip: client_ip,
+            credentials: nil,
+            request: nil
+          )
+        )
+      end
+
+      def webservice
+        @webservice ||= ::Authentication::Webservice.new(
+          account: account,
+          authenticator_name: authenticator_name,
+          service_id: service_id
+        )
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -481,6 +481,16 @@ module Errors
         code: "CONJ00188E"
       )
 
+      IdentitySecretIsEmpty = ::Util::TrackableErrorClass.new(
+        msg: "Identity secret value is empty",
+        code: "CONJ00189E"
+      )
+
+      ServiceIdMissing = ::Util::TrackableErrorClass.new(
+        msg: "Service id is required when authenticating with authn-jwt",
+        code: "CONJ00190E"
+      )
+
     end
 
     module ResourceRestrictions

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -448,6 +448,47 @@ module LogMessages
         msg: "Successfully created JWKS",
         code: "CONJ00088D"
       )
+
+      ValidatedIdentityConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated identity configuration",
+        code: "CONJ00089D"
+      )
+
+      ValidatingJwtStatusConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating JWT status configuration...",
+        code: "CONJ00090D"
+      )
+
+      ValidatedUserHasAccessToStatusWebservice = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated user has access to status webservice",
+        code: "CONJ00091D"
+      )
+
+      ValidatedAuthenticatorWebServiceExists = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated status webservice exists",
+        code: "CONJ00092D"
+      )
+
+      ValidatedStatusWebserviceIsWhitelisted = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully status webservice is whitelisted",
+        code: "CONJ00093D"
+      )
+
+      ValidatedStatusServiceIdExists = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated status service-ID exists",
+        code: "CONJ00094D"
+      )
+
+      ValidatedSigningKeyConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated Signing key configuration",
+        code: "CONJ00095D"
+      )
+
+      ValidatedIssuerConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated issuer configuration",
+        code: "CONJ00096D"
+      )
+
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
     constraints account: /[^\/?]+/ do
       constraints authenticator: /authn-?[^\/]*/, id: /[^\/?]+/ do
+        get '/authn-jwt/:service_id/:account/status' => 'authenticate#authn_jwt_status'
         get '/:authenticator(/:service_id)/:account/status' => 'authenticate#status'
         
         patch '/:authenticator/:service_id/:account' => 'authenticate#update_config'

--- a/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/create_signing_key_interface_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
         )
       end
 
-      it "raises an error" do
+      it "does not raise an error" do
         expect { subject }.to_not raise_error
       end
     end
@@ -128,7 +128,7 @@ RSpec.describe('Authentication::AuthnJwt::CreateSigningKeyInterface') do
         )
       end
 
-      it "raises an error" do
+      it "does not raise an error" do
         expect { subject }.to_not raise_error
       end
     end

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_status_input) {
+    Authentication::AuthenticatorStatusInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy_identity",
+      client_ip: "dummy",
+      credentials: nil,
+      request: nil
+    )
+  }
+
+  let(:mocked_logger) { double("Mocked logger")  }
+  let(:mocked_valid_create_signing_key_interface) { double("Mocked valid create signing key interface")  }
+  let(:mocked_invalid_create_signing_key_interface) { double("Mocked invalid create signing key interface")  }
+  let(:mocked_valid_fetch_issuer_value) { double("Mocked valid fetch issuer value")  }
+  let(:mocked_invalid_fetch_issuer_value) { double("Mocked invalid fetch issuer value")  }
+  let(:mocked_valid_identity_from_decoded_token_provider) { double("Mocked valid identity from decoded token provider")  }
+  let(:mocked_valid_identity_configured_properly) { double("Mocked valid identity configured properly")  }
+  let(:mocked_invalid_identity_from_decoded_token_provider) { double("Mocked invalid identity from decoded token provider")  }
+  let(:mocked_invalid_identity_configured_properly) { double("Mocked invalid identity configured properly")  }
+  let(:mocked_valid_validate_webservice_is_whitelisted) { double("Mocked valid validate webservice is whitelisted")  }
+  let(:mocked_invalid_validate_webservice_is_whitelisted) { double("Mocked invalid validate webservice is whitelisted")  }
+  let(:mocked_valid_validate_can_access_webservice) { double("Mocked valid validate can access webservice")  }
+  let(:mocked_invalid_validate_can_access_webservice) { double("Mocked invalid validate can access webservice")  }
+  let(:mocked_valid_validate_webservice_exists) { double("Mocked valid validate wevservice exists")  }
+  let(:mocked_invalid_validate_webservice_exists) { double("Mocked invalid validate wevservice exists")  }
+  let(:mocked_valid_validate_account_exists) { double("Mocked valid validate account exists")  }
+  let(:mocked_invalid_validate_account_exists) { double("Mocked invalid validate account exists")  }
+  let(:mocked_enabled_authenticators) { double("Mocked logger")  }
+
+  let(:create_signing_key_configuration_is_invalid_error) { "Create signing key configuration is invalid" }
+  let(:fetch_issuer_configuration_is_invalid_error) { "Fetch issuer configuration is invalid" }
+  let(:identity_configuration_is_invalid_error) { "Identity configuration is invalid" }
+  let(:webservice_is_not_whitelisted_error) { "Webservice is not whitelisted" }
+  let(:user_cant_access_webservice_error) { "User cant access webservice" }
+  let(:webservice_does_not_exist_error) { "Webservice does not exist" }
+  let(:account_does_not_exist_error) { "Account does not exist" }
+
+  before(:each) do
+    allow(mocked_valid_create_signing_key_interface).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_create_signing_key_interface).to(
+      receive(:call).and_raise(create_signing_key_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_fetch_issuer_value).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_fetch_issuer_value).to(
+      receive(:call).and_raise(fetch_issuer_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_identity_from_decoded_token_provider).to(
+      receive(:new).and_return(mocked_valid_identity_configured_properly)
+    )
+
+    allow(mocked_valid_identity_configured_properly).to(
+      receive(:identity_configured_properly?).and_return(nil)
+    )
+
+    allow(mocked_invalid_identity_from_decoded_token_provider).to(
+      receive(:new).and_return(mocked_invalid_identity_configured_properly)
+    )
+
+    allow(mocked_invalid_identity_configured_properly).to(
+      receive(:identity_configured_properly?).and_raise(identity_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_validate_webservice_is_whitelisted).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_webservice_is_whitelisted).to(
+      receive(:call).and_raise(webservice_is_not_whitelisted_error)
+    )
+
+    allow(mocked_valid_validate_can_access_webservice).to(
+      receive(:call).with(anything()).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_can_access_webservice).to(
+      receive(:call).and_raise(user_cant_access_webservice_error)
+    )
+
+    allow(mocked_valid_validate_webservice_exists).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_webservice_exists).to(
+      receive(:call).and_raise(webservice_does_not_exist_error)
+    )
+
+    allow(mocked_enabled_authenticators).to(
+      receive(:new).and_return(mocked_enabled_authenticators)
+    )
+
+    allow(mocked_valid_validate_account_exists).to(
+      receive(:call).with(account: account).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_account_exists).to(
+      receive(:call).with(account: account).and_raise(account_does_not_exist_error)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(nil)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "ValidateStatus" do
+    context "generic and authenticator validations succeed" do
+
+      subject do
+        ::Authentication::AuthnJwt::ValidateStatus.new(
+          create_signing_key: mocked_valid_create_signing_key_interface,
+          fetch_issuer_value: mocked_valid_fetch_issuer_value,
+          fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+          validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+          validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+          validate_webservice_exists: mocked_valid_validate_webservice_exists,
+          enabled_authenticators: mocked_enabled_authenticators,
+          validate_account_exists: mocked_valid_validate_account_exists,
+          logger: mocked_logger
+        ).call(
+          authenticator_status_input: authenticator_status_input
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "generic validation fails" do
+      context "account doesnt exist" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_invalid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(account_does_not_exist_error)
+        end
+      end
+
+      context "user can't access webservice" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_invalid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(user_cant_access_webservice_error)
+        end
+      end
+
+      context "authenticator webservice does not exist" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_invalid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(webservice_does_not_exist_error)
+        end
+      end
+
+      context "webservice is not whitelisted" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_invalid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(webservice_is_not_whitelisted_error)
+        end
+      end
+
+      context "service id does not exist" do
+
+        let(:authenticator_status_input_without_service_id) {
+          Authentication::AuthenticatorStatusInput.new(
+            authenticator_name: authenticator_name,
+            service_id: nil,
+            account: account,
+            username: "dummy_identity",
+            client_ip: "dummy",
+            credentials: nil,
+            request: nil
+          )
+        }
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input_without_service_id
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::ServiceIdMissing)
+        end
+      end
+    end
+
+    context "authenticator validation fails" do
+      context "signing key secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_invalid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(create_signing_key_configuration_is_invalid_error)
+        end
+      end
+
+      context "issuer secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_invalid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(fetch_issuer_configuration_is_invalid_error)
+        end
+      end
+
+      context "identity secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_invalid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(identity_configuration_is_invalid_error)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
- Added status api check to let the conjur admin know if the JWT authenticator is properly configured

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
