### PR TITLE
Usable config file validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Parsing a Conjur config with invalid YAML content now outputs a more user
+  friendly error message without a stack trace.
+  [cyberark/conjur#2256](https://github.com/cyberark/conjur/issues/2256)
+
 ## [1.11.7] - 2021-06-08
 
 ### Added
 - Enabled authenticators can now be configured via a configuration file, or the
   CONJUR_AUTHENTICATORS environment variable.
-  [cyberark/conjur##2173](https://github.com/cyberark/conjur/issues/#2173)
+  [cyberark/conjur#2173](https://github.com/cyberark/conjur/issues/2173)
 - Trusted Proxies can now be configured with a configuration file or by setting
   the CONJUR_TRUSTED_PROXIES environment variable.
   [cyberark/conjur#2168](https://github.com/cyberark/conjur/issues/2168)

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -26,6 +26,31 @@ module Conjur
       authenticators: []
     )
 
+    def initialize(*args)
+      super(*args)
+
+    # If the config file is not a valid YAML document, we want
+    # to raise a user-friendly ConfigValidationError rather than
+    # a Psych library exception.
+    rescue Psych::SyntaxError => e
+      raise(
+        ConfigValidationError,
+        "Config file contains a YAML syntax error: #{e.message}"
+      )
+
+    # If the config file is valid YAML, but the root object is
+    # not a YAML dictionary, this raises one of a number of
+    # NoMethodError exceptions because AnywayConfig assumes parsing
+    # the config file will result in a Ruby Hash. We capture
+    # this and raise a more user-friendly error message.
+    rescue NoMethodError
+      raise(
+        ConfigValidationError,
+        "Unable to parse config file. " \
+        "Please ensure that it is a valid YAML dictionary."
+      )
+    end
+
     # Perform validations and collect errors then report results as exception
     on_load do
       invalid = []


### PR DESCRIPTION
### What does this PR do?

This PR updates the Conjur config file load to output a user-friendly validation error when the config file contains a YAML syntax error, or the root YAML object is not a dictionary. Previously, these errors output a library-internal exception and stack trace.

### What ticket does this PR close?
Resolves #2256

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
