### PR TITLE
Add check to not allow password updates for hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump cyberark base images from 1.0.4 to 1.0.5
   [#2418](https://github.com/cyberark/conjur/pull/2418)
 
+### Fixed
+- Added check to stop hosts from setting passwords [#1920](https://github/cyberark/conjur/issues/1920)
+
 ## [1.14.1] - 2021-11-05
 
 ### Fixed

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -37,6 +37,7 @@ class CredentialsController < ApplicationController
   # This method requires a PUT request. The new password is in the request body.
   def update_password
     password = request.body.read
+    raise Exceptions::Forbidden if @role.resource.kind == "host"
 
     Commands::Credentials::ChangePassword.new.call(
       role: @role,

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -35,12 +35,18 @@ end
 
 shared_context "create user" do
   def create_user(login)
-    Role.create(role_id: "rspec:user:#{login}").tap do |role|
+    id = "rspec:user:#{login}"
+    user_role = Role.create(role_id: id).tap do |role|
       options = { role: role }
       options[:password] = password if defined?(password) && password
       Credentials.create(options)
       role.reload
     end
+    Resource.create(resource_id: id, owner_id: id).tap do |resource|
+      resource.reload
+    end
+
+    return user_role
   end
 
   let(:login) { "default-login" }
@@ -49,4 +55,35 @@ shared_context "create user" do
     create_user(login)
   }
   let(:api_key) { the_user.credentials.api_key }
+end
+
+shared_context "create host" do
+  def create_host(host_login)
+    id = "rspec:host:#{host_login}"
+    host_role = Role.create(role_id: id).tap do |role|
+      options = { role: role }
+      Credentials.create(options)
+      role.reload
+    end
+    Resource.create(resource_id: id, owner_id: id).tap do |resource|
+      resource.reload
+      host_role.reload
+    end
+
+    return host_role
+  end
+
+  let(:host_login) { "default-host-login" }
+  let(:host_api_key) { the_host.credentials.api_key }
+end
+
+shared_context "host authenticate Basic" do
+  let(:params) { { account: host_account, authenticator: authenticator } }
+  let(:basic_auth_header) {
+    basic = Base64.strict_encode64(['host/' + host_login, basic_password].join(':'))
+    "Basic #{basic}"
+  }
+  let(:request_env) do
+    { 'HTTP_AUTHORIZATION' => basic_auth_header }
+  end
 end


### PR DESCRIPTION
### Desired Outcome

Fix to not allow hosts to update a password since they aren't supposed to have passwords.

### Implemented Changes

Added check if the resource of the role is a host - then throw error

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
