### PR TITLE
Update secrets provider for k8s build trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -429,7 +429,7 @@ pipeline {
           script {
             if (env.BRANCH_NAME == 'master') {
               build(
-                job:'../cyberark--secrets-provider-for-k8s/master',
+                job:'../cyberark--secrets-provider-for-k8s/main',
                 wait: false
               )
             }


### PR DESCRIPTION
This PR updates our Jenkins build trigger for https://github.com/cyberark/secrets-provider-for-k8s to start a build on the `main` branch rather than the `master` branch.