### PR TITLE
Make authentication_parameters be a member of vendor configuration

### DIFF
--- a/app/domain/authentication/authn_jwt/authentication_parameters.rb
+++ b/app/domain/authentication/authn_jwt/authentication_parameters.rb
@@ -2,7 +2,7 @@ module Authentication
   module AuthnJwt
     # Data class to store data regarding jwt token that is needed during the jwt authentication process
     class AuthenticationParameters
-      attr_accessor :jwt_identity, :decoded_token, :jwt_token
+      attr_accessor :decoded_token, :jwt_token
       attr_reader :authenticator_name, :service_id, :account, :username, :client_ip, :request
 
       def initialize(authentication_input:, jwt_token:)

--- a/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
@@ -25,7 +25,7 @@ module Authentication
         relevant_authenticator = authenticator_name
         @logger.debug(LogMessages::Authentication::AuthnJwt::JWTAuthenticatorEntryPoint.new(relevant_authenticator))
 
-        jwt_authenticator_configuration = @jwt_configuration_factory.create_jwt_configuration(relevant_authenticator)
+        jwt_authenticator_configuration = @jwt_configuration_factory.create_jwt_configuration(@authenticator_input)
         @jwt_authenticator.call(
           jwt_configuration: jwt_authenticator_configuration,
           authenticator_input: @authenticator_input

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_factory.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_factory.rb
@@ -7,12 +7,13 @@ module Authentication
           "authn-jwt" => ConfigurationJWTGenericVendor
         }
 
-        def create_jwt_configuration(authenticator_name)
+        def create_jwt_configuration(authenticator_input)
+          authenticator_name = authenticator_input.authenticator_name
           unless AUTHENTICATORS[authenticator_name]
             raise Errors::Authentication::AuthnJwt::UnsupportedAuthenticator, authenticator_name
           end
 
-          AUTHENTICATORS[authenticator_name].new
+          AUTHENTICATORS[authenticator_name].new(authenticator_input)
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_interface.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_interface.rb
@@ -5,11 +5,11 @@ module Authentication
       class ConfigurationInterface
         def authentication_parameters(authenticator_input); end
 
-        def jwt_identity(authentication_parameters); end
+        def jwt_identity; end
 
-        def validate_restrictions(authentication_parameters); end
+        def validate_restrictions; end
 
-        def validate_and_decode_token(authentication_parameters); end
+        def validate_and_decode_token; end
       end
     end
   end


### PR DESCRIPTION
Make authentication_parameters be a member of vendor configuration

Makes order in absraction levels between authenticator.rb and vendor configuration. In addition it allows to remove jwt_identity accessor from the authentication parameters