### PR TITLE
Fix 11.7.1 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- The JWT Authenticator (`authn-jwt`) supports authenticating third-party vendors that utilize JWT.
+  See [design](https://github.com/cyberark/conjur/blob/master/design/authenticators/authn_jwt/authn_jwt_solution_design.md)
+
 ### Changed
 - Parsing a Conjur config with invalid YAML content now outputs a more user
   friendly error message without a stack trace.
   [cyberark/conjur#2256](https://github.com/cyberark/conjur/issues/2256)
+
+### Security
+- Upgrade bindata to 2.4.10 to resolve Unspecified Issue reported by JFrog Xray
+  [cyberark/conjur#2257](https://github.com/cyberark/conjur/issues/2257)
 
 ## [1.11.7] - 2021-06-08
 
@@ -26,8 +34,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `conjurctl configuration apply` command restart the Conjur process and
   pick up changes to the configuration file.
   [cyberark/conjur#2171](https://github.com/cyberark/conjur/issues/2171)
-- The JWT Authenticator (`authn-jwt`) supports authenticating third-party vendors that utilize JWT.
-  See [design](https://github.com/cyberark/conjur/blob/master/design/authenticators/authn_jwt/authn_jwt_solution_design.md)
 
 ### Fixed
 - Fix bug where running `conjurctl server` or `conjurctl account create` with
@@ -40,8 +46,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [PR cyberark/conjur#2191](https://github.com/cyberark/conjur/pull/2191)
 
 ### Security
-- Upgrade bindata to 2.4.10 to resolve Unspecified Issue reported by JFrog Xray
-  [cyberark/conjur#2257](https://github.com/cyberark/conjur/issues/2257)
 - Upgrade Rails to 5.2.5 to resolve CVE-2021-22885
   [cyberark/conjur#2149](https://github.com/cyberark/conjur/issues/2149)
 - Upgrade Nokogiri to 1.11.5 to resolve


### PR DESCRIPTION
### What does this PR do?
This PR fixes the Conjur CHANGELOG to move entries incorrectly added under `1.11.7` back under `Unreleased`.
This is most likely the result of an incorrect rebase after the `1.11.7` version was tagged.

