### PR TITLE
Update Changelog and Notices.txt for previous nokogiri bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Updated nokogiri to 1.12.5 in both Gemfile.lock and docs/Gemfile.lock to resolve 
+  [CVE-2021-41098](https://github.com/advisories/GHSA-2rr5-8q37-2w7h)
+  [cyberark/conjur#2376](https://github.com/cyberark/conjur/pull/2376)
+  [cyberark/conjur#2377](https://github.com/cyberark/conjur/pull/2377)
+
 ## [1.13.1] - 2021-09-13
 
 ### Fixed

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -42,7 +42,7 @@ Section 4: MIT
 >>> https://rubygems.org/gems/loofah/versions/2.5.0
 >>> https://rubygems.org/gems/mini_racer/versions/0.2.9
 >>> https://rubygems.org/gems/net-ldap/versions/0.16.2
->>> https://rubygems.org/gems/nokogiri/versions/1.11.1
+>>> https://rubygems.org/gems/nokogiri/versions/1.12.5
 >>> https://rubygems.org/gems/openid_connect/versions/1.2.0
 >>> https://rubygems.org/gems/rack-rewrite/versions/1.5.1
 >>> https://rubygems.org/gems/rails/versions/5.2.6
@@ -659,7 +659,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
->>> https://rubygems.org/gems/nokogiri/versions/1.11.1
+>>> https://rubygems.org/gems/nokogiri/versions/1.12.5
 
 Copyright 2008 -- 2018 by Aaron Patterson, Mike Dalessio, Charles Nutter, Sergio Arbeo, Patrick Mahoney, Yoko Harada, Akinori MUSHA, John Shahid, Lars Kanis
 


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
-Updates CHANGELOG and Notices.txt to reflect nokogiri bumps made in #2376 and #2377

### What ticket does this PR close?

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [X] The changes in this PR do not affect the Conjur API
