### PR TITLE
Add ability to send hostname for TLS SNI extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.17.1] - 2022-02-09
+
+### Added
+- Added support for SNI certificates when talking to the Kubernetes API 
+  server through the web socket client.
+  [ONYX-14386](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14386)
+
 ## [1.17.0] - 2022-02-09
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,6 +458,68 @@ Rake tasks are easy to run from within the `conjur` server container:
   The next available error number is 63 ( CONJ00063E )
   ```
 
+### Kubernetes specific Cucumber tests
+
+Several cucumber tests are written to verify conjur works properly when 
+authenticating to Kubernetes.  These tests have hooks to run against both 
+Openshift and Google GKE.
+
+The cucumber tests are located under `cucumber/kubernetes/features` and can be
+run by going into the `ci/authn-k8s` directory and running:
+
+```shell
+$ summon -f [secrets.ocp.yml|secrets.yml] ./init_k8s.sh [openshift|gke]
+$ summon -f [secrets.ocp.yml|secrets.yml] ./test.sh [openshift|gke]
+```
+
+- `init_k8s.sh` - executes a simple login to Openshift or GKE to verify
+credentials as well as logging into the Docker Registry defined
+- `test.sh` - executes the tests against the defined platform
+
+#### Secrets file
+
+The secrets file used for summons needs to contain the following environment
+variables
+
+  - openshift
+    - `OPENSHIFT_USERNAME` - username of an account that can create 
+      namespaces, adjust cluster properties, etc
+    - `OPENSHIFT_PASSWORD` - password of the account
+    - `OPENSHIFT_URL` - the URL of the RedHat CRC cluster
+      - If running this locally - use `https://host.docker.internal:6443` so
+         the docker container can talk to the CRC containers
+    - `OPENSHIFT_TOKEN` - the login token of the above username/password
+      - only needed for local execution because the docker container 
+      executing the commands can't redirect for login
+      - obtained by running the following command locally after login -
+      `oc whoami -t`
+  - gke
+    - `GCLOUD_CLUSTER_NAME` - cluster name of the GKE environment in the cloud
+    - `GCLOUD_ZONE` - zone of the GKE environment in the cloud
+    - `GCLOUD_PROJECT_NAME` - project name of the GKE environment
+    - `GCLOUD_SERVICE_KEY` - service key of the GKE environment
+    
+#### Local Execution Prerequisites
+
+To execute the tests locally, a few things will have to be done:
+
+  - Openshift
+    - Download and install the RedHat Code Ready Container
+      - This contains all the necessary pieces to have a local version of
+        Openshift
+    - After install, copy down the kubeadmin username/password and update the
+      secrets.ocp.yml file with the password
+    - Execute `oc whoami -t` and update the token property
+  - GKE
+    - Work with infrastructure to obtain a GKE environment
+
+If the local revision of your files don't have a docker image built yet - build
+the docker images using the following command:
+
+```shell
+$ ./build_locally.sh <sni cert file>
+```
+
 ## Pull Request Workflow
 
 1. [Fork the project](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -25,6 +25,10 @@ module Authentication
         @cert_store = OpenSSL::X509::Store.new
         @cert_store.set_default_paths
         ::Conjur::CertUtils.add_chained_cert(@cert_store, ca_cert)
+
+        return unless ENV.key?('SSL_CERT_DIRECTORY')
+
+        load_additional_certs(ENV['SSL_CERT_DIRECTORY'])
       end
 
       def bearer_token
@@ -183,6 +187,7 @@ module Authentication
           KubeClientFactory.client(
             api: 'apis/apps.openshift.io', version: 'v1', host_url: api_url,
             options: options
+
           )
         ]
       end
@@ -194,6 +199,16 @@ module Authentication
           yield
         rescue KubeException
           raise unless $!.error_code == 404
+        end
+      end
+
+      def load_additional_certs(ssl_cert_directory)
+        # allows us to add additional CA certs for things like SNI certs
+        if Dir.exist?("#{ssl_cert_directory}/ca")
+          Dir["#{ssl_cert_directory}/ca/*"].each do |file_name|
+            ::Conjur::CertUtils.add_chained_cert(@cert_store, File.read(file_name)) if
+              File.exist?(file_name)
+          end
         end
       end
     end

--- a/ci/authn-k8s/.gitignore
+++ b/ci/authn-k8s/.gitignore
@@ -1,4 +1,6 @@
 dev/interventions/*.gke.yml
-dev/tls/nginx.*
+dev/tls/*.key
+dev/tls/*.crt
 nginx.crt
 /output/
+dev/**/*.openshift.yml

--- a/ci/authn-k8s/build_locally.sh
+++ b/ci/authn-k8s/build_locally.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+sni_cert=$1
+
+if [[ ! -z "$sni_cert" ]]; then
+  sni_cert="$(realpath $1)"
+fi
+
+function copy_cert() {
+  image=$1
+  sni_cert=$2
+
+  if [[ ! -z $sni_cert ]]; then
+    docker rm temp_container || true
+    docker create --name temp_container "$image"
+    docker cp "$sni_cert" "temp_container:/opt/conjur/etc/ssl/ca/${sni_cert##*/}"
+    docker commit temp_container "$image"
+    docker rm temp_container
+  fi
+}
+
+cd "$(git rev-parse --show-toplevel)" || exit
+
+TAG="$(git rev-parse --short=8 HEAD)"
+export TAG="$TAG"
+docker build --no-cache -t "conjur:$TAG" .
+copy_cert "conjur:$TAG" "$sni_cert"
+docker build --no-cache -t "registry.tld/conjur:$TAG" .
+copy_cert "registry.tld/conjur:$TAG" "$sni_cert"
+docker build --no-cache --build-arg "VERSION=$TAG" -t "registry.tld/conjur-test:$TAG" -f Dockerfile.test .

--- a/ci/authn-k8s/dev/dev_conjur.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur.template.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
       - image: {{ CONJUR_AUTHN_K8S_TAG }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: conjur
         command: ["conjurctl", "server"]
         env:
@@ -135,7 +135,7 @@ spec:
     spec:
       containers:
       - image: {{ CONJUR_TEST_AUTHN_K8S_TAG }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: conjur
         command: ["sleep", "infinity"]
         env:
@@ -200,5 +200,5 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: {{NGINX_TAG}}
-        imagePullPolicy: Always
+        image: {{ NGINX_TAG }}
+        imagePullPolicy: IfNotPresent

--- a/ci/authn-k8s/dev/dev_conjur_sni.template.yaml
+++ b/ci/authn-k8s/dev/dev_conjur_sni.template.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conjur-authn-k8s
+  labels:
+    app: conjur-authn-k8s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: conjur-authn-k8s
+  template:
+    metadata:
+      labels:
+        app: conjur-authn-k8s
+    spec:
+      hostAliases:
+        - ip: {{ KUBERNETES_SERVICE_HOST }}
+          hostnames:
+            - "{{ KUBERNETES_API_FQDN }}"
+      containers:
+      - image: {{ CONJUR_AUTHN_K8S_TAG }}
+        imagePullPolicy: Always
+        name: conjur
+        command: ["conjurctl", "server"]
+        env:
+        - name: DATABASE_URL
+          value: postgres://postgres@postgres:5432/postgres
+        - name: CONJUR_ADMIN_PASSWORD
+          value: admin
+        - name: CONJUR_ACCOUNT
+          value: cucumber
+        - name: CONJUR_DATA_KEY
+          value: "{{ DATA_KEY }}"
+        - name: RAILS_ENV
+          value: test
+        # Enable coverage tracking.
+        - name: REQUIRE_SIMPLECOV
+          value: "true"
+        # Sleep after generating the coverage report to keep the pod alive
+        # so the report can be retrieved.
+        - name: SIMPLECOV_SLEEP
+          value: "true"
+        - name: WEB_CONCURRENCY
+          value: "0"
+        - name: RAILS_MAX_THREADS
+          value: "10"
+        - name: CONJUR_AUTHENTICATORS
+          value: authn-k8s/minikube
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ KUBERNETES_API_FQDN }}
+        - name: SSL_CERT_DIRECTORY
+          value: /opt/conjur/etc/ssl/
+        volumeMounts:
+          - mountPath: /run/authn-local
+            name: authn-local
+      volumes:
+        - name: authn-local
+          emptyDir:
+            medium: Memory

--- a/ci/authn-k8s/dev/dev_inventory.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory.template.yaml
@@ -27,9 +27,9 @@ spec:
         app: inventory-deployment
     spec:
       containers:
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: inventory
         command: ["sleep", "infinity"]
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: authenticator
         command: ["sleep", "infinity"]

--- a/ci/authn-k8s/dev/dev_inventory_deployment_config.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_deployment_config.template.yaml
@@ -16,18 +16,17 @@ metadata:
   name: inventory-deployment-cfg
 spec:
   replicas: 1
-    selector:
-      matchLabels:
-        app: inventory-deployment-cfg
+  selector:
+    app: inventory-deployment-cfg
   template:
     metadata:
       labels:
         app: inventory-deployment-cfg
     spec:
       containers:
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: inventory
         command: ["sleep", "infinity"]
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: authenticator
         command: ["sleep", "infinity"]

--- a/ci/authn-k8s/dev/dev_inventory_example.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_example.template.yaml
@@ -5,7 +5,7 @@ metadata:
   name: inventory-pod-in-namespace
 spec:
   containers:
-  - image: {{INVENTORY_TAG}}
+  - image: {{ INVENTORY_TAG }}
     imagePullPolicy: IfNotPresent
     name: inventory
     env:
@@ -22,7 +22,7 @@ spec:
       - mountPath: /run/conjur
         name: conjur-access-token
         readOnly: true
-  - image: {{AUTHENTICATOR_TAG}}
+  - image: {{ AUTHENTICATOR_TAG }}
     imagePullPolicy: IfNotPresent
     name: authenticator
     env:
@@ -45,7 +45,7 @@ spec:
       - name: CONJUR_ACCOUNT
         value: cucumber
       - name: CONJUR_AUTHN_LOGIN
-        value: {{CONJUR_AUTHN_K8S_TEST_NAMESPACE}}/*/*
+        value: {{ CONJUR_AUTHN_K8S_TEST_NAMESPACE }}/*/*
       - name: CONJUR_SSL_CERTIFICATE
         valueFrom:
           configMapKeyRef:

--- a/ci/authn-k8s/dev/dev_inventory_pod.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_pod.template.yaml
@@ -19,11 +19,11 @@ metadata:
 spec:
   serviceAccountName: inventory-pod-only
   containers:
-  - image: {{INVENTORY_TAG}}
+  - image: {{ INVENTORY_TAG }}
     imagePullPolicy: IfNotPresent
     name: inventory
     command: ["sleep", "infinity"]
-  - image: {{INVENTORY_TAG}}
+  - image: {{ INVENTORY_TAG }}
     imagePullPolicy: IfNotPresent
     name: authenticator
     command: ["sleep", "infinity"]
@@ -40,11 +40,11 @@ metadata:
 spec:
   serviceAccountName: inventory-pod-only
   containers:
-  - image: {{INVENTORY_BASE_TAG}}
+  - image: {{ INVENTORY_BASE_TAG }}
     imagePullPolicy: IfNotPresent
     name: inventory
     command: ["sleep", "infinity"]
-  - image: {{INVENTORY_BASE_TAG}}
+  - image: {{ INVENTORY_BASE_TAG }}
     imagePullPolicy: IfNotPresent
     name: authenticator
     command: ["sleep", "infinity"]

--- a/ci/authn-k8s/dev/dev_inventory_stateful.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_stateful.template.yaml
@@ -30,9 +30,9 @@ spec:
         app: inventory-stateful
     spec:
       containers:
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: inventory
         command: ["sleep", "infinity"]
-      - image: {{INVENTORY_TAG}}
+      - image: {{ INVENTORY_TAG }}
         name: authenticator
         command: ["sleep", "infinity"]

--- a/ci/authn-k8s/dev/dev_inventory_unauthorized.template.yaml
+++ b/ci/authn-k8s/dev/dev_inventory_unauthorized.template.yaml
@@ -5,9 +5,9 @@ metadata:
   name: inventory-unauthorized
 spec:
   containers:
-  - image: {{INVENTORY_TAG}}
+  - image: {{ INVENTORY_TAG }}
     name: inventory
     command: ["sleep", "infinity"]
-  - image: {{INVENTORY_TAG}}
+  - image: {{ INVENTORY_TAG }}
     name: authenticator
     command: ["sleep", "infinity"]

--- a/ci/authn-k8s/dev/tls/api-test-com.conf
+++ b/ci/authn-k8s/dev/tls/api-test-com.conf
@@ -1,0 +1,39 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+x509_extensions = v3_ca # The extentions to add to the self signed cert
+req_extensions  = v3_req
+x509_extensions = usr_cert
+
+[ dn ]
+C = US
+ST = Wisconsin
+L = Madison
+O = CyberArk
+OU = Onyx
+CN = api.test.com
+
+[ usr_cert ]
+basicConstraints = CA:FALSE
+nsCertType = client, server, email
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+nsComment = "OpenSSL Generated Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+
+[ v3_req ]
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = api.test.com
+IP.1 = 127.0.0.1

--- a/ci/authn-k8s/dev/utils.sh
+++ b/ci/authn-k8s/dev/utils.sh
@@ -46,6 +46,13 @@ function initialize_gke() {
 
 function initialize_oc() {
   # setup kubectl, oc and docker
-  oc login $OPENSHIFT_URL --username=$OPENSHIFT_USERNAME --password=$OPENSHIFT_PASSWORD --insecure-skip-tls-verify=true
-  docker login -u _ -p $(oc whoami -t) $OPENSHIFT_REGISTRY_URL
+  url=$OPENSHIFT_URL
+
+  if [ -z "$OPENSHIFT_TOKEN" ]; then
+    oc login "$url" --username="$OPENSHIFT_USERNAME" --password="$OPENSHIFT_PASSWORD" --insecure-skip-tls-verify=true
+  else
+    oc login "$url" --token="$OPENSHIFT_TOKEN" --insecure-skip-tls-verify=true
+  fi
+
+  docker login -u _ -p "$(oc whoami -t)" "$OPENSHIFT_REGISTRY_URL"
 }

--- a/ci/authn-k8s/secrets.ocp.yml
+++ b/ci/authn-k8s/secrets.ocp.yml
@@ -1,0 +1,18 @@
+# Global vars
+OPENSHIFT_CLI_URL: https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+
+# Dev vars
+OPENSHIFT_URL: !var dev/openshift/current/api-url
+OPENSHIFT_USERNAME: !var dev/openshift/current/username
+OPENSHIFT_PASSWORD: !var dev/openshift/current/password
+OPENSHIFT_REGISTRY_URL: !var dev/openshift/current/registry-url
+OPENSHIFT_INTERNAL_REGISTRY_URL: !var dev/openshift/current/internal-registry-url
+SNI_FQDN: sni-test.dev.conjur.net
+SNI_PORT: 6443
+
+# Local Vars
+#OPENSHIFT_USERNAME: kubeadmin
+#OPENSHIFT_PASSWORD: A753x-ziqxZ-VFjmX-GxrAy
+#OPENSHIFT_REGISTRY_URL: default-route-openshift-image-registry.apps-crc.testing
+#OPENSHIFT_URL: https://host.docker.internal:6443
+#OPENSHIFT_TOKEN: sha256~u6bQl0-d3RoMGKMun_Kcm5GRygMHq4a7Qqvelmr29Mg

--- a/cucumber/kubernetes/features/sni.feature
+++ b/cucumber/kubernetes/features/sni.feature
@@ -1,0 +1,12 @@
+Feature: A permitted Conjur host can authenticate with a valid resource restrictions
+  that is defined in the id and the kubernetes host has a corresponding SSL certificate
+
+  @sni_fails
+  Scenario: Authenticate as a Pod.
+    When I authenticate with authn-k8s as "pod/inventory-pod" without cert and key
+    Then the HTTP status is "401"
+
+  @sni_success
+  Scenario: Authenticate as a Pod.
+    Given I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
+    Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "*/*"

--- a/cucumber/kubernetes/features/support/hooks.rb
+++ b/cucumber/kubernetes/features/support/hooks.rb
@@ -3,7 +3,7 @@ Before('@skip') do
 end
 
 Before('@k8s_skip') do
-  skip_this_scenario if ENV['PLATFORM'] == 'kubernetes'
+  skip_this_scenario if ENV['PLATFORM'] == 'kubernetes' || ENV['PLATFORM'] == 'openshift'
 end
 
 Before do

--- a/spec/app/domain/authentication/authn_k8s/web_socket_client_spec_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/web_socket_client_spec_spec.rb
@@ -1,0 +1,438 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class TestServer
+  attr_reader(:handshake)
+  attr_reader(:ca)
+  attr_reader(:message)
+
+  def initialize(port)
+    @port = port
+    @server = TCPServer.open("127.0.0.1", port)
+  end
+
+  def add_old_ssl(host)
+    build_ca
+    @server = OpenSSL::SSL::SSLServer.new(@server, build_ssl_context(:SSLv23, build_cert(host)))
+  end
+
+  def add_tls_without_sni(host)
+    build_ca
+    @server = OpenSSL::SSL::SSLServer.new(@server, build_ssl_context(:TLSv1, build_cert(host)))
+  end
+
+  def add_tls_with_sni
+    build_ca
+    testing_com_cert = build_cert("testing.com")
+    another_site_com_cert = build_cert("another-site.com")
+    ssl_context = OpenSSL::SSL::SSLContext.new
+    ssl_context.servername_cb = proc { |ssl_socket, hostname|
+      new_context = OpenSSL::SSL::SSLContext.new
+      new_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      new_context.ssl_version = :TLSv1
+      new_context.key = OpenSSL::PKey::RSA.new(@ca.key)
+
+      case hostname
+      when "testing.com"
+        new_context.cert = OpenSSL::X509::Certificate.new(testing_com_cert)
+      else
+        new_context.cert = OpenSSL::X509::Certificate.new(another_site_com_cert)
+      end
+
+      new_context
+    }
+    @server = OpenSSL::SSL::SSLServer.new(@server, ssl_context)
+  end
+
+  def add_websocket
+    @handshake = WebSocket::Handshake::Server.new(host: "127.0.0.1", port: @port)
+  end
+
+  def add_bad_websocket
+    @handshake = WebSocket::Handshake::Server.new(host: "127.0.0.1", port: @port)
+    @bad_handshake = true
+  end
+
+  def run
+    @thread = Thread.new do
+      client = @server.accept
+      string = ""
+      while part = client.gets
+        string = string + part
+        break if string =~ /Sec-WebSocket-Key/
+      end
+      if @handshake
+        @handshake << string + "\r\n"
+        if @bad_handshake
+          client.puts("bad handshake")
+        else
+          client.puts(@handshake.to_s)
+        end
+      end
+    end
+  end
+
+  def close
+    @thread.kill if @thread
+    @server.close
+  end
+
+  private
+
+  def build_cert(common_name)
+    @ca.signed_cert(
+      Util::OpenSsl::X509::SmartCsr.new(
+        Util::OpenSsl::X509::QuickCsr.new(common_name: common_name, rsa_key: @ca.key).request
+      )
+    )
+  end
+
+  def build_ca
+    @ca ||= Util::OpenSsl::CA.from_subject("/CN=testing.com/OU=Conjur Kubernetes CA/O=user")
+  end
+
+  def build_ssl_context(ssl_version, cert)
+    ssl_context = OpenSSL::SSL::SSLContext.new
+    ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    ssl_context.ssl_version = ssl_version
+    ssl_context.key = OpenSSL::PKey::RSA.new(@ca.key)
+    ssl_context.cert = OpenSSL::X509::Certificate.new(cert)
+    ssl_context
+  end
+end
+
+describe 'Authentication::AuthnK8s::WebSocketClient' do
+  context 'no server running' do
+    before(:example) do
+    end
+
+    after(:example) do
+    end
+
+    it 'fails to connect' do
+      expect {
+        Authentication::AuthnK8s::WebSocketClient.connect("https://127.0.0.1")
+      }.to raise_error(Errno::ECONNREFUSED)
+    end
+  end
+
+  context 'server running - no web socket' do
+    before(:example) do
+      @test_server = TestServer.new(80)
+    end
+
+    after(:example) do
+      @test_server.close
+      @test_server = nil
+    end
+
+    it 'fails to connect - no web socket server' do
+      client = Authentication::AuthnK8s::WebSocketClient.connect("http://127.0.0.1")
+      expect(client.open?).to be_falsey
+    end
+  end
+
+  context 'server running - no security' do
+    before(:example) do
+      @test_server = TestServer.new(80)
+    end
+
+    after(:example) do
+      @test_server.close
+      @test_server = nil
+    end
+
+    it 'connects with no options' do
+      @test_server.add_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects with options' do
+      @test_server.add_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://127.0.0.1",
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "testing.com")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'does not connect with a bad handshake' do
+      @test_server.add_bad_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://127.0.0.1")
+      sleep(1)
+      expect(client.open?).to be_falsey
+      client.close
+    end
+  end
+
+  context 'server running - with old security' do
+    before(:example) do
+      @test_server = TestServer.new(443)
+      @test_server.add_old_ssl("127.0.0.1")
+    end
+
+    after(:example) do
+      @test_server.close
+      @test_server = nil
+    end
+
+    it 'does not connect with a bad handshake' do
+      @test_server.add_bad_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_falsey
+      client.close
+    end
+
+    it 'connects properly without options' do
+      @test_server.add_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects properly with options' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :SSLv23,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER)
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects properly with hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :SSLv23,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+  end
+
+  context 'server running - with tls security - no SNI' do
+    before(:example) do
+      @test_server = TestServer.new(443)
+      @test_server.add_tls_without_sni("127.0.0.1")
+    end
+
+    after(:example) do
+      @test_server.close
+      @test_server = nil
+    end
+
+    it 'does not connect with a bad handshake' do
+      @test_server.add_bad_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_falsey
+      client.close
+    end
+
+    it 'connects properly without options' do
+      @test_server.add_websocket
+      @test_server.run
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects properly with options' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER)
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects properly with hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "127.0.0.1")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'does not connect properly with bad hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "bad.com")
+      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+        |error| expect(error.message).to eq("hostname \"bad.com\" does not match the server certificate")
+      }
+    end
+  end
+
+  context 'server running - with tls security - with SNI' do
+    before(:example) do
+      @test_server = TestServer.new(443)
+      @test_server.add_tls_with_sni
+    end
+
+    after(:example) do
+      @test_server.close
+      @test_server = nil
+    end
+
+    it 'does not connect with a bad handshake' do
+      @test_server.add_bad_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "testing.com")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_falsey
+      client.close
+    end
+
+    it 'does not connect properly without options' do
+      @test_server.add_websocket
+      @test_server.run
+      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1")
+      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+        |error| expect(error.message).to eq("SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: sslv3 alert handshake failure")
+      }
+    end
+
+    it 'does not connect properly missing the hostname and no cert available for "127.0.0.1"' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      expect { client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                          ssl_version: :TLSv1,
+                                                                          cert_store: cert_store,
+                                                                          verify_mode: OpenSSL::SSL::VERIFY_PEER)
+      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+        |error| expect(error.message).to eq("hostname \"127.0.0.1\" does not match the server certificate")
+      }
+    end
+
+    it 'connects properly with hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "testing.com")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'connects properly with a different hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "another-site.com")
+      sleep(1)
+      expect(@test_server.handshake).to be_truthy
+      expect(@test_server.handshake.valid?).to be_truthy
+      expect(@test_server.handshake.finished?).to be_truthy
+      expect(client.open?).to be_truthy
+      client.close
+    end
+
+    it 'does not connect properly with bad hostname' do
+      @test_server.add_websocket
+      @test_server.run
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(@test_server.ca.cert)
+      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
+                                                                 ssl_version: :TLSv1,
+                                                                 cert_store: cert_store,
+                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
+                                                                 hostname: "bad.com")
+      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+        |error| expect(error.message).to eq("hostname \"bad.com\" does not match the server certificate")
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

Ability to define the SNI certificate hostname so the proper certificate is returned from the Kubernetes API Server.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

Added change to send the hostname during SSL connection as well as adding testing.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14386](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14386)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [X] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
