### PR TITLE
Allow Conjur longer to boot during CI

### DIFF
--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -31,7 +31,7 @@ _run_cucumber_tests() {
   echo "Start all services..."
 
   docker-compose up --no-deps --no-recreate -d pg conjur "${services[@]}"
-  docker-compose exec -T conjur conjurctl wait
+  docker-compose exec -T conjur conjurctl wait --retries 180
 
   echo "Create cucumber account..."
 


### PR DESCRIPTION
Since CI instances were upgraded to 20.04, Conjur has been taking
longer to boot in docker and causing timeouts when setting up
environments for cucubmer. The cause of this increase will need
to be investigated, but to enable builds to continue this commit
increases the time the build will wait for Conjur to boot.

### What does this PR do?
Whats Changed? The length of time ci builds wait for Conjur to boot in docker has increased.

Why is this change being made? Because Conjur has been taking close to 90s to start,
so there has been a race between Conjur starting and the timeout. For instance during a recent
build Conjur took 88 seconds to start for one test set and timed out for another.

### What ticket does this PR close?
Related: conjurinc/ops#795

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
