### PR TITLE
ONYX-14082 - Push sequel to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,7 @@ gem 'rake'
 # gem 'sprockets', '~> 3.7.0', '>= 3.7.2'
 
 gem 'pg'
-# TODO: When updating to 5, sequel-rails was throwing errors that
-# I wasn't able to resolve.  The quick fix was to pin sequel here
-# for now.  We can tackle the upgrade later.
-gem 'sequel', '4.49.0'
+gem 'sequel'
 gem 'sequel-pg_advisory_locking'
 gem 'sequel-postgres-schemata', require: false
 gem 'sequel-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.3.1)
     safe_yaml (1.0.5)
-    sequel (4.49.0)
+    sequel (5.50.0)
     sequel-pg_advisory_locking (1.0.1)
       sequel
     sequel-postgres-schemata (0.1.3)
@@ -501,7 +501,7 @@ DEPENDENCIES
   rubocop-checkstyle_formatter
   ruby-debug-ide
   ruby_dep (= 1.3.1)
-  sequel (= 4.49.0)
+  sequel
   sequel-pg_advisory_locking
   sequel-postgres-schemata
   sequel-rails

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -48,7 +48,7 @@ Section 4: MIT
 >>> https://rubygems.org/gems/rails/versions/5.2.6
 >>> https://rubygems.org/gems/rake/versions/13.0.1
 >>> https://rubygems.org/gems/ruby_dep/versions/1.3.1
->>> https://rubygems.org/gems/sequel/versions/4.49.0
+>>> https://rubygems.org/gems/sequel/versions/5.50.0
 >>> https://rubygems.org/gems/sequel-pg_advisory_locking/versions/1.0.1
 >>> https://rubygems.org/gems/sequel-postgres-schemata/versions/0.1.3
 >>> https://rubygems.org/gems/sequel-rails/versions/1.1.0
@@ -859,28 +859,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
->>> https://rubygems.org/gems/sequel/versions/4.49.0
+>>> https://rubygems.org/gems/sequel/versions/5.50.0
 
 Copyright (c) 2007-2008 Sharon Rosner
-Copyright (c) 2008-2017 Jeremy Evans
+Copyright (c) 2008-2021 Jeremy Evans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 >>> https://rubygems.org/gems/simplecov/versions/0.14.1
 

--- a/app/models/policy_log.rb
+++ b/app/models/policy_log.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: This is needed because having the same line config/application.rb is
-# not working.  I wasn't able to figure out what precisely was going wrong,
-# even after discussing with Jeremy Evans (sequel's author) on IRC, but bottom
-# line: without this line the extensions aren't loaded.
-#
 Sequel::Model.db.extension(:pg_hstore)
 
 class PolicyLog < Sequel::Model(:policy_log)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module Conjur
 
     config.sequel.after_connect = proc do
       Sequel.extension(:core_extensions, :postgres_schemata)
-      Sequel::Model.db.extension(:pg_array, :pg_inet, :pg_hstore)
+      Sequel::Model.db.extension(:pg_array, :pg_inet)
     end
 
     config.encoding = "utf-8"

--- a/db/migrate/20160628222441_create_credentials.rb
+++ b/db/migrate/20160628222441_create_credentials.rb
@@ -4,7 +4,7 @@ Sequel.migration do
   change do
     create_table :credentials do
       # Not an FK, because credentials won't be dropped when the RBAC is rebuilt
-      primary_key :role_id, type: String, null: false
+      String :role_id, primary_key: true
 
       foreign_key :client_id, :roles, type: String, null: true, on_delete: :cascade
 


### PR DESCRIPTION
### Desired Outcome

Conjur is using latest version of the `sequel` gem.

### Implemented Changes

- Version pinning has been removed from the Gemfile for `sequel` gem
- `20160628222441_create_credentials.rb` is changed following some errors during db migration.
  Now it's aligned with primary key creation in `20160628212347_create_roles.rb` file.
  DB structure remains the same
-  `config/application.rb` is running at the beginning db migration task. It's trying to initialize `:pg_hstore` db extension that does not exist before db migration. It's created as a part of `20180410092453_policy_log.rb` db migration task. So `:pg_hstore` db extension initialization during application init stage is unnecessary, either way it's initialized in `app/models/policy_log.rb` file - the only model is using the extension.

### Connected Issue/Story

[ONYX-14082](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14082)

### Definition of Done

- [X] Desired outcome has been achieved

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

The changes are tested in CE, see `sequel-upgrade` branch pipeline.

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
