### PR TITLE
Prevent caching in Dockerfile.dev image

### DIFF
--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,7 +1,6 @@
 FROM cyberark/phusion-ruby-fips:latest
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     build-essential \
     ldap-utils \
     git \


### PR DESCRIPTION
Since every RUN command is its own layer, you need the update and install
in the same RUN command or it can end up getting cached.