### PR TITLE
ONYX-9742: Reduce _class dependencies from command classes

### DIFF
--- a/app/domain/authentication/authn_jwt/authenticator.rb
+++ b/app/domain/authentication/authn_jwt/authenticator.rb
@@ -10,9 +10,9 @@ module Authentication
         logger: Rails.logger,
         audit_log: ::Audit.logger,
         validate_origin: ::Authentication::ValidateOrigin.new,
+        validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
         role_class: ::Role,
         webservice_class: ::Authentication::Webservice,
-        validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
         role_id_class: Audit::Event::Authn::RoleId
       },
       inputs: %i[vendor_configuration authenticator_input]

--- a/app/domain/authentication/authn_jwt/identity_providers/create_identity_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/create_identity_provider.rb
@@ -5,8 +5,8 @@ module Authentication
     module IdentityProviders
       CreateIdentityProvider = CommandClass.new(
         dependencies: {
-          identity_from_url_provider_class: Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider,
-          identity_from_decoded_token_class: Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider,
+          identity_from_url_provider: Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider.new,
+          identity_from_decoded_token: Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider.new,
           check_authenticator_secret_exists: Authentication::Util::CheckAuthenticatorSecretExists.new,
           logger: Rails.logger
         },
@@ -53,9 +53,7 @@ module Authentication
             )
           )
 
-          @identity_from_decoded_token_class.new(
-            jwt_authenticator_input: @jwt_authenticator_input
-          )
+          @identity_from_decoded_token
         end
 
         def identity_should_be_in_url?
@@ -69,9 +67,7 @@ module Authentication
             )
           )
 
-          @identity_from_url_provider_class.new(
-            jwt_authenticator_input: @jwt_authenticator_input
-          )
+          @identity_from_url_provider
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_cached_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_cached_signing_key.rb
@@ -8,7 +8,7 @@ module Authentication
       # :reek:InstanceVariableAssumption
       FetchCachedSigningKey = CommandClass.new(
         dependencies: {},
-        inputs: %i[signing_key_provider]
+        inputs: %i[signing_key_provider authenticator_input]
       ) do
         def call
           fetch_signing_key
@@ -17,7 +17,9 @@ module Authentication
         private
 
         def fetch_signing_key
-          @signing_key_provider.fetch_signing_key
+          @signing_key_provider.fetch_signing_key(
+            authenticator_input: @authenticator_input
+          )
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -7,9 +7,7 @@ module Authentication
     module SigningKey
       # This class is responsible for fetching JWK Set from JWKS-uri
       class FetchJwksUriSigningKey
-
         def initialize(
-          authenticator_input:,
           fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
           http_lib: Net::HTTP,
           create_jwks_from_http_response: CreateJwksFromHttpResponse.new,
@@ -19,31 +17,22 @@ module Authentication
           @http_lib = http_lib
           @create_jwks_from_http_response = create_jwks_from_http_response
           @fetch_authenticator_secrets = fetch_authenticator_secrets
-
-          @authenticator_input = authenticator_input
         end
 
-        def fetch_signing_key
-          fetch_jwks_uri
+        def fetch_signing_key(authenticator_input:)
+          @authenticator_input = authenticator_input
           fetch_jwks_keys
         end
 
-        def signing_key_uri
-          jwks_uri
+        def signing_key_uri(authenticator_input:)
+          @authenticator_input = authenticator_input
+          jwks_uri_secret
         end
 
         private
 
-        def fetch_jwks_uri
-          jwks_uri
-        end
-
-        def jwks_uri
-          @jwks_uri ||= jwks_uri_secret
-        end
-
         def jwks_uri_secret
-          @jwks_uri_secret ||= @fetch_authenticator_secrets.call(
+          @jwks_uri_secret = @fetch_authenticator_secrets.call(
             conjur_account: @authenticator_input.account,
             authenticator_name: @authenticator_input.authenticator_name,
             service_id: @authenticator_input.service_id,
@@ -53,9 +42,9 @@ module Authentication
 
         def fetch_jwks_keys
           begin
-            uri = URI(jwks_uri)
+            jwks_uri = jwks_uri_secret
             @logger.info(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(jwks_uri))
-            response = @http_lib.get_response(uri)
+            response = @http_lib.get_response(URI(jwks_uri))
             @logger.debug(LogMessages::Authentication::AuthnJwt::FetchJwtUriKeysSuccess.new)
           rescue => e
             raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
@@ -5,7 +5,6 @@ module Authentication
       class FetchProviderUriSigningKey
 
         def initialize(
-          authenticator_input:,
           fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
           discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new,
           logger: Rails.logger
@@ -13,38 +12,34 @@ module Authentication
           @logger = logger
           @fetch_authenticator_secrets = fetch_authenticator_secrets
           @discover_identity_provider = discover_identity_provider
-
-          @authenticator_input = authenticator_input
         end
 
-        def fetch_signing_key
+        def fetch_signing_key(authenticator_input:)
+          @authenticator_input = authenticator_input
           discover_provider
           fetch_provider_keys
         end
 
-        def signing_key_uri
-          provider_uri
+        def signing_key_uri(authenticator_input:)
+          @authenticator_input = authenticator_input
+          provider_uri_secret
         end
 
         private
 
         def discover_provider
-          @logger.info(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(provider_uri))
+          @logger.info(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(provider_uri_secret))
           discovered_provider
         end
 
         def discovered_provider
-          @discovered_provider ||= @discover_identity_provider.call(
-            provider_uri: provider_uri
+          @discovered_provider = @discover_identity_provider.call(
+            provider_uri: provider_uri_secret
           )
         end
 
-        def provider_uri
-          @provider_uri ||= provider_uri_secret
-        end
-
         def provider_uri_secret
-          @provider_uri_secret ||= @fetch_authenticator_secrets.call(
+          @provider_uri_secret = @fetch_authenticator_secrets.call(
             conjur_account: @authenticator_input.account,
             authenticator_name: @authenticator_input.authenticator_name,
             service_id: @authenticator_input.service_id,
@@ -58,7 +53,7 @@ module Authentication
           keys
         rescue => e
           raise Errors::Authentication::OAuth::FetchProviderKeysFailed.new(
-            provider_uri,
+            provider_uri_secret,
             e.inspect
           )
         end

--- a/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
@@ -20,7 +20,7 @@ module Authentication
           verify_and_decode_token: ::Authentication::Jwt::VerifyAndDecodeToken.new,
           fetch_jwt_claims_to_validate: ::Authentication::AuthnJwt::ValidateAndDecode::FetchJwtClaimsToValidate.new,
           get_verification_option_by_jwt_claim: ::Authentication::AuthnJwt::ValidateAndDecode::GetVerificationOptionByJwtClaim.new,
-          create_signing_key_provider: ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new,
+          create_signing_key_provider: ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new,
           logger: Rails.logger
         },
         inputs: %i[authenticator_input jwt_token]
@@ -54,8 +54,9 @@ module Authentication
         def fetch_signing_key(force_read: false)
           @jwks = @fetch_signing_key.call(
             refresh: force_read,
-            cache_key: signing_key_provider.signing_key_uri,
-            signing_key_provider: signing_key_provider
+            cache_key: signing_key_provider.signing_key_uri(authenticator_input: @authenticator_input),
+            signing_key_provider: signing_key_provider,
+            authenticator_input: @authenticator_input
           )
           @logger.debug(LogMessages::Authentication::AuthnJwt::SigningKeysFetchedFromCache.new)
         end

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -13,7 +13,7 @@ module Authentication
           max_concurrent_requests: CACHE_MAX_CONCURRENT_REQUESTS,
           logger: Rails.logger
         ),
-        create_signing_key_provider: Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new,
+        create_signing_key_provider: Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new,
         fetch_issuer_value: Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new,
         fetch_audience_value: Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new,
         fetch_enforced_claims: Authentication::AuthnJwt::RestrictionValidation::FetchEnforcedClaims.new,
@@ -151,8 +151,9 @@ module Authentication
 
       def validate_signing_key
         @fetch_signing_key.call(
-          cache_key: signing_key_provider.signing_key_uri,
-          signing_key_provider: signing_key_provider
+          cache_key: signing_key_provider.signing_key_uri(authenticator_input: authenticator_input),
+          signing_key_provider: signing_key_provider,
+          authenticator_input: authenticator_input
         )
         @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedSigningKeyConfiguration.new)
       end

--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -4,7 +4,7 @@ Feature: JWT Authenticator - Status Check
   authenticator or policy that can be found before authentication request.
 
   Background:
-    Given I initialize remote JWKS endpoint with file "authn-jwt-configuration" and alg "RS256"
+    Given I initialize remote JWKS endpoint with file "authn-jwt-status" and alg "RS256"
 
   @sanity
   Scenario: ONYX-9122: A valid JWT status request, 200 OK
@@ -59,7 +59,7 @@ Feature: JWT Authenticator - Status Check
       - !user alice
     """
     And I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-configuration/RS256" in service "raw"
+    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-status/RS256" in service "raw"
     And I successfully set authn-jwt "token-app-property" variable to value "user"
     And I successfully set authn-jwt "issuer" variable to value "gitlab"
     And I successfully set authn-jwt "audience" variable to value "conjur"
@@ -281,7 +281,7 @@ Feature: JWT Authenticator - Status Check
       - !user alice
     """
     And I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-configuration/RS256" in service "raw"
+    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-status/RS256" in service "raw"
     And I successfully set authn-jwt "token-app-property" variable to value "user"
     And I login as "alice"
     And I save my place in the log file
@@ -767,7 +767,7 @@ Feature: JWT Authenticator - Status Check
       - !user alice
     """
     And I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-configuration/RS256" in service "raw"
+    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-status/RS256" in service "raw"
     And I successfully set authn-jwt "token-app-property" variable to value "user"
     And I successfully set authn-jwt "identity-path" variable to value "apps"
     And I successfully set authn-jwt "issuer" variable to value "gitlab"
@@ -835,7 +835,7 @@ Feature: JWT Authenticator - Status Check
       - !user alice
     """
     And I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-configuration/RS256" in service "raw"
+    And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-status/RS256" in service "raw"
     And I successfully set authn-jwt "token-app-property" variable to value "user"
     And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
     And I successfully set authn-jwt "enforced-claims" variable to value "ref"

--- a/spec/app/domain/authentication/authn-jwt/identity_providers/create_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/identity_providers/create_identity_provider_spec.rb
@@ -3,16 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFactory') do
-  # Mock to inject to test in order check returning type
-  class MockedURLIdentityProvider
-    def initialize(jwt_authenticator_input); end
-  end
-
-  # Mock to inject to test in order check returning type
-  class MockedDecodedTokenIdentityProvider
-    def initialize(jwt_authenticator_input); end
-  end
-
   # Mock to CheckAuthenticatorSecretExists that returns always false
   class MockedCheckAuthenticatorSecretExistsFalse
     # this what the object gets and its a mock
@@ -74,8 +64,6 @@ RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFac
     context "Decoded token identity available and url identity available" do
       subject do
         ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
-          identity_from_url_provider_class: MockedURLIdentityProvider,
-          identity_from_decoded_token_class: MockedDecodedTokenIdentityProvider,
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsTrue.new
         )
       end
@@ -90,8 +78,6 @@ RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFac
     context "Decoded token identity available and url identity is not available" do
       subject do
         ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
-          identity_from_url_provider_class: MockedURLIdentityProvider,
-          identity_from_decoded_token_class: MockedDecodedTokenIdentityProvider,
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsTrue.new
         )
       end
@@ -99,15 +85,13 @@ RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFac
       it "factory to return IdentityFromDecodedTokenProvider" do
         expect(subject.call(
           jwt_authenticator_input: jwt_authenticator_input_no_url_identity
-        )).to be_a(MockedDecodedTokenIdentityProvider)
+        )).to be_a(Authentication::AuthnJwt::IdentityProviders::IdentityFromDecodedTokenProvider)
       end
     end
 
     context "Decoded token identity is not available and url identity is available" do
       subject do
         ::Authentication::AuthnJwt::IdentityProviders::CreateIdentityProvider.new(
-          identity_from_url_provider_class: MockedURLIdentityProvider,
-          identity_from_decoded_token_class: MockedDecodedTokenIdentityProvider,
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsFalse.new
         )
       end
@@ -115,7 +99,7 @@ RSpec.describe('Authentication::AuthnJwt::IdentityProviders::IdentityProviderFac
       it "factory to return IdentityFromUrlProvider" do
         expect(subject.call(
           jwt_authenticator_input: jwt_authenticator_input_url_identity
-        )).to be_a(MockedURLIdentityProvider)
+        )).to be_a(Authentication::AuthnJwt::IdentityProviders::IdentityFromUrlProvider)
       end
     end
 

--- a/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_provider_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
     context "'jwks-uri' and 'provider-uri' exist" do
 
       subject do
-        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new(
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new(
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsTrue.new,
           logger: mocked_logger
         ).call(
@@ -99,7 +99,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
     context "'jwks-uri' and 'provider-uri' does not exist" do
 
       subject do
-        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new(
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new(
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsFalse.new,
           logger: mocked_logger
         ).call(
@@ -115,7 +115,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
     context "'jwks-uri' exits and 'provider-uri' does not exists" do
 
       subject do
-        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new(
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new(
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsJWKS.new,
           logger: mocked_logger
         ).call(
@@ -131,7 +131,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
     context "'jwks-uri' does not exists and 'provider-uri' exist" do
 
       subject do
-        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new(
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyFetcher.new(
           check_authenticator_secret_exists: MockedCheckAuthenticatorSecretExistsProviderUri.new,
           logger: mocked_logger
         ).call(

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
@@ -23,17 +23,17 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
   let(:required_jwks_uri_configuration_error) { "required jwks_uri configuration missing error" }
   let(:bad_response_error) { "bad response error" }
   let(:required_secret_missing_error) { "required secret missing error" }
-  let(:mocked_logger) { double("Mocked Logger")  }
-  let(:mocked_fetch_authenticator_secrets_exist_values)  {  double("MockedFetchAuthenticatorSecrets") }
-  let(:mocked_fetch_authenticator_secrets_empty_values)  {  double("MockedFetchAuthenticatorSecrets") }
-  let(:mocked_bad_http_response) { double("Mocked bad http response")  }
-  let(:mocked_good_http_response) { double("Mocked good http response")  }
-  let(:mocked_bad_response) { double("Mocked bad http body")  }
-  let(:mocked_good_response) { double("Mocked good http body")  }
-  let(:mocked_create_jwks_from_http_response) { double("Mocked good jwks")  }
+  let(:mocked_logger) { double("Mocked Logger") }
+  let(:mocked_fetch_authenticator_secrets_exist_values) { double("MockedFetchAuthenticatorSecrets") }
+  let(:mocked_fetch_authenticator_secrets_empty_values) { double("MockedFetchAuthenticatorSecrets") }
+  let(:mocked_bad_http_response) { double("Mocked bad http response") }
+  let(:mocked_good_http_response) { double("Mocked good http response") }
+  let(:mocked_bad_response) { double("Mocked bad http body") }
+  let(:mocked_good_response) { double("Mocked good http body") }
+  let(:mocked_create_jwks_from_http_response) { double("Mocked good jwks") }
 
-  let(:good_response) { "good-response"}
-  let(:bad_response) { "bad-response"}
+  let(:good_response) { "good-response" }
+  let(:bad_response) { "bad-response" }
   let(:valid_jwks) { "valid-jwls" }
 
   before(:each) do
@@ -79,17 +79,15 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
   #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
 
-
-
   context "FetchJwksUriSigningKey fetch_signing_key " do
     context "'jwks-uri' secret is not valid" do
       subject do
-        ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authenticator_input: mocked_authenticator_input,
-                                                                           logger: mocked_logger,
-                                                                           fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
-                                                                           http_lib: mocked_bad_http_response,
-                                                                           create_jwks_from_http_response: mocked_create_jwks_from_http_response
-        ).fetch_signing_key
+        ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(
+          logger: mocked_logger,
+          fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
+          http_lib: mocked_bad_http_response,
+          create_jwks_from_http_response: mocked_create_jwks_from_http_response
+        ).fetch_signing_key(authenticator_input: mocked_authenticator_input)
       end
 
       it "raises an error" do
@@ -100,12 +98,12 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
     context "'jwks-uri' secret is valid" do
       context "provider return valid http response" do
         subject do
-          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authenticator_input: mocked_authenticator_input,
-                                                                             logger: mocked_logger,
-                                                                             fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
-                                                                             http_lib: mocked_good_http_response,
-                                                                             create_jwks_from_http_response: mocked_create_jwks_from_http_response
-          ).fetch_signing_key
+          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(
+            logger: mocked_logger,
+            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
+            http_lib: mocked_good_http_response,
+            create_jwks_from_http_response: mocked_create_jwks_from_http_response
+          ).fetch_signing_key(authenticator_input: mocked_authenticator_input)
         end
 
         it "returns jwks value" do
@@ -115,12 +113,12 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
 
       context "provider return bad http response" do
         subject do
-          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(authenticator_input: mocked_authenticator_input,
-                                                                             logger: mocked_logger,
-                                                                             fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
-                                                                             http_lib: mocked_bad_http_response,
-                                                                             create_jwks_from_http_response: mocked_create_jwks_from_http_response
-          ).fetch_signing_key
+          ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(
+            logger: mocked_logger,
+            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
+            http_lib: mocked_bad_http_response,
+            create_jwks_from_http_response: mocked_create_jwks_from_http_response
+          ).fetch_signing_key(authenticator_input: mocked_authenticator_input)
         end
 
         it "raises an error" do

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
@@ -23,15 +23,15 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
   let(:required_discover_identity_error) { "Provider uri identity error" }
   let(:required_secret_missing_error) { "required secret missing error" }
 
-  let(:mocked_logger) { double("Mocked Logger")  }
-  let(:mocked_fetch_authenticator_secrets_exist_values)  {  double("MockedFetchAuthenticatorSecrets") }
-  let(:mocked_fetch_authenticator_secrets_empty_values)  {  double("MockedFetchAuthenticatorSecrets") }
-  let(:mocked_discover_identity_provider) { double("Mocked discover identity provider")  }
-  let(:mocked_invalid_uri_discover_identity_provider) { double("Mocked invalid uri discover identity provider")  }
-  let(:mocked_provider_uri) { double("Mocked provider uri")  }
+  let(:mocked_logger) { double("Mocked Logger") }
+  let(:mocked_fetch_authenticator_secrets_exist_values) { double("MockedFetchAuthenticatorSecrets") }
+  let(:mocked_fetch_authenticator_secrets_empty_values) { double("MockedFetchAuthenticatorSecrets") }
+  let(:mocked_discover_identity_provider) { double("Mocked discover identity provider") }
+  let(:mocked_invalid_uri_discover_identity_provider) { double("Mocked invalid uri discover identity provider") }
+  let(:mocked_provider_uri) { double("Mocked provider uri") }
 
   let(:mocked_valid_discover_identity_result) { "some jwks" }
-  let(:valid_jwks_result) { {:keys=> mocked_valid_discover_identity_result} }
+  let(:valid_jwks_result) { { :keys => mocked_valid_discover_identity_result } }
 
   before(:each) do
     allow(mocked_logger).to(
@@ -76,10 +76,11 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
     context "'provider-uri' variable is configured in authenticator policy" do
       context "'provider-uri' value is invalid" do
         subject do
-          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authenticator_input: mocked_authenticator_input,
-                                                                                 logger: mocked_logger,
-                                                                                 fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
-                                                                                 discover_identity_provider: mocked_invalid_uri_discover_identity_provider).fetch_signing_key
+          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(
+            logger: mocked_logger,
+            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
+            discover_identity_provider: mocked_invalid_uri_discover_identity_provider
+          ).fetch_signing_key(authenticator_input: mocked_authenticator_input)
         end
 
         it "raises an error" do
@@ -89,10 +90,11 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
 
       context "'provider-uri' value is valid" do
         subject do
-          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(authenticator_input: mocked_authenticator_input,
-                                                                                 logger: mocked_logger,
-                                                                                 fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
-                                                                                 discover_identity_provider: mocked_discover_identity_provider).fetch_signing_key
+          ::Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey.new(
+            logger: mocked_logger,
+            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
+            discover_identity_provider: mocked_discover_identity_provider
+          ).fetch_signing_key(authenticator_input: mocked_authenticator_input)
         end
 
         it "does not raise error" do

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       receive(:call).with(
         refresh: false,
         cache_key: anything(),
-        signing_key_provider: anything()
+        signing_key_provider: anything(),
+        authenticator_input: authenticator_input
       ).and_raise(fetch_signing_key_1st_time_error)
     )
 
@@ -140,7 +141,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       receive(:call).with(
         refresh: false,
         cache_key: anything(),
-        signing_key_provider: anything()
+        signing_key_provider: anything(),
+        authenticator_input: authenticator_input
       ).and_return(jwks_from_2nd_call)
     )
 
@@ -148,7 +150,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       receive(:call).with(
         refresh: true,
         cache_key: anything(),
-        signing_key_provider: anything()
+        signing_key_provider: anything(),
+        authenticator_input: authenticator_input
       ).and_raise(fetch_signing_key_2nd_time_error)
     )
 
@@ -160,7 +163,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       receive(:call).with(
         refresh: false,
         cache_key: anything(),
-        signing_key_provider: anything()
+        signing_key_provider: anything(),
+        authenticator_input: authenticator_input
       ).and_return(jwks_from_1st_call)
     )
 
@@ -168,7 +172,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       receive(:call).with(
         refresh: true,
         cache_key: anything(),
-        signing_key_provider: anything()
+        signing_key_provider: anything(),
+        authenticator_input: authenticator_input
       ).and_return(jwks_from_2nd_call)
     )
 


### PR DESCRIPTION
### What does this PR do?
Refactor to authn-jwt according this rule of thamb
![image](https://user-images.githubusercontent.com/73157235/129916308-416da8a8-e80d-4d9e-9575-348c6120ec56.png)

Need to decide if really needed

### What ticket does this PR close?
ONYX-9742

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
