### PR TITLE
Default http error code in authenticate controller is 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix bug of cache not working in authn jwt. [cyberark/conjur#2353](https://github.com/cyberark/conjur/pull/2353)
 
+### Changed
+- OIDC based authenticators no longer return Bad Gateway and Gateway Timeout http error codes.
+  Unauthorised is returned instead.
+  [cyberark/conjur#2360](https://github.com/cyberark/conjur/pull/2360)
+
 ## [1.13.0] - 2021-07-29
 
 ### Added

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -202,17 +202,6 @@ class AuthenticateController < ApplicationController
     log_backtrace(err)
 
     case err
-    when Errors::Authentication::Security::AuthenticatorNotWhitelisted,
-      Errors::Authentication::Security::WebserviceNotFound,
-      Errors::Authentication::Security::RoleNotFound,
-      Errors::Authentication::Security::AccountNotDefined,
-      Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty,
-      Errors::Authentication::Jwt::TokenVerificationFailed,
-      Errors::Authentication::Jwt::TokenDecodeFailed,
-      Errors::Conjur::RequiredSecretMissing,
-      Errors::Conjur::RequiredResourceMissing
-      raise Unauthorized
-
     when Errors::Authentication::Security::RoleNotAuthorizedOnResource
       raise Forbidden
 
@@ -222,15 +211,8 @@ class AuthenticateController < ApplicationController
     when Errors::Authentication::Jwt::TokenExpired
       raise Unauthorized.new(err.message, true)
 
-    when Errors::Authentication::OAuth::ProviderDiscoveryTimeout
-      raise GatewayTimeout
-
     when Errors::Util::ConcurrencyLimitReachedBeforeCacheInitialization
       raise ServiceUnavailable
-
-    when Errors::Authentication::OAuth::ProviderDiscoveryFailed,
-      Errors::Authentication::OAuth::FetchProviderKeysFailed
-      raise BadGateway
 
     when Errors::Authentication::AuthnK8s::CSRMissingCNEntry,
       Errors::Authentication::AuthnK8s::CertMissingCNEntry

--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -124,7 +124,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
-  Scenario: Bad Gateway is raised in case of an invalid ID Provider hostname
+  Scenario: Unauthorized is raised in case of an invalid ID Provider hostname
     Given I load a policy:
     """
     - !policy
@@ -150,7 +150,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     When I authenticate via Azure with token as host "test-app"
-    Then it is bad gateway
+    Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
     Errors::Authentication::OAuth::ProviderDiscoveryFailed

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -54,7 +54,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     Then host "test-app" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
 
-  Scenario: Changing provider-uri dynamically reflects on the ID Provider endpoint
+  Scenario: Changing provider-uri dynamically reflects on the ID Provider endpoint
     Given I fetch a non-assigned-identity Azure access token from inside machine
     And I authenticate via Azure with token as host "test-app"
     And host "test-app" has been authorized by Conjur
@@ -63,7 +63,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
     And I authenticate via Azure with token as host "test-app"
-    Then it is bad gateway
+    Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
     CONJ00007D Working with Identity Provider https://different-provider:8443

--- a/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
@@ -363,7 +363,7 @@ Feature: JWT Authenticator - Check registered claim
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the audit log file
     When I authenticate via authn-jwt with the ID token
-    Then the HTTP response status code is 502
+    Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'incorrect.com'). Reason: '#<AttrRequired::AttrMissing: 'host' required.>'

--- a/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
@@ -46,7 +46,6 @@ Feature: JWT Authenticator - Fetch signing key
     When I authenticate via authn-jwt with the ID token
     Then host "alice" has been authorized by Conjur
 
-  # BUG: ONYX-10132 , expected error code should be 401
   Scenario: ONYX-8704: provider uri configured with bad value
     Given I load a policy:
     """
@@ -83,7 +82,7 @@ Feature: JWT Authenticator - Fetch signing key
     And I save my place in the log file
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate via authn-jwt with the ID token
-    Then the HTTP response status code is 502
+    Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'unknown-host.com')
@@ -376,7 +375,7 @@ Feature: JWT Authenticator - Fetch signing key
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the log file
     And I authenticate via authn-jwt with the ID token
-    And the HTTP response status code is 502
+    And the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'incorrect.com'). Reason: '#<AttrRequired::AttrMissing: 'host' required.>'
@@ -551,7 +550,6 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')
     """
 
-  # BUG: ONYX-10132 , expected error code should be 401
   Scenario: ONYX-8914: provider-uri with untrusted self sign certificate
     Given I load a policy:
     """
@@ -568,7 +566,7 @@ Feature: JWT Authenticator - Fetch signing key
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the log file
     When I authenticate via authn-jwt with the ID token
-    Then the HTTP response status code is 502
+    Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'https://jwks'). Reason: '#<OpenIDConnect::Discovery::DiscoveryFailed: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -164,14 +164,14 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     # Update provider uri to a different hostname and verify `provider-uri` has changed
     When I add the secret value "https://different-provider:8443" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/provider-uri"
     And I authenticate via OIDC with id token
-    Then it is bad gateway
+    Then it is unauthorized
     # Check recovery to a valid provider uri
     When I successfully set OIDC variables
     And I fetch an ID Token for username "alice" and password "alice"
     And I authenticate via OIDC with id token
     Then user "alice" has been authorized by Conjur
 
-  Scenario: Bad Gateway is raised in case of an invalid OIDC Provider hostname
+  Scenario: Unauthenticated is raised in case of an invalid OIDC Provider hostname
     Given I fetch an ID Token for username "alice" and password "alice"
     And I authenticate via OIDC with id token
     And user "alice" has been authorized by Conjur
@@ -179,7 +179,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     When I add the secret value "http://127.0.0.1.com/" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/provider-uri"
     And I save my place in the log file
     And I authenticate via OIDC with id token
-    Then it is bad gateway
+    Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
     Errors::Authentication::OAuth::ProviderDiscoveryFailed


### PR DESCRIPTION
### What does this PR do?

Aligns error handling in authenticate controller. It returns http error code 401 by default.

While serving authentication request conjur approaches OIDC provider in order to fetch keys.
During key fetching procedure exceptions could occur.
Before the change some exceptions were translated into [Bad Gateway](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) and [Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) http error codes.

Strictly speaking conjur does not act as a [gateway](https://en.wikipedia.org/wiki/Gateway_(telecommunications)) during OIDC like authentication flows, it does not routes/transfers an authenticated request to the OIDC provider rather just fetches from the provider keys.

During authentication a REST caller is unauthenticated, means anonymous, until authentication flow succeeded. It's a bad practice to signalize anonymous user about internal server state. `authn-jwt` especially emphasizes the point when `provider-uri` and `jwks-uri` will return different http codes in case of similar situation (timeout for example).

In any case:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/29942758/129577168-ddf4d3c7-e241-411c-a9d6-d2738eae9b93.png">
means in both unauthenticated and gateway error codes REST caller will demand to approach an another person with appropriate permissions in order to understand what's the issue.


### What ticket does this PR close?
[ONYX- 9758](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-9758)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation

#### API Changes
- [X] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
