### PR TITLE
Jwt dynamic jwks uri automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -423,6 +423,7 @@ Below is the list of the available Cucumber suites:
   * authenticators_azure
   * authenticators_config
   * authenticators_gcp
+  * authenticators_jwt
   * authenticators_ldap
   * authenticators_oidc
   * authenticators_status

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,6 +191,7 @@ pipeline {
                       authenticators_azure/cucumber_results.html,
                       authenticators_ldap/cucumber_results.html,
                       authenticators_oidc/cucumber_results.html,
+                      authenticators_jwt/cucumber_results.html,
                       authenticators_status/cucumber_results.html
                       policy/cucumber_results.html,
                       rotators/cucumber_results.html
@@ -457,6 +458,7 @@ pipeline {
                 authenticators_azure/cucumber_results.html,
                 authenticators_ldap/cucumber_results.html,
                 authenticators_oidc/cucumber_results.html,
+                authenticators_jwt/cucumber_results.html,
                 authenticators_gcp/cucumber_results.html,
                 authenticators_status/cucumber_results.html,
                 policy/cucumber_results.html,
@@ -620,6 +622,9 @@ def runConjurTests() {
       },
       "OIDC Authenticator - ${env.STAGE_NAME}": {
         sh 'ci/test authenticators_oidc'
+      },
+      "JWT Authenticator - ${env.STAGE_NAME}": {
+        sh 'ci/test authenticators_jwt'
       },
       "Policy - ${env.STAGE_NAME}": {
         sh 'ci/test policy'

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -90,8 +90,7 @@ class AuthenticateController < ApplicationController
   def authenticate_jwt
     params[:authenticator] = "authn-jwt"
     authn_token = Authentication::AuthnJwt::OrchestrateAuthentication.new.call(
-      authenticator_input: authenticator_input_without_credentials,
-      enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV)
+      authenticator_input: authenticator_input_without_credentials
     )
     render_authn_token(authn_token)
   rescue => e

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -31,6 +31,16 @@ class AuthenticateController < ApplicationController
     render(status_failure_response(e))
   end
 
+  def authn_jwt_status
+    Authentication::AuthnJwt::ValidateStatus.new.call(
+      authenticator_status_input: status_input("authn-jwt")
+    )
+    render(json: { status: "ok" })
+  rescue => e
+    log_backtrace(e)
+    render(status_failure_response(e))
+  end
+
   def update_config
     body_params = Rack::Utils.parse_nested_query(request.body.read)
 
@@ -47,9 +57,9 @@ class AuthenticateController < ApplicationController
     handle_authentication_error(e)
   end
 
-  def status_input
+  def status_input(authenticator_name = params[:authenticator])
     Authentication::AuthenticatorStatusInput.new(
-      authenticator_name: params[:authenticator],
+      authenticator_name: authenticator_name,
       service_id: params[:service_id],
       account: params[:account],
       username: ::Role.username_from_roleid(current_user.role_id),
@@ -72,14 +82,18 @@ class AuthenticateController < ApplicationController
       authenticators: installed_authenticators,
       enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str
     )
-    content_type = :json
-    if encoded_response?
-      logger.debug(LogMessages::Authentication::EncodedJWTResponse.new)
-      content_type = :plain
-      authn_token = ::Base64.strict_encode64(authn_token.to_json)
-      response.set_header("Content-Encoding", "base64")
-    end
-    render(content_type => authn_token)
+    render_authn_token(authn_token)
+  rescue => e
+    handle_authentication_error(e)
+  end
+
+  def authenticate_jwt
+    params[:authenticator] = "authn-jwt"
+    authn_token = Authentication::AuthnJwt::OrchestrateAuthentication.new.call(
+      authenticator_input: authenticator_input_without_credentials,
+      enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV)
+    )
+    render_authn_token(authn_token)
   rescue => e
     handle_authentication_error(e)
   end
@@ -117,6 +131,32 @@ class AuthenticateController < ApplicationController
       client_ip: request.ip,
       request: request
     )
+  end
+
+  # create authenticator input without reading the request body
+  # request body can be relatively large
+  # authenticator will read it after basic validation check
+  def authenticator_input_without_credentials
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: params[:authenticator],
+      service_id: params[:service_id],
+      account: params[:account],
+      username: params[:id],
+      credentials: nil,
+      client_ip: request.ip,
+      request: request
+    )
+  end
+
+  def render_authn_token(authn_token)
+    content_type = :json
+    if encoded_response?
+      logger.debug(LogMessages::Authentication::EncodedJWTResponse.new)
+      content_type = :plain
+      authn_token = ::Base64.strict_encode64(authn_token.to_json)
+      response.set_header("Content-Encoding", "base64")
+    end
+    render(content_type => authn_token)
   end
 
   def k8s_inject_client_cert

--- a/app/domain/authentication/authn_jwt/authentication_parameters.rb
+++ b/app/domain/authentication/authn_jwt/authentication_parameters.rb
@@ -1,0 +1,23 @@
+module Authentication
+  module AuthnJwt
+    # Data class to store data regarding jwt token that is needed during the jwt authentication process
+    class AuthenticationParameters
+      attr_accessor :jwt_identity, :decoded_token, :jwt_token
+      attr_reader :authenticator_name, :service_id, :account, :username, :client_ip, :request
+
+      def initialize(authentication_input:, jwt_token:)
+        @authenticator_name = authentication_input.authenticator_name
+        @service_id = authentication_input.service_id
+        @account = authentication_input.account
+        @username = authentication_input.username
+        @client_ip = authentication_input.client_ip
+        @request = authentication_input.request
+        @jwt_token = jwt_token
+      end
+
+      def authenticator_resource_id
+        "#{@account}:variable:conjur/#{@authenticator_name}/#{@service_id}"
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -1,0 +1,144 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    # Generic JWT authenticator that receive JWT vendor configuration and uses to validate that the authentication
+    # request is valid, and return conjur authn token accordingly
+    Authenticator = CommandClass.new(
+      dependencies: {
+        token_factory: TokenFactory.new,
+        logger: Rails.logger,
+        audit_log: ::Audit.logger,
+        validate_origin: ::Authentication::ValidateOrigin.new,
+        role_class: ::Role,
+        webservice_class: ::Authentication::Webservice,
+        validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new
+      },
+      inputs: %i[jwt_configuration authenticator_input]
+    ) do
+      extend(Forwardable)
+      def_delegators(:@authenticator_input, :account, :username, :client_ip, :authenticator_name, :service_id)
+
+      def call
+        create_authentication_parameters
+        validate_and_decode_token
+        get_jwt_identity
+        validate_user_has_access_to_webservice
+        validate_origin
+        validate_restrictions
+        audit_success
+        new_token
+      rescue => e
+        audit_failure(e)
+        raise e
+      end
+
+      private
+
+      def create_authentication_parameters
+        authentication_parameters
+      end
+
+      def authentication_parameters
+        @authentication_parameters ||= @jwt_configuration.authentication_parameters(@authenticator_input)
+      end
+
+      def validate_and_decode_token
+        @logger.debug(LogMessages::Authentication::AuthnJwt::VALIDATE_AND_DECODE_TOKEN.new)
+        @authentication_parameters.decoded_token = @jwt_configuration.validate_and_decode_token(@authentication_parameters)
+      end
+
+      def get_jwt_identity
+        # Will be changed when real get identity implemented
+        @logger.debug(LogMessages::Authentication::AuthnJwt::GET_JWT_IDENTITY.new)
+        @authentication_parameters.jwt_identity =  @jwt_configuration.jwt_identity(@authentication_parameters)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::FOUND_JWT_IDENTITY.new(@authentication_parameters.jwt_identity))
+      end
+
+      def validate_user_has_access_to_webservice
+        @validate_role_can_access_webservice.(
+          webservice: webservice,
+          account: account,
+          user_id: @authentication_parameters.jwt_identity,
+          privilege: PRIVILEGE_AUTHENTICATE
+        )
+      end
+
+      def validate_origin
+        @validate_origin.(
+          account: account,
+          username: @authentication_parameters.jwt_identity,
+          client_ip: client_ip
+        )
+      end
+
+      def validate_restrictions
+        @logger.debug(LogMessages::Authentication::AuthnJwt::CALLING_VALIDATE_RESTRICTIONS.new)
+        @jwt_configuration.validate_restrictions(@authentication_parameters)
+      end
+
+      def audit_success
+        @audit_log.log(
+          ::Audit::Event::Authn::Authenticate.new(
+            authenticator_name: authenticator_name,
+            service: webservice,
+            role_id: audit_role_id,
+            client_ip: client_ip,
+            success: true,
+            error_message: nil
+          )
+        )
+      end
+
+      def audit_failure(err)
+        @audit_log.log(
+          ::Audit::Event::Authn::Authenticate.new(
+            authenticator_name: authenticator_name,
+            service: webservice,
+            role_id: audit_role_id,
+            client_ip: client_ip,
+            success: false,
+            error_message: err.message
+          )
+        )
+      end
+
+      def role
+        if @authentication_parameters && @authentication_parameters.jwt_identity
+          return @role_class.by_login(
+            @authentication_parameters.jwt_identity,
+            account: account
+          )
+        end
+        @role_class.by_login(
+          "",
+          account: account
+        )
+      end
+
+      def audit_role_id
+        ::Audit::Event::Authn::RoleId.new(
+          role: role,
+          account: account,
+          username: @authentication_parameters.jwt_identity
+        ).to_s
+      end
+
+      def webservice
+        @webservice ||= @webservice_class.new(
+          account: account,
+          authenticator_name: authenticator_name,
+          service_id: service_id
+        )
+      end
+
+      def new_token
+        @logger.debug(LogMessages::Authentication::AuthnJwt::JWT_AUTHENTICATION_PASSED.new)
+        @token_factory.signed_token(
+          account: account,
+          username: @authentication_parameters.jwt_identity
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Authentication
+  module AuthnJwt
+    PROVIDER_URI_RESOURCE_NAME = "provider-uri".freeze
+    JWKS_URI_RESOURCE_NAME = "jwks-uri".freeze
+    ISSUER_RESOURCE_NAME = "issuer".freeze
+    IDENTITY_FIELD_VARIABLE = "token-app-property".freeze
+    IDENTITY_NOT_RETRIEVED_YET = "Identity not retrieved yet".freeze
+    PRIVILEGE_AUTHENTICATE="authenticate".freeze
+    ISS_CLAIM_NAME = "iss".freeze
+    EXP_CLAIM_NAME = "exp".freeze
+    NBF_CLAIM_NAME = "nbf".freeze
+    IAT_CLAIM_NAME = "iat".freeze
+    RSA_ALGORITHMS = %w[RS256 RS384 RS512].freeze
+    ECDSA_ALGORITHMS = %w[ES256 ES384 ES512].freeze
+    SUPPORTED_ALGORITHMS = (RSA_ALGORITHMS + ECDSA_ALGORITHMS).freeze
+    CACHE_REFRESHES_PER_INTERVAL = 10.freeze
+    CACHE_RATE_LIMIT_INTERVAL = 300.freeze # 300 seconds (every 5 mins)
+    CACHE_MAX_CONCURRENT_REQUESTS = 3.freeze
+  end
+end

--- a/app/domain/authentication/authn_jwt/identity_providers/create_identity_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/create_identity_provider.rb
@@ -1,0 +1,41 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    module IdentityProviders
+      # Factory for jwt identity providers.
+      # If Identity variable is configured factory return the decoded_token_provider
+      # If the Identity variable is not configured and there is account field in url factory returns url provider
+      # If the above conditions are not met exception is raised
+      CreateIdentityProvider = CommandClass.new(
+        dependencies: {
+          identity_from_url_provider_class: Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider,
+          identity_from_decoded_token_class: Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        def call
+          create_identity_provider
+        end
+
+        private
+
+        def create_identity_provider
+          identity_provider = @identity_from_decoded_token_class.new(@authentication_parameters)
+          if identity_provider.identity_available?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::DECODED_TOKEN_IDENTITY_PROVIDER_SELECTED.new)
+            return identity_provider
+          end
+
+          identity_provider = @identity_from_url_provider_class.new(@authentication_parameters)
+          if identity_provider.identity_available?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::URL_IDENTITY_PROVIDER_SELECTED.new)
+            return identity_provider
+          end
+          raise Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
@@ -1,0 +1,59 @@
+module Authentication
+  module AuthnJwt
+    module IdentityProviders
+      # Class for providing jwt identity from the decoded token from the field specified in a secret
+      class IdentityFromDecodedTokenProvider < IdentityProviderInterface
+        def initialize(authentication_parameters)
+          @resource_id = authentication_parameters.authenticator_resource_id
+          @decoded_token = authentication_parameters.decoded_token
+          @secret_fetcher = Conjur::FetchRequiredSecrets.new
+          @resource_class = ::Resource
+          @logger = Rails.logger
+        end
+
+        def provide_jwt_identity
+          token_field_name = fetch_token_field_name
+          @logger.debug(LogMessages::Authentication::AuthnJwt::CHECKING_IDENTITY_FIELD_EXISTS.new(token_field_name))
+          jwt_identity = @decoded_token[token_field_name]
+          if jwt_identity.blank?
+            raise Errors::Authentication::AuthnJwt::NoSuchFieldInToken, token_field_name
+          end
+
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FOUND_JWT_FIELD_IN_TOKEN.new(token_field_name, jwt_identity))
+          jwt_identity
+        end
+
+        # Checks if variable that defined from which field in decoded token to get the id is configured
+        def identity_available?
+          identity_field_variable.present?
+        end
+
+        # This method is for the authenticator status check, unlike 'identity_available?' it checks if the
+        # secret value is not empty too
+        def identity_configured_properly?
+          fetch_token_field_name.blank? if identity_available?
+        end
+
+        private
+
+        def identity_field_variable
+          @resource_class[token_id_field_resource_id]
+        end
+
+        def token_id_field_resource_id
+          "#{@resource_id}/#{IDENTITY_FIELD_VARIABLE}"
+        end
+
+        def fetch_secret(secret_id)
+          @secret_fetcher.call(resource_ids: [secret_id])[secret_id]
+        end
+
+        def fetch_token_field_name
+          resource_id = token_id_field_resource_id
+          @logger.debug(LogMessages::Authentication::AuthnJwt::LOOKING_FOR_IDENTITY_FIELD_NAME.new(resource_id))
+          fetch_secret(resource_id)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
@@ -1,0 +1,22 @@
+module Authentication
+  module AuthnJwt
+    module IdentityProviders
+      # Provides jwt identity from information in the URL
+      class IdentityFromUrlProvider < IdentityProviderInterface
+        def initialize(authentication_parameters)
+          @authentication_parameters = authentication_parameters
+        end
+
+        def provide_jwt_identity
+          raise Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider unless identity_available?
+
+          @authentication_parameters.username
+        end
+
+        def identity_available?
+          !@authentication_parameters.username.blank?
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_provider_interface.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_provider_interface.rb
@@ -1,0 +1,13 @@
+module Authentication
+  module AuthnJwt
+    module IdentityProviders
+      class IdentityProviderInterface
+        def initialize(authentication_parameters); end
+
+        def provide_jwt_identity; end
+
+        def identity_available?; end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/input_validation/extract_token_from_credentials.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/extract_token_from_credentials.rb
@@ -1,0 +1,31 @@
+module Authentication
+  module AuthnJwt
+    module InputValidation
+      ExtractTokenFromCredentials ||= CommandClass.new(
+        dependencies: {
+          decoded_credentials_class: Authentication::Jwt::DecodedCredentials
+        },
+        inputs: %i[credentials]
+      ) do
+        def call
+          decode_credentials
+          extract_token_from_credentials
+        end
+
+        private
+
+        def decode_credentials
+          decoded_credentials
+        end
+
+        def decoded_credentials
+          @decoded_credentials ||= @decoded_credentials_class.new(@credentials)
+        end
+
+        def extract_token_from_credentials
+          decoded_credentials.jwt
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/input_validation/validate_uri_based_parameters.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/validate_uri_based_parameters.rb
@@ -1,0 +1,55 @@
+module Authentication
+  module AuthnJwt
+    module InputValidation
+      ValidateUriBasedParameters ||= CommandClass.new(
+        dependencies: {
+          # ValidateWebserviceIsWhitelisted calls ValidateAccountExists
+          # we call ValidateAccountExists for better readability and safety
+          validate_account_exists: ::Authentication::Security::ValidateAccountExists.new,
+          validate_webservice_is_whitelisted: Security::ValidateWebserviceIsWhitelisted.new
+        },
+        inputs: %i[authenticator_input enabled_authenticators]
+      ) do
+        # authenticator_input attributes
+        #  :account - from uri - has explicit validation
+        #  :authenticator_name - from uri - has implicit validation with service_id
+        #  :service_id - from uri - has implicit validation with authenticator_name
+        #  :username - can be from uri
+        #    - validation is specific for authenticator
+        #    - in jwt case undefined until token signature validation
+        #  :credentials - the web request body - validation is specific for authenticator
+        #  :client_ip - from metadata or request - depends username
+        #  :request - the web request object
+
+        def call
+          validate_account_exists
+          validate_webservice_is_whitelisted
+        end
+
+        private
+
+        def validate_account_exists
+          @validate_account_exists.(
+            account: @authenticator_input.account
+          )
+        end
+
+        def validate_webservice_is_whitelisted
+          @validate_webservice_is_whitelisted.(
+            webservice: webservice,
+            account: @authenticator_input.account,
+            enabled_authenticators: @enabled_authenticators
+          )
+        end
+
+        def webservice
+          @webservice ||= ::Authentication::Webservice.new(
+            account: @authenticator_input.account,
+            authenticator_name: @authenticator_input.authenticator_name,
+            service_id: @authenticator_input.service_id
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
@@ -9,9 +9,10 @@ module Authentication
         validate_uri_based_parameters: Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new,
         jwt_configuration_factory: Authentication::AuthnJwt::VendorConfigurations::ConfigurationFactory.new,
         jwt_authenticator: Authentication::AuthnJwt::Authenticator.new,
-        logger: Rails.logger
+        logger: Rails.logger,
+        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str,
       },
-      inputs: %i[authenticator_input enabled_authenticators]
+      inputs: %i[authenticator_input]
     ) do
       def call
         validate_uri_based_parameters

--- a/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_jwt_authentication.rb
@@ -1,0 +1,46 @@
+require 'command_class'
+
+# This class is the starting point of the JWT authenticate requests, responsible to identify the vendor configuration and to run the JWT authenticator
+module Authentication
+  module AuthnJwt
+
+    OrchestrateAuthentication ||= CommandClass.new(
+      dependencies: {
+        validate_uri_based_parameters: Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new,
+        jwt_configuration_factory: Authentication::AuthnJwt::VendorConfigurations::ConfigurationFactory.new,
+        jwt_authenticator: Authentication::AuthnJwt::Authenticator.new,
+        logger: Rails.logger
+      },
+      inputs: %i[authenticator_input enabled_authenticators]
+    ) do
+      def call
+        validate_uri_based_parameters
+        authenticate_jwt
+      end
+
+      private
+
+      def authenticate_jwt
+        relevant_authenticator = authenticator_name
+        @logger.debug(LogMessages::Authentication::AuthnJwt::JWTAuthenticatorEntryPoint.new(relevant_authenticator))
+
+        jwt_authenticator_configuration = @jwt_configuration_factory.create_jwt_configuration(relevant_authenticator)
+        @jwt_authenticator.call(
+          jwt_configuration: jwt_authenticator_configuration,
+          authenticator_input: @authenticator_input
+        )
+      end
+
+      def authenticator_name
+        @authenticator_input.authenticator_name
+      end
+
+      def validate_uri_based_parameters
+        @validate_uri_based_parameters.call(
+          authenticator_input: @authenticator_input,
+          enabled_authenticators: @enabled_authenticators
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/restriction_validators/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validators/validate_restrictions_one_to_one.rb
@@ -1,0 +1,24 @@
+module Authentication
+  module AuthnJwt
+    module RestrictionValidators
+      # This class is responsible for retrieving the correct value from the JWT token
+      # of the requested attribute.
+      class ValidateRestrictionsOneToOne
+        def initialize(decoded_token:)
+          @decoded_token = decoded_token
+        end
+
+        def valid_restriction?(restriction)
+          if restriction.value.blank?
+            raise Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven, restriction.name
+          end
+          unless @decoded_token.key?(restriction.name)
+            raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing, restriction.name
+          end
+
+          @decoded_token.fetch(restriction.name) == restriction.value
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/create_jwks_from_http_response.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/create_jwks_from_http_response.rb
@@ -1,0 +1,48 @@
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      # CreateJwksFromHttpResponse command class is responsible to create jwks object from http response
+      CreateJwksFromHttpResponse ||= CommandClass.new(
+        dependencies: {
+          logger: Rails.logger
+        },
+        inputs: [:http_response]
+      ) do
+        def call
+          validate_response_exists
+          create_jwks_from_http_respnse
+        end
+
+        private
+
+        def validate_response_exists
+          raise Errors::Authentication::AuthnJwt::MissingHttpResponse if @http_response.blank?
+        end
+
+        def create_jwks_from_http_respnse
+          @logger.debug(LogMessages::Authentication::AuthnJwt::CreatingJwksFromHttpResponse.new)
+
+          raise Errors::Authentication::AuthnJwt::InvalidHttpResponseFormat unless @http_response.respond_to?(:body)
+
+          begin
+            parsed_response = JSON.parse(@http_response.body)
+            keys = parsed_response['keys']
+            jwks = { keys: JSON::JWK::Set.new(keys) }
+          rescue => e
+            raise Errors::Authentication::AuthnJwt::FailedToConvertResponseToJwks.new(
+              Base64.encode64(@http_response.body),
+              e.inspect
+            )
+          end
+
+          if keys.blank?
+            raise Errors::Authentication::AuthnJwt::FetchJwksUriKeysNotFound, Base64.encode64(@http_response.body)
+          end
+
+          @logger.debug(LogMessages::Authentication::AuthnJwt::CreatedJwks.new)
+          jwks
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/create_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/create_signing_key_interface.rb
@@ -1,0 +1,69 @@
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      # Factory that returns the interface implementation of FetchSigningKey
+      CreateSigningKeyInterface ||= CommandClass.new(
+        dependencies: {
+          fetch_provider_uri: Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey,
+          fetch_jwks_uri: Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        def call
+          create
+        end
+
+        private
+
+        def create
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingJwtSigningKeyConfiguration.new)
+          validate_key_configuration
+
+          if provider_uri_has_valid_configuration?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingProviderUriSigningKey.new)
+            fetch_provider_uri_signing_key
+          elsif jwks_uri_has_valid_configuration?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwksUriSigningKey.new)
+            fetch_jwks_uri_signing_key
+          end
+        end
+
+        def validate_key_configuration
+          if (provider_uri_has_valid_configuration? && jwks_uri_has_valid_configuration?) ||
+              (!provider_uri_has_valid_configuration? && !jwks_uri_has_valid_configuration?)
+            raise Errors::Authentication::AuthnJwt::InvalidUriConfiguration.new(
+              PROVIDER_URI_RESOURCE_NAME,
+              JWKS_URI_RESOURCE_NAME
+            )
+          end
+        end
+
+        def provider_uri_has_valid_configuration?
+          @provider_uri_has_valid_configuration ||= fetch_provider_uri_signing_key.has_valid_configuration?
+        end
+
+        def jwks_uri_has_valid_configuration?
+          @jwks_uri_has_valid_configuration ||= fetch_jwks_uri_signing_key.has_valid_configuration?
+        end
+
+        def fetch_provider_uri_signing_key
+          @fetch_provider_uri_signing_key ||= @fetch_provider_uri.new(authentication_parameters: @authentication_parameters,
+                                                                      logger: Rails.logger,
+                                                                      fetch_required_secrets: Conjur::FetchRequiredSecrets.new,
+                                                                      resource_class: ::Resource,
+                                                                      discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new)
+        end
+
+        def fetch_jwks_uri_signing_key
+          @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri.new(authentication_parameters: @authentication_parameters,
+                                                              logger: Rails.logger,
+                                                              fetch_required_secrets: Conjur::FetchRequiredSecrets.new,
+                                                              resource_class: ::Resource,
+                                                              http_lib: Net::HTTP,
+                                                              create_jwks_from_http_response: CreateJwksFromHttpResponse.new)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_cached_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_cached_signing_key.rb
@@ -1,0 +1,25 @@
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      # FetchCachedSigningKey command class is a callable wrapper of FetchSigningKeyInterface interface,
+      # in order to be able to store the signing key in our cache mechanism
+      FetchCachedSigningKey ||= CommandClass.new(
+        dependencies: {
+          fetch_singing_key_interface: ::Authentication::AuthnJwt::SigningKey::FetchSigningKeyInterface,
+          logger: Rails.logger
+        },
+        inputs: %i[]
+      ) do
+        def call
+          fetch_signing_key
+        end
+
+        private
+
+        def fetch_signing_key
+          @fetch_singing_key_interface.fetch_signing_key
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -1,0 +1,83 @@
+require 'uri'
+require 'net/http'
+require 'base64'
+
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      # This class is responsible for fetching JWK Set from JWKS-uri
+      class FetchJwksUriSigningKey < FetchSigningKeyInterface
+
+        def initialize(authentication_parameters:,
+          logger:,
+          fetch_required_secrets:,
+          resource_class:,
+          http_lib:,
+          create_jwks_from_http_response:)
+          @logger = logger
+          @resource_id = authentication_parameters.authenticator_resource_id
+          @fetch_required_secrets = fetch_required_secrets
+          @resource_class = resource_class
+          @http_lib = http_lib
+          @create_jwks_from_http_response = create_jwks_from_http_response
+        end
+
+        def has_valid_configuration?
+          @jwks_uri_resource_exists ||= jwks_uri_resource_exists?
+        end
+
+        def fetch_signing_key
+          fetch_jwks_uri
+          fetch_jwks_keys
+        end
+
+        private
+
+        def jwks_uri_resource_exists?
+          !jwks_uri_resource.nil?
+        end
+
+        def jwks_uri_resource
+          @jwks_uri_resource ||= resource
+        end
+
+        def resource
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwtConfigurationValue.new(jwks_uri_resource_id))
+          @resource_class[jwks_uri_resource_id]
+        end
+
+        def fetch_jwks_uri
+          jwks_uri
+        end
+
+        def jwks_uri
+          @jwks_uri ||= jwks_uri_secret[jwks_uri_resource_id]
+        end
+
+        def jwks_uri_secret
+          @jwks_uri_secret ||= @fetch_required_secrets.(resource_ids: [jwks_uri_resource_id])
+        end
+
+        def jwks_uri_resource_id
+          "#{@resource_id}/#{JWKS_URI_RESOURCE_NAME}"
+        end
+
+        def fetch_jwks_keys
+          begin
+            uri = URI(jwks_uri)
+            @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(jwks_uri))
+            response = @http_lib.get_response(uri)
+            @logger.debug(LogMessages::Authentication::AuthnJwt::FetchJwtUriKeysSuccess.new)
+          rescue => e
+            raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(
+              jwks_uri,
+              e.inspect
+            )
+          end
+
+          @create_jwks_from_http_response.call(http_response: response)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
@@ -1,0 +1,78 @@
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      # This class is responsible for fetching JWK Set from provider-uri
+      class FetchProviderUriSigningKey < FetchSigningKeyInterface
+
+        def initialize(authentication_parameters:,
+          logger:,
+          fetch_required_secrets:,
+          resource_class:,
+          discover_identity_provider:)
+          @logger = logger
+          @resource_id = authentication_parameters.authenticator_resource_id
+          @fetch_required_secrets = fetch_required_secrets
+          @resource_class = resource_class
+          @discover_identity_provider = discover_identity_provider
+        end
+
+        def has_valid_configuration?
+          @provier_uri_resource_exists ||= provider_uri_resource_exists?
+        end
+
+        def fetch_signing_key
+          discover_provider
+          fetch_provider_keys
+        end
+
+        private
+
+        def provider_uri_resource_exists?
+          !provider_uri_resource.nil?
+        end
+
+        def provider_uri_resource
+          @provider_uri_resource ||= resource
+        end
+
+        def resource
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwtConfigurationValue.new(provider_uri_resource_id))
+          @resource_class[provider_uri_resource_id]
+        end
+
+        def provider_uri
+          @provider_uri ||= provider_uri_secret[provider_uri_resource_id]
+        end
+
+        def provider_uri_secret
+          @provider_uri_secret ||= @fetch_required_secrets.(resource_ids: [provider_uri_resource_id])
+        end
+
+        def provider_uri_resource_id
+          "#{@resource_id}/#{PROVIDER_URI_RESOURCE_NAME}"
+        end
+
+        def discover_provider
+          discovered_provider
+        end
+
+        def discovered_provider
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(provider_uri))
+          @discovered_provider ||= @discover_identity_provider.(
+            provider_uri: provider_uri
+          )
+        end
+
+        def fetch_provider_keys
+          @logger.debug(LogMessages::Authentication::OAuth::FetchProviderKeysSuccess.new)
+          { keys: @discovered_provider.jwks }
+        rescue => e
+          raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(
+            @provider_uri,
+            e.inspect
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_signing_key_interface.rb
@@ -1,0 +1,11 @@
+module Authentication
+  module AuthnJwt
+    module SigningKey
+      class FetchSigningKeyInterface
+        def create; end
+
+        def has_valid_configuration?; end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/fetch_issuer_value.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/fetch_issuer_value.rb
@@ -1,0 +1,149 @@
+require 'uri'
+
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # FetchIssuerValue command class is responsible to fetch the issuer secret value,
+      # in order to validate it later against the JWT token claim
+      FetchIssuerValue ||= CommandClass.new(
+        dependencies: {
+          resource_class: ::Resource,
+          fetch_secrets: ::Conjur::FetchRequiredSecrets.new,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        extend(Forwardable)
+        def_delegators(:@authentication_parameters, :service_id, :authenticator_name,
+                       :account)
+
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingIssuerConfigurationValue.new)
+          fetch_issuer_value
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchedIssuerValueFromConfiguration.new)
+
+          @issuer_value
+        end
+
+        private
+
+        # fetch_issuer_value function is responsible to fetch the issuer secret value,
+        # according to the following logic:
+        # Fetch from `issuer` authenticator resource,
+        # In case `issuer` authenticator resource not configured, then only 1 resource, `provider-uri` or `jwks-uri`,
+        # should be configured.
+        # So the priority is:
+        # 1. issuer
+        # 2. provider-uri or jwks-uri
+        # In case the resource is configured but the not initialized with secret, throw an error
+        def fetch_issuer_value
+          if issuer_resource_exists?
+            @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(ISSUER_RESOURCE_NAME)))
+
+            @issuer_value=issuer_secret_value
+          else
+            validate_issuer_configuration
+
+            if provider_uri_resource_exists?
+              @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(PROVIDER_URI_RESOURCE_NAME)))
+
+              @issuer_value=provider_uri_secret_value
+            elsif jwks_uri_resource_exists?
+              @logger.debug(LogMessages::Authentication::AuthnJwt::IssuerResourceNameConfiguration.new(resource_id(JWKS_URI_RESOURCE_NAME)))
+
+              @issuer_value=fetch_issuer_from_jwks_uri_secret
+            end
+          end
+
+          @logger.debug(LogMessages::Authentication::AuthnJwt::RetrievedIssuerValue.new(@issuer_value))
+        end
+
+        def issuer_resource_exists?
+          !issuer_resource.nil?
+        end
+
+        def issuer_resource
+          @issuer_resource ||= resource(ISSUER_RESOURCE_NAME)
+        end
+
+        def resource(resource_name)
+          @resource_class[resource_id(resource_name)]
+        end
+
+        def resource_id(resource_name)
+          "#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}"
+        end
+
+        def issuer_secret_value
+          @issuer_secret_value ||= issuer_secret[resource_id(ISSUER_RESOURCE_NAME)]
+        end
+
+        def issuer_secret
+          @issuer_secret ||= @fetch_secrets.(resource_ids: [resource_id(ISSUER_RESOURCE_NAME)])
+        end
+
+        def validate_issuer_configuration
+          if (provider_uri_resource_exists? && jwks_uri_resource_exists?) ||
+              (!provider_uri_resource_exists? && !jwks_uri_resource_exists?)
+            raise Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration.new(
+              ISSUER_RESOURCE_NAME,
+              PROVIDER_URI_RESOURCE_NAME,
+              JWKS_URI_RESOURCE_NAME
+            )
+          end
+        end
+
+        def provider_uri_resource_exists?
+          !provider_uri_resource.nil?
+        end
+
+        def jwks_uri_resource_exists?
+          !jwks_uri_resource.nil?
+        end
+
+        def provider_uri_resource
+          @provider_uri_resource ||= resource(PROVIDER_URI_RESOURCE_NAME)
+        end
+
+        def jwks_uri_resource
+          @jwks_uri_resource ||= resource(JWKS_URI_RESOURCE_NAME)
+        end
+
+        def provider_uri_secret_value
+          @provider_uri_secret_value ||= provider_uri_secret[resource_id(PROVIDER_URI_RESOURCE_NAME)]
+        end
+
+        def provider_uri_secret
+          @provider_uri_secret ||= @fetch_secrets.(resource_ids: [resource_id(PROVIDER_URI_RESOURCE_NAME)])
+        end
+
+        def fetch_issuer_from_jwks_uri_secret
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingIssuerFromUri.new(jwks_uri_secret_value))
+
+          begin
+            @issuer_from_jwks_uri_secret ||= URI.parse(jwks_uri_secret_value).hostname
+          rescue => e
+            raise Errors::Authentication::AuthnJwt::InvalidUriFormat.new(
+              jwks_uri_secret_value,
+              e.inspect
+            )
+          end
+
+          if @issuer_from_jwks_uri_secret.blank?
+            raise Errors::Authentication::AuthnJwt::FailedToParseHostnameFromUri, jwks_uri_secret_value
+          end
+
+          @issuer_from_jwks_uri_secret
+        end
+
+        def jwks_uri_secret_value
+          @jwks_uri_secret_value ||=jwks_uri_secret[resource_id(JWKS_URI_RESOURCE_NAME)]
+        end
+
+        def jwks_uri_secret
+          @jwks_uri_secret ||= @fetch_secrets.(resource_ids: [resource_id(JWKS_URI_RESOURCE_NAME)])
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/fetch_jwt_claims_to_validate.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/fetch_jwt_claims_to_validate.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # FetchJwtClaimsToValidate command class is responsible to return a list of JWT standard claims to
+      # validate, according to the following logic:
+      # For each optional claim (iss, exp, nbf, iat) that exists in the token - add to mandatory list
+      # Note: the list also contains the value to validate if necessary (for example iss: cyberark.com)
+      FetchJwtClaimsToValidate ||= CommandClass.new(
+        dependencies: {
+          fetch_issuer_value: ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new,
+          jwt_claim_class: ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        extend(Forwardable)
+        def_delegators(:@authentication_parameters, :decoded_token)
+
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingJwtClaimsToValidate.new)
+          validate_decoded_token_exists
+          fetch_jwt_claims_to_validate
+          @logger.debug(
+            LogMessages::Authentication::AuthnJwt::FetchedJwtClaimsToValidate.new(
+              jwt_claims_names_to_validate
+            )
+          )
+
+          jwt_claims_to_validate
+        end
+
+        private
+
+        MANDATORY_CLAIMS = [EXP_CLAIM_NAME].freeze
+        OPTIONAL_CLAIMS = [ISS_CLAIM_NAME, NBF_CLAIM_NAME, IAT_CLAIM_NAME].freeze
+
+        def validate_decoded_token_exists
+          raise Errors::Authentication::AuthnJwt::MissingToken if decoded_token.blank?
+        end
+
+        def fetch_jwt_claims_to_validate
+          add_mandatory_claims_to_jwt_claims_list
+          add_optional_claims_to_jwt_claims_list
+        end
+
+        def add_mandatory_claims_to_jwt_claims_list
+          MANDATORY_CLAIMS.each do |mandatory_claim|
+            add_to_jwt_claims_list(mandatory_claim)
+          end
+        end
+
+        def add_optional_claims_to_jwt_claims_list
+          OPTIONAL_CLAIMS.each do |optional_claim|
+            @logger.debug(LogMessages::Authentication::AuthnJwt::CheckingJwtClaimToValidate.new(optional_claim))
+
+            add_to_jwt_claims_list(optional_claim) if decoded_token[optional_claim]
+          end
+        end
+
+        def add_to_jwt_claims_list(claim)
+          @logger.debug(LogMessages::Authentication::AuthnJwt::AddingJwtClaimToValidate.new(claim))
+
+          jwt_claims_to_validate.push(
+            @jwt_claim_class.new(
+              name: claim,
+              value: claim_value(claim)
+            )
+          )
+        end
+
+        def jwt_claims_to_validate
+          @jwt_claims_to_validate ||= []
+        end
+
+        def claim_value(claim)
+          case claim
+          when ISS_CLAIM_NAME
+            @fetch_issuer_value.call(
+              authentication_parameters: @authentication_parameters
+            )
+          else
+            # Claims that do not need an additional value to be validated will be set with nil value
+            # For example: exp, nbf, iat
+            nil
+          end
+        end
+
+        def jwt_claims_names_to_validate
+          @jwt_claims_names_to_validate ||= (jwt_claims_to_validate.map {|claim| claim.name }).to_s
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/get_verification_option_by_jwt_claim.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/get_verification_option_by_jwt_claim.rb
@@ -1,0 +1,59 @@
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # GetVerificationOptionByJwtClaim command class is responsible to get jwt claim and return his verification option,
+      # in order to validate it against JWT 3rd party, for example:
+      # 1. Input: {name: iss, value: cyberark.com} // jwt claim
+      #    Output: {:iss => cyberark.com, :verify_iss => true} // verification option dictionary
+      # 2. Input: {name: iat, value: } // jwt claim
+      #    Output: {:verify_iat => true} // verification option dictionary
+      # 3. Input: {name: exp, value: } // jwt claim
+      #    Output: {} // verification option dictionary
+      # 4. Input: {name: nbf, value: } // jwt claim
+      #    Output: {} // verification option dictionary
+      GetVerificationOptionByJwtClaim ||= CommandClass.new(
+        dependencies: {
+          logger: Rails.logger
+        },
+        inputs: [:jwt_claim]
+      ) do
+        def call
+          validate_claim_exists
+          get_verification_option_by_jwt_claim
+        end
+
+        private
+
+        def validate_claim_exists
+          raise Errors::Authentication::AuthnJwt::MissingClaim if @jwt_claim.blank?
+        end
+
+        def get_verification_option_by_jwt_claim
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ConvertingJwtClaimToVerificationOption.new(@jwt_claim.name))
+
+          case @jwt_claim.name
+          when EXP_CLAIM_NAME, NBF_CLAIM_NAME
+            @verification_option = {}
+          when ISS_CLAIM_NAME
+            raise Errors::Authentication::AuthnJwt::MissingClaimValue, @jwt_claim.name if @jwt_claim.value.blank?
+
+            @verification_option = { iss: @jwt_claim.value, verify_iss: true }
+          when IAT_CLAIM_NAME
+            @verification_option = { verify_iat: true }
+          else
+            raise Errors::Authentication::AuthnJwt::UnsupportedClaim, @jwt_claim.name
+          end
+
+          @logger.debug(
+            LogMessages::Authentication::AuthnJwt::ConvertedJwtClaimToVerificationOption.new(
+              @jwt_claim.name,
+              @verification_option.to_s
+            )
+          )
+
+          @verification_option
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/jwt_claim.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/jwt_claim.rb
@@ -1,0 +1,15 @@
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # This class instance holds a JWT standard claim
+      class JwtClaim
+        attr_reader :name, :value
+
+        def initialize(name:, value:)
+          @name = name
+          @value = value
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
@@ -1,0 +1,143 @@
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # ValidateAndDecodeToken command class is responsible to validate the JWT token 2 times:
+      # 1st we are validating only the signature.
+      # 2nd we are validating the claims, by checking the token content to decide which claims are mandatory
+      # for the 2nd validation
+      ValidateAndDecodeToken ||= CommandClass.new(
+        dependencies: {
+          fetch_signing_key: ::Util::ConcurrencyLimitedCache.new(
+            ::Util::RateLimitedCache.new(
+              ::Authentication::AuthnJwt::SigningKey::FetchCachedSigningKey.new(
+                singing_key_interface: ::Authentication::AuthnJwt::SigningKey::FetchSigningKeyInterface
+              ),
+              refreshes_per_interval: CACHE_REFRESHES_PER_INTERVAL,
+              rate_limit_interval: CACHE_RATE_LIMIT_INTERVAL,
+              logger: Rails.logger
+            ),
+            max_concurrent_requests: CACHE_MAX_CONCURRENT_REQUESTS,
+            logger: Rails.logger
+          ),
+          verify_and_decode_token: ::Authentication::Jwt::VerifyAndDecodeToken.new,
+          fetch_jwt_claims_to_validate: ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new,
+          get_verification_option_by_jwt_claim: ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        extend(Forwardable)
+        def_delegators(:@authentication_parameters, :jwt_token)
+
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingToken.new)
+          validate_token_exists
+          fetch_signing_key
+          validate_signature
+          fetch_jwt_claims_to_validate
+          validate_claims
+          decoded_token_after_claims_validation
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedToken.new)
+
+          @decoded_token_after_claims_validation
+        end
+
+        private
+
+        def validate_token_exists
+          raise Errors::Authentication::AuthnJwt::MissingToken if jwt_token.blank?
+        end
+
+        def fetch_signing_key(force_read: false)
+          @jwks = @fetch_signing_key.call(refresh: force_read)
+          @logger.debug(LogMessages::Authentication::AuthnJwt::SigningKeysFetchedFromCache.new)
+        end
+
+        def validate_signature
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingTokenSignature.new)
+          ensure_keys_are_fresh
+          decoded_token_after_signature_only_validation
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedTokenSignature.new)
+        end
+
+        def ensure_keys_are_fresh
+          decoded_token_after_signature_only_validation
+        rescue
+          @logger.debug(
+            LogMessages::Authentication::AuthnJwt::ValidateSigningKeysAreUpdated.new
+          )
+          # maybe failed due to keys rotation. Force cache to read it again
+          fetch_signing_key(force_read: true)
+        end
+
+        def decoded_token_after_signature_only_validation
+          @decoded_token_after_signature_only_validation ||= decoded_token(verification_options_for_signature_only)
+        end
+
+        def verification_options_for_signature_only
+          @verification_options_for_signature_only = {
+            algorithms: algorithms,
+            jwks: @jwks
+          }
+        end
+
+        def algorithms
+          @algorithms ||= SUPPORTED_ALGORITHMS
+        end
+
+        def decoded_token(verification_options)
+          @decoded_token = @verify_and_decode_token.call(
+            token_jwt: jwt_token,
+            verification_options: verification_options
+          )
+        end
+
+        def fetch_jwt_claims_to_validate
+          update_authentication_parameters_with_decoded_token
+          jwt_claims_to_validate
+        end
+
+        def update_authentication_parameters_with_decoded_token
+          @authentication_parameters.decoded_token = decoded_token_after_signature_only_validation
+        end
+
+        def jwt_claims_to_validate
+          @claims_to_validate ||= @fetch_jwt_claims_to_validate.call(
+            authentication_parameters: @authentication_parameters
+          )
+        end
+
+        def validate_claims
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingTokenClaims.new)
+          jwt_claims_to_validate.each do |jwt_claim|
+            if @decoded_token[jwt_claim.name].blank?
+              raise Errors::Authentication::AuthnJwt::MissingMandatoryClaim, jwt_claim.name
+            end
+
+            verification_option = @get_verification_option_by_jwt_claim.call(jwt_claim: jwt_claim)
+            add_to_verification_options_with_claims(verification_option)
+          end
+
+          validate_token_with_claims
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedTokenClaims.new)
+        end
+
+        def add_to_verification_options_with_claims(verification_option)
+          @verification_options_with_claims = verification_options_with_claims.merge(verification_option)
+        end
+
+        def verification_options_with_claims
+          @verification_options_with_claims ||= verification_options_for_signature_only
+        end
+
+        def validate_token_with_claims
+          decoded_token_after_claims_validation
+        end
+
+        def decoded_token_after_claims_validation
+          @decoded_token_after_claims_validation ||= decoded_token(verification_options_with_claims)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -1,0 +1,122 @@
+module Authentication
+  module AuthnJwt
+
+    ValidateStatus = CommandClass.new(
+      dependencies: {
+        create_signing_key: Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new,
+        fetch_issuer_value: Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new,
+        fetch_identity_from_token: Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider,
+        validate_webservice_is_whitelisted: ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,
+        validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
+        validate_webservice_exists: ::Authentication::Security::ValidateWebserviceExists.new,
+        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV),
+        validate_account_exists: ::Authentication::Security::ValidateAccountExists.new,
+        logger: Rails.logger
+      },
+      inputs: %i[authenticator_status_input]
+    ) do
+      extend(Forwardable)
+      def_delegators(:@authenticator_status_input, :authenticator_name, :account,
+                     :username, :status_webservice, :service_id, :client_ip)
+
+      def call
+        validate_generic_status_validations
+        validate_secrets
+      end
+
+      private
+
+      def validate_generic_status_validations
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatingJwtStatusConfiguration.new)
+        validate_account_exists
+        validate_service_id_exists
+        validate_user_has_access_to_status_webservice
+        validate_authenticator_webservice_exists
+        validate_webservice_is_whitelisted
+      end
+
+      def validate_account_exists
+        @validate_account_exists.(
+          account: account
+        )
+      end
+
+      def validate_service_id_exists
+        raise Errors::Authentication::AuthnJwt::ServiceIdMissing unless service_id
+
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedStatusServiceIdExists.new)
+      end
+
+      def validate_user_has_access_to_status_webservice
+        @validate_role_can_access_webservice.(
+          webservice: status_webservice,
+          account: account,
+          user_id: username,
+          privilege: 'read'
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedUserHasAccessToStatusWebservice.new)
+      end
+
+      def validate_authenticator_webservice_exists
+        @validate_webservice_exists.(
+          webservice: webservice,
+          account: account
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedAuthenticatorWebServiceExists.new)
+      end
+
+      def validate_webservice_is_whitelisted
+        @validate_webservice_is_whitelisted.(
+          webservice: webservice,
+          account: account,
+          enabled_authenticators: @enabled_authenticators
+        )
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedStatusWebserviceIsWhitelisted.new)
+      end
+
+      def validate_secrets
+        validate_signing_key_secrets
+        validate_issuer
+        validate_identity_secrets
+      end
+
+      def validate_signing_key_secrets
+        @create_signing_key.call(authentication_parameters: authentication_parameters)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedSigningKeyConfiguration.new)
+      end
+
+      def validate_issuer
+        @fetch_issuer_value.call(authentication_parameters: authentication_parameters)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedIssuerConfiguration.new)
+      end
+
+      def validate_identity_secrets
+        @fetch_identity_from_token.new(authentication_parameters).identity_configured_properly?
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedIdentityConfiguration.new)
+      end
+
+      def authentication_parameters
+        @authentication_parameters ||= Authentication::AuthnJwt::AuthenticationParameters.new(
+          authentication_input: Authentication::AuthenticatorInput.new(
+            authenticator_name: authenticator_name,
+            service_id: service_id,
+            account: account,
+            username: username,
+            client_ip: client_ip,
+            credentials: nil,
+            request: nil
+          ),
+          jwt_token: nil
+        )
+      end
+
+      def webservice
+        @webservice ||= ::Authentication::Webservice.new(
+          account: account,
+          authenticator_name: authenticator_name,
+          service_id: service_id
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -9,7 +9,7 @@ module Authentication
         validate_webservice_is_whitelisted: ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,
         validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
         validate_webservice_exists: ::Authentication::Security::ValidateWebserviceExists.new,
-        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str(ENV),
+        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str,
         validate_account_exists: ::Authentication::Security::ValidateAccountExists.new,
         logger: Rails.logger
       },

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_factory.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_factory.rb
@@ -1,0 +1,20 @@
+module Authentication
+  module AuthnJwt
+    module VendorConfigurations
+      # Factory that receives an authenticator name and returns the appropriate JWT vendor configuration class
+      class ConfigurationFactory
+        AUTHENTICATORS = {
+          "authn-jwt" => ConfigurationJWTGenericVendor
+        }
+
+        def create_jwt_configuration(authenticator_name)
+          unless AUTHENTICATORS[authenticator_name]
+            raise Errors::Authentication::AuthnJwt::UnsupportedAuthenticator, authenticator_name
+          end
+
+          AUTHENTICATORS[authenticator_name].new
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_interface.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_interface.rb
@@ -1,0 +1,16 @@
+module Authentication
+  module AuthnJwt
+    module VendorConfigurations
+      # Interface containing JWT configuration functions to be implemented in JWTConfiguration class for a vendor
+      class ConfigurationInterface
+        def authentication_parameters(authenticator_input); end
+
+        def jwt_identity(authentication_parameters); end
+
+        def validate_restrictions(authentication_parameters); end
+
+        def validate_and_decode_token(authentication_parameters); end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -1,0 +1,124 @@
+module Authentication
+  module AuthnJwt
+    module VendorConfigurations
+      # Mock JWTConfiguration class to use it to develop other part in the jwt authenticator
+      class ConfigurationJWTGenericVendor < ConfigurationInterface
+
+        def initialize
+          @authentication_parameters_class = Authentication::AuthnJwt::AuthenticationParameters
+          @extract_token_from_credentials = Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new
+          @validate_and_decode_token_class = Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken
+          @identity_provider_factory = Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider
+          @validate_resource_restrictions_class = Authentication::ResourceRestrictions::ValidateResourceRestrictions
+          @create_identity_provider_class = Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider
+          @logger = Rails.logger
+        end
+
+        def authentication_parameters(authenticator_input)
+          @logger.debug(LogMessages::Authentication::AuthnJwt::CREATING_AUTHENTICATION_PARAMETERS_OBJECT.new)
+          jwt_token = @extract_token_from_credentials.call(
+            credentials: authenticator_input.request.body.read
+          )
+          @authentication_parameters_class.new(
+            authentication_input: authenticator_input,
+            jwt_token: jwt_token
+          )
+        end
+
+        def jwt_identity(authentication_parameters)
+          identity_provider = @create_identity_provider_class.new.call(
+            authentication_parameters: authentication_parameters
+          )
+          identity_provider.provide_jwt_identity
+        end
+
+        def validate_restrictions(authentication_parameters)
+          initialize_validate_restrictions
+          @validate_resource_restrictions.call(
+            authenticator_name: authentication_parameters.authenticator_name,
+            service_id: authentication_parameters.service_id,
+            account: authentication_parameters.account,
+            role_name: authentication_parameters.jwt_identity,
+            constraints: @constraints,
+            authentication_request: @restriction_validator.new(
+              decoded_token: authentication_parameters.decoded_token
+            )
+          )
+        end
+
+        def validate_and_decode_token(authentication_parameters)
+          set_authentication_parameters(authentication_parameters)
+          initialize_validate_and_decode_token
+          @validate_and_decode_token.call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        private
+
+        def set_authentication_parameters(authentication_parameters)
+          @authentication_parameters = authentication_parameters
+        end
+
+        def initialize_validate_and_decode_token
+          initialize_validate_and_decode_token_dependencies
+          @validate_and_decode_token ||= @validate_and_decode_token_class.new(
+            fetch_signing_key: fetch_signing_key,
+            fetch_jwt_claims_to_validate: fetch_jwt_claims_to_validate
+          )
+        end
+
+        def initialize_validate_and_decode_token_dependencies
+          fetch_signing_key
+          fetch_jwt_claims_to_validate
+        end
+
+        def fetch_signing_key
+          @fetch_signing_key ||= fetch_cached_signing_key
+        end
+
+        def fetch_cached_signing_key
+          @fetch_cached_signing_key ||= ::Util::ConcurrencyLimitedCache.new(
+            ::Util::RateLimitedCache.new(
+              ::Authentication::AuthnJwt::SigningKey::FetchCachedSigningKey.new(
+                fetch_singing_key_interface: fetch_singing_key_interface
+              ),
+              refreshes_per_interval: CACHE_REFRESHES_PER_INTERVAL,
+              rate_limit_interval: CACHE_RATE_LIMIT_INTERVAL,
+              logger: Rails.logger
+            ),
+            max_concurrent_requests: CACHE_MAX_CONCURRENT_REQUESTS,
+            logger: Rails.logger
+          )
+        end
+
+        def fetch_singing_key_interface
+          @fetch_singing_key_interface ||= create_signing_key_interface.call(
+            authentication_parameters: @authentication_parameters
+          )
+        end
+
+        def create_signing_key_interface
+          @create_signing_key_interface ||= Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new
+        end
+
+        def fetch_jwt_claims_to_validate
+          @fetch_jwt_claims_to_validate ||= ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new
+        end
+
+        def initialize_validate_restrictions
+          @restriction_validator = Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne
+          @restrictions_from_annotations_class = Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation
+          @extract_resource_restrictions = Authentication::ResourceRestrictions::ExtractResourceRestrictions.new(
+            get_restriction_from_annotation: @restrictions_from_annotations_class,
+            ignore_empty_annotations: false
+          )
+          @validate_resource_restrictions = @validate_resource_restrictions_class.new(extract_resource_restrictions: @extract_resource_restrictions)
+          @constraints = Authentication::Constraints::MultipleConstraint.new(
+            Authentication::Constraints::NotEmptyConstraint.new
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/constraints/not_empty_constraint.rb
+++ b/app/domain/authentication/constraints/not_empty_constraint.rb
@@ -1,0 +1,12 @@
+module Authentication
+  module Constraints
+
+    # This constraint returns true if the resource restriction contains at least one restriction. Otherwise it raises
+    # EmptyAnnotationsListConfigured exception
+    class NotEmptyConstraint
+      def validate(resource_restrictions:)
+        raise Errors::Authentication::Constraints::RoleMissingAnyRestrictions if resource_restrictions.empty?
+      end
+    end
+  end
+end

--- a/app/domain/authentication/jwt/decoded_credentials.rb
+++ b/app/domain/authentication/jwt/decoded_credentials.rb
@@ -4,23 +4,42 @@ module Authentication
     class DecodedCredentials
 
       JWT_REQUEST_BODY_FIELD_NAME = "jwt".freeze
+      # https://datatracker.ietf.org/doc/html/rfc4648#section-5
+      # jwt token is 3 blocks of base64url encoded strings separated by period '.'
+      # base64url encoding differs from regular base64 encoding as follows
+      # - padding is skipped so the pad character '=' doesn't have to be percent encoded
+      # - the 62nd and 63rd regular base64 encoding characters ('+' and '/') are replace with ('-' and '_')
+      #   The changes make the encoding alphabet file and URL safe.
+      # tokens without a signature part are denied
+      BASE_64_URL_REGEX = "[-A-Za-z0-9_=]+".freeze
+      JWT_REGEX = /\A#{BASE_64_URL_REGEX}\.#{BASE_64_URL_REGEX}\.#{BASE_64_URL_REGEX}\z/.freeze
 
       def initialize(credentials)
         @decoded_credentials = Hash[URI.decode_www_form(credentials)]
-        validate
+        validate_jwt_request_field_is_present
+        validate_jwt_format
       end
 
       def jwt
-        @decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME]
+        @jwt ||= @decoded_credentials[JWT_REQUEST_BODY_FIELD_NAME].strip
       end
 
       private
 
-      def validate
+      def validate_jwt_request_field_is_present
         if @decoded_credentials.fetch(JWT_REQUEST_BODY_FIELD_NAME, "") == ""
           raise Errors::Authentication::RequestBody::MissingRequestParam, JWT_REQUEST_BODY_FIELD_NAME
         end
       end
+
+      def validate_jwt_format
+        raise Errors::Authentication::Jwt::RequestBodyMissingJWTToken unless is_jwt?
+      end
+
+      def is_jwt?
+        jwt =~ JWT_REGEX
+      end
+
     end
   end
 end

--- a/app/domain/authentication/resource_restrictions/fetch_resource_annotations.rb
+++ b/app/domain/authentication/resource_restrictions/fetch_resource_annotations.rb
@@ -1,0 +1,48 @@
+require 'command_class'
+
+module Authentication
+  module ResourceRestrictions
+
+    FetchResourceAnnotations = CommandClass.new(
+      dependencies: {
+        role_class: ::Role,
+        resource_class: ::Resource
+      },
+      inputs: %i[account role_name ignore_empty_annotations]
+    ) do
+
+      def call
+        fetch_resource_annotations
+      end
+
+      private
+
+      def fetch_resource_annotations
+        resource_annotations
+      end
+
+      def resource_annotations
+        resource.annotations.each_with_object({}) do |annotation, result|
+          annotation_values = annotation.values
+          value = annotation_values[:value]
+          next if value.blank? and @ignore_empty_annotations
+
+          result[annotation_values[:name]] = value
+        end
+      end
+
+      def resource
+        return @resource if @resource
+
+        @resource = @resource_class[role_id]
+        raise Errors::Authentication::Security::RoleNotFound, role_id unless @resource
+        @resource
+      end
+
+      def role_id
+        @role_id ||= @role_class.roleid_from_username(@account, @role_name)
+      end
+
+    end
+  end
+end

--- a/app/domain/authentication/resource_restrictions/get_restriction_from_annotation.rb
+++ b/app/domain/authentication/resource_restrictions/get_restriction_from_annotation.rb
@@ -1,0 +1,45 @@
+require 'command_class'
+
+module Authentication
+  module ResourceRestrictions
+    # Parses the given annotation name and tries to extract a restriction from it.
+    # A restriction can have 2 formats:
+    # 1. "<Authenticator name>/<Restriction name>"
+    # 2. "<Authenticator name>/<Service ID>/<Restriction name>"
+    #
+    # The first format is a general restriction.
+    # This means it is relevant to all services of this authenticator.
+    #
+    # The second format is specific to the specified service ID.
+    # This means all other services will ignore it.
+    # Moreover, if both formats are found for the same restriction, the specific one will be used.
+    #
+    # This function returns the restriction name, if found (nil otherwise) and a
+    # boolean indicating if it is a general restriction or not.
+    GetRestrictionFromAnnotation = CommandClass.new(
+      dependencies: {},
+      inputs: %i[annotation_name authenticator_name service_id]
+    ) do
+
+      def call
+        get_restriction_from_annotation
+      end
+
+      private
+
+      def get_restriction_from_annotation
+        @annotation_name.match(authenticator_prefix_regex) do |prefix_match|
+          # Take the restriction name from the corresponding capture group in the match
+          restriction_name = prefix_match[:restriction_name]
+          is_general_restriction = prefix_match[:service_id].blank?
+          return restriction_name, is_general_restriction
+        end
+      end
+
+      def authenticator_prefix_regex
+        # The regex capture group <restriction_name> has the annotation name without the prefix
+        @authenticator_prefix_regex ||= Regexp.new("^#{@authenticator_name}/(?<service_id>#{@service_id}/)?(?<restriction_name>[^/]+)$")
+      end
+    end
+  end
+end

--- a/app/domain/authentication/resource_restrictions/get_service_specific_restriction_from_annotation.rb
+++ b/app/domain/authentication/resource_restrictions/get_service_specific_restriction_from_annotation.rb
@@ -1,0 +1,44 @@
+require 'command_class'
+
+module Authentication
+  module ResourceRestrictions
+    # Parses the given annotation name and tries to extract a restriction from it.
+    # A restriction in format "<Authenticator name>/<Service ID>/<Restriction name>"
+    #
+    # The first format is a general restriction.
+    # This means it is relevant to all services of this authenticator.
+    #
+    # The format is specific to the specified service ID.
+    # This means all other services will ignore it.
+    # Moreover, if both formats are found for the same restriction, the specific one will be used.
+    #
+    # This function returns the restriction name if there is service id and false, if there is no service id it returns
+    # nil and true
+    GetServiceSpecificRestrictionFromAnnotation = CommandClass.new(
+      dependencies: {},
+      inputs: %i[annotation_name authenticator_name service_id]
+    ) do
+      def call
+        get_restriction_from_annotation
+      end
+
+      private
+
+      def get_restriction_from_annotation
+        @annotation_name.match(authenticator_prefix_regex) do |prefix_match|
+          # Take the restriction name from the corresponding capture group in the match
+          is_general_restriction = prefix_match[:service_id].blank?
+          restriction_name = prefix_match[:restriction_name] unless is_general_restriction
+          return restriction_name, is_general_restriction
+        end
+      end
+
+      def authenticator_prefix_regex
+        # The regex capture group <restriction_name> has the annotation name without the prefix
+        @authenticator_prefix_regex ||= Regexp.new("^#{@authenticator_name}/(?<service_id>#{@service_id}/)?(?<restriction_name>[^/]+)$")
+      end
+
+    end
+
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -165,6 +165,11 @@ module Errors
         code: "CONJ00051E"
       )
 
+      RequestBodyMissingJWTToken = ::Util::TrackableErrorClass.new(
+        msg: "The request body does not contain JWT token",
+        code: "CONJ00077E"
+      )
+
     end
 
     module AuthnOidc
@@ -364,12 +369,125 @@ module Errors
       )
     end
 
+    module AuthnJwt
+
+      InvalidIssuerConfiguration = ::Util::TrackableErrorClass.new(
+        msg: "Issuer authenticator configuration is invalid. You should configured as authenticator variables: " \
+              "'{0-resource-name}' or one of the following: '{1-resource-name}','{2-resource-name}'",
+        code: "CONJ00170E"
+      )
+
+      FailedToParseHostnameFromUri = ::Util::TrackableErrorClass.new(
+        msg: "Failed to extract hostname from URI '{0}'",
+        code: "CONJ00171E"
+      )
+
+      InvalidUriFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse URI '{0}'. Reason: '{1}'",
+        code: "CONJ00172E"
+      )
+
+      NoSuchFieldInToken = ::Util::TrackableErrorClass.new(
+        msg: "'{0}' field not found in the token",
+        code: "CONJ00173E"
+      )
+
+      NoUsernameInTheURL = ::Util::TrackableErrorClass.new(
+        msg: "No username in the URL",
+        code: "CONJ00174E"
+      )
+
+      NoRelevantIdentityProvider = ::Util::TrackableErrorClass.new(
+        msg: "Failed to fetch the application identity",
+        code: "CONJ00175E"
+      )
+
+      JwtTokenClaimIsMissing = ::Util::TrackableErrorClass.new(
+        msg: "Claim '{0-attribute-name}' is missing from JWT token. " \
+             "Verify that you configured the host with permitted restrictions. " \
+             "In case of Compute Engine token, verify that you requested the token using 'format=full'",
+        code: "CONJ00176E"
+      )
+
+      MissingToken = ::Util::TrackableErrorClass.new(
+        msg: "Token is empty or not found.",
+        code: "CONJ00177E"
+      )
+
+      InvalidUriConfiguration = ::Util::TrackableErrorClass.new(
+        msg: "Signing key URI configuration is invalid",
+        code: "CONJ00178E"
+      )
+
+      FetchJwksKeysFailed = ::Util::TrackableErrorClass.new(
+        msg: "Failed to fetch JWKS from '{0-uri}'. Reason: '{1}'",
+        code: "CONJ00179E"
+      )
+
+      FetchJwksUriKeysNotFound = ::Util::TrackableErrorClass.new(
+        msg: "JWKS not found in response: '{0-base64-response}'",
+        code: "CONJ00180E"
+      )
+
+
+      UnsupportedClaim = ::Util::TrackableErrorClass.new(
+        msg: "Claim '{0-claim}' does not support fetching the application identity",
+        code: "CONJ00181E"
+      )
+
+      MissingClaimValue = ::Util::TrackableErrorClass.new(
+        msg: "Claim '{0-claim}' value is empty, or was not found in token.",
+        code: "CONJ00182E"
+      )
+
+      MissingMandatoryClaim = ::Util::TrackableErrorClass.new(
+        msg: "Failed to validate token, mandatory claim '{0-claim}' is missing.",
+        code: "CONJ00183E"
+      )
+
+      UnsupportedAuthenticator = ::Util::TrackableErrorClass.new(
+        msg: "Authenticator '{0-authenticator-name}' is unsupported.",
+        code: "CONJ00184E"
+      )
+
+      FailedToConvertResponseToJwks = ::Util::TrackableErrorClass.new(
+        msg: "Failed to convert HTTP response '{0-base64-response}' to JWKS type. Reason: '{1}'",
+        code: "CONJ00185E"
+      )
+
+      MissingHttpResponse = ::Util::TrackableErrorClass.new(
+        msg: "HTTP response is empty or not found.",
+        code: "CONJ00186E"
+      )
+
+      MissingClaim = ::Util::TrackableErrorClass.new(
+        msg: "Claim is empty or not found.",
+        code: "CONJ00187E"
+      )
+
+      InvalidHttpResponseFormat = ::Util::TrackableErrorClass.new(
+        msg: "HTTP response format is invalid",
+        code: "CONJ00188E"
+      )
+
+      ServiceIdMissing = ::Util::TrackableErrorClass.new(
+        msg: "Service ID is required when authenticating with authn-jwt",
+        code: "CONJ00189E"
+      )
+
+    end
+
     module ResourceRestrictions
 
       InvalidResourceRestrictions = ::Util::TrackableErrorClass.new(
         msg: "Resource restriction '{0-resource-restriction-name}' does not match " \
            "with the corresponding value in the request",
         code: "CONJ00049E"
+      )
+
+      EmptyAnnotationGiven = ::Util::TrackableErrorClass.new(
+        msg: "Annotation, '{0-annotation-name}', is empty",
+        code: "CONJ00150E"
       )
 
     end
@@ -398,6 +516,10 @@ module Errors
         code: "CONJ00069E"
       )
 
+      RoleMissingAnyRestrictions =  ::Util::TrackableErrorClass.new(
+        msg: "Role must have at least one relevant annotation",
+        code: "CONJ00070E"
+      )
     end
   end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -262,6 +262,244 @@ module LogMessages
       )
 
     end
+
+    module AuthnJwt
+
+      FetchingIssuerConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching \"issuer\" value from authenticator configuration...",
+        code: "CONJ00052D"
+      )
+
+      FetchedIssuerValueFromConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched \"issuer\" value from authenticator configuration",
+        code: "CONJ00053D"
+      )
+
+      IssuerResourceNameConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "\"issuer\" value will be taken from '{0-resource-id}'",
+        code: "CONJ00054D"
+      )
+
+      RetrievedIssuerValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Retrieved \"issuer\" with value '{0}'",
+        code: "CONJ00055D"
+      )
+
+      ParsingIssuerFromUri = ::Util::TrackableLogMessageClass.new(
+        msg: "Parsing \"issuer\" value from '{0}'...",
+        code: "CONJ00056D"
+      )
+
+      JWTAuthenticatorEntryPoint = ::Util::TrackableLogMessageClass.new(
+        msg: "Started JWT authentication flow for vendor '{0}'",
+        code: "CONJ00057D"
+      )
+
+      URL_IDENTITY_PROVIDER_SELECTED = ::Util::TrackableLogMessageClass.new(
+        msg: "The JWT ID is included in and will be retrieved from the URL",
+        code: "CONJ00058D"
+      )
+
+      DECODED_TOKEN_IDENTITY_PROVIDER_SELECTED = ::Util::TrackableLogMessageClass.new(
+        msg: "JWT Identity in decoded token is available and will be retrieved from it",
+        code: "CONJ00059D"
+      )
+
+      LOOKING_FOR_IDENTITY_FIELD_NAME = ::Util::TrackableLogMessageClass.new(
+        msg: "Looking for variable field name in '{0}'...",
+        code: "CONJ00060D"
+      )
+
+      CHECKING_IDENTITY_FIELD_EXISTS = ::Util::TrackableLogMessageClass.new(
+        msg: "Checking if field '{0}' in the token...",
+        code: "CONJ00061D"
+      )
+
+      CREATING_AUTHENTICATION_PARAMETERS_OBJECT = ::Util::TrackableLogMessageClass.new(
+        msg: "Creating authentication parameters objects...",
+        code: "CONJ00062D"
+      )
+
+      VALIDATE_AND_DECODE_TOKEN = ::Util::TrackableLogMessageClass.new(
+        msg: "Validate and decode token",
+        code: "CONJ00063D"
+      )
+
+      GET_JWT_IDENTITY = ::Util::TrackableLogMessageClass.new(
+        msg: "Getting JWT Identity",
+        code: "CONJ00064D"
+      )
+
+      CALLING_VALIDATE_RESTRICTIONS = ::Util::TrackableLogMessageClass.new(
+        msg: "Calling JWT validate restrictions",
+        code: "CONJ00065D"
+      )
+
+      JWT_AUTHENTICATION_PASSED = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully passed JWT authentication",
+        code: "CONJ00066D"
+      )
+
+      FetchingJwtClaimsToValidate = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching JWT claims to validate",
+        code: "CONJ00067D"
+      )
+
+      FetchedJwtClaimsToValidate = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetched JWT claims '{0-claims-list}' to validate",
+        code: "CONJ00068D"
+      )
+
+      AddingJwtClaimToValidate = ::Util::TrackableLogMessageClass.new(
+        msg: "Adding JWT claim, '{0-claim-name}', to list of mandatory claims to be validated...",
+        code: "CONJ00069D"
+      )
+
+      CheckingJwtClaimToValidate = ::Util::TrackableLogMessageClass.new(
+        msg: "Checking if JWT claim '{0-claim-name}' is mandatory to validate...",
+        code: "CONJ00070D"
+      )
+
+      FetchingJwtConfigurationValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching '{0-resource-id}' variable value from configuration...",
+        code: "CONJ00071D"
+      )
+
+      FetchingJwksFromProvider = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching JWKS from '{0-uri}'...",
+        code: "CONJ00072D"
+      )
+
+      FetchJwtUriKeysSuccess = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully fetched JWKS",
+        code: "CONJ00073D"
+      )
+
+      ValidatingJwtSigningKeyConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating JWT signing key URI configuration...",
+        code: "CONJ00074D"
+      )
+
+      FetchingProviderUriSigningKey = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating signing key URI configuration...",
+        code: "CONJ00075D"
+      )
+
+      FetchingJwksUriSigningKey = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching jwks-uri signing key...",
+        code: "CONJ00076D"
+      )
+      ConvertingJwtClaimToVerificationOption = ::Util::TrackableLogMessageClass.new(
+        msg: "Converting JWT claim '{0-claim-name}' to verification option",
+        code: "CONJ00077D"
+      )
+
+      ConvertedJwtClaimToVerificationOption = ::Util::TrackableLogMessageClass.new(
+        msg: "Converted JWT claim '{0-claim-name}' to verification option '{1-verification-option}'",
+        code: "CONJ00078D"
+      )
+
+      ValidateSigningKeysAreUpdated = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating that signing keys are up to date",
+        code: "CONJ00079D"
+      )
+
+      SigningKeysFetchedFromCache = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully fetched signing keys from cache",
+        code: "CONJ00080D"
+      )
+
+      ValidatingToken = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating token",
+        code: "CONJ00081D"
+      )
+
+      ValidatedToken = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated token",
+        code: "CONJ00082D"
+      )
+
+      ValidatingTokenSignature = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating token signature",
+        code: "CONJ00083D"
+      )
+
+      ValidatedTokenSignature = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated token signature",
+        code: "CONJ00084D"
+      )
+
+      ValidatingTokenClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating token claims...",
+        code: "CONJ00085D"
+      )
+
+      ValidatedTokenClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated token claims",
+        code: "CONJ00086D"
+      )
+
+      CreatingJwksFromHttpResponse = ::Util::TrackableLogMessageClass.new(
+        msg: "Creating JWKS from HTTP response...",
+        code: "CONJ00087D"
+      )
+
+      CreatedJwks = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully created JWKS",
+        code: "CONJ00088D"
+      )
+
+      ValidatedIdentityConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated identity configuration",
+        code: "CONJ00089D"
+      )
+
+      ValidatingJwtStatusConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Validating JWT status configuration...",
+        code: "CONJ00090D"
+      )
+
+      ValidatedUserHasAccessToStatusWebservice = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated user has access to status webservice",
+        code: "CONJ00091D"
+      )
+
+      ValidatedAuthenticatorWebServiceExists = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated status webservice exists",
+        code: "CONJ00092D"
+      )
+
+      ValidatedStatusWebserviceIsWhitelisted = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated status webservice is allowlisted",
+        code: "CONJ00093D"
+      )
+
+      ValidatedStatusServiceIdExists = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated that service ID exists",
+        code: "CONJ00094D"
+      )
+
+      ValidatedSigningKeyConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated signing key configuration",
+        code: "CONJ00095D"
+      )
+
+      ValidatedIssuerConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated issuer configuration",
+        code: "CONJ00096D"
+      )
+
+      FOUND_JWT_FIELD_IN_TOKEN = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully found field '{0}' in token and its value is '{1}'",
+        code: "CONJ00097D"
+      )
+
+      FOUND_JWT_IDENTITY= ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully found jwt identity '{0}'",
+        code: "CONJ00098D"
+      )
+
+    end
   end
 
   module Util

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       RAILS_ENV:
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'
@@ -89,6 +89,7 @@ services:
       - authn-local:/run/authn-local
       - ./ldap-certs:/ldap-certs:ro
       - log-volume:/src/conjur-server/log
+      - jwks-volume:/var/jwks
     links:
       - conjur
       - pg
@@ -138,7 +139,12 @@ services:
       - ./test_suites/authenticators_oidc/keycloak:/scripts
       - ./test_suites/authenticators_oidc/keycloak/standalone.xml:/opt/jboss/keycloak/standalone/configuration/standalone.xml
 
+  jwks:
+    image: nginx
+    volumes:
+      - jwks-volume:/usr/share/nginx/html
 
 volumes:
   authn-local:
   log-volume:
+  jwks-volume:

--- a/ci/test
+++ b/ci/test
@@ -60,6 +60,7 @@ SUBCOMMANDS
     authenticators_gcp     - Runs Cucumber GCP Authenticator features
     authenticators_ldap    - Runs Cucumber LDAP Authenticator features
     authenticators_oidc    - Runs Cucumber OIDC Authenticator features
+    authenticators_jwt     - Runs Cucumber JWT Authenticator features
     authenticators_status  - Runs Cucumber Authenticator status features
     policy                 - Runs Cucumber Policy features
     rotators               - Runs Cucumber Rotator features

--- a/ci/test_suites/authenticators_jwt/test
+++ b/ci/test_suites/authenticators_jwt/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# This is executed by the main "ci/test" script after cd-ing into "ci".
+# shellcheck disable=SC1091
+source "./shared.sh"
+
+additional_services='jwks'
+_run_cucumber_tests authenticators_jwt "$additional_services"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
     constraints account: /[^\/?]+/ do
       constraints authenticator: /authn-?[^\/]*/, id: /[^\/?]+/ do
+        get '/authn-jwt/:service_id/:account/status' => 'authenticate#authn_jwt_status'
         get '/:authenticator(/:service_id)/:account/status' => 'authenticate#status'
         
         patch '/:authenticator/:service_id/:account' => 'authenticate#update_config'
@@ -33,6 +34,7 @@ Rails.application.routes.draw do
         # i.e the request 'authn-oidc/:service_id/:account/authenticate' can be interpreted as
         # ':authenticator/:account/:id/authenticate'
         post '/authn-oidc(/:service_id)/:account/authenticate' => 'authenticate#authenticate_oidc'
+        post '/authn-jwt/:service_id/:account(/:id)/authenticate' => 'authenticate#authenticate_jwt'
         post '/authn-gcp/:account/authenticate' => 'authenticate#authenticate_gcp'
         post '/:authenticator(/:service_id)/:account/:id/authenticate' => 'authenticate#authenticate'
 

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -120,6 +120,24 @@ authenticators_azure: >
   -r cucumber/authenticators_azure
   cucumber/authenticators_azure
 
+authenticators_jwt: >
+  --format pretty
+  -r cucumber/api/features/step_definitions/user_steps.rb
+  -r cucumber/api/features/step_definitions/request_steps.rb
+  -r cucumber/api/features/support/step_def_transforms.rb
+  -r cucumber/api/features/support/rest_helpers.rb
+  -r cucumber/api/features/support/ssh_helpers.rb
+  -r cucumber/api/features/support/logs_helpers.rb
+  -r cucumber/api/features/step_definitions/logs_steps.rb
+  -r cucumber/api/features/support/authz_helpers.rb
+  -r cucumber/api/features/step_definitions/authz_steps.rb
+  -r cucumber/policy/features/support/policy_helpers.rb
+  -r cucumber/policy/features/step_definitions/policy_steps.rb
+  -r cucumber/_authenticators_common
+  -r cucumber/authenticators_status/features/step_definitions/authn_status_steps.rb
+  -r cucumber/authenticators_jwt
+  cucumber/authenticators_jwt
+
 # NOTE: We have to require the needed files from "api" individually, because
 #       if you mass require the folder it includes "api"s env.rb, which screws
 #       things up because (I think) it sets ENV['CONJUR_ACCOUNT'].  Cucumber

--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -1,0 +1,62 @@
+Feature: JWT Authenticator - JWKs Basic sanity
+
+  In this feature we define a JWT authenticator in policy and perform authentication
+  with Conjur. In successful scenarios we will also define a variable and permit the host to
+  execute it.
+
+  Background:
+    Given I initialize JWKs endpoint with file "myJWKs.json"
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I successfully set authn-jwt token-app-property variable to value "user"
+
+  Scenario: A valid JWT token with identity in the token
+    Given I have a "variable" resource called "test-variable"
+    And I permit host "myapp" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then host "myapp" has been authorized by Conjur
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
+    """

--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -60,3 +60,34 @@ Feature: JWT Authenticator - JWKs Basic sanity
     """
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
+
+  Scenario: Update jwks-uri dynamically
+    Given I successfully set authn-jwt jwks-uri variable with value of "NotFound.json" endpoint
+    And I issue a JWT token using key "first.json"::
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token issued by "first.json" key
+    Then it is unauthorized
+    And The following appears in the audit log after my savepoint:
+    """
+    CONJ00185E
+    """
+
+    Given I initialize JWKs endpoint with file "second.json"
+    And I successfully set authn-jwt jwks-uri variable with value of "second.json" endpoint
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token issued by "first.json" key
+    Then it is unauthorized
+    And The following appears in the audit log after my savepoint:
+    """
+    CONJ00035E
+    """
+
+    Given I successfully set authn-jwt jwks-uri variable with value of "first.json" endpoint
+    When I authenticate via authn-jwt with the JWT token issued by "first.json" key
+    Then host "myapp" has been authorized by Conjur

--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -5,7 +5,7 @@ Feature: JWT Authenticator - JWKs Basic sanity
   execute it.
 
   Background:
-    Given I initialize JWKs endpoint with file "myJWKs.json"
+    Given I initialize JWKs endpoint with file "first.json"
     And I load a policy:
     """
     - !policy
@@ -38,14 +38,14 @@ Feature: JWT Authenticator - JWKs Basic sanity
       member: !host myapp
     """
     And I am the super-user
-    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I successfully set authn-jwt jwks-uri variable with value of "first.json" endpoint
     And I successfully set authn-jwt token-app-property variable to value "user"
 
   Scenario: A valid JWT token with identity in the token
     Given I have a "variable" resource called "test-variable"
     And I permit host "myapp" to "execute" it
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
-    And I issue a JWT token:
+    And I issue a JWT token using key "first.json"::
     """
     {
       "user":"host/myapp",
@@ -53,7 +53,7 @@ Feature: JWT Authenticator - JWKs Basic sanity
     }
     """
     And I save my place in the audit log file
-    When I authenticate via authn-jwt with the JWT token
+    When I authenticate via authn-jwt with the JWT token issued by "first.json" key
     Then host "myapp" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the audit log after my savepoint:

--- a/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
@@ -1,0 +1,11 @@
+Given(/I successfully set authn-jwt jwks-uri variable with value of "([^"]*)" endpoint/) do |filename|
+  create_jwt_secret("jwks-uri", "#{JwtJwksHelper::JWKS_BASE_URI}/#{filename}")
+end
+
+Given(/I successfully set authn-jwt token-app-property variable to value "([^"]*)"/) do |value|
+  create_jwt_secret("token-app-property", value)
+end
+
+When(/I authenticate via authn-jwt with the JWT token/) do
+  authenticate_jwt_token(jwt_token)
+end

--- a/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
@@ -6,6 +6,6 @@ Given(/I successfully set authn-jwt token-app-property variable to value "([^"]*
   create_jwt_secret("token-app-property", value)
 end
 
-When(/I authenticate via authn-jwt with the JWT token/) do
-  authenticate_jwt_token(jwt_token)
+When(/I authenticate via authn-jwt with the JWT token issued by "([^"]*)" key/) do |key_name|
+  authenticate_jwt_token(jwt_token(key_name))
 end

--- a/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
@@ -2,11 +2,12 @@ Given(/I initialize JWKs endpoint with file "([^"]*)"/) do |filename|
   init_jwks_file(filename)
 end
 
-Given(/I issue a JWT token:/) do |token_body_string|
+Given(/I issue a JWT token using key "([^"]*)":/) do |key_name, token_body_string|
   # token body has to be an object (not a string) for correct token creation
   issue_jwt_token(
     token_body_with_valid_expiration(
       JSON.parse(token_body_string)
-    )
+    ),
+    key_name
   )
 end

--- a/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
@@ -1,0 +1,12 @@
+Given(/I initialize JWKs endpoint with file "([^"]*)"/) do |filename|
+  init_jwks_file(filename)
+end
+
+Given(/I issue a JWT token:/) do |token_body_string|
+  # token body has to be an object (not a string) for correct token creation
+  issue_jwt_token(
+    token_body_with_valid_expiration(
+      JSON.parse(token_body_string)
+    )
+  )
+end

--- a/cucumber/authenticators_jwt/features/support/authn_jwt_helper.rb
+++ b/cucumber/authenticators_jwt/features/support/authn_jwt_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Utility methods for JWT authenticator
+
+module AuthnJwtHelper
+  include AuthenticatorHelpers
+
+  ACCOUNT = 'cucumber'.freeze
+  SERVICE_ID = 'raw'.freeze
+
+  def authenticate_jwt_token(jwt_token)
+    path = "#{conjur_hostname}/authn-jwt/#{SERVICE_ID}/#{ACCOUNT}/authenticate"
+
+    payload = {}
+    payload["jwt"] = jwt_token
+
+    post(path, payload)
+  end
+
+  def create_jwt_secret(variable_name, value)
+    path = "#{ACCOUNT}:variable:conjur/authn-jwt/#{SERVICE_ID}"
+    Secret.create(resource_id: "#{path}/#{variable_name}", value: value)
+  end
+
+end
+
+World(AuthnJwtHelper)

--- a/cucumber/authenticators_jwt/features/support/authn_jwt_helper.rb
+++ b/cucumber/authenticators_jwt/features/support/authn_jwt_helper.rb
@@ -11,8 +11,9 @@ module AuthnJwtHelper
   def authenticate_jwt_token(jwt_token)
     path = "#{conjur_hostname}/authn-jwt/#{SERVICE_ID}/#{ACCOUNT}/authenticate"
 
-    payload = {}
-    payload["jwt"] = jwt_token
+    payload = {
+      "jwt" => jwt_token
+    }
 
     post(path, payload)
   end

--- a/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
+++ b/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
@@ -13,41 +13,52 @@ module JwtJwksHelper
 
   JWKS_ROOT_PATH = "/var/jwks".freeze
   JWKS_BASE_URI = "http://jwks".freeze
-  BITS_2048 = 2048
-  HOUR_IN_SECONDS = 3600
+  BITS_2048 = 2048.freeze
+  HOUR_IN_SECONDS = 3600.freeze
 
   def init_jwks_file(file_name)
-    jwks = { keys: [jwk.export] }
     File.write(
       "#{JWKS_ROOT_PATH}/#{file_name}", 
-      JSON.pretty_generate(jwks)
+      JSON.pretty_generate({ keys: [state_entity(file_name)["jwk"].export] })
     )
   end
 
-  def issue_jwt_token(token_body, algorithm = Algorithms::RS256)
-    @jwt_token = JWT.encode(
+  def issue_jwt_token(token_body, key_name, algorithm = Algorithms::RS256)
+    @state[key_name]["jwt_token"] = JWT.encode(
       token_body,
-      rsa_key,
+      @state[key_name]["rsa_key"],
       algorithm,
-      { kid: jwk.kid }
+      { kid: @state[key_name]["jwk"].kid }
     )
   end
 
-  def jwt_token
-    @jwt_token
-  end
-
-  def jwk
-    @jwk ||= JWT::JWK.new(rsa_key)
-  end
-
-  def rsa_key
-    @rsa_key ||= OpenSSL::PKey::RSA.new(BITS_2048)
+  def jwt_token(key_name)
+    @state[key_name]["jwt_token"]
   end
 
   def token_body_with_valid_expiration(token_body)
     token_body["exp"] = Time.now.to_i + HOUR_IN_SECONDS
     token_body
+  end
+
+  private
+
+  def jwk(rsa_key)
+    JWT::JWK.new(rsa_key)
+  end
+
+  def rsa_key(length)
+    OpenSSL::PKey::RSA.new(length)
+  end
+
+  def state_entity(name)
+    rsa_key = rsa_key(BITS_2048)
+    jwk = jwk(rsa_key)
+    @state ||= {}
+    @state[name] = {
+      "rsa_key" => rsa_key,
+      "jwk" => jwk
+    }
   end
 
 end

--- a/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
+++ b/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Utility methods for JWT and JWKs manipulation
+
+require 'openssl'
+require 'jwt'
+
+module JwtJwksHelper
+
+  module Algorithms
+    RS256 = "RS256".freeze
+  end
+
+  JWKS_ROOT_PATH = "/var/jwks".freeze
+  JWKS_BASE_URI = "http://jwks".freeze
+  BITS_2048 = 2048
+  HOUR_IN_SECONDS = 3600
+
+  def init_jwks_file(file_name)
+    jwks = { keys: [jwk.export] }
+    File.write(
+      "#{JWKS_ROOT_PATH}/#{file_name}", 
+      JSON.pretty_generate(jwks)
+    )
+  end
+
+  def issue_jwt_token(token_body, algorithm = Algorithms::RS256)
+    @jwt_token = JWT.encode(
+      token_body,
+      rsa_key,
+      algorithm,
+      { kid: jwk.kid }
+    )
+  end
+
+  def jwt_token
+    @jwt_token
+  end
+
+  def jwk
+    @jwk ||= JWT::JWK.new(rsa_key)
+  end
+
+  def rsa_key
+    @rsa_key ||= OpenSSL::PKey::RSA.new(BITS_2048)
+  end
+
+  def token_body_with_valid_expiration(token_body)
+    token_body["exp"] = Time.now.to_i + HOUR_IN_SECONDS
+    token_body
+  end
+
+end
+
+World(JwtJwksHelper)

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     - ../ci/ldap-certs:/ldap-certs:ro
     # TODO: authenticators_oidc/test has a dep on this
     - ../ci/test_suites/authenticators_oidc/keycloak:/authn-oidc/keycloak/scripts
+    - jwks-volume:/var/jwks
     links:
     - pg:pg
     - ldap-server
@@ -77,6 +78,7 @@ services:
       - ..:/src/conjur-server
       - authn-local:/run/authn-local
       - ../ci/ldap-certs:/ldap-certs:ro
+      - jwks-volume:/var/jwks
     links:
       - conjur
       - pg
@@ -145,5 +147,13 @@ services:
     entrypoint: sleep
     command: infinity
 
+  jwks:
+    image: nginx
+    ports:
+      - 8880:80
+    volumes:
+      - jwks-volume:/usr/share/nginx/html
+
 volumes:
   authn-local:
+  jwks-volume:

--- a/dev/start
+++ b/dev/start
@@ -21,6 +21,8 @@ Usage: start [options]
 
     --authn-gcp     Starts with authn-gcp as authenticator
 
+    --authn-jwt     Starts with authn-jwt as authenticator
+
     --oidc-adfs     Adds to authn-oidc adfs static env configuration
 
     --oidc-okta     Adds to authn-oidc okta static env configuration
@@ -80,6 +82,7 @@ ENABLE_AUTHN_IAM=false
 ENABLE_AUTHN_AZURE=false
 ENABLE_AUTHN_OIDC=false
 ENABLE_AUTHN_GCP=false
+ENABLE_AUTHN_JWT=false
 ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
@@ -90,6 +93,7 @@ while true ; do
     --authn-azure ) ENABLE_AUTHN_AZURE=true ; shift ;;
     --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
     --authn-gcp ) ENABLE_AUTHN_GCP=true ; shift ;;
+    --authn-jwt ) ENABLE_AUTHN_JWT=true ; shift ;;
     --authn-oidc ) ENABLE_AUTHN_OIDC=true ; shift ;;
     --oidc-adfs ) ENABLE_OIDC_ADFS=true ; shift ;;
     --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
@@ -170,6 +174,11 @@ fi
 
 if [[ $ENABLE_AUTHN_GCP = true ]]; then
   enabled_authenticators="$enabled_authenticators,authn-gcp"
+fi
+
+if [[ $ENABLE_AUTHN_JWT = true ]]; then
+  enabled_authenticators="$enabled_authenticators,authn-jwt/raw"
+  services="$services jwks"
 fi
 
 if [[ $ENABLE_AUTHN_OIDC = false && ($ENABLE_OIDC_ADFS = true || $ENABLE_OIDC_OKTA = true) ]]; then

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -84,7 +84,7 @@ module Conjur
       # in the DB. However, we need to figure out how to use code from the
       # application without introducing warnings.
       authenticators_regex =
-        %r{^(authn|authn-(k8s|oidc|iam|ldap|gcp|azure)(/.+)?)$}
+        %r{^(authn|authn-(k8s|oidc|iam|ldap|gcp|jwt|azure)(/.+)?)$}
       authenticators.all? do |authenticator|
         authenticators_regex.match?(authenticator.strip)
       end

--- a/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-azure/authenticator_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe('Authentication::AuthnAzure::Authenticator') do
+  include_context "base64url"
   include_context "security mocks"
   include_context "fetch secrets", %w[provider-uri]
 
@@ -19,7 +20,7 @@ RSpec.describe('Authentication::AuthnAzure::Authenticator') do
 
   before(:each) do
     allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
-      JSON.parse(args[0][:token_jwt]).to_hash
+      JSON.parse(base64_url_decode(args[0][:token_jwt].split('.')[1])).to_hash
     }
 
     allow(mocked_validate_resource_restrictions).to receive(:call).and_return(true)
@@ -45,15 +46,21 @@ RSpec.describe('Authentication::AuthnAzure::Authenticator') do
   end
 
   let(:authenticate_azure_token_request) do
-    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}")
+    mock_authenticate_azure_token_request(
+      request_body_data:
+        "jwt=aa.#{base64_url_encode("{\"xms_mirid\": \"some_xms_mirid_value\", \"oid\": \"some_oid_value\"}")}.cc")
   end
 
   let(:authenticate_azure_token_request_missing_xms_mirid_field) do
-    mock_authenticate_azure_token_request(request_body_data: "jwt={\"oid\": \"some_oid_value\"}")
+    mock_authenticate_azure_token_request(
+      request_body_data:
+        "jwt=aa.#{base64_url_encode("{\"oid\": \"some_oid_value\"}")}.cc")
   end
 
   let(:authenticate_azure_token_request_missing_oid_field) do
-    mock_authenticate_azure_token_request(request_body_data: "jwt={\"xms_mirid\": \"some_xms_mirid_value\"}")
+    mock_authenticate_azure_token_request(
+      request_body_data:
+        "jwt=aa.#{base64_url_encode("{\"xms_mirid\": \"some_xms_mirid_value\"}")}.cc")
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___

--- a/spec/app/domain/authentication/authn-gcp/update_authenticator_input_spec.rb
+++ b/spec/app/domain/authentication/authn-gcp/update_authenticator_input_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe('Authentication::AuthnGcp::UpdateAuthenticatorInput') do
+  include_context "base64url"
   include_context "security mocks"
 
   let(:account) { "my-acct" }
@@ -16,7 +17,7 @@ RSpec.describe('Authentication::AuthnGcp::UpdateAuthenticatorInput') do
 
   before(:each) do
     allow(mocked_verify_and_decode_token).to receive(:call) { |*args|
-      JSON.parse(args[0][:token_jwt]).to_hash
+      JSON.parse(base64_url_decode(args[0][:token_jwt].split('.')[1])).to_hash
     }
   end
 
@@ -39,7 +40,9 @@ RSpec.describe('Authentication::AuthnGcp::UpdateAuthenticatorInput') do
   end
 
   let(:authenticate_gcp_token_request) do
-    mock_authenticate_gcp_token_request(request_body_data: "jwt={\"jwt_claim\": \"jwt_claim_value\"}")
+    mock_authenticate_gcp_token_request(
+      request_body_data:
+        "jwt=aa.#{base64_url_encode("{\"jwt_claim\": \"jwt_claim_value\"}")}.cc")
   end
 
   let(:valid_audience) { "conjur/#{account}/#{hostname}" }

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/create_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/create_identity_provider_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFactory') do
+  class FalseIdentityProvider
+    def initialize(authentication_parameters); end
+
+    def identity_available?
+      false
+    end
+  end
+
+  class MockedURLIdentityProvider
+    def initialize(authentication_parameters); end
+    def identity_available?
+      true
+    end
+  end
+
+  class MockedDecodedTokenIdentityProvider
+    def initialize(authentication_parameters); end
+    def identity_available?
+      true
+    end
+  end
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authentication_parameters_url_identity) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: authenticator_name,
+        service_id: service_id,
+        account: account,
+        username: "dummy_identity",
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil
+    )
+  }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "IdentityProviderFactory" do
+    context "Decoded token identity available and url identity available" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
+          identity_from_url_provider_class: MockedURLIdentityProvider,
+          identity_from_decoded_token_class: MockedDecodedTokenIdentityProvider
+        )
+      end
+
+      it "factory to return IdentityFromDecodedTokenProvider" do
+        expect(subject.call(
+          authentication_parameters: authentication_parameters_url_identity
+        )).to be_a(MockedDecodedTokenIdentityProvider)
+      end
+    end
+
+    context "Decoded token identity available and url identity is not available" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
+          identity_from_url_provider_class: FalseIdentityProvider,
+          identity_from_decoded_token_class: MockedDecodedTokenIdentityProvider
+        )
+      end
+
+      it "factory to return IdentityFromDecodedTokenProvider" do
+        expect(subject.call(
+          authentication_parameters: authentication_parameters_url_identity
+        )).to be_a(MockedDecodedTokenIdentityProvider)
+      end
+    end
+
+    context "Decoded token identity is not available and url identity is available" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
+          identity_from_url_provider_class: MockedURLIdentityProvider,
+          identity_from_decoded_token_class: FalseIdentityProvider
+        )
+      end
+
+      it "factory to return IdentityFromUrlProvider" do
+        expect(subject.call(
+          authentication_parameters: authentication_parameters_url_identity
+        )).to be_a(MockedURLIdentityProvider)
+      end
+    end
+
+    context "Decoded token is not identity available and url identity is not available" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
+          identity_from_url_provider_class: FalseIdentityProvider,
+          identity_from_decoded_token_class: FalseIdentityProvider
+        )
+      end
+
+      it "factory raises NoRelevantIdentityProvider" do
+        expect { subject.call(
+          authentication_parameters: authentication_parameters_url_identity
+        ) }.to raise_error(Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_decoded_token_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_decoded_token_provider_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ConjurIdFromDecodedTokenProvider') do
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+  let(:decoded_token) {
+    {
+      "namespace_id" => "1",
+      "namespace_path" => "root",
+      "project_id" => "34",
+      "project_path" => "root/test-proj",
+      "user_id" => "1",
+      "user_login" => "cucumber",
+      "user_email" => "admin@example.com",
+      "pipeline_id" => "1",
+      "job_id" => "4",
+      "ref" => "master",
+      "ref_type" => "branch",
+      "ref_protected" => "true",
+      "jti" => "90c4414b-f7cf-4b98-9a4f-2c29f360e6d0",
+      "iss" => "ec2-18-157-123-113.eu-central-1.compute.amazonaws.com",
+      "iat" => 1619352275,
+      "nbf" => 1619352270,
+      "exp" => 1619355875,
+      "sub" => "job_4"
+    }
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: authenticator_name,
+        service_id: service_id,
+        account: account,
+        username: "dummy_identity",
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil
+    )
+  }
+
+  let(:non_existing_field_name) { "non existing field name" }
+
+  before(:each) do
+    allow(authentication_parameters).to(
+      receive(:decoded_token).and_return(decoded_token)
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "ConjurIdFromDecodedTokenProvider" do
+    context "Variable is configured and populated and decoded token containing it" do
+      subject do
+        id_from_decoded_token_provider = ::Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider.new(authentication_parameters)
+        allow(id_from_decoded_token_provider).to receive(:token_id_field_resource_id).and_return("dummy_secret_id")
+        allow(id_from_decoded_token_provider).to receive(:fetch_secret).and_return("user_email")
+        allow(id_from_decoded_token_provider).to receive(:identity_field_variable).and_return("token-app-property")
+        id_from_decoded_token_provider
+      end
+
+      it "identity_available? returns true" do
+        expect(subject.identity_available?).to eql(true)
+      end
+
+      it "get identity from decoded token successfully" do
+        expect(subject.provide_jwt_identity).to eql("admin@example.com")
+      end
+
+      it "identity_configured_properly? does not raise an error" do
+        expect { subject.identity_configured_properly? }.to_not raise_error
+      end
+    end
+
+    context "Variable is configured and populated but decoded token not containing it" do
+      subject do
+        id_from_decoded_token_provider = ::Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider.new(authentication_parameters)
+        allow(id_from_decoded_token_provider).to receive(:token_id_field_resource_id).and_return("dummy_secret_id")
+        allow(id_from_decoded_token_provider).to receive(:fetch_secret).and_return(non_existing_field_name)
+        allow(id_from_decoded_token_provider).to receive(:identity_field_variable).and_return("token-app-property")
+        id_from_decoded_token_provider
+      end
+
+      it "identity_available? returns true" do
+        expect(subject.identity_available?).to eql(true)
+      end
+
+      it "NoSuchFieldInToken error is raised" do
+        expect { subject.provide_jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoSuchFieldInToken)
+      end
+
+      it "identity_configured_properly? does not raise an error" do
+        expect{ subject.identity_configured_properly? }.to_not raise_error
+      end
+    end
+
+    context "Variable is configured but not populated" do
+      subject do
+        id_from_decoded_token_provider = ::Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider.new(authentication_parameters)
+        allow(id_from_decoded_token_provider).to receive(:token_id_field_resource_id).and_return("dummy_secret_id")
+        allow(id_from_decoded_token_provider).to receive(:fetch_secret).and_raise(Errors::Conjur::RequiredSecretMissing)
+        allow(id_from_decoded_token_provider).to receive(:identity_field_variable).and_return("token-app-property")
+        id_from_decoded_token_provider
+      end
+
+      it "identity_available? returns true" do
+        expect(subject.identity_available?).to eql(true)
+      end
+
+      it "RequiredSecretMissing error is raised" do
+        expect { subject.provide_jwt_identity }.to raise_error(Errors::Conjur::RequiredSecretMissing)
+      end
+
+      it "identity_configured_properly? raises error" do
+        expect{ subject.identity_configured_properly? }.to raise_error(Errors::Conjur::RequiredSecretMissing)
+      end
+    end
+
+    context "Variable is not configured" do
+      subject do
+        id_from_decoded_token_provider = ::Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider.new(authentication_parameters)
+        allow(id_from_decoded_token_provider).to receive(:identity_field_variable).and_return(nil)
+        id_from_decoded_token_provider
+      end
+
+      it "identity_available? returns false" do
+        expect(subject.identity_available?).to eql(false)
+      end
+
+      it "identity_configured_properly? does not raise an error" do
+        expect{ subject.identity_configured_properly? }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_url_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_url_provider_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::IdFromUrlProvider') do
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authentication_parameters_url_identity) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: authenticator_name,
+        service_id: service_id,
+        account: account,
+        username: "dummy_identity",
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil
+    )
+  }
+
+  let(:authentication_parameters_no_url_identity) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: authenticator_name,
+        service_id: service_id,
+        account: account,
+        username: nil,
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil)
+  }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "IdFromUrlProvider" do
+    context "There is identity in the url" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider.new(authentication_parameters_url_identity)
+      end
+
+      it "id_available? return true" do
+        expect(subject.identity_available?).to eql(true)
+      end
+
+      it "provide_jwt_id to provide identity from url successfully" do
+        expect(subject.provide_jwt_identity).to eql("dummy_identity")
+      end
+    end
+
+    context "There is no identity in the url" do
+      subject do
+        ::Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider.new(authentication_parameters_no_url_identity)
+      end
+
+      it "id_available? return false" do
+        expect(subject.identity_available?).to eql(false)
+      end
+
+      it "provide_jwt_id to raise NoUsernameInTheURL" do
+        expect { subject.provide_jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/input_validation/extract_token_from_credentials_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/extract_token_from_credentials_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials) do
+
+  let(:header) do
+    'eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9'
+  end
+
+  let(:body) do
+    'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0'
+  end
+
+  let(:signature) do
+    'hZnl5amPk_I3tb4O-Otci_5XZdVWhPlFyVRvcqSwnDo_srcysDvhhKOD01DigPK1lJvTSTolyUgKGtpLqMfRDXQlekRsF4XhA'\
+'jYZTmcynf-C-6wO5EI4wYewLNKFGGJzHAknMgotJFjDi_NCVSjHsW3a10nTao1lB82FRS305T226Q0VqNVJVWhE4G0JQvi2TssRtCxYTqzXVt22iDKkXe'\
+'ZJARZ1paXHGV5Kd1CljcZtkNZYIGcwnj65gvuCwohbkIxAnhZMJXCLaVvHqv9l-AAUV7esZvkQR1IpwBAiDQJh4qxPjFGylyXrHMqh5NlT_pWL2ZoULWT'\
+'g_TJjMO9TuQ'
+  end
+
+  let(:jwt_token) do
+    "#{header}.#{body}.#{signature}"
+  end
+
+  let(:credentials) do
+    "jwt=#{jwt_token}"
+  end
+
+  context "Request body" do
+    context "that contains a valid jwt token parameter" do
+      subject do
+        Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new().call(
+          credentials: credentials
+        )
+      end
+
+      it 'does not raise error' do
+        expect { subject }.not_to raise_error
+      end
+
+      it 'authentication parameters contain jwt token' do
+        expect(subject).to eq(jwt_token)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/input_validation/validate_uri_based_parameters_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/validate_uri_based_parameters_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters) do
+  include_context "security mocks"
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: 'authn-dummy',
+      service_id: 'my-service-id',
+      account: 'my-account',
+      username: nil,
+      credentials: nil,
+      client_ip: '127.0.0.1',
+      request: { }
+    )
+  }
+
+  let(:enabled_authenticators) { 'csv,example' }
+
+  context "A ValidateUriBasedParameters invocation" do
+    context "that passes all validations" do
+      subject do
+        Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new(
+          validate_account_exists: mock_validate_account_exists(validation_succeeded: true),
+          validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true)
+        ).call(
+          authenticator_input: authenticator_input,
+          enabled_authenticators: enabled_authenticators
+        )
+      end
+
+      it 'does not raise error' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "that does not pass account validation" do
+      subject do
+        Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new(
+          validate_account_exists: mock_validate_account_exists(validation_succeeded: false),
+          validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true)
+        ).call(
+          authenticator_input: authenticator_input,
+          enabled_authenticators: enabled_authenticators
+        )
+      end
+
+      it 'raises an error' do
+        expect { subject }.to(
+          raise_error(
+            validate_account_exists_error
+          )
+        )
+      end
+    end
+
+    context "that does not pass webservice validation" do
+      subject do
+        Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new(
+          validate_account_exists: mock_validate_account_exists(validation_succeeded: true),
+          validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: false)
+        ).call(
+          authenticator_input: authenticator_input,
+          enabled_authenticators: enabled_authenticators
+        )
+      end
+
+      it 'raises an error' do
+        expect { subject }.to(
+          raise_error(
+            validate_webservice_is_whitelisted_error
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/restriction_validators/validate_restrictions_one_to_one_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validators/validate_restrictions_one_to_one_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne') do
+  let(:right_email) { "admin@example.com" }
+  let(:wrong_email) { "wrong@example.com" }
+  let(:empty_email) { "" }
+  let(:spaced_email) { "  " }
+
+  let(:decoded_token) {
+    {
+      "namespace_id" => "1",
+      "namespace_path" => "root",
+      "project_id" => "34",
+      "project_path" => "root/test-proj",
+      "user_id" => "1",
+      "user_login" => "cucumber",
+      "user_email" => right_email,
+      "pipeline_id" => "1",
+      "job_id" => "4",
+      "ref" => "master",
+      "ref_type" => "branch",
+      "ref_protected" => "true",
+      "jti" => "90c4414b-f7cf-4b98-9a4f-2c29f360e6d0",
+      "iss" => "ec2-18-157-123-113.eu-central-1.compute.amazonaws.com",
+      "iat" => 1619352275,
+      "nbf" => 1619352270,
+      "exp" => 1619355875,
+      "sub" => "job_4"
+    }
+  }
+
+  let(:empty_decoded_token) {
+    {}
+  }
+
+  let(:existing_right_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: right_email)
+  }
+
+  let(:existing_wrong_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: wrong_email)
+  }
+
+  let(:non_existing_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: wrong_email)
+  }
+
+  let(:empty_annotation_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: "")
+  }
+
+  let(:spaced_annotation_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "not_existing", value: "    ")
+  }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "ValidateRestrictionsOneToOne" do
+    context "Decoded token is not empty" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne.new(decoded_token: decoded_token)
+      end
+
+      it "returns true when the restriction is for existing for existing field and its value equals the token" do
+        expect(subject.valid_restriction?(existing_right_restriction)).to eql(true)
+      end
+
+      it "return false when the restriction is for existing field but the value is different then the token" do
+        expect(subject.valid_restriction?(existing_wrong_restriction)).to eql(false)
+      end
+
+      it "raises JwtTokenClaimIsMissing when restriction is not in the decoded token" do
+        expect { subject.valid_restriction?(non_existing_restriction) }.to raise_error(Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is empty" do
+        expect { subject.valid_restriction?(empty_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is just spaces" do
+        expect { subject.valid_restriction?(spaced_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+    end
+
+    context "Decoded token is empty" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne.new(decoded_token: empty_decoded_token)
+      end
+
+      it "raises JwtTokenClaimIsMissing" do
+        expect { subject.valid_restriction?(non_existing_restriction) }.to raise_error(Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is empty" do
+        expect { subject.valid_restriction?(empty_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+
+      it "raises EmptyAnnotationGiven when annotation is just spaces" do
+        expect { subject.valid_restriction?(spaced_annotation_restriction) }.to raise_error(Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/create_jwks_from_http_response_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/create_jwks_from_http_response_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse') do
+
+  let(:mocked_http_response_without_body) { double("MockedHttpResponse") }
+  let(:mocked_http_response_with_invalid_json_structure) { double("MockedHttpResponse") }
+  let(:mocked_http_response_without_keys) { double("MockedHttpResponse") }
+  let(:mocked_http_response_with_empty_keys) { double("MockedHttpResponse") }
+  let(:mocked_http_response_with_valid_keys) { double("MockedHttpResponse") }
+  let(:http_response_invalid_json_structure) { "{  invalid:  {  structure: true  }" }
+  let(:http_response_without_keys) { '{"no_keys":[{"kty":"RSA","kid":"kewiQq9jiC84CvSsJYOB-N6A8WFLSV20Mb-y7IlWDSQ","e":"AQAB","n":"5RyvCSgBoOGNE03CMcJ9Bzo1JDvsU8XgddvRuJtdJAIq5zJ8fiUEGCnMfAZI4of36YXBuBalIycqkgxrRkSOENRUCWN45bf8xsQCcQ8zZxozu0St4w5S-aC7N7UTTarPZTp4BZH8ttUm-VnK4aEdMx9L3Izo0hxaJ135undTuA6gQpK-0nVsm6tRVq4akDe3OhC-7b2h6z7GWJX1SD4sAD3iaq4LZa8y1mvBBz6AIM9co8R-vU1_CduxKQc3KxCnqKALbEKXm0mTGsXha9aNv3pLNRNs_J-cCjBpb1EXAe_7qOURTiIHdv8_sdjcFTJ0OTeLWywuSf7mD0Wpx2LKcD6ImENbyq5IBuR1e2ghnh5Y9H33cuQ0FRni8ikq5W3xP3HSMfwlayhIAJN_WnmbhENRU-m2_hDPiD9JYF2CrQneLkE3kcazSdtarPbg9ZDiydHbKWCV-X7HxxIKEr9N7P1V5HKatF4ZUrG60e3eBnRyccPwmT66i9NYyrcy1_ZNN8D1DY8xh9kflUDy4dSYu4R7AEWxNJWQQov525v0MjD5FNAS03rpk4SuW3Mt7IP73m-_BpmIhW3LZsnmfd8xHRjf0M9veyJD0--ETGmh8t3_CXh3I3R9IbcSEntUl_2lCvc_6B-m8W-t2nZr4wvOq9-iaTQXAn1Au6EaOYWvDRE","use":"sig","alg":"RS256"},{"kty":"RSA","kid":"4i3sFE7sxqNPOT7FdvcGA1ZVGGI_r-tsDXnEuYT4ZqE","e":"AQAB","n":"4cxDjTcJRJFID6UCgepPV45T1XDz_cLXSPgMur00WXB4jJrR9bfnZDx6dWqwps2dCw-lD3Fccj2oItwdRQ99In61l48MgiJaITf5JK2c63halNYiNo22_cyBG__nCkDZTZwEfGdfPRXSOWMg1E0pgGc1PoqwOdHZrQVqTcP3vWJt8bDQSOuoZBHSwVzDSjHPY6LmJMEO42H27t3ZkcYtS5crU8j2Yf-UH5U6rrSEyMdrCpc9IXe9WCmWjz5yOQa0r3U7M5OPEKD1-8wuP6_dPw0DyNO_Ei7UerVtsx5XSTd-Z5ujeB3PFVeAdtGxJ23oRNCq2MCOZBa58EGeRDLR7Q","use":"sig","alg":"RS256"}]}' }
+  let(:http_response_with_empty_keys) { '{"keys":[]}' }
+  let(:http_response_with_valid_keys) { '{"keys":[{"kty":"RSA","kid":"kewiQq9jiC84CvSsJYOB-N6A8WFLSV20Mb-y7IlWDSQ","e":"AQAB","n":"5RyvCSgBoOGNE03CMcJ9Bzo1JDvsU8XgddvRuJtdJAIq5zJ8fiUEGCnMfAZI4of36YXBuBalIycqkgxrRkSOENRUCWN45bf8xsQCcQ8zZxozu0St4w5S-aC7N7UTTarPZTp4BZH8ttUm-VnK4aEdMx9L3Izo0hxaJ135undTuA6gQpK-0nVsm6tRVq4akDe3OhC-7b2h6z7GWJX1SD4sAD3iaq4LZa8y1mvBBz6AIM9co8R-vU1_CduxKQc3KxCnqKALbEKXm0mTGsXha9aNv3pLNRNs_J-cCjBpb1EXAe_7qOURTiIHdv8_sdjcFTJ0OTeLWywuSf7mD0Wpx2LKcD6ImENbyq5IBuR1e2ghnh5Y9H33cuQ0FRni8ikq5W3xP3HSMfwlayhIAJN_WnmbhENRU-m2_hDPiD9JYF2CrQneLkE3kcazSdtarPbg9ZDiydHbKWCV-X7HxxIKEr9N7P1V5HKatF4ZUrG60e3eBnRyccPwmT66i9NYyrcy1_ZNN8D1DY8xh9kflUDy4dSYu4R7AEWxNJWQQov525v0MjD5FNAS03rpk4SuW3Mt7IP73m-_BpmIhW3LZsnmfd8xHRjf0M9veyJD0--ETGmh8t3_CXh3I3R9IbcSEntUl_2lCvc_6B-m8W-t2nZr4wvOq9-iaTQXAn1Au6EaOYWvDRE","use":"sig","alg":"RS256"},{"kty":"RSA","kid":"4i3sFE7sxqNPOT7FdvcGA1ZVGGI_r-tsDXnEuYT4ZqE","e":"AQAB","n":"4cxDjTcJRJFID6UCgepPV45T1XDz_cLXSPgMur00WXB4jJrR9bfnZDx6dWqwps2dCw-lD3Fccj2oItwdRQ99In61l48MgiJaITf5JK2c63halNYiNo22_cyBG__nCkDZTZwEfGdfPRXSOWMg1E0pgGc1PoqwOdHZrQVqTcP3vWJt8bDQSOuoZBHSwVzDSjHPY6LmJMEO42H27t3ZkcYtS5crU8j2Yf-UH5U6rrSEyMdrCpc9IXe9WCmWjz5yOQa0r3U7M5OPEKD1-8wuP6_dPw0DyNO_Ei7UerVtsx5XSTd-Z5ujeB3PFVeAdtGxJ23oRNCq2MCOZBa58EGeRDLR7Q","use":"sig","alg":"RS256"}]}' }
+  let(:valid_jwks) { {:keys => JSON::JWK::Set.new(JSON.parse(http_response_with_valid_keys)['keys'])} }
+
+  before(:each) do
+    allow(mocked_http_response_with_invalid_json_structure).to(
+      receive(:blank?).and_return(false)
+    )
+
+    allow(mocked_http_response_with_invalid_json_structure).to(
+      receive(:respond_to?).with(:body).and_return(true)
+    )
+
+    allow(mocked_http_response_with_invalid_json_structure).to(
+      receive(:body).and_return(http_response_invalid_json_structure)
+    )
+
+    allow(mocked_http_response_without_keys).to(
+      receive(:blank?).and_return(false)
+    )
+
+    allow(mocked_http_response_without_keys).to(
+      receive(:respond_to?).with(:body).and_return(true)
+    )
+
+    allow(mocked_http_response_without_keys).to(
+      receive(:body).and_return(http_response_without_keys)
+    )
+
+    allow(mocked_http_response_with_empty_keys).to(
+      receive(:blank?).and_return(false)
+    )
+
+    allow(mocked_http_response_with_empty_keys).to(
+      receive(:respond_to?).with(:body).and_return(true)
+    )
+
+    allow(mocked_http_response_with_empty_keys).to(
+      receive(:body).and_return(http_response_with_empty_keys)
+    )
+
+    allow(mocked_http_response_with_valid_keys).to(
+      receive(:blank?).and_return(false)
+    )
+
+    allow(mocked_http_response_with_valid_keys).to(
+      receive(:respond_to?).with(:body).and_return(true)
+    )
+
+    allow(mocked_http_response_with_valid_keys).to(
+      receive(:body).and_return(http_response_with_valid_keys)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'http_response' input" do
+    context "with nil value" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+          http_response: nil
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingHttpResponse)
+      end
+    end
+
+    context "with empty value" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+          http_response: ""
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingHttpResponse)
+      end
+    end
+
+    context "without body" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+          http_response: mocked_http_response_without_body
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidHttpResponseFormat)
+      end
+    end
+
+    context "with invalid json structure" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+          http_response: mocked_http_response_with_invalid_json_structure
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToConvertResponseToJwks)
+      end
+    end
+
+    context "with valid json structure" do
+      context "when 'keys' are missing" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+            http_response: mocked_http_response_without_keys
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FetchJwksUriKeysNotFound)
+        end
+      end
+
+      context "with empty 'keys' value" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+            http_response: mocked_http_response_with_empty_keys
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FetchJwksUriKeysNotFound)
+        end
+      end
+
+      context "with valid 'keys' value" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::CreateJwksFromHttpResponse.new().call(
+            http_response: mocked_http_response_with_valid_keys
+          )
+        end
+
+        it "returns jwks value" do
+          expect(subject).to eql(valid_jwks)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_interface_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_interface_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: authenticator_name,
+        service_id: service_id,
+        account: account,
+        username: "dummy_identity",
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil
+    )
+  }
+
+  let(:mocked_fetch_exists_provider_uri) { double("Mocked fetch with existing provider-uri")  }
+  let(:mocked_fetch_non_exists_provider_uri) { double("Mocked fetch with non-existing provider-uri")  }
+  let(:mocked_fetch_exists_jwks_uri) { double("Mocked fetch with existing jwks-uri")  }
+  let(:mocked_fetch_non_exists_jwks_uri) { double("Mocked fetch with non-existing jwks-uri")  }
+  let(:mocked_exists_has_valid_configuration) { double("Mocked valid configuration")  }
+  let(:mocked_non_exists_has_valid_configuration) { double("Mocked invalid configuration")  }
+  let(:mocked_logger) { double("Mocked logger")  }
+
+  before(:each) do
+    allow(mocked_fetch_exists_provider_uri).to(
+      receive(:new).and_return(mocked_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_non_exists_provider_uri).to(
+      receive(:new).and_return(mocked_non_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_exists_jwks_uri).to(
+      receive(:new).and_return(mocked_exists_has_valid_configuration)
+    )
+
+    allow(mocked_fetch_non_exists_jwks_uri).to(
+      receive(:new).and_return(mocked_non_exists_has_valid_configuration)
+    )
+
+    allow(mocked_exists_has_valid_configuration).to(
+      receive(:has_valid_configuration?).and_return(true)
+    )
+
+    allow(mocked_non_exists_has_valid_configuration).to(
+      receive(:has_valid_configuration?).and_return(false)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(nil)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "CreateSigningKeyInterface " do
+    context "'jwks-uri' and 'provider-uri' exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
+          logger: mocked_logger
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+    context "'jwks-uri' and 'provider-uri' does not exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
+          logger: mocked_logger
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriConfiguration)
+      end
+    end
+
+    context "'jwks-uri' does not exits and 'provider-uri' exists" do
+
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_non_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_exists_jwks_uri,
+          logger: mocked_logger
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "'jwks-uri' exists and 'provider-uri' does not exist" do
+
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyInterface.new(
+          fetch_provider_uri: mocked_fetch_exists_provider_uri,
+          fetch_jwks_uri: mocked_fetch_non_exists_jwks_uri,
+          logger: mocked_logger
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') do
+
+  let(:authenticator_name) { "authn-jwt" }
+  let(:service_id) { "my-service" }
+  let(:account) { "my-account" }
+
+  let(:required_jwks_uri_configuration_error) { "required jwks_uri configuration missing error" }
+  let(:bad_response_error) { "bad response error" }
+  let(:mocked_logger) { double("Mocked Logger")  }
+  let(:mocked_authentication_parameters) { double("mocked authenticator params")  }
+  let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
+  let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
+  let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
+  let(:mocked_resource_value_exists) { double("Mocked resource value exists")  }
+  let(:mocked_bad_http_response) { double("Mocked bad http response")  }
+  let(:mocked_good_http_response) { double("Mocked good http response")  }
+  let(:mocked_bad_response) { double("Mocked bad http body")  }
+  let(:mocked_good_response) { double("Mocked good http body")  }
+  let(:mocked_create_jwks_from_http_response) { double("Mocked good jwks")  }
+
+  let(:good_response) { "good-response"}
+  let(:bad_response) { "bad-response"}
+  let(:valid_jwks) { "valid-jwls" }
+
+  before(:each) do
+    allow(mocked_logger).to(
+      receive(:call).and_return(true)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(true)
+    )
+
+    allow(mocked_authentication_parameters).to(
+      receive(:authenticator_resource_id).and_return('resource_id')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:[]).and_return('resource_id/jwks-uri' => 'https://jwks-uri.com/jwks')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:call).and_return('resource_id/jwks-uri' => 'https://jwks-uri.com/jwks')
+    )
+
+    allow(mocked_fetch_required_empty_secret).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_value_not_exists).to(
+      receive(:[]).and_raise(required_jwks_uri_configuration_error)
+    )
+
+    allow(mocked_resource_value_exists).to(
+      receive(:[]).and_return("resource")
+    )
+
+    allow(mocked_bad_http_response).to(
+      receive(:get_response).and_return(bad_response)
+    )
+
+    allow(mocked_good_http_response).to(
+      receive(:get_response).and_return(good_response)
+    )
+
+    allow(mocked_create_jwks_from_http_response).to(
+      receive(:call).with(http_response: good_response).and_return(valid_jwks)
+    )
+
+    allow(mocked_create_jwks_from_http_response).to(
+      receive(:call).with(http_response: bad_response).and_raise(bad_response_error)
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "FetchJwksUriSigningKey has_valid_configuration " do
+    context "'jwks-uri' variable is not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                               logger: mocked_logger,
+                                                               fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                               resource_class: mocked_resource_value_not_exists,
+                                                               http_lib: mocked_good_http_response,
+                                                               create_jwks_from_http_response: mocked_create_jwks_from_http_response
+        ).has_valid_configuration?
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_jwks_uri_configuration_error)
+      end
+    end
+
+    context "'jwks-uri' variable is configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                               logger: mocked_logger,
+                                                               fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                               resource_class: mocked_resource_value_exists,
+                                                               http_lib: mocked_good_http_response,
+                                                               create_jwks_from_http_response: mocked_create_jwks_from_http_response
+        ).has_valid_configuration?
+      end
+
+      it "does not raise error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+  end
+
+  context "FetchJwksUriSigningKey fetch_signing_key " do
+    context "'jwks-uri' secret is not valid" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                               logger: mocked_logger,
+                                                               fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                               resource_class: mocked_resource_value_exists,
+                                                               http_lib: mocked_bad_http_response,
+                                                               create_jwks_from_http_response: mocked_create_jwks_from_http_response
+        ).fetch_signing_key
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(bad_response_error)
+      end
+    end
+
+    context "'jwks-uri' secret is valid" do
+      context "provider return valid http response" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                 logger: mocked_logger,
+                                                                 fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                 resource_class: mocked_resource_value_exists,
+                                                                 http_lib: mocked_good_http_response,
+                                                                 create_jwks_from_http_response: mocked_create_jwks_from_http_response
+          ).fetch_signing_key
+        end
+
+        it "returns jwks value" do
+          expect(subject).to eql(valid_jwks)
+        end
+      end
+
+      context "provider return bad http response" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                 logger: mocked_logger,
+                                                                 fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                 resource_class: mocked_resource_value_exists,
+                                                                 http_lib: mocked_bad_http_response,
+                                                                 create_jwks_from_http_response: mocked_create_jwks_from_http_response
+          ).fetch_signing_key
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(bad_response_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:required_provider_uri_configuration_error) { "required provider_uri configuration missing error" }
+  let(:required_discover_identity_error) { "Provider uri identity error" }
+
+  let(:mocked_logger) { double("Mocked Logger")  }
+  let(:mocked_authentication_parameters) { double("mocked authenticator params")  }
+  let(:mocked_fetch_required_existing_secret) { double("mocked fetch required existing secret")  }
+  let(:mocked_fetch_required_empty_secret) { double("mocked fetch required empty secret")  }
+  let(:mocked_resource_value_not_exists) { double("Mocked resource value not exists")  }
+  let(:mocked_resource_value_exists) { double("Mocked resource value exists")  }
+  let(:mocked_discover_identity_provider) { double("Mocked discover identity provider")  }
+  let(:mocked_invalid_uri_discover_identity_provider) { double("Mocked invalid uri discover identity provider")  }
+  let(:mocked_provider_uri) { double("Mocked provider uri")  }
+
+  let(:mocked_valid_discover_identity_result) { "some jwks" }
+  let(:valid_jwks_result) { {:keys=> mocked_valid_discover_identity_result} }
+
+  before(:each) do
+    allow(mocked_logger).to(
+      receive(:call).and_return(true)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(true)
+    )
+
+    allow(mocked_authentication_parameters).to(
+      receive(:authenticator_resource_id).and_return('resource_id')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:[]).and_return('resource_id/provider-uri' => 'https://provider-uri.com/provider')
+    )
+
+    allow(mocked_fetch_required_existing_secret).to(
+      receive(:call).and_return('resource_id/provider-uri' => 'https://provider-uri.com/provider')
+    )
+
+    allow(mocked_fetch_required_empty_secret).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_value_not_exists).to(
+      receive(:[]).and_raise(required_provider_uri_configuration_error)
+    )
+
+    allow(mocked_resource_value_exists).to(
+      receive(:[]).and_return("resource")
+    )
+
+    allow(mocked_discover_identity_provider).to(
+      receive(:call).and_return(mocked_provider_uri)
+    )
+
+    allow(mocked_provider_uri).to(
+      receive(:jwks).and_return(mocked_valid_discover_identity_result)
+    )
+
+    allow(mocked_invalid_uri_discover_identity_provider).to(
+      receive(:call).and_raise(required_discover_identity_error)
+    )
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "FetchProviderUriSigningKey has_valid_configuration " do
+    context "'provider-uri' variable is not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                   logger: mocked_logger,
+                                                                   fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                   resource_class: mocked_resource_value_not_exists,
+                                                                   discover_identity_provider: mocked_discover_identity_provider).has_valid_configuration?
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_provider_uri_configuration_error)
+      end
+    end
+
+    context "'provider-uri' value is valid" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                   logger: mocked_logger,
+                                                                   fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                   resource_class: mocked_resource_value_exists,
+                                                                   discover_identity_provider: mocked_discover_identity_provider).has_valid_configuration?
+      end
+
+      it "does not raise error" do
+        expect(subject).to eql(true)
+      end
+    end
+  end
+
+  context "FetchProviderUriSigningKey fetch_signing_key " do
+    context "'provider-uri' variable is configured in authenticator policy" do
+      context "'provider-uri' value is invalid" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                     logger: mocked_logger,
+                                                                     fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                     resource_class: mocked_resource_value_exists,
+                                                                     discover_identity_provider: mocked_invalid_uri_discover_identity_provider).fetch_signing_key
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(required_discover_identity_error)
+        end
+      end
+
+      context "'provider-uri' value is valid" do
+        subject do
+          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authentication_parameters: mocked_authentication_parameters,
+                                                                     logger: mocked_logger,
+                                                                     fetch_required_secrets: mocked_fetch_required_existing_secret,
+                                                                     resource_class: mocked_resource_value_exists,
+                                                                     discover_identity_provider: mocked_discover_identity_provider).fetch_signing_key
+        end
+
+        it "does not raise error" do
+          expect(subject).to eql(valid_jwks_result)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_issuer_value_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_issuer_value_spec.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:issuer_resource_name) {'issuer'}
+  let(:provider_uri_resource_name) {'provider-uri'}
+  let(:jwks_uri_resource_name) {'jwks-uri'}
+  let(:issuer_secret_value) {'issuer-secret-value'}
+  let(:provider_uri_secret_value) {'provider-uri-secret-value'}
+  let(:jwks_uri_secret_value) {'jwks-uri-secret-value'}
+  let(:jwks_uri_with_bad_uri_format_value) {'=>=>=>////'}
+  let(:jwks_uri_with_bad_uri_hostname_value) {'https://'}
+  let(:jwks_uri_with_valid_hostname_value) {'https://jwt-provider.com/jwks'}
+  let(:valid_hostname_value) {'jwt-provider.com'}
+
+  def mock_resource_id(resource_name:)
+    %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
+  end
+
+  let(:mocked_resource) { double("MockedResource") }
+  let(:mocked_resource_exists_values) { double("MockedResource") }
+  let(:mocked_resource_not_exists_values) { double("MockedResource") }
+  let(:mocked_resource_both_provider_and_jwks_exist_values) { double("MockedResource") }
+  let(:mocked_resource_just_provider_uri_exists_values) { double("MockedResource") }
+  let(:mocked_resource_just_jwks_uri_exists_values) { double("MockedResource") }
+
+  let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values) {  double("MockedFetchSecrets") }
+  let(:mocked_valid_secrets) {  double("MockedValidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value) {  double("MockedInvalidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value) {  double("MockedInvalidSecrets") }
+  let(:mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value) {  double("MockedValidSecrets") }
+  let(:mocked_jwks_uri_with_bad_uri_format_secret) {  double("MockedInvalidSecrets") }
+  let(:mocked_jwks_uri_with_bad_uri_hostname_secret) {  double("MockedInvalidSecrets") }
+  let(:mocked_jwks_uri_with_valid_uri_hostname_secret) {  double("MockedValidSecrets") }
+
+  let(:required_secret_missing_error) { "required secret missing error" }
+  let(:invalid_issuer_configuration_error) { "invalid issuer configuration error" }
+
+  before(:each) do
+    allow(mocked_resource_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_not_exists_values).to(
+      receive(:[]).and_return(nil)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_both_provider_and_jwks_exist_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_just_provider_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).and_return(nil)
+    )
+
+    allow(mocked_resource_just_jwks_uri_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_fetch_secrets_empty_values).to(
+      receive(:call).and_raise(required_secret_missing_error)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: issuer_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: issuer_resource_name)).
+        and_return(issuer_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: provider_uri_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: provider_uri_resource_name)).
+        and_return(provider_uri_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(jwks_uri_resource_name)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_bad_uri_format_secret)
+    )
+
+    allow(mocked_jwks_uri_with_bad_uri_format_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_bad_uri_format_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_bad_uri_hostname_secret)
+    )
+
+    allow(mocked_jwks_uri_with_bad_uri_hostname_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_bad_uri_hostname_value)
+    )
+
+    allow(mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: jwks_uri_resource_name)]).
+        and_return(mocked_jwks_uri_with_valid_uri_hostname_secret)
+    )
+
+    allow(mocked_jwks_uri_with_valid_uri_hostname_secret).to(
+      receive(:[]).with(mock_resource_id(resource_name: jwks_uri_resource_name)).
+        and_return(jwks_uri_with_valid_hostname_value)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'issuer' variable is configured in authenticator policy" do
+    context "with empty variable value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_secrets: mocked_fetch_secrets_empty_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_secret_missing_error)
+      end
+    end
+
+    context "with valid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_secrets: mocked_fetch_secrets_exist_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "returns issuer value" do
+        expect(subject).to eql(issuer_secret_value)
+      end
+    end
+  end
+
+  context "'issuer' variable is not configured in authenticator policy" do
+    context "And both provider-uri and jwks-uri not configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+          resource_class: mocked_resource_not_exists_values,
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration)
+      end
+    end
+
+    context "And both provider-uri and jwks-uri configured in authenticator policy" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+          resource_class: mocked_resource_both_provider_and_jwks_exist_values,
+          ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidIssuerConfiguration)
+      end
+    end
+
+    context "And just provider-uri configured in authenticator policy" do
+      context "with empty variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_provider_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_empty_values
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(required_secret_missing_error)
+        end 
+      end
+
+      context "with valid variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_provider_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_exist_values
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "returns provider-uri as issuer value" do
+          expect(subject).to eql(provider_uri_secret_value)
+        end
+      end
+    end
+
+    context "And just jwks-uri configured in authenticator policy" do
+      context "with empty variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_empty_values
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(required_secret_missing_error)
+        end
+      end
+
+      context "with bad URI format as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_bad_uri_format_value
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidUriFormat)
+        end
+      end
+
+      context "with bad URI hostname as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_bad_uri_hostname_value
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToParseHostnameFromUri)
+        end
+      end
+
+      context "with valid URI hostname as variable value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new(
+            resource_class: mocked_resource_just_jwks_uri_exists_values,
+            fetch_secrets: mocked_fetch_secrets_jwks_uri_with_valid_uri_hostname_value
+          ).call(
+            authentication_parameters: authentication_parameters
+          )
+        end
+
+        it "returns extracted hostname from jwks-uri as issuer value" do
+          expect(subject).to eql(valid_hostname_value)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_jwt_claims_to_validate_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_jwt_claims_to_validate_spec.rb
@@ -1,0 +1,419 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate') do
+
+  RSpec::Matchers.define :eql_claims_list do |expected|
+    match do |actual|
+      return false unless actual.length == expected.length
+      actual_sorted = actual.sort_by {|obj| obj.name}
+      expected_sorted = expected.sort_by {|obj| obj.name}
+
+      actual_sorted.length.times do |index|
+        return false unless actual_sorted[index].name == expected_sorted[index].name &&
+          actual_sorted[index].value == expected_sorted[index].value
+      end
+
+      return true
+    end
+  end
+
+  let(:iss_claim_valid_value) { "iss claim valid value" }
+  let(:token_claim_value) { "value" }
+
+  def jwt_claims_to_validate_list_with_values(claims)
+    jwt_claims_to_validate_list = []
+    claims.each do |claim|
+      jwt_claims_to_validate_list.push(::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(name: claim, value: claim_value(claim)))
+    end
+
+    jwt_claims_to_validate_list
+  end
+
+  def claim_value(claim)
+    if claim == 'iss'
+      return iss_claim_valid_value
+    end
+
+    nil
+  end
+
+  def token(claims)
+    token_dictionary = {}
+    claims.each do |claim|
+      token_dictionary[claim] = token_claim_value
+    end
+
+    token_dictionary
+  end
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: Authentication::AuthenticatorInput.new(
+        authenticator_name: "dummy",
+        service_id: "dummy",
+        account: "dummy",
+        username: "dummy",
+        credentials: "dummy",
+        client_ip: "dummy",
+        request: "dummy"
+      ),
+      jwt_token: nil
+    )
+  }
+
+  let(:mocked_fetch_issuer_value_valid) { double("MockedFetchIssuerValueValid") }
+
+  let(:invalid_issuer_configuration_error) { "invalid issuer configuration error" }
+  let(:mocked_fetch_issuer_value_invalid_configuration) { double("MockedFetchIssuerValueInvalid") }
+
+  before(:each) do
+    allow(mocked_fetch_issuer_value_valid).to(
+      receive(:call).and_return(iss_claim_valid_value)
+    )
+
+    allow(mocked_fetch_issuer_value_invalid_configuration).to(
+      receive(:call).and_raise(invalid_issuer_configuration_error)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "JWT decoded token input" do
+    context "with mandatory claims (exp)" do
+      context "and with all supported optional claims: (iss, nbf, iat)" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iss exp nbf iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[iss exp nbf iat].freeze))
+          end
+        end
+      end
+
+      context "and with iss claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp iss].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss].freeze))
+          end
+        end
+
+        context "with invalid issuer variable configuration" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp iss].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_invalid_configuration
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(invalid_issuer_configuration_error)
+          end
+        end
+      end
+
+      context "and with nbf claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp nbf].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp nbf].freeze))
+          end
+        end
+      end
+
+      context "and with iat claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iat].freeze))
+          end
+        end
+      end
+
+      context "with none of supported optional claims" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp].freeze))
+          end
+        end
+
+        context "with invalid issuer variable configuration" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_invalid_configuration
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp].freeze))
+          end
+        end
+      end
+
+      context "with all except iss: (exp, nbf, iat)" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp nbf iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp nbf iat].freeze))
+          end
+        end
+
+        context "with invalid issuer variable configuration" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp nbf iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_invalid_configuration
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp nbf iat].freeze))
+          end
+        end
+      end
+
+      context "with all except nbf: (exp, iss, iat)" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp iss iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss iat].freeze))
+          end
+        end
+      end
+
+      context "with all except iat: (exp ,iss, nbf)" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[exp iss nbf].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss nbf].freeze))
+          end
+        end
+      end
+    end
+
+    context "without mandatory claims (exp)" do
+      context "and with all supported optional claims: (iss, nbf, iat)" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iss nbf iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss nbf iat].freeze))
+          end
+        end
+      end
+        context "with invalid issuer variable configuration" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iss nbf iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss nbf iat].freeze))
+          end
+        end
+
+      context "and with iss claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iss].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iss].freeze))
+          end
+        end
+
+        context "with invalid issuer variable configuration" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iss].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_invalid_configuration
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(invalid_issuer_configuration_error)
+          end
+        end
+      end
+
+      context "and with nbf claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[nbf].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp nbf].freeze))
+          end
+        end
+      end
+
+      context "and with iat claim" do
+        context "with valid issuer variable configuration in authenticator policy" do
+          subject do
+            authentication_parameters.decoded_token = token(%w[iat].freeze)
+
+            ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+              fetch_issuer_value: mocked_fetch_issuer_value_valid
+            ).call(
+              authentication_parameters: authentication_parameters
+            )
+          end
+
+          it "returns jwt claims to validate list" do
+            expect(subject).to eql_claims_list(jwt_claims_to_validate_list_with_values(%w[exp iat].freeze))
+          end
+        end
+      end
+      end
+
+    context "with empty token (should not happened)" do
+      subject do
+        authentication_parameters.decoded_token = token(%w[].freeze)
+
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+          fetch_issuer_value: mocked_fetch_issuer_value_valid
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingToken)
+      end
+    end
+
+    context "with nil token (should not happened)" do
+      subject do
+        authentication_parameters.decoded_token = nil
+
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new(
+          fetch_issuer_value: mocked_fetch_issuer_value_valid
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingToken)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/get_verification_option_by_jwt_claim_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/get_verification_option_by_jwt_claim_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim') do
+
+  let(:iss_claim_valid_value) { "iss claim valid value" }
+  let(:unsupported_claim_name) { "unsupported-claim-name" }
+  let(:valid_exp_verification_option) { {} }
+  let(:valid_nbf_verification_option) { {} }
+  let(:valid_iat_verification_option) { {:verify_iat => true} }
+  let(:valid_iss_verification_option) { {:iss => iss_claim_valid_value, :verify_iss => true} }
+  let(:iss_claim_empty_value) {
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(name: "iss", value: "")
+  }
+  let(:iss_claim_nil_value) {
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(name: "iss", value: "")
+  }
+
+  def claim_value(claim_name)
+    if claim_name == "iss"
+      return iss_claim_valid_value
+    end
+
+    nil
+  end
+
+  def claim(claim_name)
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(name: claim_name, value: claim_value(claim_name))
+  end
+
+  let(:empty_claim) {
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(name: "", value: "")
+  }
+
+  before(:each) do
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'jwt_claim' input" do
+    context "with nil value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+          jwt_claim: nil
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingClaim)
+      end
+    end
+
+    context "with empty name value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+          jwt_claim: empty_claim
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::UnsupportedClaim)
+      end
+    end
+
+    context "with unsupported name value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+          jwt_claim: claim(unsupported_claim_name)
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::UnsupportedClaim)
+      end
+    end
+
+    context "with supported name value" do
+      context "with 'exp' name value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+            jwt_claim: claim("exp")
+          )
+        end
+
+        it "returns verification option value" do
+          expect(subject).to eq(valid_exp_verification_option)
+        end
+      end
+
+      context "with 'nbf' name value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+            jwt_claim: claim("nbf")
+          )
+        end
+
+        it "returns verification option value" do
+          expect(subject).to eq(valid_nbf_verification_option)
+        end
+      end
+
+      context "with 'iat' name value" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+            jwt_claim: claim("iat")
+          )
+        end
+
+        it "returns verification option value" do
+          expect(subject).to eq(valid_iat_verification_option)
+        end
+      end
+
+      context "with 'iss' name value" do
+        context "with empty claim value" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+              jwt_claim: iss_claim_empty_value
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingClaimValue)
+          end
+        end
+
+        context "with nil claim value" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+              jwt_claim: iss_claim_nil_value
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingClaimValue)
+          end
+        end
+
+        context "with claim value" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new().call(
+              jwt_claim: claim("iss")
+            )
+          end
+
+          it "returns verification option value" do
+            expect(subject).to eq(valid_iss_verification_option)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
@@ -1,0 +1,506 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken') do
+
+  let(:jwt_token_valid) { "valid token" }
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: "dummy",
+      service_id: "dummy",
+      account: "dummy",
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:authentication_parameters_with_valid_token) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: jwt_token_valid
+    )
+  }
+
+  let(:authentication_parameters_with_nil_token) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:authentication_parameters_with_empty_token) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: ""
+    )
+  }
+
+  let(:mocked_fetch_signing_key_failed_on_1st_time) { double("MockedFetchSigningKeyInvalid") }
+  let(:mocked_fetch_signing_key_failed_on_2nd_time) { double("MockedFetchSigningKeyInvalid") }
+  let(:mocked_fetch_signing_key_always_succeed) { double("MockedFetchSigningKey") }
+
+  let(:fetch_signing_key_1st_time_error) { "fetch signing key 1st time error" }
+  let(:fetch_signing_key_2nd_time_error) { "fetch signing key 2nd time error" }
+
+  let(:mocked_verify_and_decode_token_invalid) { double("MockedVerifyAndDecodeToken") }
+  let(:mocked_verify_and_decode_token_succeed_on_1st_time) { double("MockedVerifyAndDecodeToken") }
+  let(:mocked_verify_and_decode_token_succeed_on_2nd_time) { double("MockedVerifyAndDecodeToken") }
+  let(:verify_and_decode_token_error) { "verify and decode token error" }
+  let(:verify_and_decode_token_1st_time_error) { "verify and decode token 1st time error" }
+
+  def valid_decoded_token(claims)
+    token_dictionary = {}
+    claims.each do |claim|
+      token_dictionary[claim.name] = claim.value
+    end
+
+    token_dictionary
+  end
+
+  let(:jwks_from_1st_call) { " jwks from 1st call "}
+  let(:jwks_from_2nd_call) { " jwks from 2nd call "}
+  let(:verification_options_for_signature_only_1st_call) {
+    {
+      algorithms: Authentication::AuthnJwt::SUPPORTED_ALGORITHMS,
+      jwks: jwks_from_1st_call
+    }
+  }
+
+  let(:verification_options_for_signature_only_2nd_call) {
+    {
+      algorithms: Authentication::AuthnJwt::SUPPORTED_ALGORITHMS,
+      jwks: jwks_from_2nd_call
+    }
+  }
+
+  let(:mocked_fetch_jwt_claims_to_validate_valid) { double("MockedFetchJwtClaimsToValidateValid") }
+
+  let(:valid_claim_name) { "valid-claim-name"}
+  let(:valid_claim_name_not_exists_in_token) { "valid-claim-name-not-exists"}
+  let(:valid_claim_value) { "valid claim value"}
+  let(:valid_claim) {
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(
+      name: valid_claim_name,
+      value: valid_claim_value
+    )
+  }
+  let(:claim_not_exists_in_token) {
+    ::Authentication::AuthnJwt::ValidateAndDecode::JwtClaim.new(
+      name: valid_claim_name_not_exists_in_token,
+      value: valid_claim_value
+    )
+  }
+  let(:claims_to_validate_valid)  { [valid_claim] }
+  let(:claims_to_validate_not_exist_in_token)  { [claim_not_exists_in_token] }
+
+  let(:mocked_get_verification_option_by_jwt_claim_valid) { double("MockedGetVerificationOptionByJwtClaimValid") }
+
+  let(:verification_options_valid) { {opt: "valid"} }
+
+  let(:valid_decoded_token_after_claims_validation) { "valid token after claims validation" }
+
+  let(:mocked_fetch_jwt_claims_to_validate_invalid) { double("MockedFetchJwtClaimsToValidateInvalid") }
+  let(:fetch_jwt_claims_to_validate_error) { "fetch jwt claims to validate error" }
+  let(:mocked_fetch_jwt_claims_to_validate_with_empty_claims) { double("MockedFetchJwtClaimsToValidateValid") }
+  let(:mocked_fetch_jwt_claims_to_validate_with_not_exist_claims_in_token) { double("MockedFetchJwtClaimsToValidateValid") }
+
+  let(:mocked_get_verification_option_by_jwt_claim_invalid) { double("MockedGetVerificationOptionInvalid") }
+  let(:get_verification_option_by_jwt_claim_error) { "get verification option by jwt claim error" }
+
+  let(:mocked_verify_and_decode_token_failed_to_validate_claims) { double("MockedVerifyAndDecodeTokenFailedToValidateClaims") }
+  let(:verify_and_decode_token_failed_to_validate_claims_error) { "verify and decode token failed to validate claims error" }
+  let(:mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_not_updated) { double("MockedVerifyAndDecodeTokenSucceedToValidateClaims") }
+  let(:mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated) { double("MockedVerifyAndDecodeTokenSucceedToValidateClaims") }
+
+  before(:each) do
+    allow(mocked_fetch_signing_key_failed_on_1st_time).to(
+      receive(:call).with(refresh: false).and_raise(fetch_signing_key_1st_time_error)
+    )
+
+    allow(mocked_fetch_signing_key_failed_on_2nd_time).to(
+      receive(:call).with(refresh: false).and_return(jwks_from_2nd_call)
+    )
+
+    allow(mocked_fetch_signing_key_failed_on_2nd_time).to(
+      receive(:call).with(refresh: true).and_raise(fetch_signing_key_2nd_time_error)
+    )
+
+    allow(mocked_verify_and_decode_token_invalid).to(
+      receive(:call).and_raise(verify_and_decode_token_error)
+    )
+
+    allow(mocked_fetch_signing_key_always_succeed).to(
+      receive(:call).with(refresh: false).and_return(jwks_from_1st_call)
+    )
+
+    allow(mocked_fetch_signing_key_always_succeed).to(
+      receive(:call).with(refresh: true).and_return(jwks_from_2nd_call)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_on_1st_time).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call
+      ).and_return(valid_decoded_token(claims_to_validate_valid))
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_on_1st_time).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call.merge(verification_options_valid)
+      ).and_return(valid_decoded_token_after_claims_validation)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_on_2nd_time).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call
+      ).and_raise(verify_and_decode_token_1st_time_error)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_on_2nd_time).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_2nd_call
+      ).and_return(valid_decoded_token(claims_to_validate_valid))
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_on_2nd_time).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_2nd_call.merge(verification_options_valid)
+      ).and_return(valid_decoded_token_after_claims_validation)
+    )
+
+    allow(mocked_fetch_jwt_claims_to_validate_valid).to(
+      receive(:call).and_return(claims_to_validate_valid)
+    )
+
+    allow(mocked_get_verification_option_by_jwt_claim_valid).to(
+      receive(:call).and_return(verification_options_valid)
+    )
+
+    allow(mocked_fetch_jwt_claims_to_validate_invalid).to(
+      receive(:call).and_raise(fetch_jwt_claims_to_validate_error)
+    )
+
+    allow(mocked_fetch_jwt_claims_to_validate_with_empty_claims).to(
+      receive(:call).and_return([])
+    )
+
+    allow(mocked_fetch_jwt_claims_to_validate_with_not_exist_claims_in_token).to(
+      receive(:call).and_return(claims_to_validate_not_exist_in_token)
+    )
+
+    allow(mocked_get_verification_option_by_jwt_claim_invalid).to(
+      receive(:call).and_raise(get_verification_option_by_jwt_claim_error)
+    )
+
+    allow(mocked_verify_and_decode_token_failed_to_validate_claims).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call
+      ).and_return(valid_decoded_token(claims_to_validate_valid))
+    )
+
+    allow(mocked_verify_and_decode_token_failed_to_validate_claims).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call.merge(verification_options_valid)
+      ).and_raise(verify_and_decode_token_failed_to_validate_claims_error)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_not_updated).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call
+      ).and_return(valid_decoded_token(claims_to_validate_valid))
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_not_updated).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call.merge(verification_options_valid)
+      ).and_return(valid_decoded_token_after_claims_validation)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_1st_call
+      ).and_raise(verify_and_decode_token_1st_time_error)
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_2nd_call
+      ).and_return(valid_decoded_token(claims_to_validate_valid))
+    )
+
+    allow(mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated).to(
+      receive(:call).with(
+        token_jwt: jwt_token_valid,
+        verification_options: verification_options_for_signature_only_2nd_call.merge(verification_options_valid)
+      ).and_return(valid_decoded_token_after_claims_validation)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'jwt_token' invalid input" do
+    context "with nil value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new().call(
+          authentication_parameters: authentication_parameters_with_nil_token
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingToken)
+      end
+    end
+
+    context "with empty value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new().call(
+          authentication_parameters: authentication_parameters_with_empty_token
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingToken)
+      end
+    end
+  end
+
+  context "Failed to fetch keys" do
+    subject do
+      ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+        fetch_signing_key: mocked_fetch_signing_key_failed_on_1st_time
+      ).call(
+        authentication_parameters: authentication_parameters_with_valid_token
+      )
+    end
+
+    it "raises an error" do
+      expect { subject }.to raise_error(fetch_signing_key_1st_time_error)
+    end
+  end
+
+  context "Validate token signature" do
+    context "when 'jwt_token' with invalid signature" do
+      context "and failed to fetch keys from provider" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+            fetch_signing_key: mocked_fetch_signing_key_failed_on_2nd_time,
+            verify_and_decode_token: mocked_verify_and_decode_token_invalid
+          ).call(
+            authentication_parameters: authentication_parameters_with_valid_token
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(fetch_signing_key_2nd_time_error)
+        end
+      end
+
+      context "and succeed to fetch keys from provider" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+            verify_and_decode_token: mocked_verify_and_decode_token_invalid
+          ).call(
+            authentication_parameters: authentication_parameters_with_valid_token
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(verify_and_decode_token_error)
+        end
+      end
+    end
+
+    context "when 'jwt_token' with valid signature" do
+      context "and keys are not updated" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+            verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_2nd_time,
+            fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+            get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
+          ).call(
+            authentication_parameters: authentication_parameters_with_valid_token
+          )
+        end
+
+        it "returns decoded token value" do
+          expect(subject).to eql(valid_decoded_token_after_claims_validation)
+        end
+      end
+
+      context "and keys are updated" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+            verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
+            fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+            get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid
+            ).call(
+            authentication_parameters: authentication_parameters_with_valid_token
+          )
+        end
+
+        it "returns decoded token value" do
+          expect(subject).to eql(valid_decoded_token_after_claims_validation)
+        end
+      end
+    end
+  end
+
+  context "Fetch mandatory claims" do
+    context "when token signature is valid" do
+      context "and failed to fetch mandatory claims" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+            verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
+            fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_invalid
+            ).call(
+            authentication_parameters: authentication_parameters_with_valid_token
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(fetch_jwt_claims_to_validate_error)
+        end
+      end
+
+      context "and succeed to fetch mandatory claims" do
+        context "with empty claims list to validate" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+              verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
+              fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_with_empty_claims
+            ).call(
+              authentication_parameters: authentication_parameters_with_valid_token
+            )
+          end
+
+          it "returns decoded token value" do
+            expect(subject).to eql(valid_decoded_token(claims_to_validate_valid))
+          end
+        end
+
+        context "with mandatory claims which not exist in token" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+              verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
+              fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_with_not_exist_claims_in_token
+            ).call(
+              authentication_parameters: authentication_parameters_with_valid_token
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MissingMandatoryClaim)
+          end
+        end
+
+        context "and failed to get verification options" do
+          subject do
+            ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+              verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
+              fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+              get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_invalid
+            ).call(
+              authentication_parameters: authentication_parameters_with_valid_token
+            )
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(get_verification_option_by_jwt_claim_error)
+          end
+        end
+      end
+    end
+  end
+
+  context "Validate token claims" do
+    context "when token signature is valid" do
+      context "when fetch mandatory claims successfully" do
+        context "when get verification options successfully" do
+          context "and failed to validate claims" do
+            subject do
+              ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+                fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+                verify_and_decode_token: mocked_verify_and_decode_token_failed_to_validate_claims,
+                fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+                get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid
+              ).call(
+                authentication_parameters: authentication_parameters_with_valid_token
+              )
+            end
+
+            it "raises an error" do
+              expect { subject }.to raise_error(verify_and_decode_token_failed_to_validate_claims_error)
+            end
+          end
+
+          context "and succeed to validate claims" do
+            context "and keys are not updated" do
+              subject do
+                ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+                  fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+                  verify_and_decode_token: mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_not_updated,
+                  fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+                  get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid
+                ).call(
+                  authentication_parameters: authentication_parameters_with_valid_token
+                )
+              end
+
+              it "returns decoded token value" do
+                expect(subject).to eql(valid_decoded_token_after_claims_validation)
+              end
+            end
+
+            context "and keys are updated" do
+              subject do
+                ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
+                  fetch_signing_key: mocked_fetch_signing_key_always_succeed,
+                  verify_and_decode_token: mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated,
+                  fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
+                  get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid
+                ).call(
+                  authentication_parameters: authentication_parameters_with_valid_token
+                )
+              end
+
+              it "returns decoded token value" do
+                expect(subject).to eql(valid_decoded_token_after_claims_validation)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_status_input) {
+    Authentication::AuthenticatorStatusInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy_identity",
+      client_ip: "dummy",
+      credentials: nil,
+      request: nil
+    )
+  }
+
+  let(:mocked_logger) { double("Mocked logger")  }
+  let(:mocked_valid_create_signing_key_interface) { double("Mocked valid create signing key interface")  }
+  let(:mocked_invalid_create_signing_key_interface) { double("Mocked invalid create signing key interface")  }
+  let(:mocked_valid_fetch_issuer_value) { double("Mocked valid fetch issuer value")  }
+  let(:mocked_invalid_fetch_issuer_value) { double("Mocked invalid fetch issuer value")  }
+  let(:mocked_valid_identity_from_decoded_token_provider) { double("Mocked valid identity from decoded token provider")  }
+  let(:mocked_valid_identity_configured_properly) { double("Mocked valid identity configured properly")  }
+  let(:mocked_invalid_identity_from_decoded_token_provider) { double("Mocked invalid identity from decoded token provider")  }
+  let(:mocked_invalid_identity_configured_properly) { double("Mocked invalid identity configured properly")  }
+  let(:mocked_valid_validate_webservice_is_whitelisted) { double("Mocked valid validate webservice is whitelisted")  }
+  let(:mocked_invalid_validate_webservice_is_whitelisted) { double("Mocked invalid validate webservice is whitelisted")  }
+  let(:mocked_valid_validate_can_access_webservice) { double("Mocked valid validate can access webservice")  }
+  let(:mocked_invalid_validate_can_access_webservice) { double("Mocked invalid validate can access webservice")  }
+  let(:mocked_valid_validate_webservice_exists) { double("Mocked valid validate wevservice exists")  }
+  let(:mocked_invalid_validate_webservice_exists) { double("Mocked invalid validate wevservice exists")  }
+  let(:mocked_valid_validate_account_exists) { double("Mocked valid validate account exists")  }
+  let(:mocked_invalid_validate_account_exists) { double("Mocked invalid validate account exists")  }
+  let(:mocked_enabled_authenticators) { double("Mocked logger")  }
+
+  let(:create_signing_key_configuration_is_invalid_error) { "Create signing key configuration is invalid" }
+  let(:fetch_issuer_configuration_is_invalid_error) { "Fetch issuer configuration is invalid" }
+  let(:identity_configuration_is_invalid_error) { "Identity configuration is invalid" }
+  let(:webservice_is_not_whitelisted_error) { "Webservice is not whitelisted" }
+  let(:user_cant_access_webservice_error) { "User cant access webservice" }
+  let(:webservice_does_not_exist_error) { "Webservice does not exist" }
+  let(:account_does_not_exist_error) { "Account does not exist" }
+
+  before(:each) do
+    allow(mocked_valid_create_signing_key_interface).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_create_signing_key_interface).to(
+      receive(:call).and_raise(create_signing_key_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_fetch_issuer_value).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_fetch_issuer_value).to(
+      receive(:call).and_raise(fetch_issuer_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_identity_from_decoded_token_provider).to(
+      receive(:new).and_return(mocked_valid_identity_configured_properly)
+    )
+
+    allow(mocked_valid_identity_configured_properly).to(
+      receive(:identity_configured_properly?).and_return(nil)
+    )
+
+    allow(mocked_invalid_identity_from_decoded_token_provider).to(
+      receive(:new).and_return(mocked_invalid_identity_configured_properly)
+    )
+
+    allow(mocked_invalid_identity_configured_properly).to(
+      receive(:identity_configured_properly?).and_raise(identity_configuration_is_invalid_error)
+    )
+
+    allow(mocked_valid_validate_webservice_is_whitelisted).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_webservice_is_whitelisted).to(
+      receive(:call).and_raise(webservice_is_not_whitelisted_error)
+    )
+
+    allow(mocked_valid_validate_can_access_webservice).to(
+      receive(:call).with(anything()).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_can_access_webservice).to(
+      receive(:call).and_raise(user_cant_access_webservice_error)
+    )
+
+    allow(mocked_valid_validate_webservice_exists).to(
+      receive(:call).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_webservice_exists).to(
+      receive(:call).and_raise(webservice_does_not_exist_error)
+    )
+
+    allow(mocked_enabled_authenticators).to(
+      receive(:new).and_return(mocked_enabled_authenticators)
+    )
+
+    allow(mocked_valid_validate_account_exists).to(
+      receive(:call).with(account: account).and_return(nil)
+    )
+
+    allow(mocked_invalid_validate_account_exists).to(
+      receive(:call).with(account: account).and_raise(account_does_not_exist_error)
+    )
+
+    allow(mocked_logger).to(
+      receive(:debug).and_return(nil)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "ValidateStatus" do
+    context "generic and authenticator validations succeed" do
+
+      subject do
+        ::Authentication::AuthnJwt::ValidateStatus.new(
+          create_signing_key: mocked_valid_create_signing_key_interface,
+          fetch_issuer_value: mocked_valid_fetch_issuer_value,
+          fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+          validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+          validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+          validate_webservice_exists: mocked_valid_validate_webservice_exists,
+          enabled_authenticators: mocked_enabled_authenticators,
+          validate_account_exists: mocked_valid_validate_account_exists,
+          logger: mocked_logger
+        ).call(
+          authenticator_status_input: authenticator_status_input
+        )
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "generic validation fails" do
+      context "account doesnt exist" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_invalid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(account_does_not_exist_error)
+        end
+      end
+
+      context "user can't access webservice" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_invalid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(user_cant_access_webservice_error)
+        end
+      end
+
+      context "authenticator webservice does not exist" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_invalid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(webservice_does_not_exist_error)
+        end
+      end
+
+      context "webservice is not whitelisted" do
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_invalid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(webservice_is_not_whitelisted_error)
+        end
+      end
+
+      context "service id does not exist" do
+
+        let(:authenticator_status_input_without_service_id) {
+          Authentication::AuthenticatorStatusInput.new(
+            authenticator_name: authenticator_name,
+            service_id: nil,
+            account: account,
+            username: "dummy_identity",
+            client_ip: "dummy",
+            credentials: nil,
+            request: nil
+          )
+        }
+
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input_without_service_id
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::ServiceIdMissing)
+        end
+      end
+    end
+
+    context "authenticator validation fails" do
+      context "signing key secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_invalid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(create_signing_key_configuration_is_invalid_error)
+        end
+      end
+
+      context "issuer secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_invalid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(fetch_issuer_configuration_is_invalid_error)
+        end
+      end
+
+      context "identity secrets are not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_identity_from_token: mocked_invalid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            enabled_authenticators: mocked_enabled_authenticators,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(identity_configuration_is_invalid_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/constraints/not_empty_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/not_empty_constraint_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::Constraints::NotEmptyConstraint) do
+  let(:right_email) { "admin@example.com" }
+  let(:username) { "admin" }
+
+  let(:no_restrictinos){ [] }
+
+  let(:one_restriction) {
+    [
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: right_email)
+    ]
+  }
+
+  let(:two_restrictions) {
+    [
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "user_email", value: right_email),
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "username", value: username)
+    ]
+  }
+
+  context "NotEmptyConstraint" do
+    subject do
+      ::Authentication::Constraints::NotEmptyConstraint.new
+    end
+
+    it "validate runs successfully for one restriction" do
+      expect { subject.validate(resource_restrictions: one_restriction) }.to_not raise_error
+    end
+
+    it "validate runs successfully for two restrictions" do
+      expect { subject.validate(resource_restrictions: two_restrictions) }.to_not raise_error
+    end
+
+    it "validate raises EmptyAnnotationsListConfigured when there are not annotations" do
+      expect { subject.validate(resource_restrictions: no_restrictinos) }.to raise_error(Errors::Authentication::Constraints::RoleMissingAnyRestrictions)
+    end
+  end
+end

--- a/spec/app/domain/authentication/jwt/decoded_credentials_spec.rb
+++ b/spec/app/domain/authentication/jwt/decoded_credentials_spec.rb
@@ -3,38 +3,64 @@
 require 'spec_helper'
 
 RSpec.describe('Authentication::Jwt::DecodedCredentials') do
-  ####################################
-  # request mock
-  ####################################
 
-  def mock_authenticate_token_request(request_body_data:)
-    double('JwtRequest').tap do |request|
-      request_body = StringIO.new
-      request_body.puts(request_body_data)
-      request_body.rewind
-
-      allow(request).to receive(:body).and_return(request_body)
-    end
+  let(:prefix) do
+    'jwt='
   end
 
-  def request_body(request)
-    request.body.read.chomp
+  let(:header) do
+    'eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9'
   end
 
-  let(:valid_jwt_claim_value) do
-    "{\"jwt_claim\": \"jwt_claim_value\"}"
+  let(:body) do
+    'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0'
+  end
+
+  let(:signature) do
+    'hZnl5amPk_I3tb4O-Otci_5XZdVWhPlFyVRvcqSwnDo_srcysDvhhKOD01DigPK1lJvTSTolyUgKGtpLqMfRDXQlekRsF4XhA'\
+'jYZTmcynf-C-6wO5EI4wYewLNKFGGJzHAknMgotJFjDi_NCVSjHsW3a10nTao1lB82FRS305T226Q0VqNVJVWhE4G0JQvi2TssRtCxYTqzXVt22iDKkXe'\
+'ZJARZ1paXHGV5Kd1CljcZtkNZYIGcwnj65gvuCwohbkIxAnhZMJXCLaVvHqv9l-AAUV7esZvkQR1IpwBAiDQJh4qxPjFGylyXrHMqh5NlT_pWL2ZoULWT'\
+'g_TJjMO9TuQ'
+  end
+
+  let(:header_body) do
+    "#{prefix}#{header}.#{body}"
+  end
+
+  let(:header_body_period) do
+    "#{prefix}#{header}.#{body}."
+  end
+
+  let(:header_signature) do
+    "#{prefix}#{header}..#{signature}"
+  end
+
+  let(:valid_token) do
+    "#{header}.#{body}.#{signature}"
   end
 
   let(:authenticate_token_request) do
-    mock_authenticate_token_request(request_body_data: "jwt=#{valid_jwt_claim_value}")
+    "#{prefix}#{valid_token}"
   end
 
-  let(:authenticate_token_request_missing_jwt_claim) do
-    mock_authenticate_token_request(request_body_data: "some_key=some_value")
+  let(:control_character_token_request) do
+    "#{prefix}#{header}.#{body}\b.#{signature}"
   end
 
-  let(:authenticate_token_request_empty_jwt_claim) do
-    mock_authenticate_token_request(request_body_data: "jwt=")
+  let(:new_line_token_request) do
+    "#{prefix}#{header}.#{body}.#{signature}\n"
+  end
+
+  let(:authenticate_token_request_missing_jwt_parameter) do
+    "some_key=some_value"
+  end
+
+  let(:empty_authenticate_token_request) do
+    ""
+  end
+
+  let(:multiple_parameters_request) do
+    "#{authenticate_token_request_missing_jwt_parameter}&#{authenticate_token_request}"
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
@@ -43,11 +69,9 @@ RSpec.describe('Authentication::Jwt::DecodedCredentials') do
   #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
 
   context "Credentials" do
-    context "with a jwt claim" do
+    context "with a jwt token as a single parameter" do
       subject(:decoded_credentials) do
-        ::Authentication::Jwt::DecodedCredentials.new(
-          request_body(authenticate_token_request)
-        )
+        ::Authentication::Jwt::DecodedCredentials.new(authenticate_token_request)
       end
 
       it "does not raise an error" do
@@ -55,15 +79,27 @@ RSpec.describe('Authentication::Jwt::DecodedCredentials') do
       end
 
       it "parses the jwt claim expectedly" do
-        expect(decoded_credentials.jwt).to eq(valid_jwt_claim_value)
+        expect(decoded_credentials.jwt).to eq(valid_token)
       end
     end
 
-    context "with no jwt claim in the request" do
+    context "with a jwt token and additional parameters" do
+      subject(:decoded_credentials) do
+        ::Authentication::Jwt::DecodedCredentials.new(authenticate_token_request)
+      end
+
+      it "does not raise an error" do
+        expect { decoded_credentials }.to_not raise_error
+      end
+
+      it "parses the jwt claim expectedly" do
+        expect(decoded_credentials.jwt).to eq(valid_token)
+      end
+    end
+
+    context "with empty request body" do
       subject do
-        ::Authentication::Jwt::DecodedCredentials.new(
-          request_body(authenticate_token_request_missing_jwt_claim)
-        )
+        ::Authentication::Jwt::DecodedCredentials.new(empty_authenticate_token_request)
       end
 
       it "raises a MissingRequestParam error" do
@@ -71,16 +107,79 @@ RSpec.describe('Authentication::Jwt::DecodedCredentials') do
       end
     end
 
-    context "with an empty jwt claim in the request" do
+    context "with no jwt parameter in the request" do
       subject do
-        ::Authentication::Jwt::DecodedCredentials.new(
-          request_body(authenticate_token_request_empty_jwt_claim)
-        )
+        ::Authentication::Jwt::DecodedCredentials.new(authenticate_token_request_missing_jwt_parameter)
       end
 
       it "raises a MissingRequestParam error" do
         expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
       end
     end
+
+    context "with an empty jwt token in the request" do
+      subject do
+        ::Authentication::Jwt::DecodedCredentials.new(prefix)
+      end
+
+      it "raises a MissingRequestParam error" do
+        expect { subject }.to raise_error(::Errors::Authentication::RequestBody::MissingRequestParam)
+      end
+    end
+
+    context "with invalid JWT token #1" do
+      subject do
+        ::Authentication::Jwt::DecodedCredentials.new(header_body)
+      end
+
+      it "raises a RequestBodyIsNotJWTToken error" do
+        expect { subject }.to raise_error(::Errors::Authentication::Jwt::RequestBodyMissingJWTToken)
+      end
+    end
+
+    context "with invalid JWT token #2" do
+      subject do
+        ::Authentication::Jwt::DecodedCredentials.new(header_body_period)
+      end
+
+      it "raises a RequestBodyIsNotJWTToken error" do
+        expect { subject }.to raise_error(::Errors::Authentication::Jwt::RequestBodyMissingJWTToken)
+      end
+    end
+
+    context "with invalid JWT token #3" do
+      subject do
+        ::Authentication::Jwt::DecodedCredentials.new(header_signature)
+      end
+
+      it "raises a RequestBodyIsNotJWTToken error" do
+        expect { subject }.to raise_error(::Errors::Authentication::Jwt::RequestBodyMissingJWTToken)
+      end
+    end
+
+    context "with JWT token contains a control character" do
+      subject do
+        ::Authentication::Jwt::DecodedCredentials.new(control_character_token_request)
+      end
+
+      it "raises a RequestBodyIsNotJWTToken error" do
+        expect { subject }.to raise_error(::Errors::Authentication::Jwt::RequestBodyMissingJWTToken)
+      end
+    end
+
+    context "with JWT token ends by new line" do
+      subject(:decoded_credentials) do
+        ::Authentication::Jwt::DecodedCredentials.new(new_line_token_request)
+      end
+
+      it "does not raise an error" do
+        expect { decoded_credentials }.to_not raise_error
+      end
+
+      it "parses the jwt claim expectedly" do
+        expect(decoded_credentials.jwt).to eq(valid_token)
+      end
+    end
+
   end
 end

--- a/spec/app/domain/authentication/resource_restrictions/get_restriction_from_annotation_spec.rb
+++ b/spec/app/domain/authentication/resource_restrictions/get_restriction_from_annotation_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::ResourceRestrictions::GetRestrictionFromAnnotation) do
+  let(:authenticator_name) { 'authn-dummy' }
+  let(:service_name) { 'dummy_service' }
+  let(:restriction_name) { 'user_email' }
+  let(:general_annotation_name) { "#{authenticator_name}/#{restriction_name}" }
+  let(:service_specific_annotation_name) { "#{authenticator_name}/#{service_name}/#{restriction_name}" }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "GetRestrictionFromAnnotation" do
+    context "Annotation is general" do
+      subject do
+        Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+          annotation_name: general_annotation_name,
+          authenticator_name: authenticator_name,
+          service_id: nil
+        )
+      end
+
+      it "returns restriction name and true" do
+        returned_restriction_name, returned_is_general_restriction = subject
+        expect(returned_restriction_name).to eql(restriction_name)
+        expect(returned_is_general_restriction).to eql(true)
+      end
+    end
+
+    context "Annotation is with service id" do
+      subject do
+        Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+          annotation_name: service_specific_annotation_name,
+          authenticator_name: authenticator_name,
+          service_id: service_name
+        )
+      end
+
+      it "returns restriction name and false" do
+        returned_restriction_name, returned_is_general_restriction = subject
+        expect(returned_restriction_name).to eql(restriction_name)
+        expect(returned_is_general_restriction).to eql(false)
+      end
+    end
+
+    context "Annotation is invalid" do
+      context "Annotation built from one part" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "aaa",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with wrong authenticator name and no service id" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "authn-wrong/bla",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with wrong authenticator name with service id" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "authn-wrong/bla/ya",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with service id and then authenticator name" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "#{service_name}/#{authenticator_name}",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "More than three part annotation" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "#{authenticator_name}/#{service_name}/a/b",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/resource_restrictions/get_service_specific_restriction_from_annotation_spec.rb
+++ b/spec/app/domain/authentication/resource_restrictions/get_service_specific_restriction_from_annotation_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation) do
+  let(:authenticator_name) { 'authn-dummy' }
+  let(:service_name) { 'dummy_service' }
+  let(:restriction_name) { 'user_email' }
+  let(:general_annotation_name) { "#{authenticator_name}/#{restriction_name}" }
+  let(:service_specific_annotation_name) { "#{authenticator_name}/#{service_name}/#{restriction_name}" }
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "GetServiceSpecificRestrictionFromAnnotation" do
+    context "Annotation is general" do
+      subject do
+        Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation.new.call(
+          annotation_name: general_annotation_name,
+          authenticator_name: authenticator_name,
+          service_id: nil
+        )
+      end
+
+      it "returns nil name and true" do
+        returned_restriction_name, returned_is_general_restriction = subject
+        expect(returned_restriction_name).to eql(nil)
+        expect(returned_is_general_restriction).to eql(true)
+      end
+    end
+
+    context "Annotation is with service id" do
+      subject do
+        Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation.new.call(
+          annotation_name: service_specific_annotation_name,
+          authenticator_name: authenticator_name,
+          service_id: service_name
+        )
+      end
+
+      it "returns restriction name and false" do
+        returned_restriction_name, returned_is_general_restriction = subject
+        expect(returned_restriction_name).to eql(restriction_name)
+        expect(returned_is_general_restriction).to eql(false)
+      end
+    end
+
+    context "Annotation is invalid" do
+      context "Annotation built from one part" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "aaa",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with wrong authenticator name and no service id" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "authn-wrong/bla",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with wrong authenticator name with service id" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "authn-wrong/bla/ya",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "Annotation with service id and then authenticator name" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "#{service_name}/#{authenticator_name}",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+
+      context "More than three part annotation" do
+        subject do
+          Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new.call(
+            annotation_name: "#{authenticator_name}/#{service_name}/a/b",
+            authenticator_name: authenticator_name,
+            service_id: service_name
+          )
+        end
+
+        it "returns nil,nil" do
+          returned_restriction_name, returned_is_general_restriction = subject
+          expect(returned_restriction_name).to eql(nil)
+          expect(returned_is_general_restriction).to eql(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/base64url_helper.rb
+++ b/spec/support/base64url_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_context "base64url" do
+
+  def base64_url_decode(str)
+    str += '=' * (4 - str.length.modulo(4))
+    Base64.decode64(str.tr('-_','+/'))
+  end
+
+  def base64_url_encode(str)
+    Base64.strict_encode64(str).tr('+/','-_').tr('=','')
+  end
+
+end


### PR DESCRIPTION
### What does this PR do?

Adds dynamic `jwks-uri` variable scenario.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
