### PR TITLE
ONYX 8710: Add tests for authn jwt signing key dynamically changes

### DIFF
--- a/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
@@ -70,8 +70,7 @@ Feature: JWT Authenticator - Check standard claim
     And I permit host "alice" to "execute" it
 
   Scenario: Issuer configured with incorrect value, iss claim not exists in token, 200 ok
-    Given I have a "variable" resource called "test-variable"
-    And I extend the policy with:
+    Given I extend the policy with:
     """
     - !policy
       id: conjur/authn-jwt/raw
@@ -262,8 +261,7 @@ Feature: JWT Authenticator - Check standard claim
     """
 
   Scenario: jwks-uri configured with correct value, issuer configured with correct value, iss claim with correct value, 200 OK
-    Given I have a "variable" resource called "test-variable"
-    And I extend the policy with:
+    Given I extend the policy with:
     """
     - !policy
       id: conjur/authn-jwt/raw

--- a/cucumber/authenticators_jwt/features/authn_jwt_provider_uri.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_provider_uri.feature
@@ -56,3 +56,30 @@ Feature: JWT Authenticator - JWKs fetched from Keycloak as OIDC provider
       |CONJ00054I "issuer" value will be taken from 'cucumber:variable:conjur/authn-jwt/keycloak/issuer'|
       |CONJ00055I Retrieved "issuer" with value 'http://keycloak:8080/auth/realms/master'               |
       |CONJ00098I Successfully found JWT identity 'host/alice'                                          |
+
+
+  Scenario: provider-uri dynamically changed, 502 ERROR resolves to 200 OK
+    Given I am the super-user
+    And I successfully set authn-jwt "provider-uri" variable in keycloack service to "incorrect.com"
+    And I successfully set authn-jwt "token-app-property" variable with OIDC value from env var "ID_TOKEN_USER_PROPERTY"
+    And I successfully set authn-jwt "issuer" variable with OIDC value from env var "PROVIDER_ISSUER"
+    And I fetch an ID Token for username "alice" and password "alice"
+    And I save my place in the log file
+    And I authenticate via authn-jwt with the ID token
+    And the HTTP response status code is 502
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00011E Failed to discover Identity Provider (Provider URI: 'incorrect.com'). Reason: '#<AttrRequired::AttrMissing: 'host' required.>'
+    """
+    When I successfully set authn-jwt "provider-uri" variable with OIDC value from env var "PROVIDER_URI"
+    And I fetch an ID Token for username "alice" and password "alice"
+    And I save my place in the log file
+    And I authenticate via authn-jwt with the ID token
+    Then host "alice" has been authorized by Conjur
+    And The following lines appear in the log after my savepoint:
+      |                                                                                                 |
+      |CONJ00076I Selected signing key interface: 'provider-uri'                                        |
+      |CONJ00072I Fetching JWKS from 'https://keycloak:8443/auth/realms/master'...                      |
+      |CONJ00054I "issuer" value will be taken from 'cucumber:variable:conjur/authn-jwt/keycloak/issuer'|
+      |CONJ00055I Retrieved "issuer" with value 'http://keycloak:8080/auth/realms/master'               |
+      |CONJ00098I Successfully found JWT identity 'host/alice'                                          |


### PR DESCRIPTION
### What does this PR do?
Adds tests for provider uri and jwks uri changed dynnamicly to see how authentication fails at first and then when we change to correct value authentication passes successfuly

### What ticket does this PR close?
ONYX 8710
ONYX 8709

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
