### PR TITLE
Add -L flag to curl for auto redirect

### DIFF
--- a/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
+++ b/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
@@ -59,7 +59,7 @@ _get_token_to_files() {
     local token=""
 
     if [ -z "$auth_token" ]; then
-      token="$(curl --location --silent -H "Metadata-Flavor: Google" $token_url)" || exit 1
+      token="$(curl --location --silent -H 'Metadata-Flavor: Google' $token_url)" || exit 1
     else
       token=$(curl --location --silent \
       -H "Authorization: bearer $auth_token" \

--- a/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
+++ b/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
@@ -59,9 +59,9 @@ _get_token_to_files() {
     local token=""
 
     if [ -z "$auth_token" ]; then
-      token="$(curl -s -H 'Metadata-Flavor: Google' $token_url)" || exit 1
+      token="$(curl -L -s -H 'Metadata-Flavor: Google' $token_url)" || exit 1
     else
-      token=$(curl -s \
+      token=$(curl -L -s \
       -H "Authorization: bearer $auth_token" \
       -H 'Metadata-Flavor: Google' "$token_url") || exit 1
     fi

--- a/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
+++ b/ci/test_suites/authenticators_gcp/get_tokens_to_files.sh
@@ -59,9 +59,9 @@ _get_token_to_files() {
     local token=""
 
     if [ -z "$auth_token" ]; then
-      token="$(curl -L -s -H 'Metadata-Flavor: Google' $token_url)" || exit 1
+      token="$(curl --location --silent -H "Metadata-Flavor: Google" $token_url)" || exit 1
     else
-      token=$(curl -L -s \
+      token=$(curl --location --silent \
       -H "Authorization: bearer $auth_token" \
       -H 'Metadata-Flavor: Google' "$token_url") || exit 1
     fi


### PR DESCRIPTION
### What does this PR do?
When working with GCP Authenticator preparation, sometimes we get error , when GCP token redirect to other http address
This PR is created to handle http 302 (redirect) msg

Log example:
``` Function returned error, HTTP Status: '302',   cannot obtain token from URL: https://us-central1-ca-rnd-emerging-devops-cli-gcp.cloudfunctions.net/fetch_token_1619?audience=conjur/cucumber/host/test-app```


### What ticket does this PR close?
https://github.com/cyberark/conjur/issues/1993

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
