### PR TITLE
ONYX-11560 - Replace "+" in tag by "_" while pushing images into internal registry

### DIFF
--- a/push-image.sh
+++ b/push-image.sh
@@ -79,7 +79,7 @@ elif [[ ! -z "${REGISTRY_PREFIX}" ]]; then
   # been supplied. Publish to the specified registry.
 
   # Push the VERSION-SHA tagged images to our internal registry
-  v="$(< VERSION)"
+  v="$(tr "+" "_" < VERSION)"
   tag_and_push "${v}-${TAG}" "${LOCAL_IMAGE}" "${REGISTRY_PREFIX}/conjur"
   tag_and_push "${v}-${TAG}" "conjur-test:${TAG}" "${REGISTRY_PREFIX}/conjur-test"
   tag_and_push "${v}-${TAG}" "conjur-ubi:${TAG}" "${REGISTRY_PREFIX}/conjur-ubi"


### PR DESCRIPTION
### Desired Outcome

Build is pushing docker images with version in tag when version number contains plus sign `+`.

### Implemented Changes

Replace `+` by `_` in the version before using it as a docker image tag.

### Connected Issue/Story

[ONYX-11560](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-11560)

### Definition of Done

- [X] Desired outcome is achieved.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
