### PR TITLE
ONYX-11118 - FetchAudienceValue class

### DIFF
--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -17,6 +17,7 @@ module Authentication
     IDENTITY_TYPE_HOST = "host"
     ENFORCED_CLAIMS_RESOURCE_NAME = "enforced-claims"
     MAPPING_CLAIMS_RESOURCE_NAME = "mapping-claims"
+    AUDIENCE_RESOURCE_NAME = "audience"
     PRIVILEGE_AUTHENTICATE="authenticate"
     ISS_CLAIM_NAME = "iss"
     EXP_CLAIM_NAME = "exp"

--- a/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
@@ -1,0 +1,79 @@
+require 'command_class'
+
+module Authentication
+  module AuthnJwt
+    module ValidateAndDecode
+      # Fetch and validate the audience from the JWT authenticator policy
+      FetchAudienceValue = CommandClass.new(
+        dependencies: {
+          resource_class: ::Resource,
+          fetch_required_secrets: ::Conjur::FetchRequiredSecrets.new,
+          logger: Rails.logger
+        },
+        inputs: %i[authentication_parameters]
+      ) do
+        def call
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingAudienceValue.new)
+          
+          return empty_audience_value unless audience_resource_exists?
+
+          fetch_audience_secret_value
+          validate_audience_secret_value
+          audience_secret_value
+        end
+
+        private
+        
+        def audience_resource_exists?
+          return @audience_resource_exists unless @audience_resource_exists.nil?
+
+          @audience_resource_exists ||= !audience_resource.nil?
+        end
+
+        def audience_resource
+          @audience_resource ||= @resource_class[audience_resource_id]
+        end
+
+        def audience_resource_id
+          @audience_resource_id ||= "#{@authentication_parameters.authn_jwt_variable_id_prefix}/#{AUDIENCE_RESOURCE_NAME}"
+        end
+        
+        def empty_audience_value
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingAudienceValue.new)
+          @empty_audience ||= ""
+        end
+        
+        def fetch_audience_secret_value
+          audience_secret_value
+        end
+
+        def audience_secret_value
+          @audience_secret_value ||= audience_required_secret[audience_resource_id]
+        end
+        
+        def audience_required_secret
+          @audience_required_secret ||= @fetch_required_secrets.call(resource_ids: [audience_resource_id])
+        end
+
+        def validate_audience_secret_value
+          audience_secret_value_is_not_empty
+          audience_secret_value_is_stringoruri
+        end
+
+        def audience_secret_value_is_not_empty
+          raise Errors::Authentication::AuthnJwt::AudienceValueIsEmpty if audience_secret_value.blank?
+        end
+
+        # https://datatracker.ietf.org/doc/html/rfc7519#section-2 => StringOrURI
+        # any value containing a ":" character MUST be a URI [RFC3986]
+        def audience_secret_value_is_stringoruri
+          begin
+            URI::RFC3986_PARSER.parse(audience_secret_value) if audience_secret_value.include?(":")
+          rescue => e
+            raise Errors::Authentication::AuthnJwt::AudienceValueIsNotURI.new(e.inspect)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
@@ -18,7 +18,7 @@ module Authentication
           return empty_audience_value unless audience_resource_exists?
 
           fetch_audience_secret_value
-          validate_audience_secret_value
+          validate_audience_secret_has_value
 
           @logger.info(LogMessages::Authentication::AuthnJwt::FetchedAudienceValue.new(audience_secret_value))
 
@@ -43,7 +43,7 @@ module Authentication
         
         def empty_audience_value
           @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingAudienceValue.new)
-          String.new
+          ''
         end
         
         def fetch_audience_secret_value
@@ -58,21 +58,8 @@ module Authentication
           @audience_required_secret ||= @fetch_required_secrets.call(resource_ids: [audience_resource_id])
         end
 
-        def validate_audience_secret_value
-          validate_audience_secret_has_value
-          audience_secret_value_is_stringoruri
-        end
-
         def validate_audience_secret_has_value
           raise Errors::Authentication::AuthnJwt::AudienceValueIsEmpty if audience_secret_value.blank?
-        end
-
-        # https://datatracker.ietf.org/doc/html/rfc7519#section-2 => StringOrURI
-        # any value containing a ":" character MUST be a URI [RFC3986]
-        def audience_secret_value_is_stringoruri
-          URI::RFC3986_PARSER.parse(audience_secret_value) if audience_secret_value.include?(":")
-        rescue => e
-          raise Errors::Authentication::AuthnJwt::AudienceValueIsNotURI.new(e.inspect)
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/fetch_audience_value.rb
@@ -19,6 +19,9 @@ module Authentication
 
           fetch_audience_secret_value
           validate_audience_secret_value
+
+          @logger.info(LogMessages::Authentication::AuthnJwt::FetchedAudienceValue.new(audience_secret_value))
+
           audience_secret_value
         end
 
@@ -40,7 +43,7 @@ module Authentication
         
         def empty_audience_value
           @logger.debug(LogMessages::Authentication::AuthnJwt::FetchingAudienceValue.new)
-          @empty_audience ||= ""
+          String.new
         end
         
         def fetch_audience_secret_value
@@ -56,22 +59,20 @@ module Authentication
         end
 
         def validate_audience_secret_value
-          audience_secret_value_is_not_empty
+          validate_audience_secret_has_value
           audience_secret_value_is_stringoruri
         end
 
-        def audience_secret_value_is_not_empty
+        def validate_audience_secret_has_value
           raise Errors::Authentication::AuthnJwt::AudienceValueIsEmpty if audience_secret_value.blank?
         end
 
         # https://datatracker.ietf.org/doc/html/rfc7519#section-2 => StringOrURI
         # any value containing a ":" character MUST be a URI [RFC3986]
         def audience_secret_value_is_stringoruri
-          begin
-            URI::RFC3986_PARSER.parse(audience_secret_value) if audience_secret_value.include?(":")
-          rescue => e
-            raise Errors::Authentication::AuthnJwt::AudienceValueIsNotURI.new(e.inspect)
-          end
+          URI::RFC3986_PARSER.parse(audience_secret_value) if audience_secret_value.include?(":")
+        rescue => e
+          raise Errors::Authentication::AuthnJwt::AudienceValueIsNotURI.new(e.inspect)
         end
       end
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -547,6 +547,17 @@ module Errors
         msg: "Role can't have standard claim or a mapped claim. Error : '{0-error}'",
         code: "CONJ00069E"
       )
+
+      AudienceValueIsEmpty = ::Util::TrackableErrorClass.new(
+        msg: "Failed to fetch audience value: audience value is empty",
+        code: "CONJ00115E"
+      )
+
+      AudienceValueIsNotURI = ::Util::TrackableErrorClass.new(
+        msg: "Failed to fetch audience value: audience value have to be URI if it contains a colon ':'. " \
+             "Error: {0-uri-parse-error}.",
+        code: "CONJ00116E"
+      )
     end
 
     module ResourceRestrictions

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -552,12 +552,6 @@ module Errors
         msg: "Failed to fetch audience value: audience value is empty",
         code: "CONJ00115E"
       )
-
-      AudienceValueIsNotURI = ::Util::TrackableErrorClass.new(
-        msg: "Failed to fetch audience value: audience value have to be URI if it contains a colon ':'. " \
-             "Error: {0-uri-parse-error}.",
-        code: "CONJ00116E"
-      )
     end
 
     module ResourceRestrictions

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -693,6 +693,11 @@ module LogMessages
         msg: "Checking restriction '{0-annotation-value}', fetching value from '{1-claim-name}' claim...",
         code: "CONJ00137D"
       )
+
+      FetchingAudienceValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Fetching audience value...",
+        code: "CONJ00138D"
+      )
     end
   end
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -698,6 +698,11 @@ module LogMessages
         msg: "Fetching audience value...",
         code: "CONJ00138D"
       )
+
+      FetchedAudienceValue = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully fetched audience value '{0-value}'",
+        code: "CONJ00139I"
+      )
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_audience_value_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_audience_value_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue') do
+
+  let(:authenticator_name) { 'authn-jwt' }
+  let(:service_id) { "my-service" }
+  let(:account) { 'my-account' }
+
+  let(:authenticator_input) {
+    Authentication::AuthenticatorInput.new(
+      authenticator_name: authenticator_name,
+      service_id: service_id,
+      account: account,
+      username: "dummy",
+      credentials: "dummy",
+      client_ip: "dummy",
+      request: "dummy"
+    )
+  }
+
+  let(:authentication_parameters) {
+    Authentication::AuthnJwt::AuthenticationParameters.new(
+      authentication_input: authenticator_input,
+      jwt_token: nil
+    )
+  }
+
+  let(:audience_resource_name) {Authentication::AuthnJwt::AUDIENCE_RESOURCE_NAME}
+  let(:audience_valid_secret_value_string) {'valid-string-value'}
+  let(:audience_valid_secret_value_uri) {'https://host.com/path'}
+  let(:audience_invalid_secret_value_uri) {':scheme::something::else'}
+
+  def mock_resource_id(resource_name:)
+    %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
+  end
+
+  let(:mocked_resource) { double("MockedResource") }
+  let(:mocked_resource_exists_values) { double("MockedResource") }
+  let(:mocked_resource_not_exists_values) { double("MockedResource") }
+
+  let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values_string) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_exist_values_uri) {  double("MockedFetchSecrets") }
+  let(:mocked_fetch_secrets_invalid_values) {  double("MockedFetchInvalidSecrets") }
+  
+  let(:mocked_valid_secrets_string) {  double("MockedValidSecrets") }
+  let(:mocked_valid_secrets_uri) {  double("MockedValidSecrets") }
+  let(:mocked_invalid_secrets) {  double("MockedInvalidSecrets") }
+
+  let(:required_secret_missing_error) { "required secret missing error" }
+
+  before(:each) do
+    allow(mocked_resource_exists_values).to(
+      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).and_return(mocked_resource)
+    )
+
+    allow(mocked_resource_not_exists_values).to(
+      receive(:[]).and_return(nil)
+    )
+    
+    allow(mocked_fetch_secrets_empty_values).to(
+      receive(:call).and_raise(required_secret_missing_error)
+    )
+
+    allow(mocked_fetch_secrets_exist_values_string).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
+        and_return(mocked_valid_secrets_string)
+    )
+
+    allow(mocked_valid_secrets_string).to(
+      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
+        and_return(audience_valid_secret_value_string)
+    )
+
+    allow(mocked_fetch_secrets_exist_values_uri).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
+        and_return(mocked_valid_secrets_uri)
+    )
+
+    allow(mocked_valid_secrets_uri).to(
+      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
+        and_return(audience_valid_secret_value_uri)
+    )
+
+    allow(mocked_fetch_secrets_invalid_values).to(
+      receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
+        and_return(mocked_invalid_secrets)
+    )
+
+    allow(mocked_invalid_secrets).to(
+      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
+        and_return(audience_invalid_secret_value_uri)
+    )
+
+  end
+
+  #  ____  _   _  ____    ____  ____  ___  ____  ___
+  # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
+  #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
+  #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
+
+  context "'audience' variable is configured in authenticator policy" do
+    context "with empty variable value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_empty_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(required_secret_missing_error)
+      end
+    end
+
+    context "with invalid variable value" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_invalid_values
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(
+                                Errors::Authentication::AuthnJwt::AudienceValueIsNotURI,
+                                /.*CONJ00116E.*URI::InvalidURIError.*/
+                              )
+      end
+    end
+    
+    context "with valid variable value string" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_exist_values_string
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "returns the value" do
+        expect(subject).to eql(audience_valid_secret_value_string)
+      end
+    end
+
+    context "with valid variable value uri" do
+      subject do
+        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
+          resource_class: mocked_resource_exists_values,
+          fetch_required_secrets: mocked_fetch_secrets_exist_values_uri
+        ).call(
+          authentication_parameters: authentication_parameters
+        )
+      end
+
+      it "returns the value" do
+        expect(subject).to eql(audience_valid_secret_value_uri)
+      end
+    end
+  end
+
+  context "'audience' variable is not configured in authenticator policy" do
+    subject do
+      ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
+        resource_class: mocked_resource_not_exists_values
+      ).call(
+        authentication_parameters: authentication_parameters
+      )
+    end
+
+    it "returns an empty string" do
+      expect(subject).to eql("")
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_audience_value_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/fetch_audience_value_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue'
   }
 
   let(:audience_resource_name) {Authentication::AuthnJwt::AUDIENCE_RESOURCE_NAME}
-  let(:audience_valid_secret_value_string) {'valid-string-value'}
-  let(:audience_valid_secret_value_uri) {'https://host.com/path'}
-  let(:audience_invalid_secret_value_uri) {':scheme::something::else'}
+  let(:audience_valid_secret_value) {'valid-string-value'}
 
   def mock_resource_id(resource_name:)
     %r{#{account}:variable:conjur/#{authenticator_name}/#{service_id}/#{resource_name}}
@@ -41,13 +39,9 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue'
   let(:mocked_resource_not_exists_values) { double("MockedResource") }
 
   let(:mocked_fetch_secrets_empty_values) {  double("MockedFetchSecrets") }
-  let(:mocked_fetch_secrets_exist_values_string) {  double("MockedFetchSecrets") }
-  let(:mocked_fetch_secrets_exist_values_uri) {  double("MockedFetchSecrets") }
-  let(:mocked_fetch_secrets_invalid_values) {  double("MockedFetchInvalidSecrets") }
-  
-  let(:mocked_valid_secrets_string) {  double("MockedValidSecrets") }
-  let(:mocked_valid_secrets_uri) {  double("MockedValidSecrets") }
-  let(:mocked_invalid_secrets) {  double("MockedInvalidSecrets") }
+  let(:mocked_fetch_secrets_exist_values) {  double("MockedFetchSecrets") }
+
+  let(:mocked_valid_secrets) {  double("MockedValidSecrets") }
 
   let(:required_secret_missing_error) { "required secret missing error" }
 
@@ -64,36 +58,15 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue'
       receive(:call).and_raise(required_secret_missing_error)
     )
 
-    allow(mocked_fetch_secrets_exist_values_string).to(
+    allow(mocked_fetch_secrets_exist_values).to(
       receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
-        and_return(mocked_valid_secrets_string)
+        and_return(mocked_valid_secrets)
     )
 
-    allow(mocked_valid_secrets_string).to(
+    allow(mocked_valid_secrets).to(
       receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
-        and_return(audience_valid_secret_value_string)
+        and_return(audience_valid_secret_value)
     )
-
-    allow(mocked_fetch_secrets_exist_values_uri).to(
-      receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
-        and_return(mocked_valid_secrets_uri)
-    )
-
-    allow(mocked_valid_secrets_uri).to(
-      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
-        and_return(audience_valid_secret_value_uri)
-    )
-
-    allow(mocked_fetch_secrets_invalid_values).to(
-      receive(:call).with(resource_ids: [mock_resource_id(resource_name: audience_resource_name)]).
-        and_return(mocked_invalid_secrets)
-    )
-
-    allow(mocked_invalid_secrets).to(
-      receive(:[]).with(mock_resource_id(resource_name: audience_resource_name)).
-        and_return(audience_invalid_secret_value_uri)
-    )
-
   end
 
   #  ____  _   _  ____    ____  ____  ___  ____  ___
@@ -117,51 +90,18 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue'
       end
     end
 
-    context "with invalid variable value" do
-      subject do
-        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
-          resource_class: mocked_resource_exists_values,
-          fetch_required_secrets: mocked_fetch_secrets_invalid_values
-        ).call(
-          authentication_parameters: authentication_parameters
-        )
-      end
-
-      it "raises an error" do
-        expect { subject }.to raise_error(
-                                Errors::Authentication::AuthnJwt::AudienceValueIsNotURI,
-                                /.*CONJ00116E.*URI::InvalidURIError.*/
-                              )
-      end
-    end
-    
     context "with valid variable value string" do
       subject do
         ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
           resource_class: mocked_resource_exists_values,
-          fetch_required_secrets: mocked_fetch_secrets_exist_values_string
+          fetch_required_secrets: mocked_fetch_secrets_exist_values
         ).call(
           authentication_parameters: authentication_parameters
         )
       end
 
       it "returns the value" do
-        expect(subject).to eql(audience_valid_secret_value_string)
-      end
-    end
-
-    context "with valid variable value uri" do
-      subject do
-        ::Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new(
-          resource_class: mocked_resource_exists_values,
-          fetch_required_secrets: mocked_fetch_secrets_exist_values_uri
-        ).call(
-          authentication_parameters: authentication_parameters
-        )
-      end
-
-      it "returns the value" do
-        expect(subject).to eql(audience_valid_secret_value_uri)
+        expect(subject).to eql(audience_valid_secret_value)
       end
     end
   end


### PR DESCRIPTION
### What does this PR do?

Introduces `FetchAudienceValue` class responsible for fetching `audience` variable of `author-jwt`.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
