### PR TITLE
Add mandatory claims parsing

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -30,5 +30,6 @@ module Authentication
     OPTIONAL_CLAIMS = [ISS_CLAIM_NAME, NBF_CLAIM_NAME, IAT_CLAIM_NAME].freeze
     VALID_CLAIM_NAME_REGEX = /^[a-zA-Z|$|_][a-zA-Z|$|_|0-9]*$/.freeze # starts with letter $ or _ can contains digits
     MANDATORY_CLAIMS_DENY_LIST = [ISS_CLAIM_NAME, EXP_CLAIM_NAME, NBF_CLAIM_NAME, IAT_CLAIM_NAME, JTI_CLAIM_NAME, AUD_CLAIM_NAME].freeze
+    CLAIMS_CHARACTER_DELIMITER = ","
   end
 end

--- a/app/domain/authentication/authn_jwt/input_validation/parse_mandatory_claims.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/parse_mandatory_claims.rb
@@ -1,0 +1,86 @@
+module Authentication
+  module AuthnJwt
+    module InputValidation
+      # Parse mandatory-claims secret value and return a validated claims list
+      ParseMandatoryClaims ||= CommandClass.new(
+        dependencies: {
+          validate_claim_name: ValidateClaimName.new(
+            deny_claims_list_value: MANDATORY_CLAIMS_DENY_LIST
+          ),
+          logger: Rails.logger
+        },
+        inputs: %i[mandatory_claims]
+      ) do
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingMandatoryClaims.new(@mandatory_claims))
+          validate_mandatory_claims_exists
+          validate_mandatory_claims_list_format
+          validate_mandatory_claims_list_value
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsedMandatoryClaims.new(parsed_mandatory_claims_list))
+
+          parsed_mandatory_claims_list
+        end
+
+        private
+
+        def validate_mandatory_claims_exists
+          raise Errors::Authentication::AuthnJwt::FailedToParseMandatoryClaimsMissingInput if @mandatory_claims.blank?
+        end
+        
+        def validate_mandatory_claims_list_format
+          validate_delimiter_format
+          validate_duplications
+        end
+
+        def validate_delimiter_format
+          if mandatory_claims_starts_or_ends_with_delimiter? || 
+              mandatory_claims_has_connected_delimiter?
+            raise Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat, @mandatory_claims
+          end
+        end
+        
+        def mandatory_claims_starts_or_ends_with_delimiter?
+          mandatory_claims_first_character == CLAIMS_CHARACTER_DELIMITER ||
+            mandatory_claims_last_character == CLAIMS_CHARACTER_DELIMITER
+        end
+          
+        def mandatory_claims_first_character
+          @mandatory_claims_first_character ||= @mandatory_claims[0, 1]
+        end
+
+        def mandatory_claims_last_character
+          @mandatory_claims_last_character ||= @mandatory_claims[-1]
+        end
+        
+        def mandatory_claims_has_connected_delimiter?
+          parsed_mandatory_claims_list.include?('')
+        end
+
+        def validate_duplications
+          if parsed_mandatory_claims_list.uniq.length != parsed_mandatory_claims_list.length
+            raise Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormatContainsDuplication, @mandatory_claims
+          end
+        end
+        
+        def parsed_mandatory_claims_list
+          @parsed_mandatory_claims_list ||= mandatory_claims_strip_claims
+        end
+
+        def mandatory_claims_split_by_delimiter
+          @mandatory_claims_split_by_delimiter ||= @mandatory_claims.split(CLAIMS_CHARACTER_DELIMITER)
+        end
+        
+        def mandatory_claims_strip_claims
+          @mandatory_claims_strip_claims ||= mandatory_claims_split_by_delimiter.collect(&:strip)
+        end
+        
+        
+        def validate_mandatory_claims_list_value
+          parsed_mandatory_claims_list.each do |claim_name|
+            @validate_claim_name.call(claim_name: claim_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -499,6 +499,21 @@ module Errors
         msg: "Failed to validate claim, claim name '{0-claim-name}' is in denylist '{1-deny-list}'",
         code: "CONJ00105E"
       )
+      FailedToParseMandatoryClaimsMissingInput = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mandatory claims, mandatory claims value is empty, or was not found.",
+        code: "CONJ00106E"
+      )
+
+      InvalidMandatoryClaimsFormat = ::Util::TrackableErrorClass.new(
+        msg: "mandatory claims value '{0-mandatory-claims-value}' is in invalid format. " \
+             "The format should be claim names separated with comma.",
+        code: "CONJ00107E"
+      )
+
+      InvalidMandatoryClaimsFormatContainsDuplication = ::Util::TrackableErrorClass.new(
+        msg: "mandatory claims value '{0-mandatory-claims-value}' should not contains duplications.",
+        code: "CONJ00108E"
+      )
     end
 
     module ResourceRestrictions

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -604,6 +604,16 @@ module LogMessages
         msg: "Successfully validated claim name '{0-claim-name}'",
         code: "CONJ00119D"
       )
+      ParsingMandatoryClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Parsing mandatory claims value '{0-mandatory-claims}'",
+        code: "CONJ00120D"
+      )
+
+      ParsedMandatoryClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully parsed mandatory claims '{0-mandatory-claims-list}'",
+        code: "CONJ00121D"
+      )
+
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/input_validation/parse_mandatory_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/parse_mandatory_claims_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims') do
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "Input validation" do
+    context "with empty claim name value value" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: ""
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToParseMandatoryClaimsMissingInput)
+      end
+    end
+
+    context "with nil claim name value" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: nil
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToParseMandatoryClaimsMissingInput)
+      end
+    end
+  end
+
+  context "Invalid format" do
+    context "with invalid commas format" do
+      context "when input with 1 comma value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: ","
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+
+      context "when input with multiple commas value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: ",,,,,"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+
+      context "when input with commas at start value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: ",claim1, claim2"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+
+      context "when input with commas at end value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim1, claim2,"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+    end
+
+    context "with connected commas" do
+      context "when input with multiple connected commas value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim1,, claim2"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+
+      context "when input with multiple connected commas with spaces value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim1,   , claim2"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+        end
+      end
+    end
+    
+    context "with claims duplications values" do
+      context "when input with connected duplicate claims value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim1, claim2,claim2, claim3"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormatContainsDuplication)
+        end
+      end
+
+      context "when input with duplicate claims value at the start and at the end" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim1, claim2,claim3, claim1"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormatContainsDuplication)
+        end
+      end
+    end
+
+    context "with claim names with spaces" do
+      context "when input with 1 claim name" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "claim      1"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+        end
+      end
+
+      context "when input with multiple claims " do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+            mandatory_claims: "valid, valid2   ,   claim1    rr, claim      1"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+        end
+      end
+    end
+  end
+
+  context "Valid format" do
+    context "when input with 1 claim name" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "claim1"
+        )
+      end
+
+      it "returns a valid claims list" do
+        expect(subject).to eql(["claim1"])
+      end
+    end
+
+    context "when input with multiple valid claims values no spaces" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "claim1,claim2,claim3"
+        )
+      end
+
+      it "returns a valid claims list" do
+        expect(subject).to eql(%w[claim1 claim2 claim3])
+      end
+    end
+
+    context "when input with multiple valid claims values and spaces at start" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "       claim1,claim2,claim3"
+        )
+      end
+
+      it "returns a valid claims list" do
+        expect(subject).to eql(%w[claim1 claim2 claim3])
+      end
+    end
+
+    context "when input with multiple valid claims values and spaces at end" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "claim1,claim2,claim3     "
+        )
+      end
+
+      it "returns a valid claims list" do
+        expect(subject).to eql(%w[claim1 claim2 claim3])
+      end
+    end
+
+    context "when input with multiple valid claims values and spaces in the middle" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "claim1,          claim2, claim3"
+        )
+      end
+
+      it "returns a valid claims list" do
+        expect(subject).to eql(%w[claim1 claim2 claim3])
+      end
+    end
+  end
+
+  context "Valid claim name" do
+    context "when input with 1 invalid claim name" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "1claim"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
+
+    context "when input with multiple invalid claims" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "1claim, 2claim, 3claim"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
+
+    context "when input with 1 invalid claim and multiple valid claims" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new().call(
+          mandatory_claims: "1claim, claim2, claim3"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
+  end
+end
+

--- a/spec/app/domain/authentication/authn-jwt/input_validation/validate_claim_name_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/validate_claim_name_spec.rb
@@ -106,6 +106,42 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ValidateClaimName') d
         expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
       end
     end
+
+    context "When claim name starts with spaces" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ValidateClaimName.new().call(
+          claim_name: "   claim"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
+
+    context "When claim name ends with spaces" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ValidateClaimName.new().call(
+          claim_name: "claim   "
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
+
+    context "When claim name contains spaces" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ValidateClaimName.new().call(
+          claim_name: "claim  name"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName)
+      end
+    end
   end
 
   context "Valid claim name value" do


### PR DESCRIPTION
### What does this PR do?
Add  mandatory claims parsing logic

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
