### PR TITLE
Remove temporary .trivyignore for CVE-2021-33910

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,3 @@
-# Temporarily ignored while CVE is analyzed and score determined. Andy to revisit.
-CVE-2021-33910
-
 # NULL pointer deref. OpenSSL 1.0.2 is not impacted
 CVE-2021-3449
 
@@ -9,14 +6,6 @@ CVE-2021-3449
 # vulnerable version of Rake in their development dependencies, but do not pose 
 # a risk to Conjur.
 CVE-2020-8130
-
-# These vulnerabilites are present in the Ubuntu 18.04 base image and are being
-# analyzed to determined their impact on the Conjur container image.
-# Follow up issue: https://github.com/cyberark/conjur/issues/1461
-CVE-2019-10220
-CVE-2019-19813
-CVE-2019-19814
-CVE-2019-19816
 
 # Applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake
 # may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert"


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Removes extra ignores from .trivyignore file. No longer needed as the underlying issues are no longer present. 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
