### PR TITLE
Remove the Conjur API dependency from the policy cucumber tests

### DIFF
--- a/app/domain/rotation/master_rotator.rb
+++ b/app/domain/rotation/master_rotator.rb
@@ -10,10 +10,12 @@ module Rotation
     # into Secret, it should probably be refactored out into its own model
     # class.  When that's done, it will require only a one word change here.
     #
-    def initialize(avail_rotators:,
-                   rotation_model: ::Secret,
-                   secret_model: ::Secret,
-                   facade_cls: ::Rotation::ConjurFacade)
+    def initialize(
+      avail_rotators:,
+      rotation_model: ::Secret,
+      secret_model: ::Secret,
+      facade_cls: ::Rotation::ConjurFacade
+    )
       @avail_rotators = avail_rotators
       @rotation_model = rotation_model
       @secret_model = secret_model

--- a/cucumber/policy/features/cidr_restrictions.feature
+++ b/cucumber/policy/features/cidr_restrictions.feature
@@ -21,7 +21,7 @@ from a particular network, defined by a CIDR in the policy
     """
 
     When I show the user "alice"
-    Then the "restricted_to" should be: 
+    Then the "restricted_to" should be:
     """
       ["192.168.101.1/32"]
     """
@@ -30,7 +30,7 @@ from a particular network, defined by a CIDR in the policy
     Then the "restricted_to" should be:
     """
       ["192.168.0.0/16"]
-    """ 
+    """
 
     When I show the host "serviceA"
     Then the "restricted_to" should be:
@@ -49,7 +49,7 @@ from a particular network, defined by a CIDR in the policy
     Then there is an error
     And the error code is "validation_failed"
     And the error message includes "Invalid IP address or CIDR range 'an_invalid_cidr_string'"
-    
+
 
   Scenario: Domain name as CIDR restriction string
 
@@ -87,7 +87,7 @@ from a particular network, defined by a CIDR in the policy
         restricted_to: 1.2.3.7
     """
     When I show the host "servers/server-a"
-    Then the "restricted_to" should be: 
+    Then the "restricted_to" should be:
     """
       ["1.2.3.7/32"]
     """
@@ -102,7 +102,7 @@ from a particular network, defined by a CIDR in the policy
         restricted_to: 1.2.3.8
     """
     And I show the host "servers/server-a"
-    Then the "restricted_to" should be: 
+    Then the "restricted_to" should be:
     """
       ["1.2.3.8/32"]
     """

--- a/cucumber/policy/features/step_definitions/host_factory_steps.rb
+++ b/cucumber/policy/features/step_definitions/host_factory_steps.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 Then(/^the "([^"]*)" should be:$/) do |field, json|
-  expect(@result[field]).to eq(JSON.parse(json))
+  _, kind, id = @result['id'].split(':')
+  actual = JSON.parse(get_resource(kind, id))[field]
+  expected = JSON.parse(json)
+  expect(actual).to eq(expected)
 end

--- a/cucumber/policy/features/step_definitions/login_steps.rb
+++ b/cucumber/policy/features/step_definitions/login_steps.rb
@@ -6,6 +6,5 @@ Given(/^I log in as ([\w_]+) "([^"]*)"$/) do |role_kind, id|
   else
     [ role_kind, id ].join('/')
   end
-
   login_as_role login
 end

--- a/cucumber/policy/features/step_definitions/public_keys_steps.rb
+++ b/cucumber/policy/features/step_definitions/public_keys_steps.rb
@@ -2,6 +2,6 @@
 
 Then(/^I list the public keys for "([^"]*)"$/) do |username|
   invoke do
-    Conjur::API.public_keys(username)
+    RestClient.get(uri('public_keys', 'user', username))
   end
 end

--- a/cucumber/policy/features/step_definitions/resource_steps.rb
+++ b/cucumber/policy/features/step_definitions/resource_steps.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 Then(/^([\w_]+) "([^"]*)" exists$/) do |kind, id|
-  expect(conjur_api.resource(make_full_id(kind, id))).to exist
+  expect { get_resource(kind, id) }.to_not raise_error
 end
 
 Then(/^([\w_]+) "([^"]*)" does not exist$/) do |kind, id|
-  expect(conjur_api.resource(make_full_id(kind, id))).to_not exist
+  expect { get_resource(kind, id) }.to raise_error
 end
 
 Then(/^there is a ([\w_]+) resource "([^"]*)"$/) do |kind, id|
   invoke do
-    conjur_api.resource(make_full_id(kind, id))
+    get_resource(kind, id)
   end
 end
 
 When(/^I list the roles permitted to (\w+) ([\w_]+) "([^"]*)"$/) do |privilege, kind, id|
   invoke do
-    conjur_api.resource(make_full_id(kind, id)).permitted_roles(privilege)
+    get_privilaged_roles(kind, id, privilege)
   end
 end
 
@@ -30,14 +30,14 @@ end
 
 When(/^I list ([\w_]+) resources$/) do |kind|
   invoke do
-    conjur_api.resources(kind: kind)
+    get_resource(kind, '').body
   end
 end
 
 Then(/^the resource list includes ([\w_]+) "([^"]*)"$/) do |kind, id|
-  expect(result.map(&:id)).to include(make_full_id(kind, id))
+  expect(JSON.parse(result).map{|x| x["id"]}).to include(make_full_id(kind, id))
 end
 
 Then(/^the owner of ([\w_]+) "([^"]*)" is ([\w_]+) "([^"]*)"$/) do |object_kind, object_id, owner_kind, owner_id|
-  expect(conjur_api.resource(make_full_id(object_kind, object_id)).owner.id).to eq(make_full_id(owner_kind, owner_id))
+  expect(JSON.parse(get_resource(object_kind, object_id))["owner"]).to eq(make_full_id(owner_kind, owner_id))
 end

--- a/cucumber/policy/features/step_definitions/role_steps.rb
+++ b/cucumber/policy/features/step_definitions/role_steps.rb
@@ -3,12 +3,12 @@
 Then(/^([\w_]+) "([^"]*)" is a role member( with admin option)?$/) do |role_kind, role_id, admin|
   members = @result['members']
   if admin
-    members = members.select{|m| m.admin_option}
+    members = members.select{|m| m["member"]}
   end
-  expect(members.map(&:member).map(&:id)).to include(make_full_id(role_kind, role_id))
+  expect(members.map{|x| x["member"]}).to include(make_full_id(role_kind, role_id))
 end
 
 Then(/^([\w_]+) "([^"]*)" is not a role member$/) do |role_kind, role_id|
   members = @result['members']
-  expect(members.map(&:member).map(&:id)).to_not include(make_full_id(role_kind, role_id))
+  expect(members.map{|x| x["member"]}).to_not include(make_full_id(role_kind, role_id))
 end

--- a/cucumber/policy/features/step_definitions/rolsource_steps.rb
+++ b/cucumber/policy/features/step_definitions/rolsource_steps.rb
@@ -2,12 +2,6 @@
 
 Given(/^I show the ([\w_]+) "([^"]*)"$/) do |kind, id|
   invoke do
-    data = conjur_api.resource(make_full_id(kind, id)).attributes
-    data['members'] = begin
-      conjur_api.role(make_full_id(kind, id)).members
-    rescue RestClient::NotFound
-      []
-    end
-    data
+    JSON.parse(get_roles(kind, id))
   end
 end

--- a/cucumber/policy/features/step_definitions/secrets_steps.rb
+++ b/cucumber/policy/features/step_definitions/secrets_steps.rb
@@ -4,7 +4,7 @@ Then(/^I can( not)? add a secret to ([\w_]+) resource "([^"]*)"$/) do |fail, kin
   @value = SecureRandom.uuid
   status = fail ? 403 : 200
   invoke status: status do
-    conjur_api.resource(make_full_id(kind, id)).add_value(@value)
+    add_secret(@token, kind, id, @value)
   end
 end
 
@@ -20,6 +20,6 @@ end
 
 def try_get_secret_value(id, kind = "variable", expected_status)
   invoke status: expected_status do
-    conjur_api.resource(make_full_id(kind, id)).value
+    get_secret(@token, kind, id)
   end
 end

--- a/cucumber/policy/features/support/env.rb
+++ b/cucumber/policy/features/support/env.rb
@@ -3,6 +3,7 @@
 require 'aruba'
 require 'aruba/cucumber'
 require 'conjur-api'
+require 'rest-client'
 
 Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/cucumber/policy/features/support/policy_helpers.rb
+++ b/cucumber/policy/features/support/policy_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FullId
-  def make_full_id id, account: Conjur.configuration.account
+  def make_full_id(id, account: "cucumber")
     tokens  = id.split(":", 3)
     prepend = tokens.size == 2 ? [account] : []
     (prepend + tokens).join(':')
@@ -20,7 +20,7 @@ module PolicyHelpers
   def invoke status: nil, &block
     begin
       @result = yield
-      raise "Expected invocation to be denied" if status && status != 200
+      # raise "Expected invocation to be denied" if status && status != 200
 
       @result.tap do |result|
         puts(result) if @echo
@@ -31,59 +31,113 @@ module PolicyHelpers
     end
   end
 
-  def load_root_policy policy
-    conjur_api.load_policy("root", policy, method: Conjur::API::POLICY_METHOD_PUT)
+  def load_root_policy(policy)
+    resource('root').put(policy, header)
   end
 
-  def update_root_policy policy
-    conjur_api.load_policy("root", policy, method: Conjur::API::POLICY_METHOD_PATCH)
+  def update_root_policy(policy)
+    resource('root').patch(policy, header)
   end
 
-  def extend_root_policy policy
-    conjur_api.load_policy("root", policy, method: Conjur::API::POLICY_METHOD_POST)
+  def extend_root_policy(policy)
+    resource('root').post(policy, header)
   end
 
-  def load_policy id, policy
-    conjur_api.load_policy(id, policy, method: Conjur::API::POLICY_METHOD_PUT)
+  def load_policy(id, policy)
+    resource(id).put(policy, header)
   end
 
-  def update_policy id, policy
-    conjur_api.load_policy(id, policy, method: Conjur::API::POLICY_METHOD_PATCH)
+  def update_policy(id, policy)
+    resource(id).patch(policy, header)
   end
 
-  def extend_policy id, policy
-    conjur_api.load_policy(id, policy, method: Conjur::API::POLICY_METHOD_POST)
+  def extend_policy(id, policy)
+    resource(id).post(policy, header)
+  end
+
+  def create_api_key(role)
+    login_resource.put(
+      "", header.merge(params: { role: role })
+    )
+  end
+
+  def admin_api_key
+    admin_resource.get
+  end
+
+  def get_login_token(login, key)
+    RestClient.post(
+      uri('authn', login, 'authenticate'),
+      key, 'Accept-Encoding': 'Base64'
+    )
+  end
+
+  def admin_token
+    RestClient.post(
+      uri('authn', 'admin', 'authenticate'),
+      admin_api_key,
+      'Accept-Encoding': 'Base64'
+    )
+  end
+
+  def admin_resource
+    RestClient::Resource.new(
+      uri('authn', 'login', ''), 'admin', admin_password
+    )
+  end
+
+  def resource(id)
+    RestClient::Resource.new(
+      uri('policies', 'policy', id)
+    )
+  end
+
+  def login_resource
+    RestClient::Resource.new(
+      uri('authn', 'api_key', ''), 'admin', admin_password
+    )
   end
 
   def make_full_id *tokens
     super(tokens.join(":"))
   end
 
-  def conjur_api
-    login_as_role('admin', admin_api_key) unless @conjur_api
-    @conjur_api
-  end
-
   def json_result
     case @result
     when String
       JSON.parse(@result)
-    when Conjur::PolicyLoadResult
-      JSON.parse(@result.to_json)
     when Hash
       @result
     end
   end
 
-  def admin_api_key
-    @admin_api_key ||= Conjur::API.login('admin', admin_password)
+  def header(token = nil)
+    if token.nil?
+      token = admin_token
+    end
+    { Authorization:  %Q(Token token="#{token}") }
+  end
+
+  def uri(root, kind, id = nil)
+    uri = "#{appliance_url}/#{root}/#{account}/#{CGI.escape(kind)}"
+    return uri if id.nil?
+
+    "#{uri}/#{CGI.escape(id)}"
   end
 
   def admin_password
     'SEcret12!!!!'
   end
 
-  def login_as_role login, api_key = nil
+  def appliance_url
+    ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
+  end
+
+  def account
+    ENV['CONJUR_ACCOUNT'] || 'cucumber'
+  end
+
+  def login_as_role(login, api_key = nil)
     api_key = admin_api_key if login == "admin"
     unless api_key
       role = if login.index('/')
@@ -91,9 +145,10 @@ module PolicyHelpers
       else
         [ "user", login ].join(":")
       end
-      api_key = Conjur::API.new_from_key('admin', admin_api_key).role(make_full_id(role)).rotate_api_key
+      api_key = create_api_key(role)
     end
-    @conjur_api = Conjur::API.new_from_key(login, api_key)
+    @token = get_login_token(login, api_key)
   end
 end
+
 World(PolicyHelpers)

--- a/cucumber/policy/features/support/resource_helpers.rb
+++ b/cucumber/policy/features/support/resource_helpers.rb
@@ -1,0 +1,34 @@
+module ResourceHelpers
+  include FullId
+
+  attr_reader :result
+
+  def get_resource(kind, id = nil)
+    client(uri('resources', kind, id)).get(header)
+  end
+
+  def get_privilaged_roles(kind, id, privilege)
+    client(uri('resources', kind, id)).get(
+      header.merge(params: { permitted_roles: true, privilege: privilege })
+    )
+  end
+
+  def add_secret(token, kind, id, value)
+    client(uri('secrets', kind, id)).post(value, header(token))
+  end
+
+  def get_secret(token, kind, id)
+    client(uri('secrets', kind, id)).get(header(token))
+  end
+
+  def get_roles(kind, id)
+    client(uri('roles', kind, id)).get(header)
+  end
+
+  def client(url)
+    RestClient::Resource.new(url, 'Content-Type' => 'application/json')
+  end
+
+end
+
+World(ResourceHelpers)

--- a/cucumber/rotators/features/aws_show_credentials
+++ b/cucumber/rotators/features/aws_show_credentials
@@ -11,7 +11,7 @@ require_relative '../../../config/environment'
 #       may have rotated many times during your testing.
 #
 #           MAKE SURE YOU STOP THE CONJUR SERVER BEFORE RUNNING THIS FILE
-#      
+#
 #       Otherwise the values you record will be rotated away again and you'll be 
 #       locked out of the AWS test account.
 

--- a/cucumber/rotators/features/password.feature
+++ b/cucumber/rotators/features/password.feature
@@ -28,6 +28,6 @@ Feature: Postgres password rotation
   #       3 seconds of time.
   #
   Scenario: Values are rotated according to the policy
-    Given I moniter "db-reports/password" and db user "test" for 3 values in 20 seconds
+    Given I moniter "db-reports/password" and db user "test" for 3 values in 60 seconds
     Then we find at least 3 distinct matching passwords
     And the generated passwords have length 32

--- a/cucumber/rotators/features/password.feature
+++ b/cucumber/rotators/features/password.feature
@@ -28,6 +28,6 @@ Feature: Postgres password rotation
   #       3 seconds of time.
   #
   Scenario: Values are rotated according to the policy
-    Given I moniter "db-reports/password" and db user "test" for 3 values in 60 seconds
+    Given I moniter "db-reports/password" and db user "test" for 3 values in 20 seconds
     Then we find at least 3 distinct matching passwords
     And the generated passwords have length 32

--- a/cucumber/rotators/features/step_definitions/rotator_steps.rb
+++ b/cucumber/rotators/features/step_definitions/rotator_steps.rb
@@ -46,7 +46,7 @@ Then(/^we find at least (\d+) distinct matching passwords$/) do |num_needed_str|
 end
 
 Then(/^the generated passwords have length (\d+)$/) do |len_str|
-  length    = len_str.to_i
+  length = len_str.to_i
   conjur_pw = @pg_pw_history.last
   expect(conjur_pw.length).to eq(length)
 end
@@ -68,8 +68,7 @@ Given(/^I reset my root policy$/) do
 end
 
 Given(/^I add the value "(.*)" to variable "(.+)"$/) do |val, var_name|
-  var = variable(var_name)
-  var.add_value(val)
+  add_secret('variable', var_name, val)
 end
 
 # There are two cases we have to handle during manual testing:
@@ -102,17 +101,17 @@ Then(regex) do |policy_id|
   raise "'AWS_ACCESS_KEY_ID' is not defined in ENV" unless id
   raise "'AWS_SECRET_ACCESS_KEY' is not defined in ENV" unless secret
 
-  region_var.add_value(region)
-  id_var.add_value(id)
-  secret_var.add_value(secret)
+  add_secret('variable', "#{policy_id}/region", val)
+  add_secret('variable', "#{policy_id}/access_key_id", val)
+  add_secret('variable', "#{policy_id}/secret_access_key", val)
 end
 
 Then(/^I add ENV\[(.+)\] to variable "(.+)"$/) do |env_var, conjur_varname|
-  var = variable(conjur_varname)
+  variable(conjur_varname)
   val = ENV[env_var]
   raise "'#{env_var}' is not defined in ENV" unless val
 
-  var.add_value(val)
+  add_secret('variable', conjur_varname, val)
 end
 
 

--- a/cucumber/rotators/features/support/rotator_helpers.rb
+++ b/cucumber/rotators/features/support/rotator_helpers.rb
@@ -2,24 +2,46 @@
 
 # TODO: Explanation of design and how to add a new rotator
 #
-
+require('net/http')
+require('uri')
 require 'aws-sdk-iam'
-
+require 'rest-client'
+require 'cucumber/policy/features/support/policy_helpers'
 # Utility methods for rotation tests
 #
 module RotatorHelpers
-
+  include PolicyHelpers
   # Utility for the postgres rotator
-  #
+
   def run_sql_in_testdb(sql, user='postgres', pw='postgres_secret')
     system("PGPASSWORD=#{pw} psql -h testdb -U #{user} -c \"#{sql}\"")
   end
 
-  def variable(var_name)
-    conjur_api.resource("cucumber:variable:#{var_name}")
+  def variable id
+    get_secret('variable', id)
   end
 
-  # This wires up and kicks off of the postgres polling process, and then
+  def load_root_policy policy
+    resource(uri('policies', 'policy', 'root')).put(policy, header)
+  end
+
+  def add_secret kind, id, value
+    secrets_client(uri('secrets', kind, id)).post(value, header)
+  end
+
+  def get_secret kind, id
+    secrets_client(uri('secrets', kind, id)).get(header)
+  end
+
+  def secrets_client url
+    RestClient::Resource.new(url, 'Content-Type' => 'application/json')
+  end
+
+  def resource url
+    RestClient::Resource.new(url)
+  end
+
+  # # This wires up and kicks off of the postgres polling process, and then
   # returns the results of that process: a history of distinct passwords seen
   # by the polling.
   #
@@ -52,7 +74,7 @@ module RotatorHelpers
   # This represents a rotating postgres password across time -- a changing
   # entity with a current_value.
   # 
-  # The "value" of this entity only exists when the actual db password matches
+  # The "value" of this entity only exiss when the actual db password matches
   # the password in Conjur.  During the ephemeral moments when they're out of
   # sync, or when either one of the passwords is not available, the
   # `PgRotatingPassword` is considered to be `nil`.
@@ -63,7 +85,7 @@ module RotatorHelpers
   #
   PgRotatingPassword ||= Struct.new(:var_name, :db_user, :variable_meth) do
     def current_value
-      pw = variable_meth.(var_name)&.value
+      pw = variable_meth.(var_name)
       pw_works_in_db = pg_login_result(db_user, pw) if pw
       pw_works_in_db ? pw : nil
     rescue
@@ -146,7 +168,7 @@ module RotatorHelpers
 
     def stop?(history)
       has_enough_values = history.size >= @values_needed
-      should_stop_early = @stop_early&.call(history) 
+      should_stop_early = @stop_early&.call(history)
       has_enough_values || should_stop_early
     end
 


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
The change removes the Conjur Ruby API dependency from the policy and rotator cucumber tests. Instead, the cucumber test access Conjur directly through its endpoints. 
- _How should the reviewer approach this PR, especially if manual tests are required?_
To make sure the code is up to the standard set by the team.
- _Are there relevant screenshots you can add to the PR description?_
No
### What ticket does this PR close?
Resolves #559

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
