### PR TITLE
Add 'default' account when no name is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Create default account when no account is specified in `conjurctl account create`.
+  [cyberark/conjur#2388](https://github.com/cyberark/conjur/pull/2388)
+
 ### Security
 - GCP Authenticator: When defining the host using the instance-name annotation,
   you now need to define at least one additional annotation.

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -130,12 +130,13 @@ command :account do |cgrp|
     be read from STDIN. If the flag is not provided, the "admin" user API key
     will be outputted to STDOUT.
 
-    The 'name' flag or command argument must be present. It will specify the 
-    name of the account that will be created.
+    The 'name' flag or command argument will specify the name of the account
+    that will be created. If it is not provided, the account name will be
+    'default'.
 
     Example:
 
-    $ conjurctl account create [--password-from-stdin] --name myorg
+    $ conjurctl account create [--password-from-stdin] [--name myorg]
   DESC
   cgrp.arg(:name, :optional)
   cgrp.command :create do |c|

--- a/bin/conjur-cli/commands/account/create.rb
+++ b/bin/conjur-cli/commands/account/create.rb
@@ -17,7 +17,8 @@ module Commands
       ]
     ) do
       def call
-        raise "No account name was provided" unless @account
+        # Create a new account named 'default' if no name is provided
+        @account ||= 'default'
 
         # Ensure the database is available
         @connect_database.call

--- a/spec/conjurctl/account_spec.rb
+++ b/spec/conjurctl/account_spec.rb
@@ -6,11 +6,14 @@ describe "account" do
     system("conjurctl account delete #{name}")
   end
 
-  it "no account name provided" do
-    _, stderr_str, = Open3.capture3(
+  it "creates default account when no name provided" do
+    stdout_str, = Open3.capture3(
       "conjurctl account create"
     )
-    expect(stderr_str).to include("No account name was provided")
+    expect(stdout_str).to include("API key for admin")
+    expect(Slosilo["authn:default"]).to be
+    expect(Role["default:user:admin"]).to be
+    delete_account("default")
   end
 
   context "create with name demo" do


### PR DESCRIPTION
### What does this PR do?
- `conjurctl account create` without a name argument will create an account with the name "default".

### What ticket does this PR close?
Resolves #2082
[ONYX-13320](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13320)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes

#### Documentation
- [x] Docs were updated in this PR - **updated command description in CLI**

#### API Changes
- [x] The changes in this PR do not affect the Conjur API
