### PR TITLE
Prevent security fork builds from pushing to dockerhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -535,7 +535,7 @@ pipeline {
         }
 
         stage('On a master build') {
-          when { branch "master" }
+          when { environment name: 'JOB_NAME', value: 'cyberark--conjur/master' }
           steps {
             script {
               def tasks = [:]


### PR DESCRIPTION
### What does this PR do?
Currently the Jenkinsfile pushes to dockerhub on all master branch builds.
The problem is that security forks also have master branches so they also
push to the edge tag to dockerhub. However the security fork master branches
are not kept up to date so they push old versions to edge.

This commit modifies the stage conditional to ensure that only builds
for the master branch in the main repo push to dockerhub.

### What ticket does this PR close?
Related: conjurinc/ops#790

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
