### PR TITLE
ONYX-12680: Remove redundant dependencies from IdentityFromURLProvider

### DIFF
--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_url_provider.rb
@@ -6,10 +6,6 @@ module Authentication
       # Provides jwt identity from information in the URL
       IdentityFromUrlProvider = CommandClass.new(
         dependencies: {
-          fetch_identity_path: Authentication::AuthnJwt::IdentityProviders::FetchIdentityPath.new,
-          fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-          check_authenticator_secret_exists: Authentication::Util::CheckAuthenticatorSecretExists.new,
-          add_prefix_to_identity: Authentication::AuthnJwt::IdentityProviders::AddPrefixToIdentity.new,
           logger: Rails.logger
         },
         inputs: %i[jwt_authenticator_input]


### PR DESCRIPTION
### What does this PR do?
Remove redundant dependencies for IdentityFromURLProvider

### What ticket does this PR close?
ONYX-12680

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [ ] The changes in this PR do not affect the Conjur API
