### PR TITLE
authn-jwt - move cache binding point

### DIFF
--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -10,6 +10,7 @@ module Authentication
 
         def initialize(
           authenticator_input:,
+          fetch_signing_key:,
           fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
           http_lib: Net::HTTP,
           create_jwks_from_http_response: CreateJwksFromHttpResponse.new,
@@ -21,15 +22,20 @@ module Authentication
           @fetch_authenticator_secrets = fetch_authenticator_secrets
 
           @authenticator_input = authenticator_input
+          @fetch_signing_key = fetch_signing_key
+        end
+
+        def call(force_read:)
+          @fetch_signing_key.call(
+            refresh: force_read,
+            cache_key: jwks_uri,
+            signing_key_provider: self
+          )
         end
 
         def fetch_signing_key
           fetch_jwks_uri
           fetch_jwks_keys
-        end
-
-        def signing_key_uri
-          jwks_uri
         end
 
         private

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -25,9 +25,9 @@ module Authentication
           @fetch_signing_key = fetch_signing_key
         end
 
-        def call(force_read:)
+        def call(force_fetch:)
           @fetch_signing_key.call(
-            refresh: force_read,
+            refresh: force_fetch,
             cache_key: jwks_uri,
             signing_key_provider: self
           )

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
@@ -19,9 +19,9 @@ module Authentication
           @fetch_signing_key = fetch_signing_key
         end
 
-        def call(force_read:)
+        def call(force_fetch:)
           @fetch_signing_key.call(
-            refresh: force_read,
+            refresh: force_fetch,
             cache_key: provider_uri,
             signing_key_provider: self
           )

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
@@ -6,6 +6,7 @@ module Authentication
 
         def initialize(
           authenticator_input:,
+          fetch_signing_key:,
           fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
           discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new,
           logger: Rails.logger
@@ -15,15 +16,20 @@ module Authentication
           @discover_identity_provider = discover_identity_provider
 
           @authenticator_input = authenticator_input
+          @fetch_signing_key = fetch_signing_key
+        end
+
+        def call(force_read:)
+          @fetch_signing_key.call(
+            refresh: force_read,
+            cache_key: provider_uri,
+            signing_key_provider: self
+          )
         end
 
         def fetch_signing_key
           discover_provider
           fetch_provider_keys
-        end
-
-        def signing_key_uri
-          provider_uri
         end
 
         private

--- a/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
+++ b/app/domain/authentication/authn_jwt/validate_and_decode/validate_and_decode_token.rb
@@ -41,9 +41,9 @@ module Authentication
           raise Errors::Authentication::AuthnJwt::MissingToken if @jwt_token.blank?
         end
 
-        def fetch_signing_key(force_read: false)
+        def fetch_signing_key(force_fetch: false)
           @jwks = signing_key_provider.call(
-            force_read: force_read
+            force_fetch: force_fetch
           )
           @logger.debug(LogMessages::Authentication::AuthnJwt::SigningKeysFetchedFromCache.new)
         end
@@ -62,7 +62,7 @@ module Authentication
             LogMessages::Authentication::AuthnJwt::ValidateSigningKeysAreUpdated.new
           )
           # maybe failed due to keys rotation. Force cache to read it again
-          fetch_signing_key(force_read: true)
+          fetch_signing_key(force_fetch: true)
         end
 
         def fetch_decoded_token_for_signature_only

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -3,16 +3,6 @@ module Authentication
 
     ValidateStatus = CommandClass.new(
       dependencies: {
-        fetch_signing_key: ::Util::ConcurrencyLimitedCache.new(
-          ::Util::RateLimitedCache.new(
-            ::Authentication::AuthnJwt::SigningKey::FetchCachedSigningKey.new,
-            refreshes_per_interval: CACHE_REFRESHES_PER_INTERVAL,
-            rate_limit_interval: CACHE_RATE_LIMIT_INTERVAL,
-            logger: Rails.logger
-          ),
-          max_concurrent_requests: CACHE_MAX_CONCURRENT_REQUESTS,
-          logger: Rails.logger
-        ),
         create_signing_key_provider: Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new,
         fetch_issuer_value: Authentication::AuthnJwt::ValidateAndDecode::FetchIssuerValue.new,
         fetch_audience_value: Authentication::AuthnJwt::ValidateAndDecode::FetchAudienceValue.new,
@@ -150,9 +140,8 @@ module Authentication
       end
 
       def validate_signing_key
-        @fetch_signing_key.call(
-          cache_key: signing_key_provider.signing_key_uri,
-          signing_key_provider: signing_key_provider
+        signing_key_provider.call(
+          force_read: false
         )
         @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedSigningKeyConfiguration.new)
       end

--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -141,7 +141,7 @@ module Authentication
 
       def validate_signing_key
         signing_key_provider.call(
-          force_read: false
+          force_fetch: false
         )
         @logger.debug(LogMessages::Authentication::AuthnJwt::ValidatedSigningKeyConfiguration.new)
       end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
                                                                            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                            http_lib: mocked_bad_http_response,
                                                                            create_jwks_from_http_response: mocked_create_jwks_from_http_response
-        ).call(force_read: false)
+        ).call(force_fetch: false)
       end
 
       it "returns false" do
@@ -109,7 +109,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
                                                                            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                            http_lib: mocked_bad_http_response,
                                                                            create_jwks_from_http_response: mocked_create_jwks_from_http_response
-        ).call(force_read: true)
+        ).call(force_fetch: true)
       end
 
       it "returns true" do
@@ -125,7 +125,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
                                                                            fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                            http_lib: mocked_bad_http_response,
                                                                            create_jwks_from_http_response: mocked_create_jwks_from_http_response
-        ).call(force_read: false)
+        ).call(force_fetch: false)
       end
 
       it "raises an error" do
@@ -142,7 +142,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
                                                                              fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                              http_lib: mocked_good_http_response,
                                                                              create_jwks_from_http_response: mocked_create_jwks_from_http_response
-          ).call(force_read: false)
+          ).call(force_fetch: false)
         end
 
         it "returns jwks value" do
@@ -158,7 +158,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
                                                                              fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                              http_lib: mocked_bad_http_response,
                                                                              create_jwks_from_http_response: mocked_create_jwks_from_http_response
-          ).call(force_read: false)
+          ).call(force_fetch: false)
         end
 
         it "raises an error" do

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_provider_uri_signing_key_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
                                                                                  logger: mocked_logger,
                                                                                  fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                                  discover_identity_provider: mocked_discover_identity_provider
-          ).call(force_read: false)
+          ).call(force_fetch: false)
         end
 
         it "returns false" do
@@ -101,7 +101,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
                                                                                  logger: mocked_logger,
                                                                                  fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                                  discover_identity_provider: mocked_discover_identity_provider
-          ).call(force_read: true)
+          ).call(force_fetch: true)
         end
 
         it "returns true" do
@@ -118,7 +118,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
                                                                                  logger: mocked_logger,
                                                                                  fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                                  discover_identity_provider: mocked_invalid_uri_discover_identity_provider
-          ).call(force_read: false)
+          ).call(force_fetch: false)
         end
 
         it "raises an error" do
@@ -133,7 +133,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey
                                                                                  logger: mocked_logger,
                                                                                  fetch_authenticator_secrets: mocked_fetch_authenticator_secrets_exist_values,
                                                                                  discover_identity_provider: mocked_discover_identity_provider
-          ).call(force_read: false)
+          ).call(force_fetch: false)
         end
 
         it "does not raise error" do

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
@@ -122,31 +122,31 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
 
     allow(mocked_fetch_signing_key_provider_always_succeed).to(
       receive(:call).with(
-        force_read: false
+        force_fetch: false
       ).and_return(jwks_from_1st_call)
     )
 
     allow(mocked_fetch_signing_key_provider_always_succeed).to(
       receive(:call).with(
-        force_read: true
+        force_fetch: true
       ).and_return(jwks_from_2nd_call)
     )
 
     allow(mocked_fetch_signing_key_provider_failed_on_1st_time).to(
       receive(:call).with(
-        force_read: false
+        force_fetch: false
       ).and_raise(fetch_signing_key_1st_time_error)
     )
 
     allow(mocked_fetch_signing_key_provider_failed_on_2nd_time).to(
       receive(:call).with(
-        force_read: false
+        force_fetch: false
       ).and_return(jwks_from_2nd_call)
     )
 
     allow(mocked_fetch_signing_key_provider_failed_on_2nd_time).to(
       receive(:call).with(
-        force_read: true
+        force_fetch: true
       ).and_raise(fetch_signing_key_2nd_time_error)
     )
 

--- a/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_and_decode/validate_and_decode_token_spec.rb
@@ -17,20 +17,16 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
     )
   }
 
-  let(:mocked_create_signing_key_provider_valid) { double("MockedSigningKeyInterfaceFactoryValid") }
-  let(:mocked_create_signing_key_provider_invalid) { double("MockedSigningKeyInterfaceFactoryInvalid") }
   let(:mocked_create_signing_key_provider_failed) { double("MockedSigningKeyInterfaceFactoryFailed") }
+  let(:mocked_create_signing_key_provider_always_succeed) { double("MockedSigningKeyInterfaceFactoryAlwaysSucceed") }
+  let(:mocked_create_signing_key_provider_failed_on_1st_time) { double("MockedSigningKeyInterfaceFactoryFailedOn1") }
+  let(:mocked_create_signing_key_provider_failed_on_2st_time) { double("MockedSigningKeyInterfaceFactoryFailedOn2") }
 
   let(:create_signing_key_provider_error) { "signing key interface factory error" }
 
-  let(:mocked_fetch_signing_key_provider_valid) { double("MockedSigningKeyInterfaceValid") }
-  let(:mocked_fetch_signing_key_provider_failed) { double("MockedSigningKeyInterfaceFailed") }
-
-  let(:fetch_signing_key_provider_error) { "fetch signing key interface error" }
-
-  let(:mocked_fetch_signing_key_failed_on_1st_time) { double("MockedFetchSigningKeyInvalid") }
-  let(:mocked_fetch_signing_key_failed_on_2nd_time) { double("MockedFetchSigningKeyInvalid") }
-  let(:mocked_fetch_signing_key_always_succeed) { double("MockedFetchSigningKey") }
+  let(:mocked_fetch_signing_key_provider_always_succeed) { double("MockedFetchSigningKeyProviderAlwaysSucceed") }
+  let(:mocked_fetch_signing_key_provider_failed_on_1st_time) { double("MockedFetchSigningKeyProviderFailedOn1") }
+  let(:mocked_fetch_signing_key_provider_failed_on_2nd_time) { double("MockedFetchSigningKeyProviderFailedOn2") }
 
   let(:fetch_signing_key_1st_time_error) { "fetch signing key 1st time error" }
   let(:fetch_signing_key_2nd_time_error) { "fetch signing key 2nd time error" }
@@ -108,68 +104,54 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
   let(:mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated) { double("MockedVerifyAndDecodeTokenSucceedToValidateClaims") }
 
   before(:each) do
-    allow(mocked_fetch_signing_key_provider_valid).to(
-      receive(:signing_key_uri).and_return(valid_signing_key_uri)
-    )
-
-    allow(mocked_create_signing_key_provider_valid).to(
-      receive(:call).and_return(mocked_fetch_signing_key_provider_valid)
-    )
-
-    allow(mocked_fetch_signing_key_provider_failed).to(
-      receive(:signing_key_uri).and_raise(fetch_signing_key_provider_error)
-    )
-
-    allow(mocked_create_signing_key_provider_invalid).to(
-      receive(:call).and_return(mocked_fetch_signing_key_provider_failed)
-    )
-
     allow(mocked_create_signing_key_provider_failed).to(
       receive(:call).and_raise(create_signing_key_provider_error)
     )
 
-    allow(mocked_fetch_signing_key_failed_on_1st_time).to(
-      receive(:call).with(
-        refresh: false,
-        cache_key: anything(),
-        signing_key_provider: anything()
-      ).and_raise(fetch_signing_key_1st_time_error)
+    allow(mocked_create_signing_key_provider_always_succeed).to(
+      receive(:call).and_return(mocked_fetch_signing_key_provider_always_succeed)
     )
 
-    allow(mocked_fetch_signing_key_failed_on_2nd_time).to(
+    allow(mocked_create_signing_key_provider_failed_on_1st_time).to(
+      receive(:call).and_return(mocked_fetch_signing_key_provider_failed_on_1st_time)
+    )
+
+    allow(mocked_create_signing_key_provider_failed_on_2st_time).to(
+      receive(:call).and_return(mocked_fetch_signing_key_provider_failed_on_2nd_time)
+    )
+
+    allow(mocked_fetch_signing_key_provider_always_succeed).to(
       receive(:call).with(
-        refresh: false,
-        cache_key: anything(),
-        signing_key_provider: anything()
+        force_read: false
+      ).and_return(jwks_from_1st_call)
+    )
+
+    allow(mocked_fetch_signing_key_provider_always_succeed).to(
+      receive(:call).with(
+        force_read: true
       ).and_return(jwks_from_2nd_call)
     )
 
-    allow(mocked_fetch_signing_key_failed_on_2nd_time).to(
+    allow(mocked_fetch_signing_key_provider_failed_on_1st_time).to(
       receive(:call).with(
-        refresh: true,
-        cache_key: anything(),
-        signing_key_provider: anything()
+        force_read: false
+      ).and_raise(fetch_signing_key_1st_time_error)
+    )
+
+    allow(mocked_fetch_signing_key_provider_failed_on_2nd_time).to(
+      receive(:call).with(
+        force_read: false
+      ).and_return(jwks_from_2nd_call)
+    )
+
+    allow(mocked_fetch_signing_key_provider_failed_on_2nd_time).to(
+      receive(:call).with(
+        force_read: true
       ).and_raise(fetch_signing_key_2nd_time_error)
     )
 
     allow(mocked_verify_and_decode_token_invalid).to(
       receive(:call).and_raise(verify_and_decode_token_error)
-    )
-
-    allow(mocked_fetch_signing_key_always_succeed).to(
-      receive(:call).with(
-        refresh: false,
-        cache_key: anything(),
-        signing_key_provider: anything()
-      ).and_return(jwks_from_1st_call)
-    )
-
-    allow(mocked_fetch_signing_key_always_succeed).to(
-      receive(:call).with(
-        refresh: true,
-        cache_key: anything(),
-        signing_key_provider: anything()
-      ).and_return(jwks_from_2nd_call)
     )
 
     allow(mocked_verify_and_decode_token_succeed_on_1st_time).to(
@@ -319,7 +301,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
     context "When error is during signing key factory call" do
       subject do
         ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-          fetch_signing_key: mocked_fetch_signing_key_failed_on_1st_time,
           create_signing_key_provider: mocked_create_signing_key_provider_failed
         ).call(
           authenticator_input: authenticator_input,
@@ -332,27 +313,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       end
     end
 
-    context "When error is during signing_key_uri call" do
+    context "When error is during fetching from provider" do
       subject do
         ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-          fetch_signing_key: mocked_fetch_signing_key_failed_on_1st_time,
-          create_signing_key_provider: mocked_create_signing_key_provider_invalid
-        ).call(
-          authenticator_input: authenticator_input,
-          jwt_token: jwt_token_valid
-        )
-      end
-
-      it "raises an error" do
-        expect { subject }.to raise_error(fetch_signing_key_provider_error)
-      end
-    end
-
-    context "When error is during fetching from cache" do
-      subject do
-        ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-          fetch_signing_key: mocked_fetch_signing_key_failed_on_1st_time,
-          create_signing_key_provider: mocked_create_signing_key_provider_valid
+          create_signing_key_provider: mocked_create_signing_key_provider_failed_on_1st_time
         ).call(
           authenticator_input: authenticator_input,
           jwt_token: jwt_token_valid
@@ -370,9 +334,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       context "and failed to fetch keys from provider" do
         subject do
           ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-            fetch_signing_key: mocked_fetch_signing_key_failed_on_2nd_time,
             verify_and_decode_token: mocked_verify_and_decode_token_invalid,
-            create_signing_key_provider: mocked_create_signing_key_provider_valid
+            create_signing_key_provider: mocked_create_signing_key_provider_failed_on_2st_time
           ).call(
             authenticator_input: authenticator_input,
             jwt_token: jwt_token_valid
@@ -387,9 +350,8 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       context "and succeed to fetch keys from provider" do
         subject do
           ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
             verify_and_decode_token: mocked_verify_and_decode_token_invalid,
-            create_signing_key_provider: mocked_create_signing_key_provider_valid
+            create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
           ).call(
             authenticator_input: authenticator_input,
             jwt_token: jwt_token_valid
@@ -406,11 +368,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       context "and keys are not updated" do
         subject do
           ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
             verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_2nd_time,
             fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
             get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
-            create_signing_key_provider: mocked_create_signing_key_provider_valid
+            create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
           ).call(
             authenticator_input: authenticator_input,
             jwt_token: jwt_token_valid
@@ -425,11 +386,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       context "and keys are updated" do
         subject do
           ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
             verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
             fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
             get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
-            create_signing_key_provider: mocked_create_signing_key_provider_valid
+            create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
           ).call(
             authenticator_input: authenticator_input,
             jwt_token: jwt_token_valid
@@ -448,10 +408,9 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
       context "and failed to fetch enforced claims" do
         subject do
           ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-            fetch_signing_key: mocked_fetch_signing_key_always_succeed,
             verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
             fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_invalid,
-            create_signing_key_provider: mocked_create_signing_key_provider_valid
+            create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
           ).call(
             authenticator_input: authenticator_input,
             jwt_token: jwt_token_valid
@@ -467,10 +426,9 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
         context "with empty claims list to validate" do
           subject do
             ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
               verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
               fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_with_empty_claims,
-              create_signing_key_provider: mocked_create_signing_key_provider_valid
+              create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
             ).call(
               authenticator_input: authenticator_input,
               jwt_token: jwt_token_valid
@@ -485,10 +443,9 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
         context "with mandatory claims which do not exist in token" do
           subject do
             ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
               verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
               fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_with_not_exist_claims_in_token,
-              create_signing_key_provider: mocked_create_signing_key_provider_valid
+              create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
             ).call(
               authenticator_input: authenticator_input,
               jwt_token: jwt_token_valid
@@ -503,11 +460,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
         context "and failed to get verification options" do
           subject do
             ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-              fetch_signing_key: mocked_fetch_signing_key_always_succeed,
               verify_and_decode_token: mocked_verify_and_decode_token_succeed_on_1st_time,
               fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
               get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_invalid,
-              create_signing_key_provider: mocked_create_signing_key_provider_valid
+              create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
             ).call(
               authenticator_input: authenticator_input,
               jwt_token: jwt_token_valid
@@ -529,11 +485,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
           context "and failed to validate claims" do
             subject do
               ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-                fetch_signing_key: mocked_fetch_signing_key_always_succeed,
                 verify_and_decode_token: mocked_verify_and_decode_token_failed_to_validate_claims,
                 fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
                 get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
-                create_signing_key_provider: mocked_create_signing_key_provider_valid
+                create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
               ).call(
                 authenticator_input: authenticator_input,
                 jwt_token: jwt_token_valid
@@ -549,11 +504,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
             context "and keys are not updated" do
               subject do
                 ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-                  fetch_signing_key: mocked_fetch_signing_key_always_succeed,
                   verify_and_decode_token: mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_not_updated,
                   fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
                   get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
-                  create_signing_key_provider: mocked_create_signing_key_provider_valid
+                  create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
                 ).call(
                   authenticator_input: authenticator_input,
                   jwt_token: jwt_token_valid
@@ -568,11 +522,10 @@ RSpec.describe('Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeTo
             context "and keys are updated" do
               subject do
                 ::Authentication::AuthnJwt::ValidateAndDecode::ValidateAndDecodeToken.new(
-                  fetch_signing_key: mocked_fetch_signing_key_always_succeed,
                   verify_and_decode_token: mocked_verify_and_decode_token_succeed_to_validate_claims_when_keys_updated,
                   fetch_jwt_claims_to_validate: mocked_fetch_jwt_claims_to_validate_valid,
                   get_verification_option_by_jwt_claim: mocked_get_verification_option_by_jwt_claim_valid,
-                  create_signing_key_provider: mocked_create_signing_key_provider_valid
+                  create_signing_key_provider: mocked_create_signing_key_provider_always_succeed
                 ).call(
                   authenticator_input: authenticator_input,
                   jwt_token: jwt_token_valid

--- a/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/validate_status_spec.rb
@@ -55,8 +55,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
   let(:account_does_not_exist_error) { "Account does not exist" }
   let(:identity_not_configured_properly) { "Identity not configured properly" }
   let(:mocked_valid_signing_key_provider) { double("Mocked valid signing key interface")  }
-  let(:mocked_valid_fetch_signing_key) { double("Mocked valid fetch signing key interface")  }
-
 
   before(:each) do
     allow(mocked_valid_create_signing_key_provider).to(
@@ -64,13 +62,9 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
     )
 
     allow(mocked_valid_signing_key_provider).to(
-      receive(:signing_key_uri).and_return(valid_signing_key_uri)
-    )
-
-    allow(mocked_valid_fetch_signing_key).to(
       receive(:call).and_return(valid_signing_key)
     )
-    
+
     allow(mocked_invalid_create_signing_key_provider).to(
       receive(:call).and_raise(create_signing_key_configuration_is_invalid_error)
     )
@@ -93,7 +87,7 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
     allow(mocked_invalid_fetch_claim_aliases).to(
       receive(:call).and_raise(fetch_claim_aliases_configuration_is_invalid_error)
     )
-    
+
     allow(mocked_valid_identity_from_decoded_token_provider).to(
       receive(:new).and_return(mocked_valid_identity_configured_properly)
     )
@@ -162,7 +156,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
       subject do
         ::Authentication::AuthnJwt::ValidateStatus.new(
-          fetch_signing_key: mocked_valid_fetch_signing_key,
           create_signing_key_provider: mocked_valid_create_signing_key_provider,
           fetch_issuer_value: mocked_valid_fetch_issuer_value,
           identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -187,7 +180,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -211,7 +203,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -235,7 +226,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -259,7 +249,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -295,7 +284,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
 
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -320,7 +308,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "signing key secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_invalid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -343,7 +330,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "issuer secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_invalid_fetch_issuer_value,
             identity_from_decoded_token_provider_class: mocked_valid_identity_from_decoded_token_provider,
@@ -366,7 +352,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "audience secret is not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             fetch_audience_value: mocked_invalid_fetch_audience_value,
@@ -390,7 +375,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "enforced claims is not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             fetch_enforced_claims: mocked_invalid_fetch_enforced_claims,
@@ -414,7 +398,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "claim aliases is not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             fetch_claim_aliases: mocked_invalid_fetch_claim_aliases,
@@ -438,7 +421,6 @@ RSpec.describe('Authentication::AuthnJwt::ValidateStatus') do
       context "identity secrets are not configured properly" do
         subject do
           ::Authentication::AuthnJwt::ValidateStatus.new(
-            fetch_signing_key: mocked_valid_fetch_signing_key,
             create_signing_key_provider: mocked_valid_create_signing_key_provider,
             fetch_issuer_value: mocked_valid_fetch_issuer_value,
             validate_identity_configured_properly: mocked_validate_identity_not_configured_properly,


### PR DESCRIPTION
### Desired Outcome

Code is ready to have a Signing key fetcher class that does not require cashing.

### Implemented Changes

Reactor code area around `Fetch*SigningKey` classes and caching signing keys.

More details can be found in in the [design document](https://github.com/cyberark/conjur/blob/master/design/authenticators/authn_jwt/authn-jwt-fetch-more-keys.md#s4) (PR #2437)

### Connected Issue/Story

[ONYX-15138](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15138)

### Definition of Done

- [X] Validate status and Validate and decode classes do not depend cache anymore
- [X] JWKS and Provider URI signing keys fetchers are working with cache
- [X] Cache behavior preserved (tested in appliance)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
