### PR TITLE
Write to audit in the controller instead of in Authenticate class

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -25,8 +25,13 @@ class AuthenticateController < ApplicationController
       authenticator_status_input: status_input,
       enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str
     )
+    log_audit_success(::Audit::Event::Authn::ValidateStatus)
     render(json: { status: "ok" })
   rescue => e
+    log_audit_failure(
+      audit_event_class: ::Audit::Event::Authn::ValidateStatus,
+      error: e
+    )
     log_backtrace(e)
     render(status_failure_response(e))
   end

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -125,7 +125,7 @@ class AuthenticateController < ApplicationController
     # We don't audit success here as the authentication process is not done
   rescue => e
     log_audit_failure(
-      authn_params: input,
+      authn_params: input.nil? ? authenticator_input : input,
       audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -53,9 +53,13 @@ class AuthenticateController < ApplicationController
       username: ::Role.username_from_roleid(current_user.role_id),
       enabled: body_params['enabled'] || false
     )
-
+    log_audit_success(::Audit::Event::Authn::UpdateAuthenticatorConfig)
     head(:no_content)
   rescue => e
+    log_audit_failure(
+      audit_event_class: ::Audit::Event::Authn::UpdateAuthenticatorConfig,
+      error: e
+    )
     handle_authentication_error(e)
   end
 
@@ -93,7 +97,7 @@ class AuthenticateController < ApplicationController
     )
     handle_authentication_error(e)
   end
-  
+
   def authenticate_jwt
     params[:authenticator] = "authn-jwt"
     authn_token = Authentication::AuthnJwt::OrchestrateAuthentication.new.call(

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -125,7 +125,7 @@ class AuthenticateController < ApplicationController
     # We don't audit success here as the authentication process is not done
   rescue => e
     log_audit_failure(
-      authn_params: authenticator_input,
+      authn_params: input,
       audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )
@@ -158,13 +158,13 @@ class AuthenticateController < ApplicationController
         enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str
     )
     log_audit_success(
-      authn_params: authenticator_input,
+      authn_params: input,
       audit_event_class: Audit::Event::Authn::Authenticate
     )
     render_authn_token(authn_token)
   rescue => e
     log_audit_failure(
-      authn_params: authenticator_input,
+      authn_params: input,
       audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -151,8 +151,8 @@ class AuthenticateController < ApplicationController
   def authenticate(input = authenticator_input)
     authn_token = Authentication::Authenticate.new.(
       authenticator_input: input,
-        authenticators: installed_authenticators,
-        enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str
+      authenticators: installed_authenticators,
+      enabled_authenticators: Authentication::InstalledAuthenticators.enabled_authenticators_str
     )
     log_audit_success(
       authn_params: input,

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -27,13 +27,13 @@ class AuthenticateController < ApplicationController
     )
     log_audit_success(
       authn_params: status_input,
-      audit_event_class: :Audit::Event::Authn::ValidateStatus
+      audit_event_class: Audit::Event::Authn::ValidateStatus
     )
     render(json: { status: "ok" })
   rescue => e
     log_audit_failure(
       authn_params: status_input,
-      audit_event_class: ::Audit::Event::Authn::ValidateStatus,
+      audit_event_class: Audit::Event::Authn::ValidateStatus,
       error: e
     )
     log_backtrace(e)
@@ -73,13 +73,13 @@ class AuthenticateController < ApplicationController
     )
     log_audit_success(
       authn_params: update_config_input,
-      audit_event_class: ::Audit::Event::Authn::UpdateAuthenticatorConfig
+      audit_event_class: Audit::Event::Authn::UpdateAuthenticatorConfig
     )
     head(:no_content)
   rescue => e
     log_audit_failure(
       authn_params: update_config_input,
-      audit_event_class: ::Audit::Event::Authn::UpdateAuthenticatorConfig,
+      audit_event_class: Audit::Event::Authn::UpdateAuthenticatorConfig,
       error: e
     )
     handle_authentication_error(e)
@@ -126,7 +126,7 @@ class AuthenticateController < ApplicationController
   rescue => e
     log_audit_failure(
       authn_params: authenticator_input,
-      audit_event_class: ::Audit::Event::Authn::Authenticate,
+      audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )
     handle_authentication_error(e)
@@ -143,7 +143,7 @@ class AuthenticateController < ApplicationController
   rescue => e
     log_audit_failure(
       authn_params: authenticator_input,
-      audit_event_class: ::Audit::Event::Authn::Authenticate,
+      audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )
     handle_authentication_error(e)
@@ -159,13 +159,13 @@ class AuthenticateController < ApplicationController
     )
     log_audit_success(
       authn_params: authenticator_input,
-      audit_event_class: ::Audit::Event::Authn::Authenticate
+      audit_event_class: Audit::Event::Authn::Authenticate
     )
     render_authn_token(authn_token)
   rescue => e
     log_audit_failure(
       authn_params: authenticator_input,
-      audit_event_class: ::Audit::Event::Authn::Authenticate,
+      audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )
     handle_authentication_error(e)

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -124,7 +124,7 @@ class AuthenticateController < ApplicationController
   end
 
   def authenticator_input
-    Authentication::AuthenticatorInput.new(
+    @authenticator_input ||= Authentication::AuthenticatorInput.new(
       authenticator_name: params[:authenticator],
       service_id: params[:service_id],
       account: params[:account],

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -40,7 +40,6 @@ class AuthenticateController < ApplicationController
     render(status_failure_response(e))
   end
 
-
   def status_input
     @status_input ||= Authentication::AuthenticatorStatusInput.new(
       authenticator_name: params[:authenticator],
@@ -65,11 +64,7 @@ class AuthenticateController < ApplicationController
 
   def update_config
     Authentication::UpdateAuthenticatorConfig.new.(
-      account: update_config_input.account,
-      authenticator_name: update_config_input.authenticator_name,
-      service_id: update_config_input.service_id,
-      username: update_config_input.username,
-      enabled: update_config_input.enabled
+      update_config_input: update_config_input
     )
     log_audit_success(
       authn_params: update_config_input,
@@ -235,12 +230,7 @@ class AuthenticateController < ApplicationController
     audit_event_class:
   )
     ::Authentication::LogAuditEvent.new.call(
-      authenticator_name: authn_params.authenticator_name,
-      webservice: authn_params.webservice,
-      client_ip: authn_params.client_ip,
-      role: authn_params.role,
-      account: authn_params.account,
-      username: authn_params.username,
+      authentication_params: authn_params,
       audit_event_class: audit_event_class,
       error: nil
     )
@@ -252,12 +242,7 @@ class AuthenticateController < ApplicationController
     error:
   )
     ::Authentication::LogAuditEvent.new.call(
-      authenticator_name: authn_params.authenticator_name,
-      webservice: authn_params.webservice,
-      client_ip: authn_params.client_ip,
-      role: authn_params.role,
-      account: authn_params.account,
-      username: authn_params.username,
+      authentication_params: authn_params,
       audit_event_class: audit_event_class,
       error: error
     )

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -124,8 +124,9 @@ class AuthenticateController < ApplicationController
     )
     # We don't audit success here as the authentication process is not done
   rescue => e
+    # At this point authenticator_input.username is always empty (e.g. cucumber:user:USERNAME_MISSING)
     log_audit_failure(
-      authn_params: input.nil? ? authenticator_input : input,
+      authn_params: authenticator_input,
       audit_event_class: Audit::Event::Authn::Authenticate,
       error: e
     )
@@ -141,6 +142,7 @@ class AuthenticateController < ApplicationController
     )
     # We don't audit success here as the authentication process is not done
   rescue => e
+    # At this point authenticator_input.username is always empty (e.g. cucumber:user:USERNAME_MISSING)
     log_audit_failure(
       authn_params: authenticator_input,
       audit_event_class: Audit::Event::Authn::Authenticate,

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -9,7 +9,7 @@ module Authentication
       token_factory: TokenFactory.new,
       validate_webservice_is_whitelisted: ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,
       validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
-      validate_origin: ::Authentication::ValidateOrigin.new,
+      validate_origin: ::Authentication::ValidateOrigin.new
     },
     inputs: %i[authenticator_input authenticators enabled_authenticators]
   ) do

--- a/app/domain/authentication/authenticate.rb
+++ b/app/domain/authentication/authenticate.rb
@@ -10,7 +10,6 @@ module Authentication
       validate_webservice_is_whitelisted: ::Authentication::Security::ValidateWebserviceIsWhitelisted.new,
       validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
       validate_origin: ::Authentication::ValidateOrigin.new,
-      audit_log: ::Audit.logger
     },
     inputs: %i[authenticator_input authenticators enabled_authenticators]
   ) do
@@ -26,10 +25,8 @@ module Authentication
       validate_user_has_access_to_webservice
       validate_origin
       validate_credentials
-      audit_success
       new_token
     rescue => e
-      audit_failure(e)
       raise e
     end
 
@@ -70,38 +67,6 @@ module Authentication
         username: username,
         client_ip: client_ip
       )
-    end
-
-    def audit_success
-      @audit_log.log(
-        ::Audit::Event::Authn::Authenticate.new(
-          authenticator_name: authenticator_name,
-          service: webservice,
-          role_id: audit_role_id,
-          client_ip: client_ip,
-          success: true,
-          error_message: nil
-        )
-      )
-    end
-
-    def audit_failure(err)
-      @audit_log.log(
-        ::Audit::Event::Authn::Authenticate.new(
-          authenticator_name: authenticator_name,
-          service: webservice,
-          role_id: audit_role_id,
-          client_ip: client_ip,
-          success: false,
-          error_message: err.message
-        )
-      )
-    end
-
-    def audit_role_id
-      ::Audit::Event::Authn::RoleId.new(
-        role: role, account: account, username: username
-      ).to_s
     end
 
     def new_token

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -9,7 +9,7 @@ module Authentication
       audit_logger: Audit.logger,
       audit_role_id_class: ::Audit::Event::Authn::RoleId
     },
-    inputs: %i[authenticator_input audit_event_class error]
+    inputs: %i[authenticator_name webservice client_ip role account username audit_event_class error]
   ) do
 
     def call
@@ -21,10 +21,10 @@ module Authentication
     def log_audit_event
       @audit_logger.log(
         @audit_event_class.new(
-          authenticator_name: @authenticator_input.authenticator_name,
-          service: @authenticator_input.webservice,
+          authenticator_name: @authenticator_name,
+          service: @webservice,
           role_id: audit_role_id,
-          client_ip: @authenticator_input.client_ip,
+          client_ip: @client_ip,
           success: successful_event?,
           error_message: @error
         )
@@ -33,9 +33,9 @@ module Authentication
 
     def audit_role_id
       @audit_role_id_class.new(
-        role: @authenticator_input.role,
-        account: @authenticator_input.account,
-        username: @authenticator_input.username
+        role: @role,
+        account: @account,
+        username: @username
       ).to_s
     end
 

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -13,7 +13,7 @@ module Authentication
   ) do
     extend(Forwardable)
     def_delegators(:@update_config_input, :account, :authenticator_name, :webservice,
-                   :client_ip, :role, :account, :username)
+                   :client_ip, :role, :username)
     def call
       log_audit_event
     end
@@ -23,10 +23,10 @@ module Authentication
     def log_audit_event
       @audit_logger.log(
         @audit_event_class.new(
-          authenticator_name: @authenticator_name,
-          service: @webservice,
+          authenticator_name: authenticator_name,
+          service: webservice,
           role_id: audit_role_id,
-          client_ip: @client_ip,
+          client_ip: client_ip,
           success: successful_event?,
           error_message: @error
         )
@@ -35,9 +35,9 @@ module Authentication
 
     def audit_role_id
       @audit_role_id_class.new(
-        role: @role,
-        account: @account,
-        username: @username
+        role: role,
+        account: account,
+        username: username
       ).to_s
     end
 

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -12,7 +12,7 @@ module Authentication
     inputs: %i[authentication_params audit_event_class error]
   ) do
     extend(Forwardable)
-    def_delegators(:@update_config_input, :account, :authenticator_name, :webservice,
+    def_delegators(:@authentication_params, :account, :authenticator_name, :webservice,
                    :client_ip, :role, :username)
     def call
       log_audit_event

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -9,9 +9,11 @@ module Authentication
       audit_logger: Audit.logger,
       audit_role_id_class: ::Audit::Event::Authn::RoleId
     },
-    inputs: %i[authenticator_name webservice client_ip role account username audit_event_class error]
+    inputs: %i[authentication_params audit_event_class error]
   ) do
-
+    extend(Forwardable)
+    def_delegators(:@update_config_input, :account, :authenticator_name, :webservice,
+                   :client_ip, :role, :account, :username)
     def call
       log_audit_event
     end

--- a/app/domain/authentication/log_audit_event.rb
+++ b/app/domain/authentication/log_audit_event.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'command_class'
+
+module Authentication
+
+  LogAuditEvent ||= CommandClass.new(
+    dependencies: {
+      audit_logger: Audit.logger,
+      audit_role_id_class: ::Audit::Event::Authn::RoleId
+    },
+    inputs: %i[authenticator_input audit_event_class error]
+  ) do
+
+    def call
+      log_audit_event
+    end
+
+    private
+
+    def log_audit_event
+      @audit_logger.log(
+        @audit_event_class.new(
+          authenticator_name: @authenticator_input.authenticator_name,
+          service: @authenticator_input.webservice,
+          role_id: audit_role_id,
+          client_ip: @authenticator_input.client_ip,
+          success: successful_event?,
+          error_message: @error
+        )
+      )
+    end
+
+    def audit_role_id
+      @audit_role_id_class.new(
+        role: @authenticator_input.role,
+        account: @authenticator_input.account,
+        username: @authenticator_input.username
+      ).to_s
+    end
+
+    def successful_event?
+      @error.nil?
+    end
+  end
+end

--- a/app/domain/authentication/update_authenticator_config.rb
+++ b/app/domain/authentication/update_authenticator_config.rb
@@ -11,8 +11,11 @@ module Authentication
       validate_webservice_is_authenticator: ::Authentication::Security::ValidateWebserviceIsAuthenticator.new,
       validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new
     },
-    inputs: %i[account authenticator_name service_id enabled username]
+    inputs: %i[update_config_input]
   ) do
+    extend(Forwardable)
+    def_delegators(:@update_config_input, :account, :authenticator_name, :service_id,
+                   :enabled, :username)
     def call
       validate_account_exists
       validate_webservice_exists
@@ -25,14 +28,14 @@ module Authentication
 
     def validate_account_exists
       @validate_account_exists.(
-        account: @account
+        account: account
       )
     end
 
     def validate_webservice_exists
       @validate_webservice_exists.(
         webservice: webservice,
-        account: @account
+        account: account
       )
     end
 
@@ -45,8 +48,8 @@ module Authentication
     def validate_user_can_update_webservice
       @validate_role_can_access_webservice.(
         webservice: webservice,
-        account: @account,
-        user_id: @username,
+        account: account,
+        user_id: username,
         privilege: 'update'
       )
     end
@@ -54,14 +57,14 @@ module Authentication
     def update_authenticator_config
       @authenticator_config_class
         .find_or_create(resource_id: resource_id)
-        .update(enabled: @enabled)
+        .update(enabled: enabled)
     end
 
     def webservice
       @webservice ||= @webservice_class.new(
-        account: @account,
-        authenticator_name: @authenticator_name,
-        service_id: @service_id
+        account: account,
+        authenticator_name: authenticator_name,
+        service_id: service_id
       )
     end
 

--- a/app/domain/authentication/update_authenticator_config.rb
+++ b/app/domain/authentication/update_authenticator_config.rb
@@ -14,8 +14,12 @@ module Authentication
     inputs: %i[update_config_input]
   ) do
     extend(Forwardable)
-    def_delegators(:@update_config_input, :account, :authenticator_name, :service_id,
-                   :enabled, :username)
+    def_delegators(:@update_config_input,
+                   :account,
+                   :authenticator_name,
+                   :service_id,
+                   :enabled,
+                   :username)
     def call
       validate_account_exists
       validate_webservice_exists

--- a/app/domain/authentication/update_authenticator_config_input.rb
+++ b/app/domain/authentication/update_authenticator_config_input.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'types'
+
+module Authentication
+
+  # :reek:InstanceVariableAssumption
+  class UpdateAuthenticatorConfigInput < ::Dry::Struct
+
+    attribute :authenticator_name, ::Types::NonEmptyString
+    attribute :service_id, ::Types::NonEmptyString.optional
+    attribute :account, ::Types::NonEmptyString
+    attribute :username, ::Types::NonEmptyString
+    attribute :enabled, ::Types::NonEmptyString
+    attribute :client_ip, ::Types::NonEmptyString
+
+    def webservice
+      @webservice ||= ::Authentication::Webservice.new(
+        account: @account,
+        authenticator_name: @authenticator_name,
+        service_id: @service_id
+      )
+    end
+
+    # :reek:NilCheck
+    def role
+      return nil if @username.nil?
+
+      ::Role.by_login(@username, account: @account)
+    end
+  end
+end

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -10,7 +10,7 @@ module Authentication
       validate_role_can_access_webservice: ::Authentication::Security::ValidateRoleCanAccessWebservice.new,
       validate_webservice_exists: ::Authentication::Security::ValidateWebserviceExists.new,
       role_class: ::Role,
-      implemented_authenticators: Authentication::InstalledAuthenticators.authenticators(ENV),
+      implemented_authenticators: Authentication::InstalledAuthenticators.authenticators(ENV)
     },
     inputs: %i[authenticator_status_input enabled_authenticators]
   ) do

--- a/app/domain/authentication/validate_status.rb
+++ b/app/domain/authentication/validate_status.rb
@@ -11,7 +11,6 @@ module Authentication
       validate_webservice_exists: ::Authentication::Security::ValidateWebserviceExists.new,
       role_class: ::Role,
       implemented_authenticators: Authentication::InstalledAuthenticators.authenticators(ENV),
-      audit_log: ::Audit.logger
     },
     inputs: %i[authenticator_status_input enabled_authenticators]
   ) do
@@ -29,10 +28,7 @@ module Authentication
       validate_webservice_is_whitelisted
 
       validate_authenticator_requirements
-
-      audit_success
     rescue => e
-      audit_failure(e)
       raise e
     end
 
@@ -76,40 +72,6 @@ module Authentication
         webservice: webservice,
         account: account
       )
-    end
-
-    def audit_success
-      @audit_log.log(
-        ::Audit::Event::Authn::ValidateStatus.new(
-          authenticator_name: authenticator_name,
-          service: webservice,
-          role_id: audit_role_id,
-          client_ip: client_ip,
-          success: true,
-          error_message: nil
-        )
-      )
-    end
-
-    def audit_failure(err)
-      @audit_log.log(
-        ::Audit::Event::Authn::ValidateStatus.new(
-          authenticator_name: authenticator_name,
-          service: webservice,
-          role_id: audit_role_id,
-          client_ip: client_ip,
-          success: false,
-          error_message: err.message
-        )
-      )
-    end
-
-    def audit_role_id
-      ::Audit::Event::Authn::RoleId.new(
-        role: role,
-        account: @authenticator_status_input.account,
-        username: @authenticator_status_input.username
-      ).to_s
     end
 
     def authenticator

--- a/app/models/audit/event/authn/update_authenticator_config.rb
+++ b/app/models/audit/event/authn/update_authenticator_config.rb
@@ -1,0 +1,50 @@
+module Audit
+  module Event
+    class Authn
+      class UpdateAuthenticatorConfig
+        extend Forwardable
+        def_delegators(
+          :@authn, :facility, :message_id, :severity, :structured_data,
+          :progname
+        )
+
+        def initialize(
+          role_id:,
+          client_ip:,
+          authenticator_name:,
+          service:,
+          success:,
+          error_message: nil
+        )
+          @role_id = role_id
+          @error_message = error_message
+          @authn = Authn.new(
+            role_id: role_id,
+            client_ip: client_ip,
+            authenticator_name: authenticator_name,
+            service: service,
+            success: success,
+            operation: "update-authenticator-configuration"
+          )
+        end
+
+        def to_s
+          message
+        end
+
+        def message
+          auth_description = @authn.authenticator_description
+          @authn.message(
+            success_msg:
+              "#{@role_id} successfully updated authenticator configuration"\
+                "#{auth_description}",
+            failure_msg:
+              "#{@role_id} failed to update authenticator configuration "\
+                "#{auth_description}",
+            error_msg: @error_message
+          )
+        end
+      end
+    end
+  end
+end

--- a/cucumber/authenticators_gcp/features/authn_gce.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce.feature
@@ -121,7 +121,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     """
     And The following appears in the audit log after my savepoint:
     """
-    non_existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
+    non-existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
   Scenario: Authenticate using token in standard format and host with only service-account-id annotation set

--- a/cucumber/authenticators_gcp/features/authn_gce.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce.feature
@@ -108,7 +108,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     """
     And The following appears in the audit log after my savepoint:
     """
-    non_existing_account:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
+    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
   Scenario: Non-existing account in URL request is denied
@@ -121,7 +121,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     """
     And The following appears in the audit log after my savepoint:
     """
-    non_existing_account:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
+    non_existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
   Scenario: Authenticate using token in standard format and host with only service-account-id annotation set

--- a/cucumber/authenticators_gcp/features/authn_gce.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce.feature
@@ -106,6 +106,10 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     """
     CONJ00070E 'audience' token claim .* is invalid. The account in the audience .* does not match the account in the URL request .*
     """
+    And The following appears in the audit log after my savepoint:
+    """
+    non_existing_account:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
+    """
 
   Scenario: Non-existing account in URL request is denied
     Given I save my place in the log file
@@ -114,6 +118,10 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     And The following matches the log after my savepoint:
     """
     CONJ00008E Account '.*' is not defined in Conjur
+    """
+    And The following appears in the audit log after my savepoint:
+    """
+    non_existing_account:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
   Scenario: Authenticate using token in standard format and host with only service-account-id annotation set

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -132,6 +132,10 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     """
     Errors::Authentication::RequestBody::MissingRequestParam
     """
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+    """
 
   Scenario: Empty id token is a bad request
     Given I save my place in the log file
@@ -140,6 +144,10 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And The following appears in the log after my savepoint:
     """
     Errors::Authentication::RequestBody::MissingRequestParam
+    """
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
   Scenario: non-existing account in request is denied
@@ -150,6 +158,10 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     """
     Errors::Authentication::Security::AccountNotDefined
     """
+    And The following appears in the audit log after my savepoint:
+    """
+    non-existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+    """
 
   Scenario: admin user is denied
     And I fetch an ID Token for username "admin" and password "admin"
@@ -159,6 +171,10 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And The following appears in the log after my savepoint:
     """
     Errors::Authentication::AdminAuthenticationDenied
+    """
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
   Scenario: provider-uri dynamic change

--- a/spec/app/domain/authentication/authenticate_spec.rb
+++ b/spec/app/domain/authentication/authenticate_spec.rb
@@ -44,24 +44,12 @@ RSpec.describe('Authentication::Authenticate') do
     double('TokenFactory', signed_token: a_new_token)
   end
 
-  ####################################
-  # AuditEvent double
-  ####################################
-
-  let(:audit_success) { true }
-  let(:mocked_audit_logger) do
-    double('audit_logger').tap do |logger|
-      expect(logger).to receive(:log)
-    end
-  end
-
   #  ____  _   _  ____    ____  ____  ___  ____  ___
   # (_  _)( )_( )( ___)  (_  _)( ___)/ __)(_  _)/ __)
   #   )(   ) _ (  )__)     )(   )__) \__ \  )(  \__ \
   #  (__) (_) (_)(____)   (__) (____)(___/ (__) (___/
 
   context "An unavailable authenticator" do
-    let(:audit_success) { false }
     subject do
       input_ = Authentication::AuthenticatorInput.new(
         authenticator_name: 'AUTHN-MISSING',
@@ -77,8 +65,7 @@ RSpec.describe('Authentication::Authenticate') do
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
         validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true),
         validate_origin: mocked_origin_validator,
-        token_factory: mocked_token_factory,
-        audit_log: mocked_audit_logger
+        token_factory: mocked_token_factory
       ).call(
         authenticator_input: input_,
         authenticators: authenticators,
@@ -97,7 +84,6 @@ RSpec.describe('Authentication::Authenticate') do
 
   context "An available authenticator" do
     context "that receives invalid credentials" do
-      let(:audit_success) { false }
       subject do
         input_ = Authentication::AuthenticatorInput.new(
           authenticator_name: 'authn-always-fail',
@@ -114,7 +100,6 @@ RSpec.describe('Authentication::Authenticate') do
           validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true),
           validate_origin: mocked_origin_validator,
           token_factory: mocked_token_factory,
-          audit_log: mocked_audit_logger
         ).call(
           authenticator_input: input_,
           authenticators: authenticators,
@@ -133,8 +118,6 @@ RSpec.describe('Authentication::Authenticate') do
 
     context "that receives valid credentials" do
       context "with an inaccessible webservice" do
-        let(:audit_success) { true }
-
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-always-pass',
@@ -150,8 +133,7 @@ RSpec.describe('Authentication::Authenticate') do
             validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: false),
             validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true),
             validate_origin: mocked_origin_validator,
-            token_factory: mocked_token_factory,
-            audit_log: mocked_audit_logger
+            token_factory: mocked_token_factory
           ).call(
             authenticator_input: input_,
             authenticators: authenticators,
@@ -169,8 +151,6 @@ RSpec.describe('Authentication::Authenticate') do
       end
 
       context "with a non-whitelisted webservice" do
-        let(:audit_success) { true }
-
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-always-pass',
@@ -186,8 +166,7 @@ RSpec.describe('Authentication::Authenticate') do
             validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
             validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: false),
             validate_origin: mocked_origin_validator,
-            token_factory: mocked_token_factory,
-            audit_log: mocked_audit_logger
+            token_factory: mocked_token_factory
           ).call(
             authenticator_input: input_,
             authenticators: authenticators,
@@ -205,8 +184,6 @@ RSpec.describe('Authentication::Authenticate') do
       end
 
       context "when webservice validations succeed" do
-        let(:audit_success) { true }
-
         subject do
           input_ = Authentication::AuthenticatorInput.new(
             authenticator_name: 'authn-always-pass',
@@ -222,8 +199,7 @@ RSpec.describe('Authentication::Authenticate') do
             validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
             validate_webservice_is_whitelisted: mock_validate_webservice_is_whitelisted(validation_succeeded: true),
             validate_origin: mocked_origin_validator,
-            token_factory: mocked_token_factory,
-            audit_log: mocked_audit_logger
+            token_factory: mocked_token_factory
           ).call(
             authenticator_input: input_,
             authenticators: authenticators,

--- a/spec/app/domain/authentication/update_authenticator_config_spec.rb
+++ b/spec/app/domain/authentication/update_authenticator_config_spec.rb
@@ -8,20 +8,29 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
 
   let(:mock_model) { double(::AuthenticatorConfig) }
 
-  let(:call_params) do
-    {
-      account: test_account,
-      authenticator_name: authenticator_name,
-      service_id: service_id,
-      enabled: true,
-      username: test_user_id
-    }
-  end
-
   before do
     allow(mock_model)
       .to receive_message_chain(:find_or_create, :update)
       .and_return(1)
+  end
+
+  def mock_update_config_input
+    double('update_config_input').tap do |update_config_input|
+      allow(update_config_input).to receive(:authenticator_name)
+                               .and_return(authenticator_name)
+
+      allow(update_config_input).to receive(:account)
+                               .and_return(test_account)
+
+      allow(update_config_input).to receive(:service_id)
+                               .and_return(service_id)
+
+      allow(update_config_input).to receive(:username)
+                               .and_return(test_user_id)
+
+      allow(update_config_input).to receive(:enabled)
+                               .and_return(true)
+    end
   end
 
   context "webservice resource exists and the current user has correct permissions" do
@@ -32,7 +41,7 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         validate_webservice_is_authenticator: mock_validate_webservice_is_authenticator(validation_succeeded: true),
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true)
-      ).call(call_params)
+      ).call(update_config_input: mock_update_config_input)
     end
 
     it "updates the config record of an authenticator" do
@@ -48,7 +57,7 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         validate_webservice_is_authenticator: mock_validate_webservice_is_authenticator(validation_succeeded: true),
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true)
-      ).call(call_params)
+      ).call(update_config_input: mock_update_config_input)
     end
 
     it "raises the error raised by validate_account_exists" do
@@ -64,7 +73,7 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: false),
         validate_webservice_is_authenticator: mock_validate_webservice_is_authenticator(validation_succeeded: true),
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true)
-      ).call(call_params)
+      ).call(update_config_input: mock_update_config_input)
     end
 
     it "raises the error raised by validate_webservice_exists" do
@@ -80,7 +89,7 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         validate_webservice_is_authenticator: mock_validate_webservice_is_authenticator(validation_succeeded: true),
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: false)
-      ).call(call_params)
+      ).call(update_config_input: mock_update_config_input)
     end
 
     it "raises the error raised by validate_role_can_access_webservice" do
@@ -96,7 +105,7 @@ RSpec.describe(Authentication::UpdateAuthenticatorConfig) do
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         validate_webservice_is_authenticator: mock_validate_webservice_is_authenticator(validation_succeeded: false),
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true)
-      ).call(call_params)
+      ).call(update_config_input: mock_update_config_input)
     end
 
     it "raises the error raised by validate_webservice_is_authenticator" do

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -77,12 +77,6 @@ RSpec.describe(Authentication::ValidateStatus) do
     end
   end
 
-  let(:mocked_audit_logger) do
-    double('audit_logger').tap do |logger|
-      expect(logger).to receive(:log)
-    end
-  end
-
   let(:mock_implemented_authenticators) do
     {
       'authn-status-pass' => authenticator(is_status_defined: true, is_failing_requirements: false),
@@ -124,7 +118,6 @@ RSpec.describe(Authentication::ValidateStatus) do
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         implemented_authenticators: mock_implemented_authenticators,
-        audit_log: mocked_audit_logger
       ).call(
         authenticator_status_input: mock_status_input("authn-status-pass"),
         enabled_authenticators: mock_enabled_authenticators
@@ -144,7 +137,6 @@ RSpec.describe(Authentication::ValidateStatus) do
         validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
         validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
         implemented_authenticators: mock_implemented_authenticators,
-        audit_log: mocked_audit_logger
       ).call(
         authenticator_status_input: mock_status_input("authn-non-exist"),
         enabled_authenticators: mock_enabled_authenticators
@@ -165,7 +157,6 @@ RSpec.describe(Authentication::ValidateStatus) do
           validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
           validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
           implemented_authenticators: mock_implemented_authenticators,
-          audit_log: mocked_audit_logger
         ).call(
           authenticator_status_input: mock_status_input("authn-status-not-implemented"),
           enabled_authenticators: mock_enabled_authenticators
@@ -186,7 +177,6 @@ RSpec.describe(Authentication::ValidateStatus) do
             validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: false),
             validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
             implemented_authenticators: mock_implemented_authenticators,
-            audit_log: mocked_audit_logger
           ).call(
             authenticator_status_input: mock_status_input("authn-status-pass"),
             enabled_authenticators: mock_enabled_authenticators
@@ -207,7 +197,6 @@ RSpec.describe(Authentication::ValidateStatus) do
               validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
               validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: false),
               implemented_authenticators: mock_implemented_authenticators,
-              audit_log: mocked_audit_logger
             ).call(
               authenticator_status_input: mock_status_input("authn-status-pass"),
               enabled_authenticators: mock_enabled_authenticators
@@ -228,7 +217,6 @@ RSpec.describe(Authentication::ValidateStatus) do
                 validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
                 validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
                 implemented_authenticators: mock_implemented_authenticators,
-                audit_log: mocked_audit_logger
               ).call(
                 authenticator_status_input: mock_status_input("authn-status-pass"),
                 enabled_authenticators: not_including_enabled_authenticators
@@ -249,7 +237,6 @@ RSpec.describe(Authentication::ValidateStatus) do
                   validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
                   validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
                   implemented_authenticators: mock_implemented_authenticators,
-                  audit_log: mocked_audit_logger
                 ).call(
                   authenticator_status_input: mock_status_input("authn-status-fail"),
                   enabled_authenticators: mock_enabled_authenticators

--- a/spec/app/domain/authentication/validate_status_spec.rb
+++ b/spec/app/domain/authentication/validate_status_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe(Authentication::ValidateStatus) do
                   validate_webservice_is_whitelisted: mock_validate_webservice_exists(validation_succeeded: true),
                   validate_role_can_access_webservice: mock_validate_role_can_access_webservice(validation_succeeded: true),
                   validate_webservice_exists: mock_validate_webservice_exists(validation_succeeded: true),
-                  implemented_authenticators: mock_implemented_authenticators,
+                  implemented_authenticators: mock_implemented_authenticators
                 ).call(
                   authenticator_status_input: mock_status_input("authn-status-fail"),
                   enabled_authenticators: mock_enabled_authenticators


### PR DESCRIPTION
The OIDC & GCP authenticators start their work with updating the authenticator
input with the username that is retrieved from the JWT token. If this operation
fails then we do not proceed in to the `Authenticate` class and thus the audit
message is not written. To overcome this, we move the audit logic to the controller

### Connected Issue/Story

Resolves ONYX-13556


#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
