### PR TITLE
Wrap dynamic parallel blocks in script blocks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,21 +148,23 @@ pipeline {
               agent { label 'executor-v2-rhel-ee' }
 
               steps {
-                // Catch errors so remaining steps always run.
-                catchError {
-                  runConjurTests()
-                }
+                script {
+                  // Catch errors so remaining steps always run.
+                  catchError {
+                    runConjurTests()
+                  }
 
-                stash(
-                  name: 'testResultEE',
-                  includes: '''
-                    cucumber/*/*.*,
-                    container_logs/*/*,
-                    spec/reports/*.xml,
-                    spec/reports-audit/*.xml,
-                    cucumber/*/features/reports/**/*.xml
-                  '''
-                )
+                  stash(
+                    name: 'testResultEE',
+                    includes: '''
+                      cucumber/*/*.*,
+                      container_logs/*/*,
+                      spec/reports/*.xml,
+                      spec/reports-audit/*.xml,
+                      cucumber/*/features/reports/**/*.xml
+                    '''
+                  )
+                }
               }
 
               post {
@@ -212,7 +214,9 @@ pipeline {
           parallel {
             stage('Standard agent tests') {
               steps {
-                runConjurTests()
+                script {
+                  runConjurTests()
+                }
               }
             }
 


### PR DESCRIPTION
### What does this PR do?
- Blocks with dynamically generated parallel stages will add an additional stage of the wrapping stage if they aren't nested within a script block when viewed in the Blue Ocean view.  This will fix the display output of those builds.
- When viewed in Blue Ocean, builds should not have an additional stage of "Standard agent tests", and instead should have a header over parallel stages called "Standard agent tests"

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
