### PR TITLE
Update tagging reference for the Conjur UBI image

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -102,7 +102,7 @@ elif [[ ! -z "${TAG_NAME:-}" ]]; then
     # Push to Internal Registry - this is so the current release tags
     # are also present in the internal registry.
     tag_and_push "${v}" "${LOCAL_IMAGE}" "registry.tld/conjur"
-    tag_and_push "${v}" "conjur-ubi:${TAG}" "registry.tld/conjur-ubi"
+    tag_and_push "${v}" "${RH_LOCAL_IMAGE}" "registry.tld/conjur-ubi"
   done
 
   # Publish only the tag version to the Redhat container registry


### PR DESCRIPTION
This PR updates the reference to Conjur UBI image to version it correctly during tag builds.