### PR TITLE
ONYX-12932 - Rename claim mapping variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2376](https://github.com/cyberark/conjur/pull/2376)
   [cyberark/conjur#2377](https://github.com/cyberark/conjur/pull/2377)
 
+### Changed
+- Changed claims mapping variable name ('mapping-claims' => 'claim-aliases').
+  [cyberark/conjur#2382](https://github.com/cyberark/conjur/pull/2382)
+
 ## [1.13.1] - 2021-09-13
 
 ### Fixed

--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -16,7 +16,7 @@ module Authentication
     IDENTITY_PATH_CHARACTER_DELIMITER = "/"
     IDENTITY_TYPE_HOST = "host"
     ENFORCED_CLAIMS_RESOURCE_NAME = "enforced-claims"
-    MAPPING_CLAIMS_RESOURCE_NAME = "mapping-claims"
+    MAPPING_CLAIMS_RESOURCE_NAME = "claim-aliases"
     AUDIENCE_RESOURCE_NAME = "audience"
     PRIVILEGE_AUTHENTICATE="authenticate"
     ISS_CLAIM_NAME = "iss"

--- a/app/domain/authentication/authn_jwt/input_validation/parse_mapping_claims.rb
+++ b/app/domain/authentication/authn_jwt/input_validation/parse_mapping_claims.rb
@@ -1,7 +1,7 @@
 module Authentication
   module AuthnJwt
     module InputValidation
-      # Parse mapping-claims secret value and return a validated mapping hashtable
+      # Parse claim-aliases secret value and return a validated mapping hashtable
       ParseMappingClaims ||= CommandClass.new(
         dependencies: {
           validate_claim_name: ValidateClaimName.new(

--- a/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/fetch_mapping_claims.rb
@@ -3,7 +3,7 @@ require 'command_class'
 module Authentication
   module AuthnJwt
     module RestrictionValidation
-      # Fetch the mapping claims from the JWT authenticator policy which enforce
+      # Fetch the claim aliases from the JWT authenticator policy which enforce
       # definition of annotations keys on JWT hosts 
       FetchMappingClaims = CommandClass.new(
         dependencies: {

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -516,30 +516,30 @@ module Errors
       )
 
       MappingClaimsMissingInput = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims: the mapping claims value is empty or was not found.",
+        msg: "Failed to parse claim aliases: the claim aliases value is empty or was not found.",
         code: "CONJ00109E"
       )
 
       MappingClaimsBlankOrEmpty = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims: one or more mapping statements are blank or empty " \
-             "'{0-mapping-claims-value}'.",
+        msg: "Failed to parse claim aliases: one or more mapping statements are blank or empty " \
+             "'{0-claim-aliases-value}'.",
         code: "CONJ00110E"
       )
 
       MappingClaimInvalidFormat = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims: the mapping claim value '{0-mapping-claim-value}' is in invalid format."\
+        msg: "Failed to parse claim aliases: the claim alias value '{0-claim-alias-value}' is in invalid format."\
              "The correct format is: 'annotation_name:claim_name'",
         code: "CONJ00111E"
       )
 
       MappingClaimInvalidClaimFormat = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims: one of the claims in the mapping claim value '{0-mapping-claim-value}' " \
+        msg: "Failed to parse claim aliases: one of the claims in the claim alias value '{0-claim-alias-value}' " \
              "is in an invalid format : {1-claim-verification-error}.",
         code: "CONJ00112E"
       )
 
       MappingClaimDuplicationError = ::Util::TrackableErrorClass.new(
-        msg: "Failed to parse mapping claims: {0-purpose} value '{1-claim-value}' appears more than once",
+        msg: "Failed to parse claim aliases: {0-purpose} value '{1-claim-value}' appears more than once",
         code: "CONJ00113E"
       )
 

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -621,12 +621,12 @@ module LogMessages
       )
 
       ParsingMappingClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Parsing mapping claims '{0-mapping-claims}'...",
+        msg: "Parsing claim aliases '{0-claim-aliases}'...",
         code: "CONJ00125D"
       )
 
       ParsedMappingClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Successfully parsed mapping claims '{0-mapping-claims-table}'",
+        msg: "Successfully parsed claim aliases '{0-claim-aliases-table}'",
         code: "CONJ00126D"
       )
 
@@ -636,17 +636,17 @@ module LogMessages
       )
 
       FetchingMappingClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Fetching mapping claims...",
+        msg: "Fetching claim aliases...",
         code: "CONJ00128D"
       )
 
       NotConfiguredMappingClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "No mapping claims configured",
+        msg: "No claim aliases configured",
         code: "CONJ00129D"
       )
 
       FetchedMappingClaims = ::Util::TrackableLogMessageClass.new(
-        msg: "Successfully fetched mapping claims '{0-mapping-claims}'",
+        msg: "Successfully fetched claim aliases '{0-claim-aliases}'",
         code: "CONJ00130I"
       )
 
@@ -676,7 +676,7 @@ module LogMessages
       )
 
       ValidatedMappingClaimsConfiguration = ::Util::TrackableLogMessageClass.new(
-        msg: "Successfully validated the configured mapping claims",
+        msg: "Successfully validated the configured claim aliases",
         code: "CONJ00136D"
       )
 

--- a/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
@@ -224,7 +224,7 @@ Feature: JWT Authenticator - Token Schema
     Given I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/enforced-claims
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -235,7 +235,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -315,7 +315,7 @@ Feature: JWT Authenticator - Token Schema
   Scenario: ONYX-10472 Unrelated mapping
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -327,7 +327,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -345,10 +345,10 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
-  Scenario: ONYX-10473 Mapping claims with subsequent annotation
+  Scenario: ONYX-10473 Claim aliases with subsequent annotation
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     
     - !host
       id: myapp
@@ -360,7 +360,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -405,9 +405,9 @@ Feature: JWT Authenticator - Token Schema
     """
     When I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I authenticate via authn-jwt with the JWT token
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
@@ -419,7 +419,7 @@ Feature: JWT Authenticator - Token Schema
   Scenario: ONYX-10705: enforced Claims and Mappings exist and host annotation are correct
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     - !variable conjur/authn-jwt/raw/enforced-claims
 
     - !host
@@ -431,7 +431,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I successfully set authn-jwt "enforced-claims" variable to value "ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
@@ -452,7 +452,7 @@ Feature: JWT Authenticator - Token Schema
     Given I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/enforced-claims
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -464,7 +464,7 @@ Feature: JWT Authenticator - Token Schema
       member: !host myapp
     """
     And I successfully set authn-jwt "enforced-claims" variable to value "ref"
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -482,7 +482,7 @@ Feature: JWT Authenticator - Token Schema
   Scenario: ONYX-10874 - Claim being mapped to another claim - 401 Error
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -493,7 +493,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "sub:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "sub:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -510,10 +510,10 @@ Feature: JWT Authenticator - Token Schema
     CONJ00049E Resource restriction 'sub' does not match with the corresponding value in the request
     """
 
-  Scenario: ONYX-10861 - Mapping claims configured but not populated - 401 Error
+  Scenario: ONYX-10861 - Claim aliases configured but not populated - 401 Error
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     - !variable conjur/authn-jwt/raw/enforced-claims
 
     - !host
@@ -538,14 +538,14 @@ Feature: JWT Authenticator - Token Schema
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/mapping-claims
+     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/claim-aliases
     """
 
   @sanity
   Scenario: ONYX-11117: Enforced Claims and Mappings with special allowed characters. Annotations are correct. 200 OK
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     - !variable conjur/authn-jwt/raw/enforced-claims
 
     - !host
@@ -559,7 +559,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "claim_ant:claim.ant..., _:claim_name"
+    And I successfully set authn-jwt "claim-aliases" variable to value "claim_ant:claim.ant..., _:claim_name"
     And I successfully set authn-jwt "enforced-claims" variable to value "claim.name, claim.ant..."
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
@@ -581,7 +581,7 @@ Feature: JWT Authenticator - Token Schema
   Scenario Outline: ONYX-10873 - Broken claims mapping - 401 Error
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -593,7 +593,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "<mapping>"
+    And I successfully set authn-jwt "claim-aliases" variable to value "<aliases>"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -610,14 +610,14 @@ Feature: JWT Authenticator - Token Schema
     <err>
     """
     Examples:
-      | mapping                     | err                                                                             |
-      |   branch: ref, branch:sub   | CONJ00113E Failed to parse mapping claims: annotation name value 'branch' appears more than once |
-      |   branch: sub, job: sub     | CONJ00113E Failed to parse mapping claims: claim name value 'sub' appears more than once   |
+      | aliases                     | err                                                                             |
+      |   branch: ref, branch:sub   | CONJ00113E Failed to parse claim aliases: annotation name value 'branch' appears more than once |
+      |   branch: sub, job: sub     | CONJ00113E Failed to parse claim aliases: claim name value 'sub' appears more than once   |
 
   Scenario Outline: ONYX-10858 - Standard claim in mapping - 401 Error
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -629,7 +629,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "<mapping>"
+    And I successfully set authn-jwt "claim-aliases" variable to value "<mapping>"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -681,10 +681,10 @@ Feature: JWT Authenticator - Token Schema
     CONJ00104E Failed to validate claim: claim name '%@^#[{]}$~=-+_?.><&^@*@#*sdhj812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*$)'.>
     """
 
-  Scenario: ONYX-10863 - Mapping claims invalid variable - 401 Error
+  Scenario: ONYX-10863 - Claim aliases invalid variable - 401 Error
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -695,7 +695,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "aaa: %@^#&^[{]}$~=-+_?.><812ehd"
+    And I successfully set authn-jwt "claim-aliases" variable to value "aaa: %@^#&^[{]}$~=-+_?.><812ehd"
     And I permit host "myapp" to "execute" it
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
@@ -738,9 +738,9 @@ Feature: JWT Authenticator - Token Schema
     And the HTTP response status code is 200
     And I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I save my place in the audit log file
     And I authenticate via authn-jwt with the JWT token
     And the HTTP response status code is 401
@@ -789,7 +789,7 @@ Feature: JWT Authenticator - Token Schema
   Scenario: ONYX-10896:  Authn JWT - Complex Case - Changing Mapping after host configuration
     Given I extend the policy with:
     """
-    - !variable conjur/authn-jwt/raw/mapping-claims
+    - !variable conjur/authn-jwt/raw/claim-aliases
 
     - !host
       id: myapp
@@ -800,7 +800,7 @@ Feature: JWT Authenticator - Token Schema
       role: !group conjur/authn-jwt/raw/hosts
       member: !host myapp
     """
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
@@ -810,7 +810,7 @@ Feature: JWT Authenticator - Token Schema
     """
     And I authenticate via authn-jwt with the JWT token
     And the HTTP response status code is 200
-    When I successfully set authn-jwt "mapping-claims" variable to value "job:ref"
+    When I successfully set authn-jwt "claim-aliases" variable to value "job:ref"
     And I save my place in the audit log file
     And I authenticate via authn-jwt with the JWT token
     And the HTTP response status code is 401

--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -803,7 +803,7 @@ Feature: JWT Authenticator - Status Check
         id: enforced-claims
 
       - !variable
-        id: mapping-claims
+        id: claim-aliases
 
       - !group users
 
@@ -837,7 +837,7 @@ Feature: JWT Authenticator - Status Check
     And I am the super-user
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-configuration/RS256" in service "raw"
     And I successfully set authn-jwt "token-app-property" variable to value "user"
-    And I successfully set authn-jwt "mapping-claims" variable to value "branch:ref"
+    And I successfully set authn-jwt "claim-aliases" variable to value "branch:ref"
     And I successfully set authn-jwt "enforced-claims" variable to value "ref"
     And I login as "alice"
     And I save my place in the log file
@@ -903,7 +903,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/audience>"
 
-  Scenario: ONYX-10875: mapping-claims configured but secret not populated, 500 Error
+  Scenario: ONYX-10875: claim-aliases configured but secret not populated, 500 Error
     Given I load a policy:
     """
     - !policy
@@ -925,7 +925,7 @@ Feature: JWT Authenticator - Status Check
         id: token-app-property
 
       - !variable
-        id: mapping-claims
+        id: claim-aliases
 
       - !group users
 
@@ -963,7 +963,7 @@ Feature: JWT Authenticator - Status Check
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/mapping-claims>"
+    And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/claim-aliases>"
 
   Scenario: ONYX-10876: enforced-claims configured but secret not populated, 500 Error
     Given I load a policy:
@@ -1090,7 +1090,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*$)"
 
-  Scenario: ONYX-10958: mapping-claims configured with invalid value, 500 Error
+  Scenario: ONYX-10958: claim-aliases configured with invalid value, 500 Error
     Given I load a policy:
     """
     - !policy
@@ -1112,7 +1112,7 @@ Feature: JWT Authenticator - Status Check
         id: token-app-property
 
       - !variable
-        id: mapping-claims
+        id: claim-aliases
 
       - !group users
 
@@ -1146,7 +1146,7 @@ Feature: JWT Authenticator - Status Check
     And I am the super-user
     And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
     And I successfully set authn-jwt "token-app-property" variable to value "user"
-    And I successfully set authn-jwt "mapping-claims" variable to value "SDsas213sda!!A!!$$@#$# :$@$@#sdasdasdq23asd32rdf"
+    And I successfully set authn-jwt "claim-aliases" variable to value "SDsas213sda!!A!!$$@#$# :$@$@#sdasdasdq23asd32rdf"
     And I login as "alice"
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/fetch_mapping_claims_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMappingCla
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
   #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
 
-  context "'mapping-claims' variable is configured in authenticator policy" do
+  context "'claim-aliases' variable is configured in authenticator policy" do
     context "with empty variable value" do
       subject do
         ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
@@ -123,13 +123,13 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMappingCla
         )
       end
 
-      it "returns parsed mapping claims hashtable" do
+      it "returns parsed claim aliases hashtable" do
         expect(subject).to eql(mapping_claims_valid_parsed_secret_value)
       end
     end
   end
 
-  context "'mapping-claims' variable is not configured in authenticator policy" do
+  context "'claim-aliases' variable is not configured in authenticator policy" do
     subject do
       ::Authentication::AuthnJwt::RestrictionValidation::FetchMappingClaims.new(
         check_authenticator_secret_exists: mocked_authenticator_secret_not_exists
@@ -138,7 +138,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::FetchMappingCla
       )
     end
 
-    it "returns an empty mapping claims hashtable" do
+    it "returns an empty claim aliases hashtable" do
       expect(subject).to eql({})
     end
   end

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
   let(:mocked_invalid_fetch_issuer_value) { double("Mocked invalid fetch issuer value")  }
   let(:mocked_invalid_fetch_audience_value) { double("Mocked invalid audience issuer value")  }
   let(:mocked_invalid_fetch_enforced_claims) { double("Mocked invalid fetch enforced claims value")  }
-  let(:mocked_invalid_fetch_mapping_claims) { double("Mocked invalid fetch mapping claims value")  }
+  let(:mocked_invalid_fetch_mapping_claims) { double("Mocked invalid fetch claim aliases value")  }
   let(:mocked_valid_identity_from_decoded_token_provider) { double("Mocked valid identity from decoded token provider")  }
   let(:mocked_valid_identity_configured_properly) { double("Mocked valid identity configured properly")  }
   let(:mocked_invalid_identity_configured_properly) { double("Mocked invalid identity configured properly")  }
@@ -48,7 +48,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
   let(:fetch_issuer_configuration_is_invalid_error) { "Fetch issuer configuration is invalid" }
   let(:fetch_audience_configuration_is_invalid_error) { "Fetch audience configuration is invalid" }
   let(:fetch_enforced_claims_configuration_is_invalid_error) { "Fetch enforced claims configuration is invalid" }
-  let(:fetch_mapping_claims_configuration_is_invalid_error) { "Fetch mapping claims configuration is invalid" }
+  let(:fetch_mapping_claims_configuration_is_invalid_error) { "Fetch claim aliases configuration is invalid" }
   let(:webservice_is_not_whitelisted_error) { "Webservice is not whitelisted" }
   let(:user_cant_access_webservice_error) { "User cant access webservice" }
   let(:webservice_does_not_exist_error) { "Webservice does not exist" }
@@ -411,7 +411,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
         end
       end
 
-      context "mapping claims is not configured properly" do
+      context "claim aliases is not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
             fetch_signing_key: mocked_valid_fetch_signing_key,


### PR DESCRIPTION
### What does this PR do?

This change is a result of field CS request. Based on #2330.

- Renamed user facing policy-related variable. 
  Previous variable name: `mapping-claims`
  New variable name: `claim-aliases`

Please note that only user facing interface & automatic tests were changed:
- Policy variable name
- Log messages
- Error messages
- Test file were ammended to support new variable name

**Internal implementation variable names aren't changed yet.**

### What ticket does this PR close?
Resolves ONYX-12932

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
