### PR TITLE
Add audience validation to jwt status api

### DIFF
--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -5,6 +5,7 @@ module Authentication
       dependencies: {
         create_signing_key_interface: Authentication::AuthnJwt::SigningKey::CreateSigningKeyFactory.new,
         fetch_issuer_value: Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new,
+        fetch_audience_value: Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new,
         fetch_enforced_claims: Authentication::AuthnJwt::RestrictionValidation::FetchEnforcedClaims.new,
         fetch_mapping_claims: Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new,
         identity_from_decoded_token_provider_class: Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider,
@@ -24,6 +25,7 @@ module Authentication
         @logger.info(LogMessages::Authentication::AuthnJwt::ValidatingJwtStatusConfiguration.new)
         validate_generic_status_validations
         validate_issuer
+        validate_audience
         validate_enforced_claims
         validate_mapping_claims
         validate_identity_secrets
@@ -84,6 +86,11 @@ module Authentication
       def validate_issuer
         @fetch_issuer_value.call(authentication_parameters: authentication_parameters)
         @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedIssuerConfiguration.new)
+      end
+      
+      def validate_audience
+        @fetch_audience_value.call(authentication_parameters: authentication_parameters)
+        @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedAudienceConfiguration.new)
       end
 
       def validate_enforced_claims

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -703,6 +703,11 @@ module LogMessages
         msg: "Successfully fetched audience value '{0-value}'",
         code: "CONJ00139I"
       )
+
+      ValidatedAudienceConfiguration = ::Util::TrackableLogMessageClass.new(
+        msg: "Successfully validated audience configuration",
+        code: "CONJ00140D"
+      )
     end
   end
 

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
   let(:mocked_invalid_create_signing_key_interface) { double("Mocked invalid create signing key interface")  }
   let(:mocked_valid_fetch_issuer_value) { double("Mocked valid fetch issuer value")  }
   let(:mocked_invalid_fetch_issuer_value) { double("Mocked invalid fetch issuer value")  }
+  let(:mocked_invalid_fetch_audience_value) { double("Mocked invalid audience issuer value")  }
   let(:mocked_invalid_fetch_enforced_claims) { double("Mocked invalid fetch enforced claims value")  }
   let(:mocked_invalid_fetch_mapping_claims) { double("Mocked invalid fetch mapping claims value")  }
   let(:mocked_valid_identity_from_decoded_token_provider) { double("Mocked valid identity from decoded token provider")  }
@@ -43,6 +44,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
   let(:create_signing_key_configuration_is_invalid_error) { "Create signing key configuration is invalid" }
   let(:fetch_issuer_configuration_is_invalid_error) { "Fetch issuer configuration is invalid" }
+  let(:fetch_audience_configuration_is_invalid_error) { "Fetch audience configuration is invalid" }
   let(:fetch_enforced_claims_configuration_is_invalid_error) { "Fetch enforced claims configuration is invalid" }
   let(:fetch_mapping_claims_configuration_is_invalid_error) { "Fetch mapping claims configuration is invalid" }
   let(:identity_configuration_is_invalid_error) { "Identity configuration is invalid" }
@@ -71,6 +73,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
     allow(mocked_invalid_fetch_issuer_value).to(
       receive(:call).and_raise(fetch_issuer_configuration_is_invalid_error)
+    )
+
+    allow(mocked_invalid_fetch_audience_value).to(
+      receive(:call).and_raise(fetch_audience_configuration_is_invalid_error)
     )
 
     allow(mocked_invalid_fetch_enforced_claims).to(
@@ -342,6 +348,29 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         it "raises an error" do
           expect { subject }.to raise_error(fetch_issuer_configuration_is_invalid_error)
+        end
+      end
+
+      context "audience secret is not configured properly" do
+        subject do
+          ::Authentication::AuthnJwt::ValidateStatus.new(
+            create_signing_key_interface: mocked_valid_create_signing_key_interface,
+            fetch_issuer_value: mocked_valid_fetch_issuer_value,
+            fetch_audience_value: mocked_invalid_fetch_audience_value,
+            identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
+            validate_webservice_is_whitelisted: mocked_valid_validate_webservice_is_whitelisted,
+            validate_role_can_access_webservice: mocked_valid_validate_can_access_webservice,
+            validate_webservice_exists: mocked_valid_validate_webservice_exists,
+            validate_account_exists: mocked_valid_validate_account_exists,
+            logger: mocked_logger
+          ).call(
+            authenticator_status_input: authenticator_status_input,
+            enabled_authenticators: mocked_enabled_authenticators
+          )
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(fetch_audience_configuration_is_invalid_error)
         end
       end
 


### PR DESCRIPTION
### What does this PR do?
Add audience validation to jwt status api

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
