### PR TITLE
Add signing key validation to authn-jwt status check

### DIFF
--- a/app/domain/authentication/authn_jwt/signing_key/fetch_signing_key_interface.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_signing_key_interface.rb
@@ -2,7 +2,7 @@ module Authentication
   module AuthnJwt
     module SigningKey
       class FetchSigningKeyInterface
-        def create; end
+        def call; end
 
         def valid_configuration?; end
       end

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -46,12 +46,17 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
   let(:user_cant_access_webservice_error) { "User cant access webservice" }
   let(:webservice_does_not_exist_error) { "Webservice does not exist" }
   let(:account_does_not_exist_error) { "Account does not exist" }
+  let(:mocked_valid_fetch_signing_key_interface) { double("Mocked valid fetch signing key interface")  }
 
   before(:each) do
     allow(mocked_valid_create_signing_key_interface).to(
-      receive(:call).and_return(nil)
+      receive(:call).and_return(mocked_valid_fetch_signing_key_interface)
     )
 
+    allow(mocked_valid_fetch_signing_key_interface).to(
+      receive(:call).and_return(nil)
+    )
+    
     allow(mocked_invalid_create_signing_key_interface).to(
       receive(:call).and_raise(create_signing_key_configuration_is_invalid_error)
     )
@@ -136,7 +141,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
       subject do
         ::Authentication::AuthnJwt::ValidateStatus.new(
-          create_signing_key: mocked_valid_create_signing_key_interface,
+          create_signing_key_interface: mocked_valid_create_signing_key_interface,
           fetch_issuer_value: mocked_valid_fetch_issuer_value,
           identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
           validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -160,7 +165,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -183,7 +188,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -206,7 +211,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -229,7 +234,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_invalid_validate_webservice_is_whitelisted,
@@ -264,7 +269,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -288,7 +293,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "signing key secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_invalid_create_signing_key_interface,
+            create_signing_key_interface: mocked_invalid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -310,7 +315,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "issuer secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_invalid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
@@ -332,7 +337,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "identity secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            create_signing_key: mocked_valid_create_signing_key_interface,
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_invalid_identity_from_decoded_token_provider,
             validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,


### PR DESCRIPTION
### What does this PR do?
Add signing key validation to authn-jwt status check

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
