### PR TITLE
Push the edge builds into the internal registry

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -67,6 +67,12 @@ if [[ "${PUBLISH_EDGE}" = true ]]; then
   # This script is running to publish the edge tagged image to DockerHub
   tag_and_push "edge" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}${IMAGE_NAME}"
 
+  # Push the edge build into the internal registry
+  tag_and_push "edge" "${LOCAL_IMAGE}" "registry.tld/conjur"
+
+  # Push the UBI edge build into the internal registry
+  tag_and_push "edge" "conjur-ubi:${TAG}" "registry.tld/conjur-ubi"
+
 elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
 
   # This is not running on a tag-triggered build, and a registry prefix has
@@ -96,6 +102,7 @@ elif [[ ! -z "${TAG_NAME:-}" ]]; then
     # Push to Internal Registry - this is so the current release tags
     # are also present in the internal registry.
     tag_and_push "${v}" "${LOCAL_IMAGE}" "registry.tld/conjur"
+    tag_and_push "${v}" "conjur-ubi:${TAG}" "registry.tld/conjur-ubi"
   done
 
   # Publish only the tag version to the Redhat container registry


### PR DESCRIPTION
### Desired Outcome

The outcome of this PR is that the `edge` conjur builds for the debian and UBI based images are available
in the internal CyberArk registry.

### Implemented Changes

This PR updates the `push-image.sh` script to push the edge builds for `conjur` and `conjur-ubi` into the internal registry in addition to DockerHub.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-12853](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-12853)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
