### PR TITLE
PR fixes for jwt authenticator

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -8,6 +8,7 @@ module Authentication
     IDENTITY_FIELD_VARIABLE = "token-app-property".freeze
     IDENTITY_NOT_RETRIEVED_YET = "Identity not retrieved yet".freeze
     PRIVILEGE_AUTHENTICATE="authenticate".freeze
+    NOT_INITIALIZED_IDENTITY="".freeze
     ISS_CLAIM_NAME = "iss".freeze
     EXP_CLAIM_NAME = "exp".freeze
     NBF_CLAIM_NAME = "nbf".freeze

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
@@ -11,7 +11,7 @@ module Authentication
           @logger = Rails.logger
         end
 
-        def provide_jwt_identity
+        def jwt_identity
           token_field_name = fetch_token_field_name
           @logger.debug(LogMessages::Authentication::AuthnJwt::CHECKING_IDENTITY_FIELD_EXISTS.new(token_field_name))
           jwt_identity = @decoded_token[token_field_name]

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
@@ -12,15 +12,17 @@ module Authentication
         end
 
         def jwt_identity
+          return @jwt_identity if @jwt_identity
+
           token_field_name = fetch_token_field_name
           @logger.debug(LogMessages::Authentication::AuthnJwt::CHECKING_IDENTITY_FIELD_EXISTS.new(token_field_name))
-          jwt_identity = @decoded_token[token_field_name]
-          if jwt_identity.blank?
+          @jwt_identity ||= @decoded_token[token_field_name]
+          if @jwt_identity.blank?
             raise Errors::Authentication::AuthnJwt::NoSuchFieldInToken, token_field_name
           end
 
           @logger.debug(LogMessages::Authentication::AuthnJwt::FOUND_JWT_FIELD_IN_TOKEN.new(token_field_name, jwt_identity))
-          jwt_identity
+          @jwt_identity
         end
 
         # Checks if variable that defined from which field in decoded token to get the id is configured

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
@@ -7,7 +7,7 @@ module Authentication
           @authentication_parameters = authentication_parameters
         end
 
-        def provide_jwt_identity
+        def jwt_identity
           raise Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider unless identity_available?
 
           @authentication_parameters.username

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_provider_interface.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_provider_interface.rb
@@ -4,7 +4,7 @@ module Authentication
       class IdentityProviderInterface
         def initialize(authentication_parameters); end
 
-        def provide_jwt_identity; end
+        def jwt_identity; end
 
         def identity_available?; end
       end

--- a/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
+++ b/app/domain/authentication/authn_jwt/orchestrate_authentication.rb
@@ -7,7 +7,7 @@ module Authentication
     OrchestrateAuthentication ||= CommandClass.new(
       dependencies: {
         validate_uri_based_parameters: Authentication::AuthnJwt::InputValidation::ValidateUriBasedParameters.new,
-        jwt_configuration_factory: Authentication::AuthnJwt::VendorConfigurations::ConfigurationFactory.new,
+        configuration_factory: Authentication::AuthnJwt::VendorConfigurations::ConfigurationFactory.new,
         jwt_authenticator: Authentication::AuthnJwt::Authenticator.new,
         logger: Rails.logger,
         enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str,
@@ -25,7 +25,7 @@ module Authentication
         relevant_authenticator = authenticator_name
         @logger.debug(LogMessages::Authentication::AuthnJwt::JWTAuthenticatorEntryPoint.new(relevant_authenticator))
 
-        jwt_authenticator_configuration = @jwt_configuration_factory.create_jwt_configuration(@authenticator_input)
+        jwt_authenticator_configuration = @configuration_factory.create_jwt_configuration(@authenticator_input)
         @jwt_authenticator.call(
           jwt_configuration: jwt_authenticator_configuration,
           authenticator_input: @authenticator_input

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -5,14 +5,13 @@ module Authentication
       class ConfigurationJWTGenericVendor < ConfigurationInterface
 
         def initialize(authenticator_input)
-          @authentication_parameters_class = Authentication::AuthnJwt::AuthenticationParameters
-          @extract_token_from_credentials = Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new
-          @validate_and_decode_token_class = Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken
-          @identity_provider_factory = Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider
-          @validate_resource_restrictions_class = Authentication::ResourceRestrictions::ValidateResourceRestrictions
-          @create_identity_provider_class = Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider
           @logger = Rails.logger
-          init_authentication_parameters(authenticator_input)
+
+          @logger.debug(LogMessages::Authentication::AuthnJwt::CREATING_AUTHENTICATION_PARAMETERS_OBJECT.new)
+          @authentication_parameters = authentication_parameters_class.new(
+            authentication_input: authenticator_input,
+            jwt_token: jwt_token(authenticator_input)
+          )
         end
 
         def jwt_identity
@@ -20,14 +19,13 @@ module Authentication
         end
 
         def validate_restrictions
-          initialize_validate_restrictions
-          @validate_resource_restrictions.call(
+          validate_resource_restrictions.call(
             authenticator_name: @authentication_parameters.authenticator_name,
             service_id: @authentication_parameters.service_id,
             account: @authentication_parameters.account,
             role_name: jwt_identity,
-            constraints: @constraints,
-            authentication_request: @restriction_validator.new(
+            constraints: constraints,
+            authentication_request: restriction_validator_class.new(
               decoded_token: @authentication_parameters.decoded_token
             )
           )
@@ -41,29 +39,24 @@ module Authentication
 
         private
 
-        def init_authentication_parameters(authenticator_input)
-          @logger.debug(LogMessages::Authentication::AuthnJwt::CREATING_AUTHENTICATION_PARAMETERS_OBJECT.new)
-          jwt_token = @extract_token_from_credentials.call(
+        def jwt_token(authenticator_input)
+          extract_token_from_credentials.call(
             credentials: authenticator_input.request.body.read
-          )
-          @authentication_parameters = @authentication_parameters_class.new(
-            authentication_input: authenticator_input,
-            jwt_token: jwt_token
           )
         end
 
         def jwt_identity_from_request
-          @jwt_identity_from_request ||= identity_provider.jwt_identity
+          @jwt_identity_from_request = identity_provider.jwt_identity
         end
 
         def identity_provider
-          @identity_provider ||= @create_identity_provider_class.new.call(
+          @identity_provider = create_identity_provider.call(
             authentication_parameters: @authentication_parameters
           )
         end
 
         def validate_and_decode_token_instance
-          @validate_and_decode_token_instance ||= @validate_and_decode_token_class.new(
+          @validate_and_decode_token_instance ||= validate_and_decode_token_class.new(
             fetch_signing_key: fetch_signing_key,
             fetch_jwt_claims_to_validate: fetch_jwt_claims_to_validate
           )
@@ -76,7 +69,7 @@ module Authentication
         def fetch_cached_signing_key
           @fetch_cached_signing_key ||= ::Util::ConcurrencyLimitedCache.new(
             ::Util::RateLimitedCache.new(
-              ::Authentication::AuthnJwt::SigningKey::FetchCachedSigningKey.new(
+              fetch_cached_signing_key_class.new(
                 fetch_singing_key_interface: fetch_singing_key_interface
               ),
               refreshes_per_interval: CACHE_REFRESHES_PER_INTERVAL,
@@ -88,10 +81,34 @@ module Authentication
           )
         end
 
+        def authentication_parameters_class
+          @authentication_parameters_class ||= Authentication::AuthnJwt::AuthenticationParameters
+        end
+
+        def extract_token_from_credentials
+          @extract_token_from_credentials ||= Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new
+        end
+
+        def validate_and_decode_token_class
+          @validate_and_decode_token_class ||= Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken
+        end
+
+        def validate_resource_restrictions_class
+          @validate_resource_restrictions_class ||= Authentication::ResourceRestrictions::ValidateResourceRestrictions
+        end
+
+        def create_identity_provider
+          @create_identity_provider ||= Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new
+        end
+
         def fetch_singing_key_interface
           @fetch_singing_key_interface ||= create_signing_key_interface.call(
             authentication_parameters: @authentication_parameters
           )
+        end
+
+        def fetch_cached_signing_key_class
+          @fetch_cached_signing_key_class ||= Authentication::AuthnJwt::SigningKey::FetchCachedSigningKey
         end
 
         def create_signing_key_interface
@@ -102,17 +119,29 @@ module Authentication
           @fetch_jwt_claims_to_validate ||= ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new
         end
 
-        def initialize_validate_restrictions
-          @restriction_validator = Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne
-          @restrictions_from_annotations_class = Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation
-          @extract_resource_restrictions = Authentication::ResourceRestrictions::ExtractResourceRestrictions.new(
-            get_restriction_from_annotation: @restrictions_from_annotations_class,
+        def restriction_validator_class
+          @restriction_validator_class ||= Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne
+        end
+
+        def restrictions_from_annotations
+          @restrictions_from_annotations ||= Authentication::ResourceRestrictions::GetServiceSpecificRestrictionFromAnnotation.new
+        end
+
+        def extract_resource_restrictions
+          @extract_resource_restrictions ||= Authentication::ResourceRestrictions::ExtractResourceRestrictions.new(
+            get_restriction_from_annotation: restrictions_from_annotations,
             ignore_empty_annotations: false
           )
-          @validate_resource_restrictions = @validate_resource_restrictions_class.new(extract_resource_restrictions: @extract_resource_restrictions)
-          @constraints = Authentication::Constraints::MultipleConstraint.new(
+        end
+
+        def constraints
+          @constraints ||= Authentication::Constraints::MultipleConstraint.new(
             Authentication::Constraints::NotEmptyConstraint.new
           )
+        end
+
+        def validate_resource_restrictions
+          @validate_resource_restrictions ||= validate_resource_restrictions_class.new(extract_resource_restrictions: extract_resource_restrictions)
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -53,7 +53,7 @@ module Authentication
         end
 
         def jwt_identity_from_request
-          @jwt_identity_from_request ||= identity_provider.provide_jwt_identity
+          @jwt_identity_from_request ||= identity_provider.jwt_identity
         end
 
         def identity_provider

--- a/app/domain/authentication/resource_restrictions/extract_resource_restrictions.rb
+++ b/app/domain/authentication/resource_restrictions/extract_resource_restrictions.rb
@@ -6,8 +6,8 @@ module Authentication
     ExtractResourceRestrictions = CommandClass.new(
       dependencies: {
         resource_restrictions_class: Authentication::ResourceRestrictions::ResourceRestrictions,
-        get_restriction_from_annotation: Authentication::ResourceRestrictions::GetRestrictionFromAnnotation,
-        fetch_resource_annotations_class: Authentication::ResourceRestrictions::FetchResourceAnnotations,
+        get_restriction_from_annotation: Authentication::ResourceRestrictions::GetRestrictionFromAnnotation.new,
+        fetch_resource_annotations: Authentication::ResourceRestrictions::FetchResourceAnnotations.new,
         role_class: ::Role,
         resource_class: ::Resource,
         logger: Rails.logger,
@@ -23,7 +23,7 @@ module Authentication
           )
         )
 
-        fetch_resource_annotations
+        call_fetch_resource_annotations
         extract_resource_restrictions_from_annotations
         create_resource_restrictions_object
 
@@ -34,12 +34,12 @@ module Authentication
 
       private
 
-      def fetch_resource_annotations
+      def call_fetch_resource_annotations
         resource_annotations
       end
 
       def resource_annotations
-        @resource_annotations ||= @fetch_resource_annotations_class.new.call(
+        @resource_annotations ||= @fetch_resource_annotations.call(
           account: @account,
           role_name: @role_name,
           ignore_empty_annotations: @ignore_empty_annotations
@@ -58,7 +58,7 @@ module Authentication
       end
 
       def add_restriction_to_hash(annotation_name, annotation_value, resource_restrictions_hash)
-        restriction_name, is_general_restriction = @get_restriction_from_annotation.new.call(
+        restriction_name, is_general_restriction = @get_restriction_from_annotation.call(
           annotation_name: annotation_name,
           authenticator_name: @authenticator_name,
           service_id: @service_id

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_decoded_token_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_decoded_token_provider_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe('Authentication::AuthnJwt::ConjurIdFromDecodedTokenProvider') do
       end
 
       it "get identity from decoded token successfully" do
-        expect(subject.provide_jwt_identity).to eql("admin@example.com")
+        expect(subject.jwt_identity).to eql("admin@example.com")
       end
 
       it "identity_configured_properly? does not raise an error" do
@@ -94,7 +94,7 @@ RSpec.describe('Authentication::AuthnJwt::ConjurIdFromDecodedTokenProvider') do
       end
 
       it "NoSuchFieldInToken error is raised" do
-        expect { subject.provide_jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoSuchFieldInToken)
+        expect { subject.jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoSuchFieldInToken)
       end
 
       it "identity_configured_properly? does not raise an error" do
@@ -116,7 +116,7 @@ RSpec.describe('Authentication::AuthnJwt::ConjurIdFromDecodedTokenProvider') do
       end
 
       it "RequiredSecretMissing error is raised" do
-        expect { subject.provide_jwt_identity }.to raise_error(Errors::Conjur::RequiredSecretMissing)
+        expect { subject.jwt_identity }.to raise_error(Errors::Conjur::RequiredSecretMissing)
       end
 
       it "identity_configured_properly? raises error" do

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_url_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/identity_from_url_provider_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe('Authentication::AuthnJwt::IdFromUrlProvider') do
       end
 
       it "provide_jwt_id to provide identity from url successfully" do
-        expect(subject.provide_jwt_identity).to eql("dummy_identity")
+        expect(subject.jwt_identity).to eql("dummy_identity")
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe('Authentication::AuthnJwt::IdFromUrlProvider') do
       end
 
       it "provide_jwt_id to raise NoUsernameInTheURL" do
-        expect { subject.provide_jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider)
+        expect { subject.jwt_identity }.to raise_error(Errors::Authentication::AuthnJwt::NoRelevantIdentityProvider)
       end
     end
   end


### PR DESCRIPTION
1. Small refactors according to here https://github.com/cyberark/conjur/pull/2228
2. Refactor in dependencies of command classes related to validate resource restrictions. Dependencies that are command classes them selves will be initialized in the dependency injection itself
3. Bugfix to audit failiure when there is still no identity. Caused because of moving to memoized get identity function.