### PR TITLE
Set Puma Process Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Parsing a Conjur config with invalid YAML content now outputs a more user
   friendly error message without a stack trace.
   [cyberark/conjur#2256](https://github.com/cyberark/conjur/issues/2256)
+- Set the Puma process explicitly to reliably restart the correct process
+  when the Conjur configuration is reloaded.
+  [cyberark/conjur#2291](https://github.com/cyberark/conjur/pull/2291)
 
 ### Security
 - Upgrade bindata to 2.4.10 to resolve Unspecified Issue reported by JFrog Xray

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,15 @@ workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
 threads threads_count, threads_count
 
+# The tag is displayed in the Puma process description, for example:
+# ```
+# puma 4.3.8 (tcp://localhost:5000) [Conjur API Server]
+# ```
+# We use this to identify the puma process that should restarted
+# when the Conjur configuration is updated using
+# `conjurctl configuration apply`.
+tag "Conjur API Server"
+
 # [Added Aug 8, 2018]
 # With large policy files, the request can exceed the 1
 # minute default worker timeout. We've increased it to


### PR DESCRIPTION


### What does this PR do?
This PR updates the puma config to explicitly set the process tag, rather than defaulting to the directory name of the application. This allows us to reliably identify the process to restart it when reloading the Conjur configuration.

### What ticket does this PR close?
Resolves [ONYX-9564](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-9564)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require new tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
