### PR TITLE
Push version tags to internal docker registry

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -73,6 +73,12 @@ elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
   # been supplied. Publish to the specified registry.
 
   # Push the VERSION-SHA tagged images to our internal registry
+  v="$(< VERSION)"
+  tag_and_push "${v}-${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
+  tag_and_push "${v}-${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
+  tag_and_push "${v}-${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"
+
+  # Push SHA only tagged images to our internal registry
   tag_and_push "${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
   tag_and_push "${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
   tag_and_push "${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"
@@ -82,10 +88,14 @@ elif [[ ! -z "${TAG_NAME:-}" ]]; then
   # This is running on a tag-triggered build, and public images should be published
   TAG="${TAG_NAME//"v"}"
 
-  # Push latest, 1.x.y, 1.x, and 1 to DockerHub
+  # Push latest, 1.x.y, 1.x, and 1 to DockerHub and internal registry
   readarray -t prefix_versions < <(gen_versions "${TAG}")
   for v in latest "${TAG}" "${prefix_versions[@]}"; do
+    # Push to Dockerhub
     tag_and_push "${v}" "${LOCAL_IMAGE}" "${IMAGE_NAME}"
+    # Push to Internal Registry - this is so the current release tags
+    # are also present in the internal registry.
+    tag_and_push "${v}" "${LOCAL_IMAGE}" "registry.tld/conjur"
   done
 
   # Publish only the tag version to the Redhat container registry


### PR DESCRIPTION
### What does this PR do?
Currently the images pushed to the internal registry are tagged
only by sha (despite the code comment to the contrary). This makes using
images from the internal registry difficult unless you happen to know
the sha you need.

This commit changes the internal registry tag format from ${SHA} to
${version}-${SHA}.

It also adds a push to the section that creates the version tags in
dockerhub so they are also created in the internal registry.

### What ticket does this PR close?
Related: conjurinc/ops#823

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

#### API Changes
- [ ] The [OpenAPI spec](https://github.com/cyberark/conjur-openapi-spec) has been updated to meet new API changes (or an issue has been opened), or
- [x] The changes in this PR do not affect the Conjur API
