### PR TITLE
Fix direct check when mapping bug

### DIFF
--- a/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
+++ b/app/domain/authentication/authn_jwt/vendor_configurations/configuration_jwt_generic_vendor.rb
@@ -10,7 +10,7 @@ module Authentication
           logger: Rails.logger,
           authentication_parameters_class: Authentication::AuthnJwt::AuthenticationParameters,
           restriction_validator_class: Authentication::AuthnJwt::RestrictionValidation::ValidateRestrictionsOneToOne,
-          validate_and_decode_token_class:  Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken,
+          validate_and_decode_token_class: Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken,
           validate_resource_restrictions_class: Authentication::ResourceRestrictions::ValidateResourceRestrictions,
           extract_token_from_credentials: Authentication::AuthnJwt::InputValidation::ExtractTokenFromCredentials.new,
           create_identity_provider: Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new,
@@ -50,6 +50,8 @@ module Authentication
               mapped_claims: mapped_claims
             )
           )
+        rescue Errors::Authentication::Constraints::NonPermittedRestrictionGiven => e
+          raise Errors::Authentication::AuthnJwt::RoleWithStandardOrMappedClaimError, e.inspect
         end
 
         def validate_and_decode_token
@@ -139,7 +141,8 @@ module Authentication
 
         def constraints
           @constraints ||= @create_constraints.call(
-            authentication_parameters: @authentication_parameters
+            authentication_parameters: @authentication_parameters,
+            base_non_permitted_annotations: CLAIMS_DENY_LIST
           )
         end
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -542,6 +542,11 @@ module Errors
         msg: "Failed to parse mapping claims, {0-purpose} value '{1-claim-value}' appears twice or more",
         code: "CONJ00113E"
       )
+
+      RoleWithStandardOrMappedClaimError = ::Util::TrackableErrorClass.new(
+        msg: "Role can't have standard claim or a mapped claim. Error : '{0-error}'",
+        code: "CONJ00069E"
+      )
     end
 
     module ResourceRestrictions

--- a/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
@@ -216,7 +216,7 @@ Feature: JWT Authenticator - Token Schema
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-    CONJ00069E Role can't have one of these none permitted restrictions '["<claim>"]'>
+    CONJ00069E Role can't have standard claim or a mapped claim
     """
     Examples:
     | claim   |
@@ -377,7 +377,6 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
-  @skip
   Scenario: ONYX-10889 Complex Case - Adding Mapping after host configuration
     Given I extend the policy with:
     """
@@ -409,29 +408,11 @@ Feature: JWT Authenticator - Token Schema
     - !variable conjur/authn-jwt/raw/mapping-claims
     """
     And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I authenticate via authn-jwt with the JWT token
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-    CONJ00057E Role does not have the required constraints: '["ref"]'>
-    """
-    When I replace the "root" policy with:
-    """
-    - !variable conjur/authn-jwt/raw/mapping-claims
-
-    - !host
-      id: myapp
-      annotations:
-        authn-jwt/raw/branch: valid-branch
-
-    - !grant
-      role: !group conjur/authn-jwt/raw/hosts
-      member: !host myapp
-    """
-    When I authenticate via authn-jwt with the JWT token
-    Then host "myapp" has been authorized by Conjur
-    And The following appears in the log after my savepoint:
-    """
-    cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
+    Role can't have standard claim or a mapped claim
     """
 
   @sanity


### PR DESCRIPTION
Bugfix to make test ONYX-10889 work.

Currently when the mapping is given we can check a host annotation directly and according to mapping. The bugfix insures error being thrown if one of the host annotations is a mapped claim.