### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/app/domain/authentication/authn_k8s/TROUBLESHOOTING.md
+++ b/app/domain/authentication/authn_k8s/TROUBLESHOOTING.md
@@ -3,8 +3,8 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [Troubleshooting Kubernetes Authentication on Conjur OSS](#troubleshooting-kubernetes-authentication-on-conjur-oss)
-  * [Prerequisites for Troubleshooting on Conjur OSS](#prerequisites-for-troubleshooting-on-conjur-oss)
+- [Troubleshooting Kubernetes Authentication on Conjur Open Source](#troubleshooting-kubernetes-authentication-on-conjur-open-source)
+  * [Prerequisites for Troubleshooting on Conjur Open Source](#prerequisites-for-troubleshooting-on-conjur-open-source)
   * [Before We Begin Troubleshooting: Some Handy Tools and How-Tos](#before-we-begin-troubleshooting-some-handy-tools-and-how-tos)
   * [Step-by-Step: Verifying Your Conjur Authentication Configuration](#step-by-step-verifying-your-conjur-authentication-configuration)
   * [Some Useful Conjur Commands](#some-useful-conjur-commands)
@@ -22,13 +22,13 @@ functionality of
 [Conjur Kubernetes authentication (`authn-k8s`)](https://docs.conjur.org/Latest/en/Content/Operations/Services/k8s_auth.htm)
 on a [Conjur](https://docs.conjur.org/) cluster.
 
-## Troubleshooting Kubernetes Authentication on Conjur OSS
+## Troubleshooting Kubernetes Authentication on Conjur Open Source
 
 This section presents some tips and guidelines for troubleshooting
 [Conjur Kubernetes authentication (`authn-k8s`)](https://docs.conjur.org/Latest/en/Content/Operations/Services/k8s_auth.htm)
-specifically on a [Conjur OSS](https://docs.conjur.org/) cluster that has
+specifically on a [Conjur Open Source](https://docs.conjur.org/) cluster that has
 been deployed via the
-[Conjur OSS Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
+[Conjur Open Source Helm Chart](https://github.com/cyberark/conjur-oss-helm-chart/conjur-oss).
 
 The intended audience for this section of the guide is anyone who encounters
 issues when deploying Kubernetes applications that make use of Conjur
@@ -40,7 +40,7 @@ authenticate with Conjur:
 - [Conjur Kubernetes Authenticator Client](https://github.com/cyberark/conjur-authn-k8s-client)
   as either a sidecar or init container
 
-### Prerequisites for Troubleshooting on Conjur OSS
+### Prerequisites for Troubleshooting on Conjur Open Source
 
 This section of the guide assumes that you have:
 
@@ -92,7 +92,7 @@ This section of the guide assumes that you have:
   </details>
 
 - [`conjur` CLI](https://github.com/cyberark/conjur-cli) access to your
-  [Conjur OSS](https://docs.conjur.org/) server.
+  [Conjur Open Source](https://docs.conjur.org/) server.
 
   If you don't have this set up already, see the
   [Creating a Conjur CLI Pod](#creating-a-conjur-cli-pod) section below.
@@ -109,7 +109,7 @@ In some cases, it may be helpful to create a Conjur CLI pod in your
 Kubernetes cluster, and create a `conjur` command alias that executes
 commands via that Conjur CLI pod.
 
-For example, you may be exploring Conjur OSS and Kubernetes authentication
+For example, you may be exploring Conjur Open Source and Kubernetes authentication
 on a [Kubernetes-in-Docker (KinD)](https://kind.sigs.k8s.io/) or
 or [MiniKube](https://minikube.sigs.k8s.io/docs/) cluster, and you prefer
 not to install a software load balancer such as
@@ -123,7 +123,7 @@ not to install a software load balancer such as
   HELM_RELEASE=conjur-oss
   CONJUR_NAMESPACE=conjur-oss
 
-  # Create a Conjur CLI pod in the Conjur OSS namespace
+  # Create a Conjur CLI pod in the Conjur Open Source namespace
   CLI_IMAGE=cyberark/conjur-cli:5-latest
   echo "
   ---
@@ -186,7 +186,7 @@ the Kubernetes cluster.
   # Set environment. Modify as necessary to match your setup.
   CONJUR_NAMESPACE=conjur-oss
 
-  # Create a 'pod-curl' pod in the Conjur OSS namespace
+  # Create a 'pod-curl' pod in the Conjur Open Source namespace
   echo "
   ---
   apiVersion: v1
@@ -346,7 +346,7 @@ of your Conjur authentication configuration.
    - Check the [Postgres pod logs](#collecting-conjur-postgres-pod-logs)
      for warnings or errors.
    - [Enable Conjur debug logging](#enabling-debug-logs-for-the-conjur-server),
-     and then delete the Conjur OSS server pod to force a pod recreate, and
+     and then delete the Conjur Open Source server pod to force a pod recreate, and
      check the [Conjur server logs](#collecting-conjur-server-logs) again
      for warnings or errors.
 

--- a/app/domain/authentication/authn_k8s/TROUBLESHOOTING.md
+++ b/app/domain/authentication/authn_k8s/TROUBLESHOOTING.md
@@ -4,16 +4,16 @@
 
 - [Overview](#overview)
 - [Troubleshooting Kubernetes Authentication on Conjur Open Source](#troubleshooting-kubernetes-authentication-on-conjur-open-source)
-  * [Prerequisites for Troubleshooting on Conjur Open Source](#prerequisites-for-troubleshooting-on-conjur-open-source)
-  * [Before We Begin Troubleshooting: Some Handy Tools and How-Tos](#before-we-begin-troubleshooting-some-handy-tools-and-how-tos)
-  * [Step-by-Step: Verifying Your Conjur Authentication Configuration](#step-by-step-verifying-your-conjur-authentication-configuration)
-  * [Some Useful Conjur Commands](#some-useful-conjur-commands)
-  * [Failure Conditions and How to Troubleshoot](#failure-conditions-and-how-to-troubleshoot)
-    + [Conjur server cannot access application Kubernetes Resources](#conjur-server-cannot-access-application-kubernetes-resources)
-    + [Conjur Kubernetes Authenticator is not enabled](#conjur-kubernetes-authenticator-is-not-enabled)
-    + [Conjur appliance URL is set incorrectly](#conjur-appliance-url-is-set-incorrectly)
-    + [Certificate not valid for domain name in Conjur appliance URL](#certificate-not-valid-for-domain-name-in-conjur-appliance-url)
-    + [Invalid Response to Certificate Signing Request](#invalid-response-to-certificate-signing-request)
+  - [Prerequisites for Troubleshooting on Conjur Open Source](#prerequisites-for-troubleshooting-on-conjur-open-source)
+  - [Before We Begin Troubleshooting: Some Handy Tools and How-Tos](#before-we-begin-troubleshooting-some-handy-tools-and-how-tos)
+  - [Step-by-Step: Verifying Your Conjur Authentication Configuration](#step-by-step-verifying-your-conjur-authentication-configuration)
+  - [Some Useful Conjur Commands](#some-useful-conjur-commands)
+  - [Failure Conditions and How to Troubleshoot](#failure-conditions-and-how-to-troubleshoot)
+    - [Conjur server cannot access application Kubernetes Resources](#conjur-server-cannot-access-application-kubernetes-resources)
+    - [Conjur Kubernetes Authenticator is not enabled](#conjur-kubernetes-authenticator-is-not-enabled)
+    - [Conjur appliance URL is set incorrectly](#conjur-appliance-url-is-set-incorrectly)
+    - [Certificate not valid for domain name in Conjur appliance URL](#certificate-not-valid-for-domain-name-in-conjur-appliance-url)
+    - [Invalid Response to Certificate Signing Request](#invalid-response-to-certificate-signing-request)
 
 ## Overview
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,6 +1,6 @@
 # Conjur Design Documentation
 
-This folder contains design documents for some Conjur OSS components.
+This folder contains design documents for some Conjur Open Source components.
 
 The linked documents below represent the original feature designs; to learn
 more about the current state of the features, please see the official

--- a/design/authenticators/authn_azure/authn_azure_solution_design.md
+++ b/design/authenticators/authn_azure/authn_azure_solution_design.md
@@ -552,12 +552,13 @@ The default TTL of an Azure access token is one hour, but it can reduced to a sh
 - [ ] Security action items were taken care of
 - [ ] Performance tests were done and align with SLA
 - [ ] Logs were reviewed by TW and PO
-- [ ] Documentation has been written and reviewed by PO and TW for both Conjur Enterprise and Conjur
+- [ ] Documentation has been written and reviewed by PO and TW for both
+      Conjur Enterprise and Open Source
 - [ ] A demo was created for the new authenticator
 - [ ] Engineer(s) that were not involved in the project use documentation to authenticate with Conjur using Azure
 - [ ] Versions are bumped in all relevant projects
-   - [ ] Conjur
-   - [ ] Conjur Enterprise
+    - [ ] Conjur
+    - [ ] Conjur Enterprise
  
 ## Open questions
 

--- a/design/authenticators/authn_azure/authn_azure_solution_design.md
+++ b/design/authenticators/authn_azure/authn_azure_solution_design.md
@@ -411,7 +411,7 @@ Azure authenticator performance should conform with our other authenticators wit
 
 - Conjur
 
-- DAP
+- Conjur Enterprise
 
 ## Security
 
@@ -535,7 +535,7 @@ The default TTL of an Azure access token is one hour, but it can reduced to a sh
 
 - Conjur
 
-- DAP
+- Conjur Enterprise
 
 ## DoD
 
@@ -552,12 +552,12 @@ The default TTL of an Azure access token is one hour, but it can reduced to a sh
 - [ ] Security action items were taken care of
 - [ ] Performance tests were done and align with SLA
 - [ ] Logs were reviewed by TW and PO
-- [ ] Documentation has been written and reviewed by PO and TW for both DAP and Conjur
+- [ ] Documentation has been written and reviewed by PO and TW for both Conjur Enterprise and Conjur
 - [ ] A demo was created for the new authenticator
 - [ ] Engineer(s) that were not involved in the project use documentation to authenticate with Conjur using Azure
 - [ ] Versions are bumped in all relevant projects
    - [ ] Conjur
-   - [ ] DAP
+   - [ ] Conjur Enterprise
  
 ## Open questions
 

--- a/design/authenticators/authn_gcp/authn_gcp_solution_design.md
+++ b/design/authenticators/authn_gcp/authn_gcp_solution_design.md
@@ -336,7 +336,7 @@ GCP authenticator performance should conform with our other authenticators with 
 ### Affected Components
 - Conjur
 
-- DAP
+- Conjur Enterprise
 
 ## Security
 * **Future support in Service account key needs to be done very carefully** since there is a concern of impersonate other Conjur hosts, 
@@ -396,7 +396,7 @@ While Unit Tests are already automated, we will need to add some infrastructure 
 ### Scope
   - Run integration tests in OSS
   - Run a vanilla test in appliance
-  - Run automation on a DAP image that is deployed on GCP (Manual at first stage, automation on POST GA)
+  - Run automation on a Conjur Enterprise image that is deployed on GCP (Manual at first stage, automation on POST GA)
 
 ### Run Integration Tests in OSS
 GCP Authenticator tests will be added to the the general infrastructure of our integration test.
@@ -531,7 +531,7 @@ TODO: Inbal to decide which versions?
 
 - Conjur
 
-- DAP
+- Conjur Enterprise
 
 ## Open questions
 - Authenticator name may change `authn-gcp` ? TODO: Inbal to decide 
@@ -574,8 +574,8 @@ Note: LLD designs need will be decided at implementation level
 4. Release from side branch **E1**
 
     4.1 Merge stable released Conjur to our side branch
-    4.2 Update Conjur and DAP versions 
-    4.3 Release DAP as CA from side branch 
+    4.2 Update Conjur and Conjur Enterprise versions 
+    4.3 Release Conjur Enterprise as CA from side branch 
 5. Implement user extraction for aud claim indie the token **E1**
 
 #### Testing EE19
@@ -585,12 +585,12 @@ Note: LLD designs need will be decided at implementation level
     
     1.2. OSS - Issue an identity token **EE1**
     
-    1.3. DAP - Create GCE instance **EE1**
+    1.3. Conjur Enterprise - Create GCE instance **EE1**
     
-    1.4. DAP - Issue an identity token **EE1**
+    1.4. Conjur Enterprise - Issue an identity token **EE1**
         
 2. OSS - Implement integration tests **EE5**
-3. DAP - Implement integration tests for **EE3**
+3. Conjur Enterprise - Implement integration tests for **EE3**
 4. Manual tests according to docs (customer env) **EE1**
 5. Performance tests **EE3**
 6. Setting customer env **EE2**
@@ -616,7 +616,7 @@ Note: LLD designs need will be decided at implementation level
 
 ### Post GA EE6 + ??
 #### Testing
-1. Infrastructure to deploy DAP image on GCP
+1. Infrastructure to deploy Conjur Enterprise image on GCP
 
 #### Designs  
 1. LLD for K8S, Azure ang GCP to use same component of ValidateResourceRestrictions class **EE3**

--- a/design/authenticators/authn_gcp/authn_gcp_solution_design.md
+++ b/design/authenticators/authn_gcp/authn_gcp_solution_design.md
@@ -394,9 +394,10 @@ We would like to add automated tests for the GCP Authenticator.
 While Unit Tests are already automated, we will need to add some infrastructure for running integration tests.
 
 ### Scope
-  - Run integration tests in OSS
-  - Run a vanilla test in appliance
-  - Run automation on a Conjur Enterprise image that is deployed on GCP (Manual at first stage, automation on POST GA)
+- Run integration tests in OSS
+- Run a vanilla test in appliance
+- Run automation on a Conjur Enterprise image that is deployed on GCP
+  (Manual at first stage, automation on POST GA)
 
 ### Run Integration Tests in OSS
 GCP Authenticator tests will be added to the the general infrastructure of our integration test.
@@ -574,8 +575,8 @@ Note: LLD designs need will be decided at implementation level
 4. Release from side branch **E1**
 
     4.1 Merge stable released Conjur to our side branch
-    4.2 Update Conjur and Conjur Enterprise versions 
-    4.3 Release Conjur Enterprise as CA from side branch 
+    4.2 Update Conjur and Conjur Enterprise versions
+    4.3 Release Conjur Enterprise as CA from side branch
 5. Implement user extraction for aud claim indie the token **E1**
 
 #### Testing EE19

--- a/design/authenticators/authn_jwt/authn_jwt_solution_design.md
+++ b/design/authenticators/authn_jwt/authn_jwt_solution_design.md
@@ -395,7 +395,7 @@ JWT authenticator performance should conform with our other authenticators with 
 ### Affected Components
 - Conjur
 
-- DAP
+- Conjur Enterprise
 
 ## Open questions
 1. Do we want to support static keys in 1st phase?

--- a/design/authenticators/authn_k8s/inject_client_cert_solution_design.md
+++ b/design/authenticators/authn_k8s/inject_client_cert_solution_design.md
@@ -186,7 +186,8 @@ The performance of the "inject-client-cert" request will not be affected as the 
 
 ## Affected Components
 
-[//]: # "Address the components that will be affected by your solution [Conjur, Conjur Enterprise, clients, integrations, etc.]"
+[//]: # "Address the components that will be affected by your solution
+         [Conjur, Conjur Enterprise, clients, integrations, etc.]"
 - Conjur
 - Conjur Enterprise
 - conjur-authn-k8s-client
@@ -228,7 +229,11 @@ Additionally, we should address [this issue](https://github.com/cyberark/conjur/
 There are no new audit messages in this fix. We already write the inject-client-cert request to the audit log.
 
 ## Documentation
-[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or Conjur Enterprise mention which products are affected by it"
+[//]: # "Add notes on what should be documented in this solution."
+[//]: # "Elaborate on where this should be documented. If the change is in"
+[//]: # "open-source projects, we may need to update the docs in github too."
+[//]: # "If it's in Conjur and/or Conjur Enterprise mention which"
+[//]: # "products are affected by it"
 This is an internal process so it doesn't require any new documentation. A CHANGELOG entry will be added about the response code change in "inject-client-cert"
 
 ## Delivery plan

--- a/design/authenticators/authn_k8s/inject_client_cert_solution_design.md
+++ b/design/authenticators/authn_k8s/inject_client_cert_solution_design.md
@@ -186,9 +186,9 @@ The performance of the "inject-client-cert" request will not be affected as the 
 
 ## Affected Components
 
-[//]: # "Address the components that will be affected by your solution [Conjur, DAP, clients, integrations, etc.]"
+[//]: # "Address the components that will be affected by your solution [Conjur, Conjur Enterprise, clients, integrations, etc.]"
 - Conjur
-- DAP
+- Conjur Enterprise
 - conjur-authn-k8s-client
 - seed-fetcher
 - secrets-provider-for-k8s
@@ -228,7 +228,7 @@ Additionally, we should address [this issue](https://github.com/cyberark/conjur/
 There are no new audit messages in this fix. We already write the inject-client-cert request to the audit log.
 
 ## Documentation
-[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or DAP mention which products are affected by it"
+[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or Conjur Enterprise mention which products are affected by it"
 This is an internal process so it doesn't require any new documentation. A CHANGELOG entry will be added about the response code change in "inject-client-cert"
 
 ## Delivery plan

--- a/design/oss_suite_release.md
+++ b/design/oss_suite_release.md
@@ -6,8 +6,8 @@ which we define as the set of components including the Conjur server, deployment
 command line interface (CLI), client libraries, and integrations with platforms and DevOps tools.
 
 At current, we have no formal process for releasing the full suite of tools in
-the Conjur OSS ecosystem so that:
-- It is clear to end users which version of Conjur OSS they should use, and what
+the Conjur Open Source ecosystem so that:
+- It is clear to end users which version of Conjur Open Source they should use, and what
   integrations and tooling are compatible with that version.
 - Key use cases that involve more than two components working together are automatically
   tested to ensure that the end-to-end experience in those use cases works as expected.
@@ -57,7 +57,7 @@ In addition, as part of building this release, we'll also be creating:
   needed.
 
 ## Repositories Included in the Conjur OSS Suite Release
-- Conjur OSS Core
+- Conjur Open Source Core
   - [Conjur Core](https://github.com/cyberark/conjur)
   - [Conjur CLI](https://github.com/cyberark/conjur-cli)
   - Client Libraries
@@ -88,12 +88,12 @@ In addition, as part of building this release, we'll also be creating:
 
 ## Considerations
 
-### How CyberArk Dynamic Access Provider (DAP) Will Use the OSS Release
-At current, when a new DAP appliance is built it is based on a manually pinned
-version of Conjur OSS. We propose implementing automation as part of this release
-to auto-update the pinned version of Conjur OSS used in DAP with each new OSS
-Suite Release, so that DAP stays consistent with the latest stable release of
-Conjur OSS.
+### How CyberArk Conjur Enterprise Will Use the OSS Release
+At current, when a new Conjur Enterprise appliance is built it is based on a manually pinned
+version of Conjur Open Source. We propose implementing automation as part of this release
+to auto-update the pinned version of Conjur Open Source used in Conjur Enterprise with each new OSS
+Suite Release, so that Conjur Enterprise stays consistent with the latest stable release of
+Conjur Open Source.
 
 
 ### Out of Scope
@@ -141,7 +141,7 @@ Conjur OSS.
 |||
 |---|---|
 |_As a_|Conjur Open Source user|
-|_I want_|to know what versions of Conjur OSS components to use|
+|_I want_|to know what versions of Conjur Open Source components to use|
 |_so that_|I am using reliable, well-tested software that works together as expected when used within my systems.|
 
 ### OSS Suite Component Maintainers
@@ -164,7 +164,7 @@ Conjur OSS.
 |_I want_|to know what standards I need to maintain in my repository|
 |_so that_|my CHANGELOG entries, releases, READMEs, etc are compatible with the OSS suite release.|
 
-### Conjur OSS Contributors
+### Conjur Open Source Contributors
 
 |||
 |---|---|
@@ -216,7 +216,7 @@ Conjur OSS.
 
 The [OSS Suite Release Repo](https://github.com/cyberark/conjur-oss-suite-release)
 will include:
-- A user-facing README with a high level overview of how Conjur OSS end users
+- A user-facing README with a high level overview of how Conjur Open Source end users
   should leverage the repo, with links to appropriate pages in the official documentation
 - A VERSION file that includes the current version of the OSS suite release
 - A machine-readable file with the pinned versions included in the current release
@@ -230,11 +230,11 @@ will include:
   - Note: when possible, links to artifacts should link directly to the canonical
     source, rather than linking to the component README (eg link directly to Dockerhub, etc)
   - Bumping the version of Conjur pinned in the [Conjur helm chart](https://github.com/cyberark/conjur-oss-helm-chart)
-  - (optional) Build and publish the [Conjur OSS AMI](https://github.com/cyberark/conjur-aws)
+  - (optional) Build and publish the [Conjur Open Source AMI](https://github.com/cyberark/conjur-aws)
 - A test suite that can be run manually or automatically to test the pinned versions
   included in the release
   - It will be designed so that new test cases can be added as needed going forward
-  - The initial test case will test deploying Conjur OSS to GKE using the Helm Chart
+  - The initial test case will test deploying Conjur Open Source to GKE using the Helm Chart
     and enabling a sample app to connect to its database via Secretless using credentials
     pulled from Conjur
 - (optional) A test suite that can be run manually or automatically, and that runs daily against
@@ -249,7 +249,7 @@ will include:
 The GitHub landing page will include:
 - An organized view of the GitHub repositories that are part of the Conjur OSS Suite Release
 
-The Conjur OSS documentation will include:
+The Conjur Open Source documentation will include:
 - A page for Conjur OSS Suite releases
 - Updates to the "Get Started" flow and/or to OSS suite component pages directing
   end users to use
@@ -270,7 +270,7 @@ The GitHub repositories for OSS Suite components will include:
       - Known issues
       - Copy / paste of the CHANGELOG for this version
 
-The Dynamic Access Provider project will include:
+The Conjur Enterprise project will include:
 - An automatic process for proposing a version bump in the Conjur core version when a
   new Conjur OSS suite release is published
 
@@ -344,26 +344,26 @@ Sample release notes section for Secretless:
 
 #### Documentation
 - How do we ensure new documented features available in the Conjur OSS Suite Release
-  are appropriately propagated to the DAP documentation?
+  are appropriately propagated to the Conjur Enterprise documentation?
   - We propose this is out of scope for this effort, and should be decided in a
-    follow-on effort by the DAP team together with the technical writers.
+    follow-on effort by the Conjur Enterprise team together with the technical writers.
   - Based on the way documentation currently works, it is likely that new features
     in the Conjur OSS suite will require additional testing and documentation to
-    certify the new features for DAP in follow-on efforts.
+    certify the new features for Conjur Enterprise in follow-on efforts.
 
 #### Enterprise Products Built on the Core
-- How will DAP (built on the open Conjur core) run tests against the non-server
+- How will Conjur Enterprise (built on the open Conjur core) run tests against the non-server
   components of the Conjur OSS suite to ensure the enterprise product remains
-  compatible with the OSS components that are certified for DAP?
+  compatible with the OSS components that are certified for Conjur Enterprise?
   - We propose this is out of scope for this effort, and should be decided in a
-    follow-on effort by the DAP team (similarly to how the documentation changes
+    follow-on effort by the Conjur Enterprise team (similarly to how the documentation changes
     will work above).
 
 #### Automated Test Suite for the OSS Suite Release
 - What should the initial scope of the automated tests for the Conjur OSS suite
   release be?
   - The OSS release suite should include an end-to-end test for a single
-    use case: Deploy Conjur OSS with Helm Chart to GKE and enable an app to connect
+    use case: Deploy Conjur Open Source with Helm Chart to GKE and enable an app to connect
     to its database via Secretless using credentials pulled from Conjur.
   - Individual repos are responsible for running their own integration tests against
     Conjur. The suite release test suite will enable integration testing multiple

--- a/design/oss_suite_release.md
+++ b/design/oss_suite_release.md
@@ -7,8 +7,9 @@ command line interface (CLI), client libraries, and integrations with platforms 
 
 At current, we have no formal process for releasing the full suite of tools in
 the Conjur Open Source ecosystem so that:
-- It is clear to end users which version of Conjur Open Source they should use, and what
-  integrations and tooling are compatible with that version.
+
+- It is clear to end users which version of Conjur Open Source they should use,
+  and what integrations and tooling are compatible with that version.
 - Key use cases that involve more than two components working together are automatically
   tested to ensure that the end-to-end experience in those use cases works as expected.
 - Development can continue on the master branch of individual components while
@@ -57,6 +58,7 @@ In addition, as part of building this release, we'll also be creating:
   needed.
 
 ## Repositories Included in the Conjur OSS Suite Release
+
 - Conjur Open Source Core
   - [Conjur Core](https://github.com/cyberark/conjur)
   - [Conjur CLI](https://github.com/cyberark/conjur-cli)
@@ -89,11 +91,13 @@ In addition, as part of building this release, we'll also be creating:
 ## Considerations
 
 ### How CyberArk Conjur Enterprise Will Use the OSS Release
-At current, when a new Conjur Enterprise appliance is built it is based on a manually pinned
-version of Conjur Open Source. We propose implementing automation as part of this release
-to auto-update the pinned version of Conjur Open Source used in Conjur Enterprise with each new OSS
-Suite Release, so that Conjur Enterprise stays consistent with the latest stable release of
-Conjur Open Source.
+
+At current, when a new Conjur Enterprise appliance is built it is based on a manually
+pinned version of Conjur Open Source. We propose implementing automation as
+part of this release to auto-update the pinned version of Conjur Open Source
+used in Conjur Enterprise with each new OSS Suite Release, so that
+Conjur Enterprise stays consistent with the latest stable release of Conjur
+Open Source.
 
 
 ### Out of Scope
@@ -216,6 +220,7 @@ Conjur Open Source.
 
 The [OSS Suite Release Repo](https://github.com/cyberark/conjur-oss-suite-release)
 will include:
+
 - A user-facing README with a high level overview of how Conjur Open Source end users
   should leverage the repo, with links to appropriate pages in the official documentation
 - A VERSION file that includes the current version of the OSS suite release
@@ -234,9 +239,9 @@ will include:
 - A test suite that can be run manually or automatically to test the pinned versions
   included in the release
   - It will be designed so that new test cases can be added as needed going forward
-  - The initial test case will test deploying Conjur Open Source to GKE using the Helm Chart
-    and enabling a sample app to connect to its database via Secretless using credentials
-    pulled from Conjur
+  - The initial test case will test deploying Conjur Open Source to GKE using
+    the Helm Chart and enabling a sample app to connect to its database via
+    Secretless using credentials pulled from Conjur
 - (optional) A test suite that can be run manually or automatically, and that runs daily against
   the latest versions of all OSS suite components
 - A CONTRIBUTING.md guide for contributors to OSS suite releases (including release
@@ -352,19 +357,22 @@ Sample release notes section for Secretless:
     certify the new features for Conjur Enterprise in follow-on efforts.
 
 #### Enterprise Products Built on the Core
-- How will Conjur Enterprise (built on the open Conjur core) run tests against the non-server
-  components of the Conjur OSS suite to ensure the enterprise product remains
-  compatible with the OSS components that are certified for Conjur Enterprise?
+
+- How will Conjur Enterprise (built on the open Conjur core) run tests against the
+  non-server components of the Conjur OSS suite to ensure the enterprise product
+  remains compatible with the OSS components that are certified for
+  Conjur Enterprise?
   - We propose this is out of scope for this effort, and should be decided in a
-    follow-on effort by the Conjur Enterprise team (similarly to how the documentation changes
-    will work above).
+    follow-on effort by the Conjur Enterprise team (similarly to how the
+    documentation changes will work above).
 
 #### Automated Test Suite for the OSS Suite Release
 - What should the initial scope of the automated tests for the Conjur OSS suite
   release be?
   - The OSS release suite should include an end-to-end test for a single
-    use case: Deploy Conjur Open Source with Helm Chart to GKE and enable an app to connect
-    to its database via Secretless using credentials pulled from Conjur.
+    use case: Deploy Conjur Open Source with Helm Chart to GKE and enable
+    an app to connect to its database via Secretless using credentials pulled
+    from Conjur.
   - Individual repos are responsible for running their own integration tests against
     Conjur. The suite release test suite will enable integration testing multiple
     components together (not just Component X + Conjur), and as part of the initial

--- a/design/proposals/README.md
+++ b/design/proposals/README.md
@@ -1,6 +1,6 @@
 # Conjur Proposals Documentation
 
-This folder contains feature proposals documents for some Conjur OSS components.
+This folder contains feature proposals documents for some Conjur Open Source components.
 
 The linked documents below represent feature proposals; once a feature is decided to be developed, please update the proposal document according to the actual design and move it under the `design` folder.
 

--- a/design/proposals/encoded_token_response.md
+++ b/design/proposals/encoded_token_response.md
@@ -156,7 +156,7 @@ TBD
 
 ## Test Plan
 
-1. Tests should be on DAP and Conjur (HTTPS vs HTTP).
+1. Tests should be on Conjur Enterprise and Open Source (HTTPS vs HTTP).
 2. All previous tests of `authenticate` method should passed.
 3. Perform performance test (Check for possible degradation) 
 

--- a/design/proposals/spike-cli-dockerless.md
+++ b/design/proposals/spike-cli-dockerless.md
@@ -282,7 +282,11 @@ We have ***not*** reached a decision about which CLI we will pursue.
 
 ## Documentation
 
-[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or Conjur Enterprise mention which products are affected by it"
+[//]: # "Add notes on what should be documented in this solution."
+[//]: # "Elaborate on where this should be documented. If the change is in"
+[//]: # "open-source projects, we may need to update the docs in github too."
+[//]: # "If it's in Conjur and/or Conjur Enterprise mention which"
+[//]: # "products are affected by it"
 
 The CLI that we choose will require documentation.
 

--- a/design/proposals/spike-cli-dockerless.md
+++ b/design/proposals/spike-cli-dockerless.md
@@ -282,7 +282,7 @@ We have ***not*** reached a decision about which CLI we will pursue.
 
 ## Documentation
 
-[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or DAP mention which products are affected by it"
+[//]: # "Add notes on what should be documented in this solution. Elaborate on where this should be documented. If the change is in open-source projects, we may need to update the docs in github too. If it's in Conjur and/or Conjur Enterprise mention which products are affected by it"
 
 The CLI that we choose will require documentation.
 

--- a/design/templates/solution_design.md
+++ b/design/templates/solution_design.md
@@ -85,7 +85,7 @@ Output parameters:
 [//]: # "How will the design of this solution impact backwards compatibility? Address how you are going to handle backwards compatibility, if necessary"
 
 ## Affected Components
-[//]: # "List all components that will be affected by your solution [Conjur OSS, Conjur Enterprise, clients, integrations, etc.] and elaborate on the impacts"
+[//]: # "List all components that will be affected by your solution [Conjur Open Source, Conjur Enterprise, clients, integrations, etc.] and elaborate on the impacts"
 [//]: # "This list should include all downstream components that will need to be updated to consume new releases as these changes are implemented"
 
 ## Test Plan
@@ -185,7 +185,7 @@ Output parameters:
 - Test plan is reviewed
 - Acceptance criteria have been met
 - Tests are implemented according to test plan 
-- The behaviour is documented in Conjur OSS and Enterprise
+- The behaviour is documented in Conjur Open Source and Enterprise
 - All relevant components are released
 
 ## Solution Review

--- a/design/templates/solution_design.md
+++ b/design/templates/solution_design.md
@@ -85,8 +85,11 @@ Output parameters:
 [//]: # "How will the design of this solution impact backwards compatibility? Address how you are going to handle backwards compatibility, if necessary"
 
 ## Affected Components
-[//]: # "List all components that will be affected by your solution [Conjur Open Source, Conjur Enterprise, clients, integrations, etc.] and elaborate on the impacts"
-[//]: # "This list should include all downstream components that will need to be updated to consume new releases as these changes are implemented"
+[//]: # "List all components that will be affected by your solution"
+[//]: # "[Conjur Open Source/Enterprise, clients, integrations, etc.]"
+[//]: # "and elaborate on the impacts. This list should include all"
+[//]: # "downstream components that will need to be updated to consume"
+[//]: # "new releases as these changes are implemented"
 
 ## Test Plan
 

--- a/docs/_data/repositories/integrations.yml
+++ b/docs/_data/repositories/integrations.yml
@@ -1,5 +1,5 @@
 section:
-  description: Conjur OSS integrations with platforms and DevOps tools.
+  description: Conjur Open Source integrations with platforms and DevOps tools.
   categories:
   - name: Platform Integrations
     description: Tools for Conjur integrations with platforms and cloud providers.
@@ -29,7 +29,7 @@ section:
           at runtime.
 
   - name: DevOps Tools
-    description: Conjur OSS integrations with DevOps tools.
+    description: Conjur Open Source integrations with DevOps tools.
     repos:
       - name: cyberark/ansible-conjur-collection
         url: https://github.com/cyberark/ansible-conjur-collection


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

Addresses [cyberark/community#92](https://github.com/cyberark/community/issues/92)
