### PR TITLE
ONYX-10851 Fetch mapping claims

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -16,6 +16,7 @@ module Authentication
     IDENTITY_PATH_CHARACTER_DELIMITER = "/"
     IDENTITY_TYPE_HOST = "host"
     MANDATORY_CLAIMS_RESOURCE_NAME = "mandatory-claims"
+    MAPPING_CLAIMS_RESOURCE_NAME = "mapping-claims"
     PRIVILEGE_AUTHENTICATE="authenticate"
     ISS_CLAIM_NAME = "iss"
     EXP_CLAIM_NAME = "exp"

--- a/app/domain/authentication/authn_jwt/restriction_validation/fetch_mandatory_claims.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/fetch_mandatory_claims.rb
@@ -2,7 +2,7 @@ require 'command_class'
 
 module Authentication
   module AuthnJwt
-    module RestrictionValidators
+    module RestrictionValidation
       # Fetch the mandatory claims from the JWT authenticator policy which enforce 
       # definition of annotations keys on JWT hosts 
       FetchMandatoryClaims = CommandClass.new(

--- a/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
@@ -1,0 +1,74 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    module RestrictionValidation
+      # Fetch the mapping claims from the JWT authenticator policy which enforce
+      # definition of annotations keys on JWT hosts 
+      FetchMappingClaims = CommandClass.new(
+        dependencies: {
+          resource_class: ::Resource,
+          fetch_required_secrets: ::Conjur::FetchRequiredSecrets.new,
+          parse_mapped_claims: ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingMappingClaims.new)
+          
+          return empty_mapping_claims unless mapping_claims_resource_exists?
+
+          fetch_mapping_claims_secret_value
+          parse_mapping_claims_secret_value
+        end
+
+        private
+
+        def empty_mapping_claims
+          @logger.debug(LogMessages::Authentication::AuthnJwt::NotConfiguredMappingClaims.new)
+          @empty_mapping_claims ||= Hash.new
+        end
+
+        def mapping_claims_resource_exists?
+          return @mapping_claims_resource_exists unless @mapping_claims_resource_exists.nil?
+
+          @mapping_claims_resource_exists ||= !mapping_claims_resource.nil?
+        end
+
+        def mapping_claims_resource
+          @mapping_claims_resource ||= @resource_class[mapping_claims_resource_id]
+        end
+
+        def mapping_claims_resource_id
+          @mapping_claims_resource_id ||= "#{@authentication_parameters.authn_jwt_variable_id_prefix}/#{MAPPING_CLAIMS_RESOURCE_NAME}"
+        end
+
+        def fetch_mapping_claims_secret_value
+          mapping_claims_secret_value
+        end
+
+        def mapping_claims_secret_value
+          @mapping_claims_secret_value ||= mapping_claims_required_secret[mapping_claims_resource_id]
+        end
+        
+        def mapping_claims_required_secret
+          @mapping_claims_required_secret ||= @fetch_required_secrets.call(resource_ids: [mapping_claims_resource_id])
+        end
+        
+        def parse_mapping_claims_secret_value
+          mapping_claims
+        end
+
+        def mapping_claims
+          return @mapping_claims if @mapping_claims
+
+          @mapping_claims ||= @parse_mapped_claims.call(mapped_claims: mapping_claims_secret_value)
+          @logger.info(LogMessages::Authentication::AuthnJwt::FetchedMappingClaims.new(@mapping_claims))
+
+          @mapping_claims
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
@@ -1,6 +1,6 @@
 module Authentication
   module AuthnJwt
-    module RestrictionValidators
+    module RestrictionValidation
       # This class is responsible for retrieving the correct value from the JWT token
       # of the requested attribute.
       class ValidateRestrictionsOneToOne

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -8,7 +8,7 @@ module Authentication
           authenticator_input:,
           logger: Rails.logger,
           authentication_parameters_class: Authentication::AuthnJwt::AuthenticationParameters,
-          restriction_validator_class: Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne,
+          restriction_validator_class: Authentication::AuthnJwt::RestrictionValidation::ValidateRestrictionsOneToOne,
           validate_and_decode_token_class:  Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken,
           validate_resource_restrictions_class: Authentication::ResourceRestrictions::ValidateResourceRestrictions,
           extract_token_from_credentials: Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new,

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -643,6 +643,21 @@ module LogMessages
         msg: "Mapping annotation name '{0-annotation-value}' to the claim name '{1-claim-name}'",
         code: "CONJ00127D"
       )
+
+      FetchingMappingClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching mapping claims...",
+        code: "CONJ00128D"
+      )
+
+      NotConfiguredMappingClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Mapping claims are not configured",
+        code: "CONJ00129D"
+      )
+
+      FetchedMappingClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully fetched mapping claims '{0-mapping-claims}'",
+        code: "CONJ00130I"
+      )
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mandatory_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mandatory_claims_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims') do
+RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMandatoryClaims') do
 
   let(:authenticator_name) { 'authn-jwt' }
   let(:service_id) { "my-service" }
@@ -93,7 +93,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryC
   context "'mandatory-claims' variable is configured in authenticator policy" do
     context "with empty variable value" do
       subject do
-        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMandatoryClaims.new(
           resource_class: mocked_resource_exists_values,
           fetch_required_secrets: mocked_fetch_secrets_empty_values
         ).call(
@@ -108,7 +108,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryC
 
     context "with invalid variable value" do
       subject do
-        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMandatoryClaims.new(
           resource_class: mocked_resource_exists_values,
           fetch_required_secrets: mocked_fetch_secrets_invalid_values
         ).call(
@@ -123,7 +123,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryC
     
     context "with valid variable value" do
       subject do
-        ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMandatoryClaims.new(
           resource_class: mocked_resource_exists_values,
           fetch_required_secrets: mocked_fetch_secrets_exist_values
         ).call(
@@ -139,7 +139,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryC
 
   context "'mandatory-claims' variable is not configured in authenticator policy" do
     subject do
-      ::Authentication::AuthnJwt::RestrictionValidators::FetchMandatoryClaims.new(
+      ::Authentication::AuthnJwt::RestrictionValidation::FetchMandatoryClaims.new(
         resource_class: mocked_resource_not_exists_values
       ).call(
         authentication_parameters: authentication_parameters

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:mapping_claims_resource_name) {Authentication::AuthnJwt::MAPPING_CLAIMS_RESOURCE_NAME}
+  let(:mapping_claims_valid_secret_value) {'name1:name2,name2:name3,name3:name1'}
+  let(:mapping_claims_valid_parsed_secret_value) {{"name1"=>"name2", "name2"=>"name3", "name3"=>"name1"}}
+
+  let(:mapping_claims_invalid_secret_value) {'name1:name2 ,, name3:name1'}
+
+  def mock_resource_id(resource_name:)
+    %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
+  end
+
+  let(:mocked_resource) { double("MockedResource") }
+  let(:mocked_resource_exists_values) { double("MockedResource") }
+  let(:mocked_resource_not_exists_values) { double("MockedResource") }
+
+  let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_invalid_values) {  double("MockedFetchInvalidSecrets") }
+  
+  let(:mocked_valid_secrets) {  double("MockedValidSecrets") }
+  let(:mocked_invalid_secrets) {  double("MockedInvalidSecrets") }
+
+  let(:required_secret_missing_error) { "required secret missing error" }
+
+  before(:each) do
+    allow(mocked_resource_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: mapping_claims_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_not_exists_values).to(
+      receive(:[]).and_return(nil)
+    )
+    
+    allow(mocked_fetch_secrets_empty_values).to(
+      receive(:call).and_raise(required_secret_missing_error)
+    )
+
+    allow(mocked_fetch_secrets_exist_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: mapping_claims_resource_name)]).
+        and_return(mocked_valid_secrets)
+    )
+
+    allow(mocked_valid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: mapping_claims_resource_name)).
+        and_return(mapping_claims_valid_secret_value)
+    )
+
+    allow(mocked_fetch_secrets_invalid_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: mapping_claims_resource_name)]).
+        and_return(mocked_invalid_secrets)
+    )
+
+    allow(mocked_invalid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: mapping_claims_resource_name)).
+        and_return(mapping_claims_invalid_secret_value)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'mapping-claims' variable is configured in authenticator policy" do
+    context "with empty variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_empty_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_secret_missing_error)
+      end
+    end
+
+    context "with invalid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_invalid_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+      end
+    end
+    
+    context "with valid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_exist_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "returns parsed mapping claims hashtable" do
+        expect(subject).to eql(mapping_claims_valid_parsed_secret_value)
+      end
+    end
+  end
+
+  context "'mapping-claims' variable is not configured in authenticator policy" do
+    subject do
+      ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
+        resource_class: mocked_resource_not_exists_values
+      ).call(
+        authentication_parameters: authentication_parameters
+      )
+    end
+
+    it "returns an empty mapping claims hashtable" do
+      expect(subject).to eql({})
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restrictions_one_to_one_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restrictions_one_to_one_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne') do
+RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestrictionsOneToOne') do
   let(:right_email) { "admin@example.com" }
   let(:wrong_email) { "wrong@example.com" }
   let(:empty_email) { "" }
@@ -63,7 +63,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::ValidateRestric
   context "ValidateRestrictionsOneToOne" do
     context "Decoded token is not empty" do
       subject do
-        ::Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne.new(decoded_token: decoded_token)
+        ::Authentication::AuthnJwt::RestrictionValidation::ValidateRestrictionsOneToOne.new(decoded_token: decoded_token)
       end
 
       it "returns true when the restriction is for existing for existing field and its value equals the token" do
@@ -89,7 +89,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidators::ValidateRestric
 
     context "Decoded token is empty" do
       subject do
-        ::Authentication::AuthnJwt::RestrictionValidators::ValidateRestrictionsOneToOne.new(decoded_token: empty_decoded_token)
+        ::Authentication::AuthnJwt::RestrictionValidation::ValidateRestrictionsOneToOne.new(decoded_token: empty_decoded_token)
       end
 
       it "raises JwtTokenClaimIsMissing" do


### PR DESCRIPTION
### What does this PR do?

Introduces class fetches mapping claims value from respective variable.
The class invokes Mapping claim parser if variable defined and populated.

### What ticket does this PR close?
ONYX-10851

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
