### PR TITLE
ONYX-10851 Mapping claims naming alignment

### DIFF
--- a/app/domain/authentication/authn_jwt/input_validation/parse_mapping_claims.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/parse_mapping_claims.rb
@@ -1,33 +1,33 @@
 module Authentication
   module AuthnJwt
     module InputValidation
-      # Parse mapped-claims secret value and return a validated mapping hashtable
-      ParseMappedClaims ||= CommandClass.new(
+      # Parse mapping-claims secret value and return a validated mapping hashtable
+      ParseMappingClaims ||= CommandClass.new(
         dependencies: {
           validate_claim_name: ValidateClaimName.new(
             deny_claims_list_value: MANDATORY_CLAIMS_DENY_LIST
           ),
           logger: Rails.logger
         },
-        inputs: %i[mapped_claims]
+        inputs: %i[mapping_claims]
       ) do
         def call
-          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingMappedClaims.new(@mapped_claims))
-          validate_mapped_claims_secret_value_exists
-          validate_mapped_claims_value_string
-          validate_mapped_claims_list_values
-          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsedMappedClaims.new(mapping_hash))
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsingMappingClaims.new(@mapping_claims))
+          validate_mapping_claims_secret_value_exists
+          validate_mapping_claims_value_string
+          validate_mapping_claims_list_values
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ParsedMappingClaims.new(mapping_hash))
           mapping_hash
         end
 
         private
 
-        def validate_mapped_claims_secret_value_exists
-          raise Errors::Authentication::AuthnJwt::MappedClaimsMissingInput if
-            @mapped_claims.blank?
+        def validate_mapping_claims_secret_value_exists
+          raise Errors::Authentication::AuthnJwt::MappingClaimsMissingInput if
+            @mapping_claims.blank?
         end
 
-        def validate_mapped_claims_value_string
+        def validate_mapping_claims_value_string
           validate_last_symbol_is_not_list_delimiter
           validate_array_after_split
         end
@@ -35,28 +35,28 @@ module Authentication
         def validate_last_symbol_is_not_list_delimiter
           # split ignores empty values at the end of string
           # ",,ddd,,,,,".split(",") == ["", "", "ddd"]
-          raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+          raise Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty, @mapping_claims if
             mapping_claims_last_character == CLAIMS_CHARACTER_DELIMITER
         end
 
         def mapping_claims_last_character
-          @mapping_claims_last_character ||= @mapped_claims[-1]
+          @mapping_claims_last_character ||= @mapping_claims[-1]
         end
 
         def validate_array_after_split
-          raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+          raise Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty, @mapping_claims if
             mapping_tuples_list.empty?
         end
 
         def mapping_tuples_list
-          @mapping_tuples ||= @mapped_claims
+          @mapping_tuples ||= @mapping_claims
                                 .split(CLAIMS_CHARACTER_DELIMITER)
                                 .map { |value| value.strip }
         end
 
-        def validate_mapped_claims_list_values
+        def validate_mapping_claims_list_values
           mapping_tuples_list.each do |tuple|
-            raise Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty, @mapped_claims if
+            raise Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty, @mapping_claims if
               tuple.blank?
             annotation_name, claim_name = mapping_tuple_values(tuple)
             add_to_mapping_hash(annotation_name, claim_name)
@@ -67,27 +67,27 @@ module Authentication
           values = tuple
                      .split(TUPLE_CHARACTER_DELIMITER)
                      .map { |value| value.strip }
-          raise Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat, tuple unless values.length == 2
+          raise Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat, tuple unless values.length == 2
           return valid_claim_value(values[0], tuple),
             valid_claim_value(values[1], tuple)
         end
 
         def valid_claim_value(value, tuple)
-          raise Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat, tuple if value.blank?
+          raise Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat, tuple if value.blank?
           begin
             @validate_claim_name.call(
               claim_name: value
             )
           rescue => e
-            raise Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat.new(tuple, e.inspect)
+            raise Errors::Authentication::AuthnJwt::MappingClaimInvalidClaimFormat.new(tuple, e.inspect)
           end
           value
         end
 
         def add_to_mapping_hash(annotation_name, claim_name)
-          raise Errors::Authentication::AuthnJwt::MappedClaimDuplicationError.new('annotation name', annotation_name) unless
+          raise Errors::Authentication::AuthnJwt::MappingClaimDuplicationError.new('annotation name', annotation_name) unless
             key_set.add?(annotation_name)
-          raise Errors::Authentication::AuthnJwt::MappedClaimDuplicationError.new('claim name', claim_name) unless
+          raise Errors::Authentication::AuthnJwt::MappingClaimDuplicationError.new('claim name', claim_name) unless
             value_set.add?(claim_name)
           @logger.debug(LogMessages::Authentication::AuthnJwt::ClaimMapDefinition.new(annotation_name, claim_name))
           mapping_hash[annotation_name] = claim_name

--- a/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
@@ -9,7 +9,7 @@ module Authentication
         dependencies: {
           resource_class: ::Resource,
           fetch_required_secrets: ::Conjur::FetchRequiredSecrets.new,
-          parse_mapped_claims: ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new,
+          parse_mapping_claims: ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new,
           logger: Rails.logger
         },
         inputs: %i[authentication_parameters]
@@ -63,7 +63,7 @@ module Authentication
         def mapping_claims
           return @mapping_claims if @mapping_claims
 
-          @mapping_claims ||= @parse_mapped_claims.call(mapped_claims: mapping_claims_secret_value)
+          @mapping_claims ||= @parse_mapping_claims.call(mapping_claims: mapping_claims_secret_value)
           @logger.info(LogMessages::Authentication::AuthnJwt::FetchedMappingClaims.new(@mapping_claims))
 
           @mapping_claims

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -516,7 +516,7 @@ module Errors
       )
 
       MappingClaimsMissingInput = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims, mapping claims value is empty, or was not found.",
+        msg: "Failed to parse mapping claims, the mapping claims value is empty, or was not found.",
         code: "CONJ00109E"
       )
 
@@ -527,7 +527,7 @@ module Errors
       )
 
       MappingClaimInvalidFormat = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims, mapping claim value '{0-mapping-claim-value}' is in invalid format."\
+        msg: "Failed to parse mapping claims, the mapping claim value '{0-mapping-claim-value}' is in invalid format."\
              "The format should be 'annotation_name:claim_name'",
         code: "CONJ00111E"
       )

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -515,31 +515,31 @@ module Errors
         code: "CONJ00108E"
       )
 
-      MappedClaimsMissingInput = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapped claims, mapped claims value is empty, or was not found.",
+      MappingClaimsMissingInput = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapping claims, mapping claims value is empty, or was not found.",
         code: "CONJ00109E"
       )
 
-      MappedClaimsBlankOrEmpty = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapped claims, one ore more mapping statements is blank or empty " \
-             "'{0-mapped-claims-value}'.",
+      MappingClaimsBlankOrEmpty = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapping claims, one ore more mapping statements is blank or empty " \
+             "'{0-mapping-claims-value}'.",
         code: "CONJ00110E"
       )
 
-      MappedClaimInvalidFormat = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapped claims, mapped claim value '{0-mapped-claim-value}' is in invalid format."\
+      MappingClaimInvalidFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapping claims, mapping claim value '{0-mapping-claim-value}' is in invalid format."\
              "The format should be 'annotation_name:claim_name'",
         code: "CONJ00111E"
       )
 
-      MappedClaimInvalidClaimFormat = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapped claims, one of the claims in mapped claim value '{0-mapped-claim-value}' " \
+      MappingClaimInvalidClaimFormat = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapping claims, one of the claims in mapping claim value '{0-mapping-claim-value}' " \
              "is in invalid format : {1-claim-verification-error}.",
         code: "CONJ00112E"
       )
 
-      MappedClaimDuplicationError = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapped claims, {0-purpose} value '{1-claim-value}' appears twice or more",
+      MappingClaimDuplicationError = ::Util::TrackableErrorClass.new(
+        msg: "Failed to parse mapping claims, {0-purpose} value '{1-claim-value}' appears twice or more",
         code: "CONJ00113E"
       )
     end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -629,13 +629,13 @@ module LogMessages
         code: "CONJ00124I"
       )
 
-      ParsingMappedClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Parsing mapped claims value '{0-mapped-claims}'",
+      ParsingMappingClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Parsing mapping claims value '{0-mapping-claims}'",
         code: "CONJ00125D"
       )
 
-      ParsedMappedClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Successfully parsed mapped claims '{0-mapped-claims-table}'",
+      ParsedMappingClaims = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully parsed mapping claims '{0-mapping-claims-table}'",
         code: "CONJ00126D"
       )
 

--- a/design/authenticators/authn_jwt/token_schema.md
+++ b/design/authenticators/authn_jwt/token_schema.md
@@ -70,8 +70,8 @@ User will define the mandatory claims and claims mapping variables in the authen
 
 Two new variables will be added to the authenticator policy:
 
-* host_mandatory_claims
-* mapping_claims
+* mandatory-claims
+* mapping-claims
 
 ```yaml
     - !policy
@@ -80,20 +80,20 @@ Two new variables will be added to the authenticator policy:
     - !webservice
     
     - !variable
-      id: mandatory_claims
+      id: mandatory-claims
       
     - !variable
-      id: mapping_claims
+      id: mapping-claims
 ```
 
 #### Variable Values Example
 
 | Name             | Value                 | Description                                      |
 | ---------------- | --------------------- | ------------------------------------------------ |
-| mandatory_claims | ref, sub              | List of claims as they appear in host annotation |
-| mapping_claims   | branch: ref, job: ref | Mapping between host annotation to JWT claim     |
+| mandatory-claims | ref, sub              | List of claims as they appear in host annotation |
+| mapping-claims   | branch: ref, job: sub | Mapping between host annotation to JWT claim     |
 
-* For any claim mapped, we will add the host annotation to the `mandatory_claims` variable and not the JWT claim name.
+* For any claim mapped, we will add the host annotation to the `mandatory-claims` variable and not the JWT claim name.
 * The values above are examples and they can be any claims.
 * If one of the values of this variables contain these words from deny list authentication request will be denied:
   * iss
@@ -120,7 +120,7 @@ When validate_restrictions is called in JWTVendorConfiguration class the followi
 
 1. The `validate_restrictions` function will call `CreateConstraintsFromPolicy` that create constraints object checking the hosts annotations.
    1. It create instance of `NonEmptyConstraint` to check we have at least one host annotation.
-   2. Will call `LoadMandatoryClaims` command class to load the list of mandatory claims for the `mandatory_claims` variable. This class will create and return `RequiredConstraint` object.
+   2. Will call `LoadMandatoryClaims` command class to load the list of mandatory claims for the `mandatory-claims` variable. This class will create and return `RequiredConstraint` object.
       1. If variable configured but not populated error be thrown
       2. If variiable with invalid value error be thrown
       3. If variable not configured empty list will be returned

--- a/spec/app/domain/authentication/authn-jwt/input_validation/parse_mapping_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/parse_mapping_claims_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') do
+RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappingClaims') do
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
@@ -11,37 +11,37 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
   context "Input validation" do
     context "with empty claim name value value" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: ""
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: ""
         )
       end
 
       it "raises an error" do
-        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsMissingInput)
       end
     end
 
     context "with nil claim name value" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: nil
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: nil
         )
       end
 
       it "raises an error" do
-        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsMissingInput)
       end
     end
 
     context "when input is whitespaces" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: "  \t \n  "
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: "  \t \n  "
         )
       end
 
       it "raises an error" do
-        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsMissingInput)
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsMissingInput)
       end
     end
   end
@@ -50,38 +50,38 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
     context "with invalid list format" do
       context "when input is 1 coma" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: ","
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: ","
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty)
         end
       end
 
       context "when input is only comas" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: ",,,,,"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: ",,,,,"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty)
         end
       end
 
 
       context "when input contains blank mapping value" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,   , b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,   , b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty)
         end
       end
     end
@@ -89,61 +89,61 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
     context "with invalid mapping tuple format" do
       context "when mapping tuple only contains delimiter" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,  :  ,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,  :  ,b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat)
         end
       end
 
       context "when mapping tuple has no delimiter" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,value,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,value,b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat)
         end
       end
 
       context "when mapping tuple has more than one delimiter" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,x:y:z,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,x:y:z,b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat)
         end
       end
 
       context "when mapping tuple left side is empty" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,:R,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,:R,b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat)
         end
       end
 
       context "when mapping tuple right side is empty" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,L:,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,L:,b:c"
           )
         end
 
         it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimInvalidFormat)
+          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimInvalidFormat)
         end
       end
     end
@@ -151,14 +151,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
     context "with invalid claim format" do
       context "when annotation name contains illegal character" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,annota tion:claim,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,annota tion:claim,b:c"
           )
         end
 
         it "raises an error" do
           expect { subject }.to raise_error(
-                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  Errors::Authentication::AuthnJwt::MappingClaimInvalidClaimFormat,
                                   /.*FailedToValidateClaimForbiddenClaimName: CONJ00104E.*/
                                 )
         end
@@ -166,14 +166,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
 
       context "when claim name contains illegal character" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,annotation:cla#im,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,annotation:cla#im,b:c"
           )
         end
 
         it "raises an error" do
           expect { subject }.to raise_error(
-                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  Errors::Authentication::AuthnJwt::MappingClaimInvalidClaimFormat,
                                   /.*FailedToValidateClaimForbiddenClaimName: CONJ00104E.*/
                                 )
         end
@@ -183,14 +183,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
     context "with denied claims" do
       context "when annotation name is in deny list" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "a:b,iss:claim"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "a:b,iss:claim"
           )
         end
 
         it "raises an error" do
           expect { subject }.to raise_error(
-                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  Errors::Authentication::AuthnJwt::MappingClaimInvalidClaimFormat,
                                   /.*FailedToValidateClaimClaimNameInDenyList: CONJ00105E.*/
                                 )
         end
@@ -198,14 +198,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
 
       context "when claim name is in deny list" do
         subject do
-          ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-            mapped_claims: "annotation:jti,b:c"
+          ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+            mapping_claims: "annotation:jti,b:c"
           )
         end
 
         it "raises an error" do
           expect { subject }.to raise_error(
-                                  Errors::Authentication::AuthnJwt::MappedClaimInvalidClaimFormat,
+                                  Errors::Authentication::AuthnJwt::MappingClaimInvalidClaimFormat,
                                   /.*FailedToValidateClaimClaimNameInDenyList: CONJ00105E.*/
                                 )
         end
@@ -216,14 +216,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
   context "Duplication" do
     context "with duplication in annotation names" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: "a:b,a:c"
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: "a:b,a:c"
         )
       end
 
       it "raises an error" do
         expect { subject }.to raise_error(
-                                Errors::Authentication::AuthnJwt::MappedClaimDuplicationError,
+                                Errors::Authentication::AuthnJwt::MappingClaimDuplicationError,
                                 /.*annotation name.*'a'.*/
                               )
       end
@@ -231,14 +231,14 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
 
     context "with duplication in claim names" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: "x:z,y:z"
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: "x:z,y:z"
         )
       end
 
       it "raises an error" do
         expect { subject }.to raise_error(
-                                Errors::Authentication::AuthnJwt::MappedClaimDuplicationError,
+                                Errors::Authentication::AuthnJwt::MappingClaimDuplicationError,
                                 /.*claim name.*'z'.*/
                               )
       end
@@ -248,8 +248,8 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
   context "Valid format" do
     context "when input with 1 mapping statement" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: "annotation:claim"
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: "annotation:claim"
         )
       end
 
@@ -260,8 +260,8 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseMappedClaims') d
 
     context "when input with multiple mapping statements" do
       subject do
-        ::Authentication::AuthnJwt::InputValidation::ParseMappedClaims.new().call(
-          mapped_claims: "name1:\tname2,\nname2:\tname3,\nname3:name1"
+        ::Authentication::AuthnJwt::InputValidation::ParseMappingClaims.new().call(
+          mapping_claims: "name1:\tname2,\nname2:\tname3,\nname3:name1"
         )
       end
 

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMappingCla
       end
 
       it "raises an error" do
-        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappedClaimsBlankOrEmpty)
+        expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::MappingClaimsBlankOrEmpty)
       end
     end
     


### PR DESCRIPTION
### What does this PR do?

Align class names according "mapping-claims" variable name.

### What ticket does this PR close?
ONYX-10851

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
