### PR TITLE
401 for empty username

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,11 +46,11 @@ plugins:
 
   # Go
   gofmt:
-    enabled: true
+    enabled: false
   golint:
-    enabled: true
+    enabled: false
   govet:
-    enabled: true
+    enabled: false
 
   # Ruby
   flog:

--- a/.make_codeclimate
+++ b/.make_codeclimate
@@ -9,7 +9,10 @@ include() {
 }
 
 # Default CodeClimate plugins valid for all projects.
-include base.yml
+# Remove go tools because this repo doesn't use go and at the time of writing
+# the govet engine is causing buidls to fail 2021-07-19 19:09:36
+include base.yml \
+  | sed -E '/gofmt|golint|govet/,/enabled/s/true/false/'
 
 # uncomment for vanilla ruby projects
 include ruby.yml

--- a/app/domain/authentication/authenticator_input.rb
+++ b/app/domain/authentication/authenticator_input.rb
@@ -10,7 +10,7 @@ module Authentication
     attribute :authenticator_name, ::Types::NonEmptyString
     attribute :service_id, ::Types::NonEmptyString.optional
     attribute :account, ::Types::NonEmptyString
-    attribute :username, ::Types::NonEmptyString.optional
+    attribute :username, ::Types::Any.optional
     attribute :credentials, ::Types::Any.optional
     attribute :client_ip, ::Types::NonEmptyString
     attribute :request, ::Types::Any

--- a/cucumber/api/features/login.feature
+++ b/cucumber/api/features/login.feature
@@ -81,6 +81,10 @@ Feature: Exchange a role's password for its API key
       cucumber:user:non-exist failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00007E 'non-exist' not found
     """
 
+  Scenario: Empty username results in 401 response
+    When I GET "/authn/cucumber/login" with username "" and password "My-Password1"
+    Then the HTTP response status code is 401
+
   Scenario: Wrong hostname cannot be used to obtain API key
     Given I save my place in the audit log file for remote
     When I GET "/authn/cucumber/login" with username "host/non-exist" and password "My-Password1"


### PR DESCRIPTION
### What does this PR do?
Previously Conjur returned 500 when trying to login with an empty
username. This commit alters Conjur to return 401 for an empty
username. This is consistent with other invalid usernames.

### What ticket does this PR close?
Related: cyberark/conjur#2318

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
