### PR TITLE
Use latest base images for all scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Bump cyberark base images from 1.0.4 to 1.0.5
+  [#2418](https://github.com/cyberark/conjur/pull/2418)
+
 ## [1.14.1] - 2021-11-05
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:1.0.4
+FROM cyberark/ubuntu-ruby-fips:1.0.5
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PORT=80 \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,5 @@
 # Conjur Base Image (UBI)
-FROM cyberark/ubi-ruby-fips:1.0.4
+FROM cyberark/ubi-ruby-fips:1.0.5
 
 EXPOSE 8080
 ARG VERSION

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM cyberark/phusion-ruby-fips:latest
+FROM cyberark/phusion-ruby-fips:1.0.5
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     build-essential \

--- a/gems/policy-parser/Dockerfile.test
+++ b/gems/policy-parser/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:latest
+FROM cyberark/ubuntu-ruby-fips:1.0.5
 
 RUN mkdir /src
 WORKDIR /src

--- a/gems/policy-parser/docker-compose.yml
+++ b/gems/policy-parser/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   dev:
-    image: cyberark/ubuntu-ruby-fips:20.04-latest
+    image: cyberark/ubuntu-ruby-fips:1.0.5
     working_dir: /src
     volumes:
       - .:/src


### PR DESCRIPTION
### Desired Outcome

Conjur is using latests base images as base images of all docker image build processes.

### Implemented Changes

Dockerfile, Dockerfile.ubi and policy dockerc-compose are switched to latests base image.

### Connected Issue/Story

Part of CE 12.4 release process [ONYX-11563](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-11563)

### Definition of Done

- [X] Desired outcome is achieved

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
