### PR TITLE
ONYX 8733: Add tests for validate and decode jwt token

### DIFF
--- a/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
@@ -1,0 +1,72 @@
+Feature: JWT Authenticator - Validate And Decode
+
+  Background:
+    Given I load a policy:
+    """
+    - !policy
+      id: conjur/authn-jwt/raw
+      body:
+      - !webservice
+        annotations:
+          description: Authentication service for JWT tokens, based on raw JWKs.
+
+      - !variable
+        id: jwks-uri
+
+      - !variable
+        id: token-app-property
+
+      - !group hosts
+
+      - !permit
+        role: !group hosts
+        privilege: [ read, authenticate ]
+        resource: !webservice
+
+    - !host
+      id: myapp
+      annotations:
+        authn-jwt/raw/project-id: myproject
+
+    - !grant
+      role: !group conjur/authn-jwt/raw/hosts
+      member: !host myapp
+    """
+    And I am the super-user
+    And I successfully set authn-jwt "token-app-property" variable to value "host"
+    And I initialize JWKS endpoint with file "myJWKs.json"
+
+  Scenario: Signature error, kid not found
+    Given I issue unknown kid JWT token:
+    """
+    {
+      "host":"myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with raw service ID
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::DecodeError: Could not find public key for kid unknown_kid>')>
+    """
+
+  Scenario: Signature error ,sign on a valid token header and content with your own key
+    Given I issue another key JWT token:
+    """
+    {
+      "host":"myapp",
+      "project-id": "myproject"
+    }
+    """
+    And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
+    And I save my place in the audit log file
+    When I authenticate via authn-jwt with raw service ID
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')>
+    """
+

--- a/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
+++ b/cucumber/authenticators_jwt/features/step_definitions/jwt_jwks_steps.rb
@@ -11,6 +11,24 @@ Given(/I issue a JWT token:/) do |token_body_string|
   )
 end
 
+Given(/I issue unknown kid JWT token:/) do |token_body_string|
+  # token body has to be an object (not a string) for correct token creation
+  issue_jwt_token_unkown_kid(
+    token_body_with_valid_expiration(
+      JSON.parse(token_body_string)
+    )
+  )
+end
+
+Given(/I issue another key JWT token:/) do |token_body_string|
+  # token body has to be an object (not a string) for correct token creation
+  issue_jwt_token_not_memoized_key(
+    token_body_with_valid_expiration(
+      JSON.parse(token_body_string)
+    )
+  )
+end
+
 Given(/I issue a JWT token without exp:/) do |token_body_string|
   # token body has to be an object (not a string) for correct token creation
   issue_jwt_token(

--- a/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
+++ b/cucumber/authenticators_jwt/features/support/jwt_jwks_helper.rb
@@ -32,6 +32,24 @@ module JwtJwksHelper
     )
   end
 
+  def issue_jwt_token_unkown_kid(token_body, algorithm = Algorithms::RS256)
+    @jwt_token = JWT.encode(
+      token_body,
+      rsa_key,
+      algorithm,
+      { kid: "unknown_kid" }
+    )
+  end
+
+  def issue_jwt_token_not_memoized_key(token_body, algorithm = Algorithms::RS256)
+    @jwt_token = JWT.encode(
+      token_body,
+      non_memoized_rsa_key,
+      algorithm,
+      { kid: jwk.kid }
+    )
+  end
+
   def jwt_token
     @jwt_token
   end
@@ -42,6 +60,10 @@ module JwtJwksHelper
 
   def rsa_key
     @rsa_key ||= OpenSSL::PKey::RSA.new(BITS_2048)
+  end
+
+  def non_memoized_rsa_key
+    OpenSSL::PKey::RSA.new(BITS_2048)
   end
 
   def token_body_with_valid_expiration(token_body)


### PR DESCRIPTION
### What does this PR do?
Add tests for authn jwt validate and decode


### What ticket does this PR close?
![image](https://user-images.githubusercontent.com/73157235/123549184-89044700-d770-11eb-9c07-44535c1ce373.png)

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
