### PR TITLE
Test with conjur-cli 6.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'ruby_dep', '= 1.3.1'
 
 # Pinned to update for role member search, using ref so merging and removing
 # the branch doesn't immediately break this link
-gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'
+gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'main'
 gem 'conjur-policy-parser', path: 'gems/policy-parser'
 gem 'conjur-rack', '~> 4'
 gem 'conjur-rack-heartbeat'
@@ -94,7 +94,7 @@ group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'
   gem 'conjur-cli', github: 'cyberark/conjur-cli', branch: 'bump-version-6.2.6'
-  gem 'conjur-debify', require: false
+  gem 'conjur-debify'
   gem 'csr'
   gem 'cucumber'
   gem 'database_cleaner'

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "anyway_config", "2.1.0"
 group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'
-  gem 'conjur-cli', '~> 6.1'
+  gem 'conjur-cli', github: 'cyberark/conjur-cli', branch: 'bump-version-6.2.6'
   gem 'conjur-debify', require: false
   gem 'csr'
   gem 'cucumber'

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "anyway_config", "2.1.0"
 group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'
-  gem 'conjur-cli', github: 'cyberark/conjur-cli', branch: 'bump-version-6.2.6'
+  gem 'conjur-cli', '~> 6.2.5'
   gem 'conjur-debify'
   gem 'csr'
   gem 'cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,21 +7,6 @@ GIT
       activesupport
       rest-client
 
-GIT
-  remote: https://github.com/cyberark/conjur-cli.git
-  revision: 6764002d073acfc54e4337ce4618b3f1957c2ab9
-  branch: bump-version-6.2.6
-  specs:
-    conjur-cli (6.2.6)
-      activesupport (>= 4.2)
-      conjur-api (~> 5.3)
-      deep_merge (~> 1.0)
-      gli (>= 2.8.0)
-      highline (~> 2.0)
-      netrc (~> 0.10)
-      table_print (~> 1.5)
-      xdg (= 2.2.3)
-
 PATH
   remote: gems/policy-parser
   specs:
@@ -116,6 +101,15 @@ GEM
     coderay (1.1.2)
     command_class (0.0.2)
     concurrent-ruby (1.1.8)
+    conjur-cli (6.2.5)
+      activesupport (>= 4.2, < 6)
+      conjur-api (~> 5.3)
+      deep_merge (~> 1.0)
+      gli (>= 2.8.0)
+      highline (~> 2.0)
+      netrc (~> 0.10)
+      table_print (~> 1.5)
+      xdg (= 2.2.3)
     conjur-debify (1.11.4)
       conjur-api (~> 5)
       conjur-cli (~> 6)
@@ -459,7 +453,7 @@ DEPENDENCIES
   ci_reporter_rspec
   command_class
   conjur-api!
-  conjur-cli!
+  conjur-cli (~> 6.2.5)
   conjur-debify
   conjur-policy-parser!
   conjur-rack (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,26 @@
 GIT
   remote: https://github.com/cyberark/conjur-api-ruby.git
-  revision: 8f5e398aec728c1d89a0e599cc0567426887df95
-  branch: master
+  revision: 7cc88aaf790606c221614fea1aaad50be7fa2f4c
+  branch: main
   specs:
-    conjur-api (5.3.2)
+    conjur-api (5.3.5)
       activesupport
       rest-client
+
+GIT
+  remote: https://github.com/cyberark/conjur-cli.git
+  revision: 6764002d073acfc54e4337ce4618b3f1957c2ab9
+  branch: bump-version-6.2.6
+  specs:
+    conjur-cli (6.2.6)
+      activesupport (>= 4.2)
+      conjur-api (~> 5.3)
+      deep_merge (~> 1.0)
+      gli (>= 2.8.0)
+      highline (~> 2.0)
+      netrc (~> 0.10)
+      table_print (~> 1.5)
+      xdg (= 2.2.3)
 
 PATH
   remote: gems/policy-parser
@@ -101,15 +116,6 @@ GEM
     coderay (1.1.2)
     command_class (0.0.2)
     concurrent-ruby (1.1.8)
-    conjur-cli (6.2.2)
-      activesupport (>= 4.2, < 6)
-      conjur-api (~> 5.3)
-      deep_merge (~> 1.0)
-      gli (>= 2.8.0)
-      highline (~> 1.7)
-      netrc (~> 0.10)
-      table_print (~> 1.5)
-      xdg (= 2.2.3)
     conjur-debify (1.11.4)
       conjur-api (~> 5)
       conjur-cli (~> 6)
@@ -191,7 +197,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haikunator (1.1.0)
-    highline (1.7.10)
+    highline (2.0.3)
     http (4.2.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -453,7 +459,7 @@ DEPENDENCIES
   ci_reporter_rspec
   command_class
   conjur-api!
-  conjur-cli (~> 6.1)
+  conjur-cli!
   conjur-debify
   conjur-policy-parser!
   conjur-rack (~> 4)


### PR DESCRIPTION
### Desired Outcome

Conjur oss can run with (future) conjur-cli V6.2.6.

### Implemented Changes

Update gem pin in Gemfile.

### Definition of Done
All tests pass.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
