### PR TITLE
Fix another GKE flake

### DIFF
--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -2,18 +2,25 @@
 
 set -o pipefail
 
-# expects
-# GCLOUD_CLUSTER_NAME GCLOUD_ZONE GCLOUD_PROJECT_NAME GCLOUD_SERVICE_KEY
-# CONJUR_AUTHN_K8S_TEST_NAMESPACE CONJUR_AUTHN_K8S_TAG INVENTORY_TAG INVENTORY_BASE_TAG
-# LOCAL_DEV_VOLUME
-# to exist
-
+# Expects the following ENV vars to exist:
+#
+#    GCLOUD_CLUSTER_NAME
+#    GCLOUD_ZONE
+#    GCLOUD_PROJECT_NAME
+#    GCLOUD_SERVICE_KEY
+#    CONJUR_AUTHN_K8S_TEST_NAMESPACE
+#    CONJUR_AUTHN_K8S_TAG
+#    INVENTORY_TAG
+#    INVENTORY_BASE_TAG
+#    LOCAL_DEV_VOLUME
+#
 # PWD = /src (which is mapped via docker volume to ${WORKSPACE}/ci/authn-k8s)
 
-export LOCAL_DEV_VOLUME=$(cat <<- ENDOFLINE
+LOCAL_DEV_VOLUME=$(cat <<- ENDOFLINE
 emptyDir: {}
 ENDOFLINE
 )
+export LOCAL_DEV_VOLUME
 
 function finish {
   echo 'Finishing'
@@ -25,13 +32,15 @@ function finish {
       echo "Grabbing output from $pod_name"
       echo '-----'
       mkdir -p output
-      kubectl cp $pod_name:/opt/conjur-server/output output
+      kubectl cp "$pod_name:/opt/conjur-server/output" output
 
       echo "Logs from Conjur Pod $pod_name:"
-      kubectl logs $pod_name > output/gke-authn-k8s-logs.txt
+      kubectl logs "$pod_name" > output/gke-authn-k8s-logs.txt
 
       # Rails.logger writes the logs to the environment log file
-      kubectl exec $pod_name -- bash -c "cat /opt/conjur-server/log/test.log" >> output/gke-authn-k8s-logs.txt
+      kubectl exec "$pod_name" -- \
+        bash -c "cat /opt/conjur-server/log/test.log" >> \
+        output/gke-authn-k8s-logs.txt
 
       echo "Printing Logs from Conjur to the console"
       echo "==========================="
@@ -44,11 +53,14 @@ function finish {
       kubectl exec "${pod_name}" -- bash -c "pkill -f 'puma 5'"
 
       echo "Retrieving coverage report"
-      kubectl cp $pod_name:/opt/conjur-server/coverage/.resultset.json output/simplecov-resultset-authnk8s-gke.json
+      kubectl cp \
+        "$pod_name:/opt/conjur-server/coverage/.resultset.json" \
+        output/simplecov-resultset-authnk8s-gke.json
     fi
   } || {
     echo "Logs could not be extracted from $pod_name"
-    touch output/gke-authn-k8s-logs.txt  # so Jenkins artifact collection doesn't fail
+    # So Jenkins artifact collection doesn't fail.
+    touch output/gke-authn-k8s-logs.txt
   }
 
   echo "Removing namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE"
@@ -105,32 +117,42 @@ function renderResourceTemplates() {
 function createNamespace() {
   # Attempt to clean up old namespaces. If it wasn't created within minutes or
   # seconds, we will attempt to delete it.
-  old_namespaces=$(kubectl get namespaces | awk '$1 ~ /test-/ && $3 !~ /[m|s]/ { print $1; }')
-  [ ! -z "${old_namespaces}" ] && kubectl delete --ignore-not-found=true namespaces ${old_namespaces} || true
+  old_namespaces=$(
+    kubectl get namespaces | awk '$1 ~ /test-/ && $3 !~ /[m|s]/ { print $1; }'
+  )
 
-  kubectl create namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE
-  kubectl config set-context $(kubectl config current-context) --namespace=$CONJUR_AUTHN_K8S_TEST_NAMESPACE
+  if [ -n "${old_namespaces}" ]; then
+    kubectl delete --ignore-not-found=true namespaces "${old_namespaces}"
+  fi
+
+  kubectl create namespace "$CONJUR_AUTHN_K8S_TEST_NAMESPACE"
+  kubectl config set-context \
+    "$(kubectl config current-context)" \
+    "--namespace=$CONJUR_AUTHN_K8S_TEST_NAMESPACE"
 
   # Grant default service account permissions it needs for authn-k8s to:
   # 1) get + list various resources
   # 2) create + get pods/exec (to inject cert into app sidecar)
   kubectl apply -f dev/dev_conjur_authenticator_role.${TEMPLATE_TAG}yaml
   wait_for_it 1 "kubectl get clusterrole conjur-authenticator"
-  kubectl create -f dev/dev_conjur_authenticator_role_binding.${TEMPLATE_TAG}yaml
+  kubectl create \
+    -f dev/dev_conjur_authenticator_role_binding.${TEMPLATE_TAG}yaml
 }
 
 function pushDockerImages() {
-  gcloud docker -- push $CONJUR_AUTHN_K8S_TAG
-  gcloud docker -- push $CONJUR_TEST_AUTHN_K8S_TAG
-  gcloud docker -- push $INVENTORY_TAG
-  gcloud docker -- push $INVENTORY_BASE_TAG
-  gcloud docker -- push $NGINX_TAG
+  gcloud docker -- push "$CONJUR_AUTHN_K8S_TAG"
+  gcloud docker -- push "$CONJUR_TEST_AUTHN_K8S_TAG"
+  gcloud docker -- push "$INVENTORY_TAG"
+  gcloud docker -- push "$INVENTORY_BASE_TAG"
+  gcloud docker -- push "$NGINX_TAG"
 }
 
 function launchConjurMaster() {
   echo 'Launching Conjur master service'
 
-  sed -e "s#{{ CONJUR_AUTHN_K8S_TAG }}#$CONJUR_AUTHN_K8S_TAG#g" dev/dev_conjur.${TEMPLATE_TAG}yaml |
+  sed -e \
+    "s#{{ CONJUR_AUTHN_K8S_TAG }}#$CONJUR_AUTHN_K8S_TAG#g" \
+      dev/dev_conjur.${TEMPLATE_TAG}yaml |
     sed -e "s#{{ CONJUR_TEST_AUTHN_K8S_TAG }}#$CONJUR_TEST_AUTHN_K8S_TAG#g" |
     sed -e "s#{{ DATA_KEY }}#$(openssl rand -base64 32)#g" |
     sed -e "s#{{ CONJUR_AUTHN_K8S_TEST_NAMESPACE }}#$CONJUR_AUTHN_K8S_TEST_NAMESPACE#g" |
@@ -166,10 +188,15 @@ function launchConjurMaster() {
   kubectl wait --for=condition=Ready "pod/$conjur_pod" --timeout=5m
 
   # wait for the 'conjurctl server' entrypoint to finish
-  local wait_command="while ! curl --silent --head --fail localhost:80 > /dev/null; do sleep 1; done"
-  kubectl exec $conjur_pod -- bash -c "$wait_command"
+  local wait_command="while ! curl --silent --head --fail \
+    localhost:80 > /dev/null; do sleep 1; done"
+  kubectl exec "$conjur_pod" -- bash -c "$wait_command"
   
-  export API_KEY=$(kubectl exec $conjur_pod -- conjurctl account create cucumber | tail -n 1 | awk '{ print $NF }')
+  API_KEY=$(
+    kubectl exec "$conjur_pod" -- \
+      conjurctl account create cucumber | tail -n 1 | awk '{ print $NF }'
+  )
+  export API_KEY
 }
 
 function copyNginxSSLCert() {
@@ -178,8 +205,8 @@ function copyNginxSSLCert() {
   kubectl wait --for=condition=Ready "pod/$nginx_pod" --timeout=5m
   kubectl wait --for=condition=Ready "pod/$cucumber_pod" --timeout=5m
 
-  kubectl cp $nginx_pod:/etc/nginx/nginx.crt ./nginx.crt
-  kubectl cp ./nginx.crt $cucumber_pod:/opt/conjur-server/nginx.crt
+  kubectl cp "$nginx_pod:/etc/nginx/nginx.crt" ./nginx.crt
+  kubectl cp ./nginx.crt "$cucumber_pod:/opt/conjur-server/nginx.crt"
 }
 
 function copyConjurPolicies() {
@@ -195,16 +222,18 @@ function loadConjurPolicies() {
   # kubectl wait not needed -- already done in copyConjurPolicies.
   cli_pod=$(retrieve_pod conjur-cli)
   
-  kubectl exec $cli_pod -- conjur init -u conjur -a cucumber
+  kubectl exec "$cli_pod" -- conjur init -u conjur -a cucumber
   sleep 5
-  kubectl exec $cli_pod -- conjur authn login -u admin -p $API_KEY
+  kubectl exec "$cli_pod" -- conjur authn login -u admin -p "$API_KEY"
 
   # load policies
-  wait_for_it 300 "kubectl exec $cli_pod -- conjur policy load root /policies/policy.${TEMPLATE_TAG}yml"
+  wait_for_it 300 "kubectl exec $cli_pod -- \
+    conjur policy load root /policies/policy.${TEMPLATE_TAG}yml"
 
   # init ca certs
   # kubectl wait not needed -- already done in launchConjurMaster.
-  kubectl exec "$(retrieve_pod conjur-authn-k8s)" -- rake authn_k8s:ca_init["conjur/authn-k8s/minikube"]
+  kubectl exec "$(retrieve_pod conjur-authn-k8s)" -- \
+    rake authn_k8s:ca_init["conjur/authn-k8s/minikube"]
 }
 
 function launchInventoryServices() {
@@ -216,7 +245,8 @@ function launchInventoryServices() {
   # This yaml file has 2 pods
   kubectl create -f dev/dev_inventory_pod.${TEMPLATE_TAG}yaml
 
-  wait_for_it 300 "kubectl describe po inventory | grep Status: | grep -c Running | grep -q 5"
+  wait_for_it 300 "kubectl describe po inventory | \
+    grep Status: | grep -c Running | grep -q 5"
 }
 
 function runTests() {
@@ -224,7 +254,16 @@ function runTests() {
 
   conjurcmd mkdir -p /opt/conjur-server/output
 
-  echo "./bin/cucumber K8S_VERSION=1.7 PLATFORM=kubernetes --no-color --format pretty --format junit --out /opt/conjur-server/output -r ./cucumber/kubernetes/features/step_definitions/ -r ./cucumber/kubernetes/features/support/world.rb -r ./cucumber/kubernetes/features/support/hooks.rb -r ./cucumber/kubernetes/features/support/conjur_token.rb --tags ~@skip ./cucumber/kubernetes/features" | cucumbercmd -i bash
+  echo "./bin/cucumber \
+    K8S_VERSION=1.7 \
+    PLATFORM=kubernetes \
+    --no-color --format pretty --format junit \
+    --out /opt/conjur-server/output \
+    -r ./cucumber/kubernetes/features/step_definitions/ \
+    -r ./cucumber/kubernetes/features/support/world.rb \
+    -r ./cucumber/kubernetes/features/support/hooks.rb \
+    -r ./cucumber/kubernetes/features/support/conjur_token.rb \
+    --tags ~@skip ./cucumber/kubernetes/features" | cucumbercmd -i bash
 }
 
 retrieve_pod() {


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

We believe there is a GKE timing problem causing flaky failures.  In
particular, prior to this commit, we were not waiting to ensure the
conjur_cli pod was up before copying policy templates to it.  So we are
adding:

  kubectl wait --for=condition=Ready "pod/$cli_pod" --timeout=5m

to the copyConjurPolicies function. 

- _How should the reviewer approach this PR, especially if manual tests are required?_

Use commits tab.

### What ticket does this PR close?

N/A.  

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
