### PR TITLE
ONYX-8698: Add Authn JWT signing key configuration tests

### DIFF
--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -63,8 +63,6 @@ Feature: JWT Authenticator - JWKs Basic sanity
 
   Scenario: Authenticator is not enabled
     Given I have a "variable" resource called "test-variable"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I issue a JWT token:
     """
     {
@@ -82,8 +80,6 @@ Feature: JWT Authenticator - JWKs Basic sanity
 
   Scenario: Empty Token Given
     Given I have a "variable" resource called "test-variable"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I save my place in the log file
     And I issue empty JWT token
     When I authenticate via authn-jwt with the JWT token
@@ -95,8 +91,6 @@ Feature: JWT Authenticator - JWKs Basic sanity
 
   Scenario: No Token Given
     Given I have a "variable" resource called "test-variable"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I save my place in the log file
     When I authenticate via authn-jwt with the JWT token
     Then it is a bad request
@@ -114,8 +108,6 @@ Feature: JWT Authenticator - JWKs Basic sanity
       annotations:
         authn-jwt/raw/custom-claim:
     """
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I issue a JWT token:
     """
     {
@@ -140,8 +132,6 @@ Feature: JWT Authenticator - JWKs Basic sanity
       annotations:
         authn-jwt/raw/custom-claim:
     """
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I issue a JWT token:
     """
     {

--- a/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
@@ -28,8 +28,6 @@ Feature: JWT Authenticator - Configuration Check
     And I am the super-user
     And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
     And I successfully set authn-jwt "token-app-property" variable to value "user"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I issue a JWT token:
     """
     {
@@ -74,8 +72,6 @@ Feature: JWT Authenticator - Configuration Check
     And I am the super-user
     And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
     And I successfully set authn-jwt "token-app-property" variable to value "user"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I issue a JWT token:
     """
     {
@@ -128,8 +124,248 @@ Feature: JWT Authenticator - Configuration Check
     And I am the super-user
     And I successfully set authn-jwt "jwks-uri" variable to value "jwks uri placehodlder"
     And I successfully set authn-jwt "provider-uri" variable to value "provider uri placeholder"
-    And I permit host "myapp" to "execute" it
-    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00086E Signing key URI configuration is invalid
+    """
+
+  Scenario: provider-uri configured with correct value, jwks-uri configured with empty value, error
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt "jwks-uri" variable to value " "
+    And I successfully set authn-jwt "provider-uri" variable to value "provider uri placeholder"
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00086E Signing key URI configuration is invalid
+    """
+
+  Scenario: jwks-uri configured but variable not set
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Conjur::RequiredSecretMissing: CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/jwks-uri
+    """
+
+  Scenario: provider-uri configured but variable not set
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Conjur::RequiredSecretMissing: CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/provider-uri
+    """
+
+  Scenario: None of provider-uri or jwks-uri are configured
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I issue a JWT token:
+    """
+    {
+      "user":"host/myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with the JWT token
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00086E Signing key URI configuration is invalid
+    """
+
+  Scenario: provider-uri configured with empty value, jwks-uri configured with correct value
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: provider-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group users
+
+      - !permit
+        role: !group users
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/users
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I successfully set authn-jwt "provider-uri" variable to value " "
     And I issue a JWT token:
     """
     {


### PR DESCRIPTION
### What does this PR do?
Adds tests for configuration of signing key fetching in JWT Authenticator

![image](https://user-images.githubusercontent.com/73157235/122191709-a47f7000-ce9b-11eb-9021-fcf45c5c45e8.png)


### What ticket does this PR close?
ONYX-8698

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
