### PR TITLE
ONYX-13640 - Nested annotations integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2388](https://github.com/cyberark/conjur/pull/2388)
 - JWT authenticator `token-app-property` value supports nested claims.
   [cyberark/conjur#2397](https://github.com/cyberark/conjur/pull/2397)
+- JWT authenticator host annotations support nested claims.
+  [cyberark/conjur#2404](https://github.com/cyberark/conjur/pull/2404)
 
 ### Changed
 - Changed claims mapping variable name ('mapping-claims' => 'claim-aliases').

--- a/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
@@ -7,10 +7,12 @@ module Authentication
         def initialize(
           decoded_token:,
           aliased_claims:,
+          parse_claim_path: Authentication::AuthnJwt::ParseClaimPath.new,
           logger: Rails.logger
         )
           @decoded_token = decoded_token
           @aliased_claims = aliased_claims
+          @parse_claim_path = parse_claim_path
           @logger = logger
         end
 
@@ -23,12 +25,11 @@ module Authentication
             raise Errors::Authentication::ResourceRestrictions::EmptyAnnotationGiven, annotation_name
           end
 
-          unless @decoded_token.key?(claim_name)
-            raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
-                  claim_name_for_error(annotation_name, claim_name)
-          end
+          claim_value = @decoded_token.dig(*parsed_claim_path(claim_name))
+          raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
+                claim_name_for_error(annotation_name, claim_name) if claim_value.nil?
 
-          @decoded_token.fetch(claim_name) == restriction_value
+          restriction_value == claim_value
         end
 
         private
@@ -44,6 +45,10 @@ module Authentication
           return annotation_name if annotation_name == claim_name
 
           "#{claim_name} (annotation: #{annotation_name})"
+        end
+
+        def parsed_claim_path(claim_path)
+          @parse_claim_path.call(claim: claim_path)
         end
       end
     end

--- a/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
+++ b/app/domain/authentication/authn_jwt/restriction_validation/validate_restrictions_one_to_one.rb
@@ -26,8 +26,10 @@ module Authentication
           end
 
           claim_value = @decoded_token.dig(*parsed_claim_path(claim_name))
-          raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
-                claim_name_for_error(annotation_name, claim_name) if claim_value.nil?
+          if claim_value.nil?
+            raise Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
+                  claim_name_for_error(annotation_name, claim_name)
+          end
 
           restriction_value == claim_value
         end


### PR DESCRIPTION
### Desired Outcome

authn-jwt related host annotations supports nested claims.

### Implemented Changes

`ValidateRestrictionsOneToOne` is using [Hash.dig](https://apidock.com/ruby/Hash/dig) function instead of direct key access to json object.

### Connected Issue/Story

Follows design #2394
[ONYX-13640](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13640)

### Definition of Done

- [x] Desired outcome achieved
- [x] New code has appropriate UT and System tests

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [X] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
