### PR TITLE
ConjurOps V5 Compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -552,6 +552,7 @@ pipeline {
 
     stage('Build Debian and RPM packages') {
       steps {
+        sh 'echo "CONJUR_VERSION=5" >> debify.env'
         sh './package.sh'
         archiveArtifacts artifacts: '*.deb', fingerprint: true
         archiveArtifacts artifacts: '*.rpm', fingerprint: true


### PR DESCRIPTION
Debify defaults to conjur v4 api, set an env var so that it can use
v5. This is required because the conjur infrastructure team are
migrating conjurops from v4 to v5.

Related: conjurinc/ops#782