### PR TITLE
Fixup changelog message with link for keepalive timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix bug where running `conjurctl server` or `conjurctl account create` with
   passwords that contain `,`s sent via stdin raised an error.
   [cyberark/conjur#2159](https://github.com/cyberark/conjur/issues/2159)
-- Specify keepalive timeout for puma to be longer than proxy and load balancers
+- Specify keepalive timeout for puma to be longer than proxy and load balancers [cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
 
 ### Security
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix bug where running `conjurctl server` or `conjurctl account create` with
   passwords that contain `,`s sent via stdin raised an error.
   [cyberark/conjur#2159](https://github.com/cyberark/conjur/issues/2159)
-- Specify keepalive timeout for puma to be longer than proxy and load balancers [cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
+- Update the default keepalive timeout for puma to be longer than most common proxy and load balancers.
+  Previously, the load balancer in front of Conjur would commonly have a longer timeout than the
+  server itself, which can lead to Conjur closing connections even as there are pending requests and
+  the proxy returning 502 errors to the client.
+  [PR cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
 
 ### Security
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885


### PR DESCRIPTION
### What does this PR do?
- Add link for changelog message

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
