### PR TITLE
Fix server error for admin user password change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Check to stop hosts from setting passwords fixed for admin user
+  [#2440](https://github.com/cyberark/conjur/pull/2440)
+
 ## [1.14.2] - 2021-12-13
 
 ### Changed

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -37,7 +37,7 @@ class CredentialsController < ApplicationController
   # This method requires a PUT request. The new password is in the request body.
   def update_password
     password = request.body.read
-    raise Exceptions::Forbidden if @role.resource.kind == "host"
+    raise Exceptions::Forbidden if @role.login.start_with?("host/")
 
     Commands::Credentials::ChangePassword.new.call(
       role: @role,

--- a/cucumber/api/features/change_password.feature
+++ b/cucumber/api/features/change_password.feature
@@ -24,6 +24,22 @@ Feature: Change the password of a role
       cucumber:user:alice successfully changed their password
     """
 
+  Scenario: With basic authentication, user admin update their own password using the current password.
+
+    Given I set the password for "admin" to "My-Password1"
+    And I save my place in the audit log file for remote
+    When I successfully PUT "/authn/cucumber/password" with username "admin" and password "My-Password1" and plain text body "New-Password1"
+    Then I can GET "/authn/cucumber/login" with username "admin" and password "New-Password1"
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * password
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 role="cucumber:user:admin"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="change"]
+      cucumber:user:admin successfully changed their password
+    """
+
   Scenario: With basic authentication, users can update their own password using the current API key.
 
     When I successfully PUT "/authn/cucumber/password" with username "alice" and password ":cucumber:user:alice_api_key" and plain text body "New-Password1"


### PR DESCRIPTION
### Desired Outcome

Addresses #2438.

When changing a role's password, a check was recently added so that the operation would be refused for `host` roles.
This check breaks when changing the password for `user:admin`, resulting in the following server error:

```
RuntimeError (Resource not found for dev:user:admin)
app/models/role.rb:126:in `resource'
app/controllers/credentials_controller.rb:41:in `update_password'
app/controllers/application_controller.rb:79:in `run_with_transaction'
```

### Implemented Changes

- Added a cucumber test case to confirm the password change failure for user `admin`
- Updated the `host` check:

  ```diff
  - raise Exceptions::Forbidden if @role.resource.kind == "host"
  + raise Exceptions::Forbidden if @role.login.start_with?("host/")
  ```

### Connected Issue/Story

Resolves #2438

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
