### PR TITLE
ONYX-8600: Add Authn-JWT-Configuration tests

### DIFF
--- a/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
@@ -1,0 +1,146 @@
+Feature: JWT Authenticator - Configuration Check
+  Background:
+    Given I initialize JWKS endpoint with file "myJWKs.json"
+    And I have a "variable" resource called "test-variable"
+
+  Scenario: Webservice is missing in Authenticator policy
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I successfully set authn-jwt "token-app-property" variable to value "user"
+    And I permit host "myapp" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00005E Webservice 'authn-jwt/raw' not found
+    """
+
+  Scenario: Webservice with read and no authenticate permission in authenticator policy
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I successfully set authn-jwt "token-app-property" variable to value "user"
+    And I permit host "myapp" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 403
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotAuthorizedOnResource: CONJ00006E
+    """
+
+  Scenario: Both provider-uri and jwks-uri are configured
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt "jwks-uri" variable to value "jwks uri placehodlder"
+    And I successfully set authn-jwt "provider-uri" variable to value "provider uri placeholder"
+    And I permit host "myapp" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00086E Signing key URI configuration is invalid
+    """

--- a/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/authn_jwt_steps.rb
@@ -2,8 +2,8 @@ Given(/I successfully set authn-jwt jwks-uri variable with value of "([^"]*)" en
   create_jwt_secret("jwks-uri", "#{JwtJwksHelper::JWKS_BASE_URI}/#{filename}")
 end
 
-Given(/I successfully set authn-jwt token-app-property variable to value "([^"]*)"/) do |value|
-  create_jwt_secret("token-app-property", value)
+Given(/I successfully set authn-jwt "([^"]*)" variable to value "([^"]*)"/) do |variable, value|
+  create_jwt_secret(variable, value)
 end
 
 When(/I authenticate via authn-jwt with the JWT token/) do

--- a/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
@@ -1,4 +1,4 @@
-Given(/I initialize JWKs endpoint with file "([^"]*)"/) do |filename|
+Given(/I initialize JWKS endpoint with file "([^"]*)"/) do |filename|
   init_jwks_file(filename)
 end
 


### PR DESCRIPTION
### What does this PR do?
Tests for configuration checks in jwt authenticator

### What ticket does this PR close?
ONYX-8600

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
