### PR TITLE
Throw runtime error on empty annotation

### DIFF
--- a/app/domain/authentication/authn_jwt/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/configuration_jwt_generic_vendor.rb
@@ -109,7 +109,10 @@ module Authentication
       def initialize_validate_restrictions
         @restriction_validator = Authentication::AuthnJwt::ValidateRestrictionsOneToOne
         @restrictions_from_annotations_class = Authentication::ResourceRestrictions::GetServiceSpecificRestrictionsFromAnnotation
-        @extract_resource_restrictions = Authentication::ResourceRestrictions::ExtractResourceRestrictions.new(get_restriction_from_annotation: @restrictions_from_annotations_class)
+        @extract_resource_restrictions = Authentication::ResourceRestrictions::ExtractResourceRestrictions.new(
+          get_restriction_from_annotation: @restrictions_from_annotations_class,
+          ignore_empty_annotations: false
+        )
         @validate_resource_restrictions = @validate_resource_restrictions_class.new(extract_resource_restrictions: @extract_resource_restrictions)
         @constraints = Authentication::Constraints::MultipleConstraint.new(
           Authentication::Constraints::NotEmptyConstraint.new

--- a/app/domain/authentication/authn_jwt/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/validate_restrictions_one_to_one.rb
@@ -9,6 +9,9 @@ module Authentication
       end
 
       def valid_restriction?(restriction)
+        if restriction.value.blank?
+          raise Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven, restriction.name
+        end
         unless @decoded_token.key?(restriction.name)
           raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing.new(restriction.name)
         end

--- a/app/domain/authentication/resource_restrictions/fetch_resource_annotations.rb
+++ b/app/domain/authentication/resource_restrictions/fetch_resource_annotations.rb
@@ -1,0 +1,46 @@
+require 'command_class'
+
+module Authentication
+  module ResourceRestrictions
+
+    FetchResourceAnnotations = CommandClass.new(
+      dependencies: {
+        role_class: ::Role,
+        resource_class: ::Resource,
+      },
+      inputs: %i[account role_name]
+    ) do
+
+      def call
+        fetch_resource_annotations
+      end
+
+      private
+
+      def fetch_resource_annotations
+        resource_annotations
+      end
+
+      def resource_annotations
+        resource.annotations.each_with_object({}) do |annotation, result|
+          annotation_values = annotation.values
+          value = annotation_values[:value]
+          next if value.blank?
+
+          result[annotation_values[:name]] = value
+        end
+      end
+
+      def resource
+        # Validate role exists, otherwise getting role annotations return empty hash.
+        role_id = @role_class.roleid_from_username(@account, @role_name)
+        resource = @resource_class[role_id]
+
+        raise Errors::Authentication::Security::RoleNotFound, role_id unless resource
+
+        resource
+      end
+
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -496,6 +496,11 @@ module Errors
         code: "CONJ00049E"
       )
 
+      EmptyAnnotationGiven = ::Util::TrackableErrorClass.new(
+        msg: "Annotation, '{0-annotation-name}', is empty",
+        code: "CONJ00150E"
+      )
+
     end
 
     module Constraints

--- a/spec/app/domain/authentication/authn-jwt/validate_restrictions_one_to_one_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_restrictions_one_to_one_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 RSpec.describe('Authentication::AuthnJwt::ValidateRestrictionsOneToOne') do
   let(:right_email) { "admin@example.com" }
   let(:wrong_email) { "wrong@example.com" }
+  let(:empty_email) { "" }
+  let(:spaced_email) { "  " }
 
   let(:decoded_token) {
     {
@@ -45,6 +47,14 @@ RSpec.describe('Authentication::AuthnJwt::ValidateRestrictionsOneToOne') do
     Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: wrong_email)
   }
 
+  let(:empty_annotation_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: "")
+  }
+
+  let(:spaced_annotation_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: "    ")
+  }
+
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
@@ -67,6 +77,14 @@ RSpec.describe('Authentication::AuthnJwt::ValidateRestrictionsOneToOne') do
       it "raises JwtTokenClaimIsMissing when restriction is not in the decoded token" do
         expect { subject.valid_restriction?(non_existing_restriction) }.to raise_error(Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing)
       end
+
+      it "raises EmptyAnnotationGiven when annotation is empty" do
+        expect { subject.valid_restriction?(empty_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is just spaces" do
+        expect { subject.valid_restriction?(spaced_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
     end
 
     context "Decoded token is empty" do
@@ -76,6 +94,14 @@ RSpec.describe('Authentication::AuthnJwt::ValidateRestrictionsOneToOne') do
 
       it "raises JwtTokenClaimIsMissing" do
         expect { subject.valid_restriction?(non_existing_restriction) }.to raise_error(Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is empty" do
+        expect { subject.valid_restriction?(empty_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is just spaces" do
+        expect { subject.valid_restriction?(spaced_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
       end
     end
   end


### PR DESCRIPTION
Move fetching of annotation out of the ExtractResourceRestrictions Class. So we could throw errors for empty annotation only from the JWT Authenticator