### PR TITLE
Fix "evoke configuration apply" error in RHEL

### DIFF
--- a/bin/conjur-cli/commands/configuration/apply.rb
+++ b/bin/conjur-cli/commands/configuration/apply.rb
@@ -42,7 +42,7 @@ module Commands
       private
 
       def server_pid
-        cmd = "ps -ef | grep puma | grep -v grep | grep -v cluster | " \
+        cmd = "ps -ef | grep puma | grep -v grep | grep -v cluster | grep -v evoke | " \
               "grep conjur | awk '{print $2}' | tr -d '\n'"
         stdout, _ = @command_runner.capture2(cmd)
         stdout.to_i


### PR DESCRIPTION
### What does this PR do?
When running the "evoke configuration apply" command in
Conjur on RHEL we get the error `bignum too big to convert into long`.
This happens because the evoke command above tries to kill the
conjur process and it fails to properly get the conjur process id.
It happens in RHEL because we have some additional puma processes
running by the Conjur user:
```
conjur     89291       1  0 15:20 ?        00:00:04 puma 5.3.1 (tcp://0.0.0.0:2301,tcp://127.0.0.1) [evoke]
conjur     89448   89291  0 15:21 ?        00:00:01 puma 5.3.1 (tcp://0.0.0.0:2301,tcp://127.0.0.1) [evoke]
conjur     89456   89291  0 15:21 ?        00:00:00 puma 5.3.1 (tcp://0.0.0.0:2301,tcp://127.0.0.1) [evoke]
conjur     89535   89291  0 15:21 ?        00:00:00 puma 5.3.1 (tcp://0.0.0.0:2301,tcp://127.0.0.1) [evoke]
conjur     89539   89291  0 15:21 ?        00:00:00 puma 5.3.1 (tcp://0.0.0.0:2301,tcp://127.0.0.1) [evoke]
```

Filtering entries that have the `evoke` word in them fixes the issue

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
