### PR TITLE
[POC] Enable authenticator host schema validation

### DIFF
--- a/app/domain/authentication/Readme.md
+++ b/app/domain/authentication/Readme.md
@@ -1,0 +1,65 @@
+# Building Authenticators
+
+## Overview
+
+Coming soon
+
+## Details
+
+### Adding Validation
+
+Host annotations are commonly used to map a Conjur Host to a remote environments identity attributes. For example:
+
+```yml
+# Authn-K8s host
+- !host
+  id: my-k8s-host
+  annotations:
+    authn-k8s/namespace: test-app-namespace
+    authn-k8s/service-account: test-app-sa
+
+# Authn-Azure host
+- !host
+  id: my-azure-host
+  annotations:
+    authn-azure/subscription-id: test-app-subscription-id
+    authn-azure/resource-group: test-app-resource-group
+```
+
+Host Annotation Validation can be added to any authenticator with two steps:
+
+1. Add an `authn-type` annotation to the host. The annotation value is a lower-case string of the annotation name.  For example:
+    ```yml
+    # Authn-K8s host
+    - !host
+      id: my-k8s-host
+      annotations:
+        authn-type: authn-k8s
+        authn-k8s/namespace: test-app-namespace
+        authn-k8s/service-account: test-app-sa
+
+    # Authn-Azure host
+    - !host
+      id: my-azure-host
+      annotations:
+        authn-type: authn-azure
+        authn-azure/subscription-id: test-app-subscription-id
+        authn-azure/resource-group: test-app-resource-group
+    ```
+1. Add a `Validations` class in the authenticator with a `validate_host` method:
+    ```ruby
+    module Authentication
+      module <Authenticator Namespace>
+        class Validations
+
+          # The `annotations` arguement is a hash of the host's
+          # annotations prefixed with the authenticator name.
+          # [Returns] If there are errors in the schema, the error
+          # messages should be returned in an array.
+          def validate_host(annotations)
+          end
+
+        end
+      end
+    end
+    ```

--- a/app/domain/authentication/authn_k8s/validations.rb
+++ b/app/domain/authentication/authn_k8s/validations.rb
@@ -4,10 +4,12 @@ module Authentication
   module AuthnK8s
     class Validations
 
-      def validate_host(annotations:, errors:)
-        %w[namespace service-account].each do |attr|
-          unless annotations.keys.include?(attr)
-            errors << "The annotation authn-k8s/#{attr} is required for an authn-k8s host"
+      def validate_host(annotations)
+        [].tap do |errors|
+          %w[namespace service-account].each do |attr|
+            unless annotations.keys.include?(attr)
+              errors << "The annotation authn-k8s/#{attr} is required for an authn-k8s host"
+            end
           end
         end
       end

--- a/app/domain/authentication/authn_k8s/validations.rb
+++ b/app/domain/authentication/authn_k8s/validations.rb
@@ -1,0 +1,17 @@
+# Provides schema validation for authenticator specific Conjur Resources
+
+module Authentication
+  module AuthnK8s
+    class Validations
+
+      def validate_host(annotations:, errors:)
+        %w[namespace service-account].each do |attr|
+          unless annotations.keys.include?(attr)
+            errors << "The annotation authn-k8s/#{attr} is required for an authn-k8s host"
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/dev/sample-policies/validation/Readme.md
+++ b/dev/sample-policies/validation/Readme.md
@@ -1,0 +1,10 @@
+# Feature: Validation Schema PoC
+
+This is sample policy code specifically for the Schema validation PoC.
+
+## Installion
+
+```sh
+conjur policy load root sample-policies/validation/root.yaml
+conjur policy load testing/foo sample-policies/validation/host.yaml
+```

--- a/dev/sample-policies/validation/host.yaml
+++ b/dev/sample-policies/validation/host.yaml
@@ -1,0 +1,7 @@
+- !layer
+- !host
+  id: my-host
+  annotations:
+    type: authn-k8s
+    authn-k8s/namespace: test-app-namespace
+    authn-k8s/service-account: test-app-sa

--- a/dev/sample-policies/validation/host.yaml
+++ b/dev/sample-policies/validation/host.yaml
@@ -2,6 +2,6 @@
 - !host
   id: my-host
   annotations:
-    type: authn-k8s
+    authn-type: authn-k8s
     authn-k8s/namespace: test-app-namespace
     authn-k8s/service-account: test-app-sa

--- a/dev/sample-policies/validation/host.yaml
+++ b/dev/sample-policies/validation/host.yaml
@@ -2,6 +2,5 @@
 - !host
   id: my-host
   annotations:
-    authn-type: authn-k8s
     authn-k8s/namespace: test-app-namespace
     authn-k8s/service-account: test-app-sa

--- a/dev/sample-policies/validation/root.yaml
+++ b/dev/sample-policies/validation/root.yaml
@@ -1,0 +1,5 @@
+- !policy
+  id: testing
+  body:
+    - !policy foo
+    - !policy bar


### PR DESCRIPTION
### Desired Outcome

Provide a mechanism to allow Authenticator developers to define and validate the annotations specific to that authenticator.

### Implemented Changes

This change works by adding an annotation attribute `type` which allows the host to be validated.  For example, to enable Authn-K8s host validation, we'd add the `type: authn-k8s` annotation:

```yml
- !host
  id: my-host
  annotations:
    authn-type: authn-k8s
    authn-k8s/namespace: test-app-namespace
    authn-k8s/service-account: test-app-sa
```

We can then add a `Validations` class in the `AuthnK8s` namespace to validate the host:

```ruby
# app/domain/authentication/authn_k8s/validations.rb
module Authentication
  module AuthnK8s
    class Validations

      def validate_host(annotations)
        [].tap do |errors|
          %w[namespace service-account].each do |attr|
            unless annotations.keys.include?(attr)
              errors << "The annotation authn-k8s/#{attr} is required for an authn-k8s host"
            end
          end
        end
      end

    end
  end
end
```