### PR TITLE
Update bindata to 2.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [PR cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
 
 ### Security
+- Upgrade bindata to 2.4.10 to resolve Unspecified Issue reported by JFrog Xray
+  [cyberark/conjur#2257](https://github.com/cyberark/conjur/issues/2257)
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885
   [cyberark/conjur#2149](https://github.com/cyberark/conjur/issues/2149)
 - Upgrade Nokogiri to 1.11.5 to resolve

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     base32-crockford (0.1.0)
     base58 (0.2.3)
     bcrypt (3.1.13)
-    bindata (2.4.7)
+    bindata (2.4.10)
     builder (3.2.4)
     byebug (11.1.1)
     childprocess (3.0.0)


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Updates bindata gem to 2.4.10 to resolve Unspecified issue found in customer JFrog XRay scan

### What ticket does this PR close?
Resolves #2257 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
