### PR TITLE
Update .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,13 @@
 # NULL pointer deref. OpenSSL 1.0.2 is not impacted
 CVE-2021-3449
 
+# We already use a later version than the ones listed as impacted by this
+# CVE, so we believe this is just a scanner issue.
+CVE-2014-7819
+
 # Rake vulnerability for versions < 12.3.3. The version of Rake used by Conjur
 # has been updated to 13.0.1. Some of the Conjur dependencies still declare a
-# vulnerable version of Rake in their development dependencies, but do not pose 
+# vulnerable version of Rake in their development dependencies, but do not pose
 # a risk to Conjur.
 CVE-2020-8130
 


### PR DESCRIPTION
CVE-2014-7819 states that there is a security issue with sprockets
versions 3 and below but we use version 4.0.2. Therefore it is belived
to be a false flag and added to the .trivyignore.

### What does this PR do?
- _What's changed? Why were these changes made?_
We where getting a false flag on a trivy scan.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
