### PR TITLE
Add jq to Dockerfile.ubi

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -21,6 +21,7 @@ RUN INSTALL_PKGS="gcc \
                   gcc-c++ \
                   git \
                   glibc-devel \
+                  jq \
                   libxml2-devel \
                   libxslt-devel \
                   make \


### PR DESCRIPTION
The conjur image used by the operator uses jq

### Desired Outcome

jq needs to be installed on the conjur UBI image to support the opertaor.

### Implemented Changes

jq package was added to Dockerfile.ubi file.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
