### PR TITLE
Align changelog with 1.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create default account when no account is specified in `conjurctl account create`.
   [cyberark/conjur#2388](https://github.com/cyberark/conjur/pull/2388)
 
+### Changed
+- Changed claims mapping variable name ('mapping-claims' => 'claim-aliases').
+  [cyberark/conjur#2382](https://github.com/cyberark/conjur/pull/2382)
+
+## [1.13.2] - 2021-10-13
+
 ### Security
 - GCP Authenticator: When defining the host using the instance-name annotation,
   you now need to define at least one additional annotation.
   [cyberark/ONYX-9442](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-9442)
-- Updated nokogiri to 1.12.5 in both Gemfile.lock and docs/Gemfile.lock to resolve 
+- Updated nokogiri to 1.12.5 in both Gemfile.lock and docs/Gemfile.lock to resolve
   [CVE-2021-41098](https://github.com/advisories/GHSA-2rr5-8q37-2w7h)
   [cyberark/conjur#2376](https://github.com/cyberark/conjur/pull/2376)
   [cyberark/conjur#2377](https://github.com/cyberark/conjur/pull/2377)
-
-### Changed
-- Changed claims mapping variable name ('mapping-claims' => 'claim-aliases').
-  [cyberark/conjur#2382](https://github.com/cyberark/conjur/pull/2382)
 
 ## [1.13.1] - 2021-09-13
 
@@ -714,7 +716,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/conjur/compare/v1.13.1...HEAD
+[Unreleased]: https://github.com/cyberark/conjur/compare/v1.13.2...HEAD
+[1.13.2]: https://github.com/cyberark/conjur/compare/v1.13.1...v1.13.2
 [1.13.1]: https://github.com/cyberark/conjur/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/cyberark/conjur/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/cyberark/conjur/compare/v1.11.7...v1.12.0


### PR DESCRIPTION
### Desired Outcome

Changelog align with actual state: 1.13.2 has been released

### Implemented Changes

Add 1.13.2 section to the changelog and move relevant changes into the section.

### Definition of Done

Changelog is aligned with releases

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
