### PR TITLE
ONYX-10851 - Parse mapping claims

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -32,5 +32,6 @@ module Authentication
     VALID_CLAIM_NAME_REGEX = /^[a-zA-Z|$|_][a-zA-Z|$|_|0-9]*$/.freeze # starts with letter $ or _ can contains digits
     MANDATORY_CLAIMS_DENY_LIST = [ISS_CLAIM_NAME, EXP_CLAIM_NAME, NBF_CLAIM_NAME, IAT_CLAIM_NAME, JTI_CLAIM_NAME, AUD_CLAIM_NAME].freeze
     CLAIMS_CHARACTER_DELIMITER = ","
+    TUPLE_CHARACTER_DELIMITER = ":"
   end
 end

--- a/app/domain/authentication/authn_jwt/input_validation/parse_mapped_claims.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/parse_mapped_claims.rb
@@ -1,0 +1,110 @@
+module Authentication
+  module AuthnJwt
+    module InputValidation
+      # Parse mapped-claims secret value and return a validated mapping hashtable
+      ParseMappedClaims ||= CommandClass.new(
+        dependencies: {
+          validate_claim_name: ValidateClaimName.new(
+            deny_claims_list_value: MANDATORY_CLAIMS_DENY_LIST
+          ),
+          logger: Rails.logger
+        },
+        inputs: %i[mapped_claims]
+      ) do
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingMappedClaims.new(@mapped_claims))
+          validate_mapped_claims_secret_value_exists
+          validate_mapped_claims_value_string
+          validate_mapped_claims_list_values
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsedMappedClaims.new(mapping_hash))
+          mapping_hash
+        end
+
+        private
+
+        def validate_mapped_claims_secret_value_exists
+          raise Errors::Authentication::AuthnJwt::MappedClaimsMissingInput if
+            @mapped_claims.blank?
+        end
+
+        def validate_mapped_claims_value_string
+          validate_last_symbol_is_not_list_delimiter
+          validate_array_after_split
+        end
+
+        def validate_last_symbol_is_not_list_delimiter
+          # split ignores empty values at the end of string
+          # ",,ddd,,,,,".split(",") == ["", "", "ddd"]
+          raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+            mapping_claims_last_character == CLAIMS_CHARACTER_DELIMITER
+        end
+
+        def mapping_claims_last_character
+          @mapping_claims_last_character ||= @mapped_claims[-1]
+        end
+
+        def validate_array_after_split
+          raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+            mapping_tuples_list.empty?
+        end
+
+        def mapping_tuples_list
+          @mapping_tuples ||= @mapped_claims
+                                .split(CLAIMS_CHARACTER_DELIMITER)
+                                .map { |value| value.strip }
+        end
+
+        def validate_mapped_claims_list_values
+          mapping_tuples_list.each do |tuple|
+            raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+              tuple.blank?
+            annotation_name, claim_name = mapping_tuple_values(tuple)
+            add_to_mapping_hash(annotation_name, claim_name)
+          end
+        end
+
+        def mapping_tuple_values(tuple)
+          values = tuple
+                     .split(TUPLE_CHARACTER_DELIMITER)
+                     .map { |value| value.strip }
+          raise Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat, tuple unless values.length == 2
+          return valid_claim_value(values[0], tuple),
+            valid_claim_value(values[1], tuple)
+        end
+
+        def valid_claim_value(value, tuple)
+          raise Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat, tuple if value.blank?
+          begin
+            @validate_claim_name.call(
+              claim_name: value
+            )
+          rescue => e
+            raise Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat.new(tuple, e.inspect)
+          end
+          value
+        end
+
+        def add_to_mapping_hash(annotation_name, claim_name)
+          raise Errors::Authentication::AuthnJwt::MappedClaimDuplicationError.new('annotation name', annotation_name) unless
+            key_set.add?(annotation_name)
+          raise Errors::Authentication::AuthnJwt::MappedClaimDuplicationError.new('claim name', claim_name) unless
+            value_set.add?(claim_name)
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ClaimMapDefinition.new(annotation_name, claim_name))
+          mapping_hash[annotation_name] = claim_name
+        end
+
+        def key_set
+          @key_set ||= Set.new
+        end
+
+        def value_set
+          @value_set ||= Set.new
+        end
+
+        def mapping_hash
+          @mapping_hash ||= Hash.new
+        end
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -491,7 +491,7 @@ module Errors
 
       FailedToValidateClaimForbiddenClaimName = ::Util::TrackableErrorClass.new(
         msg: "Failed to validate claim, claim name '{0-claim-name}' is not " \
-             "matching '{2-regex}' regular expression.",
+             "matching '{1-regex}' regular expression.",
         code: "CONJ00104E"
       )
 
@@ -513,6 +513,34 @@ module Errors
       InvalidMandatoryClaimsFormatContainsDuplication = ::Util::TrackableErrorClass.new(
         msg: "mandatory claims value '{0-mandatory-claims-value}' should not contains duplications.",
         code: "CONJ00108E"
+      )
+
+      MappedClaimsMissingInput = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapped claims, mapped claims value is empty, or was not found.",
+        code: "CONJ00109E"
+      )
+
+      MappedClaimsBlankOrEmpty = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapped claims, one ore more mapping statements is blank or empty " \
+             "'{0-mapped-claims-value}'.",
+        code: "CONJ00110E"
+      )
+
+      MappedClaimInvalidFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapped claims, mapped claim value '{0-mapped-claim-value}' is in invalid format."\
+             "The format should be 'annotation_name:claim_name'",
+        code: "CONJ00111E"
+      )
+
+      MappedClaimInvalidClaimFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapped claims, one of the claims in mapped claim value '{0-mapped-claim-value}' " \
+             "is in invalid format : {1-claim-verification-error}.",
+        code: "CONJ00112E"
+      )
+
+      MappedClaimDuplicationError = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapped claims, {0-purpose} value '{1-claim-value}' appears twice or more",
+        code: "CONJ00113E"
       )
     end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -629,6 +629,20 @@ module LogMessages
         code: "CONJ00124I"
       )
 
+      ParsingMappedClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Parsing mapped claims value '{0-mapped-claims}'",
+        code: "CONJ00125D"
+      )
+
+      ParsedMappedClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully parsed mapped claims '{0-mapped-claims-table}'",
+        code: "CONJ00126D"
+      )
+
+      ClaimMapDefinition = ::Util::TrackableLogMessageClass.new(
+        msg: "Mapping annotation name '{0-annotation-value}' to the claim name '{1-claim-name}'",
+        code: "CONJ00127D"
+      )
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/input_validation/parse_mapped_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/parse_mapped_claims_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') do
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "Input validation" do
+    context "with empty claim name value value" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: ""
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+      end
+    end
+
+    context "with nil claim name value" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: nil
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+      end
+    end
+
+    context "when input is whitespaces" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: "  \t \n  "
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+      end
+    end
+  end
+
+  context "Invalid format" do
+    context "with invalid list format" do
+      context "when input is 1 coma" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: ","
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+        end
+      end
+
+      context "when input is only comas" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: ",,,,,"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+        end
+      end
+
+
+      context "when input contains blank mapping value" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,   , b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+        end
+      end
+    end
+
+    context "with invalid mapping tuple format" do
+      context "when mapping tuple only contains delimiter" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,  :  ,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+        end
+      end
+
+      context "when mapping tuple has no delimiter" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,value,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+        end
+      end
+
+      context "when mapping tuple has more than one delimiter" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,x:y:z,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+        end
+      end
+
+      context "when mapping tuple left side is empty" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,:R,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+        end
+      end
+
+      context "when mapping tuple right side is empty" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,L:,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+        end
+      end
+    end
+
+    context "with invalid claim format" do
+      context "when annotation name contains illegal character" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,annota tion:claim,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  /.*FailedToValidateClaimForbiddenClaimName: CONJ00104E.*/
+                                )
+        end
+      end
+
+      context "when claim name contains illegal character" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,annotation:cla#im,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  /.*FailedToValidateClaimForbiddenClaimName: CONJ00104E.*/
+                                )
+        end
+      end
+    end
+
+    context "with denied claims" do
+      context "when annotation name is in deny list" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "a:b,iss:claim"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  /.*FailedToValidateClaimClaimNameInDenyList: CONJ00105E.*/
+                                )
+        end
+      end
+
+      context "when claim name is in deny list" do
+        subject do
+          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+            mapped_claims: "annotation:jti,b:c"
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  /.*FailedToValidateClaimClaimNameInDenyList: CONJ00105E.*/
+                                )
+        end
+      end
+    end
+  end
+
+  context "Duplication" do
+    context "with duplication in annotation names" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: "a:b,a:c"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(
+                                Errors::Authentication::AuthnJwt::MappedClaimDuplicationError,
+                                /.*annotation name.*'a'.*/
+                              )
+      end
+    end
+
+    context "with duplication in claim names" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: "x:z,y:z"
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(
+                                Errors::Authentication::AuthnJwt::MappedClaimDuplicationError,
+                                /.*claim name.*'z'.*/
+                              )
+      end
+    end
+  end
+
+  context "Valid format" do
+    context "when input with 1 mapping statement" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: "annotation:claim"
+        )
+      end
+
+      it "returns a valid mapping hash" do
+        expect(subject).to eql({"annotation" => "claim"})
+      end
+    end
+
+    context "when input with multiple mapping statements" do
+      subject do
+        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
+          mapped_claims: "name1:\tname2,\nname2:\tname3,\nname3:name1"
+        )
+      end
+
+      it "returns a valid mapping hash" do
+        expect(subject).to eql({
+                                 "name1" => "name2",
+                                 "name2" => "name3",
+                                 "name3" => "name1"
+                               })
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
### What does this PR do?

Class `ParseMandatoryClaims` is responsible to parse mapping claims variable value into hashmap.
Mapping claims variable value is coma (`,`) separated tuples.
A tuple contains two parts separated by colon (`:`) **annotation name** and **claim name**. Each part is a valid claim name.
All spaces around separators are ignored.
Example: `annotation:claim, claim1:claim2, ref : branch `

Validation logic:
1. Value is not empty
2. Split value by `,` and trim each tuple
3. Split tuple by `:` and trim each component
4. Validate that there are exactly 2 tuple components after split
5. Validate that each tuple component meats `ValidateClaimName` restrictions
6. Validate that all claims in **annotation name** and **claim name** subsets are unique

### What ticket does this PR close?
ONYX-10851

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
