### PR TITLE
Fix login error message to match audit error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+- Failed Login now writes the error code in the log
+  [#2424](https://github.com/cyberark/conjur/pull/2424)
 - Bump cyberark base images from 1.0.5 to 1.0.6
   [#2420](https://github.com/cyberark/conjur/pull/2420)
 - Bump cyberark base images from 1.0.4 to 1.0.5

--- a/app/controllers/concerns/basic_authenticator.rb
+++ b/app/controllers/concerns/basic_authenticator.rb
@@ -15,12 +15,12 @@ module BasicAuthenticator
         authentication.authenticated_role = ::Role[response.role_id]
         authentication.basic_user         = true
       end
-    rescue Errors::Authentication::InvalidCredentials
-      raise ApplicationController::Unauthorized, "Invalid username or password"
-    rescue Errors::Authentication::InvalidOrigin
-      raise ApplicationController::Forbidden, "User is not authorized to login from the current origin"
-    rescue Errors::Authentication::Security::RoleNotAuthorizedOnResource
-      raise ApplicationController::Forbidden, "User is not authorized to login to Conjur"
+    rescue Errors::Authentication::InvalidCredentials => e
+      raise ApplicationController::Unauthorized, e.message
+    rescue Errors::Authentication::InvalidOrigin => e
+      raise ApplicationController::Forbidden, e.message
+    rescue Errors::Authentication::Security::RoleNotAuthorizedOnResource => e
+      raise ApplicationController::Forbidden, e.message
     end
   end
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -50,7 +50,7 @@ module Errors
     )
 
     InvalidOrigin = ::Util::TrackableErrorClass.new(
-      msg: "Invalid origin",
+      msg: "User is not authorized to login from the current origin",
       code: "CONJ00003E"
     )
 


### PR DESCRIPTION
### Desired Outcome

In login, some failures are logged without their error code, whilst audit does contain error code.

### Implemented Changes

When replacing internal raised error with response error, use the internal error message.

### Connected Issue/Story

Resolves https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13605

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
