### PR TITLE
Add conjur commit file to containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ docs/_site/
 docs/.sass-cache
 
 gems/*/Gemfile.lock
+
+# Container commit marker
+conjur_git_commit

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,11 @@ function flatten() {
   docker rm "$container"
 }
 
+# Store the current git commit sha in a file so that it can be added to the container.
+# This will enable users of the container to determine which revision of conjur
+# the container was built from.
+git rev-parse HEAD > conjur_git_commit
+
 # We want to build an image:
 # 1. Always, when we're developing locally
 if [[ $jenkins = false ]]; then


### PR DESCRIPTION
This allows container users to determine the exact commit of conjur
that the container was built from.


### What does this PR do?
When the container build script is run, a file is generated that contains the current
conjur commit SHA. This allows users of the container to determine the exact commit
of conjur that it was built from.

Isn't that what the VERSION file is for? That can help if you only deploy tagged versions,
if you deploy edge builds the VERSION file points to the last release, and doesn't tell you
which commit was used.

Example command for determining the conjur commit from a container:

  15:57 $ docker run --rm -it --entrypoint bash conjur:edge -c 'cat conjur_git_commit'
  60f85f07289058d3734ab0c62bd266cd16fb3213

### What ticket does this PR close?
Resolves #2280

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
