### PR TITLE
Fetch the mandatory claims from the JWT authenticator policy

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -15,6 +15,7 @@ module Authentication
     IDENTITY_PATH_DEFAULT_VALUE = ""
     IDENTITY_PATH_CHARACTER_DELIMITER = "/"
     IDENTITY_TYPE_HOST = "host"
+    MANDATORY_CLAIMS_RESOURCE_NAME = "mandatory-claims"
     PRIVILEGE_AUTHENTICATE="authenticate"
     ISS_CLAIM_NAME = "iss"
     EXP_CLAIM_NAME = "exp"

--- a/app/domain/authentication/authn_jwt/restriction_validators/fetch_mandatory_claims.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validators/fetch_mandatory_claims.rb
@@ -1,0 +1,70 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    module RestrictionValidators
+      # Fetch the mandatory claims from the JWT authenticator policy which enforce 
+      # definition of annotations keys on JWT hosts 
+      FetchMandatoryClaims = CommandClass.new(
+        dependencies: {
+          resource_class: ::Resource,
+          fetch_required_secrets: ::Conjur::FetchRequiredSecrets.new,
+          parse_mandatory_claims: ::Authentication::AuthnJwt::InputValidation::ParseMandatoryClaims.new,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingMandatoryClaims.new)
+          
+          return empty_mandatory_claims unless mandatory_claims_resource_exists?
+
+          fetch_mandatory_claims_secret_value
+          parse_mandatory_claims_secret_value
+        end
+
+        private
+        
+        def mandatory_claims_resource_exists?
+          return @mandatory_claims_resource_exists unless @mandatory_claims_resource_exists.nil?
+
+          @mandatory_claims_resource_exists ||= !mandatory_claims_resource.nil?
+        end
+
+        def mandatory_claims_resource
+          @mandatory_claims_resource ||= @resource_class[mandatory_claims_resource_id]
+        end
+
+        def mandatory_claims_resource_id
+          @mandatory_claims_resource_id ||= "#{@authentication_parameters.authn_jwt_variable_id_prefix}/#{MANDATORY_CLAIMS_RESOURCE_NAME}"
+        end
+        
+        def empty_mandatory_claims
+          @logger.debug(LogMessages::Authentication::AuthnJwt::NotConfiguredMandatoryClaims.new)
+          @empty_mandatory_claims ||= []
+        end
+        
+        def fetch_mandatory_claims_secret_value
+          mandatory_claims_secret_value
+        end
+
+        def mandatory_claims_secret_value
+          @mandatory_claims_secret_value ||= mandatory_claims_required_secret[mandatory_claims_resource_id]
+        end
+        
+        def mandatory_claims_required_secret
+          @mandatory_claims_required_secret ||= @fetch_required_secrets.call(resource_ids: [mandatory_claims_resource_id])
+        end
+        
+        def parse_mandatory_claims_secret_value
+          return @parse_mandatory_claims_secret_value if @parse_mandatory_claims_secret_value
+
+          @parse_mandatory_claims_secret_value ||= @parse_mandatory_claims.call(mandatory_claims: mandatory_claims_secret_value)
+          @logger.info(LogMessages::Authentication::AuthnJwt::FetchedMandatoryClaims.new(@parse_mandatory_claims_secret_value))
+          
+          @parse_mandatory_claims_secret_value
+        end
+      end
+    end
+  end
+end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -614,6 +614,21 @@ module LogMessages
         code: "CONJ00121D"
       )
 
+      FetchingMandatoryClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching mandatory claims...",
+        code: "CONJ00122D"
+      )
+
+      NotConfiguredMandatoryClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Mandatory claims is not configured",
+        code: "CONJ00123D"
+      )
+
+      FetchedMandatoryClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully fetched mandatory claims '{0-mandatory-claims}'",
+        code: "CONJ00124I"
+      )
+
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/restriction_validators/fetch_mandatory_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validators/fetch_mandatory_claims_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:mandatory_claims_resource_name) {Authentication::AuthnJwt::MANDATORY_CLAIMS_RESOURCE_NAME}
+  let(:mandatory_claims_valid_secret_value) {'claim1 , claim2'}
+  let(:mandatory_claims_valid_parsed_secret_value) {%w[claim1 claim2]}
+
+  let(:mandatory_claims_invalid_secret_value) {'claim1 ,, claim2'}
+
+  def mock_resource_id(resource_name:)
+    %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
+  end
+
+  let(:mocked_resource) { double("MockedResource") }
+  let(:mocked_resource_exists_values) { double("MockedResource") }
+  let(:mocked_resource_not_exists_values) { double("MockedResource") }
+
+  let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_invalid_values) {  double("MockedFetchInvalidSecrets") }
+  
+  let(:mocked_valid_secrets) {  double("MockedValidSecrets") }
+  let(:mocked_invalid_secrets) {  double("MockedInvalidSecrets") }
+
+  let(:required_secret_missing_error) { "required secret missing error" }
+
+  before(:each) do
+    allow(mocked_resource_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: mandatory_claims_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_not_exists_values).to(
+      receive(:[]).and_return(nil)
+    )
+    
+    allow(mocked_fetch_secrets_empty_values).to(
+      receive(:call).and_raise(required_secret_missing_error)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: mandatory_claims_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: mandatory_claims_resource_name)).
+        and_return(mandatory_claims_valid_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_invalid_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: mandatory_claims_resource_name)]).
+        and_return(mocked_invalid_secrets)
+    )
+
+    allow(mocked_invalid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: mandatory_claims_resource_name)).
+        and_return(mandatory_claims_invalid_secret_value)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'mandatory-claims' variable is configured in authenticator policy" do
+    context "with empty variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_empty_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_secret_missing_error)
+      end
+    end
+
+    context "with invalid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_invalid_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::InvalidMandatoryClaimsFormat)
+      end
+    end
+    
+    context "with valid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_exist_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "returns parsed mandatory claims list" do
+        expect(subject).to eql(mandatory_claims_valid_parsed_secret_value)
+      end
+    end
+  end
+
+  context "'mandatory-claims' variable is not configured in authenticator policy" do
+    subject do
+      ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+        resource_class: mocked_resource_not_exists_values
+      ).call(
+        authentication_parameters: authentication_parameters
+      )
+    end
+
+    it "returns an empty mandatory claims list" do
+      expect(subject).to eql([])
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?
Fetch mandatory claims from JWT authenticator policy

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
