### PR TITLE
Upgrade nokogiri to resolve GHSA-7rrm-v45f-jp64

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -207,14 +207,14 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     method_source (0.9.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.11.2)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -272,4 +272,4 @@ DEPENDENCIES
   pry
 
 BUNDLED WITH
-   1.17.3
+   2.2.18


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Updates nokogiri in the docs Gemfile to resolve 6 CVEs as specified in GHSA-7rrm-v45f-jp64 (CVE-2019-20388, CVE-2020-24977, CVE-2021-3517, CVE-2021-3518, CVE-2021-3537, CVE-2021-3541)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
