### PR TITLE
ONYX-10850 One to one restriction validator supports mapping

### DIFF
--- a/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
@@ -4,21 +4,45 @@ module Authentication
       # This class is responsible for retrieving the correct value from the JWT token
       # of the requested attribute.
       class ValidateRestrictionsOneToOne
-        def initialize(decoded_token:)
+        def initialize(
+          decoded_token:,
+          mapped_claims:,
+          logger: Rails.logger)
           @decoded_token = decoded_token
+          @mapped_claims = mapped_claims
+          @logger = logger
         end
 
         def valid_restriction?(restriction)
-          restriction_name = restriction.name
+          annotation_name = restriction.name
+          claim_name = claim_name(annotation_name)
           restriction_value = restriction.value
+
           if restriction_value.blank?
-            raise Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven, restriction_name
-          end
-          unless @decoded_token.key?(restriction_name)
-            raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing, restriction_name
+            raise Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven, annotation_name
           end
 
-          @decoded_token.fetch(restriction_name) == restriction_value
+          unless @decoded_token.key?(claim_name)
+            raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
+                  claim_name_for_error(annotation_name, claim_name)
+          end
+
+          @decoded_token.fetch(claim_name) == restriction_value
+        end
+
+        private
+
+        def claim_name(annotation_name)
+          claim_name = @mapped_claims.fetch(annotation_name, annotation_name)
+          @logger.debug(LogMessages::Authentication::AuthnJwt::ClaimMapUsage.new(annotation_name, claim_name)) unless
+            annotation_name == claim_name
+          claim_name
+        end
+
+        def claim_name_for_error(annotation_name, claim_name)
+          return annotation_name if annotation_name == claim_name
+
+          "#{claim_name} (annotation: #{annotation_name})"
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -42,7 +42,8 @@ module Authentication
             role_name: jwt_identity,
             constraints: constraints,
             authentication_request: @restriction_validator_class.new(
-              decoded_token: @authentication_parameters.decoded_token
+              decoded_token: @authentication_parameters.decoded_token,
+              mapped_claims: {}
             )
           )
         end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -668,6 +668,11 @@ module LogMessages
         msg: "Successfully validated mapping claims configuration",
         code: "CONJ00132D"
       )
+
+      ClaimMapUsage = ::Util::TrackableLogMessageClass.new(
+        msg: "Checking restriction '{0-annotation-value}', fetching value from '{1-claim-name}' claim...",
+        code: "CONJ00133D"
+      )
     end
   end
 


### PR DESCRIPTION
### What does this PR do?

Changes `ValidateRestrictionsOneToOne` class in order to support mapping

### What ticket does this PR close?
ONYX-10850

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
