### PR TITLE
Enable gcp authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Check to stop hosts from setting passwords fixed for admin user
   [#2440](https://github.com/cyberark/conjur/pull/2440)
 
+### Added
+- Added API endpoint to enable and disable GCP authenticator
+  [#2448](https://github.com/cyberark/conjur/pull/2448)
+
 ## [1.14.2] - 2021-12-13
 
 ### Changed

--- a/app/domain/authentication/security/validate_webservice_is_authenticator.rb
+++ b/app/domain/authentication/security/validate_webservice_is_authenticator.rb
@@ -21,7 +21,7 @@ module Authentication
       end
 
       def webservice_id
-        "#{@webservice.authenticator_name}/#{@webservice.service_id}"
+        @webservice.service_id.blank? ? @webservice.authenticator_name : "#{@webservice.authenticator_name}/#{@webservice.service_id}"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
         get '/authn-jwt/:service_id/:account/status' => 'authenticate#authn_jwt_status'
         get '/:authenticator(/:service_id)/:account/status' => 'authenticate#status'
 
-        patch '/:authenticator/:service_id/:account' => 'authenticate#update_config'
+        patch '/:authenticator(/:service_id)/:account' => 'authenticate#update_config'
 
         get '/:authenticator(/:service_id)/:account/login' => 'authenticate#login'
 

--- a/cucumber/authenticators_config/features/authn_config.feature
+++ b/cucumber/authenticators_config/features/authn_config.feature
@@ -181,7 +181,7 @@ Feature: Authenticator configuration
     """
     And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled
 
-  Scenario: Authenticated user can not update authenticator without service-id
+  Scenario: Unauthorized user can not update authenticator without service-id
     When I am the super-user
     And I load a policy:
     """

--- a/cucumber/authenticators_config/features/authn_config.feature
+++ b/cucumber/authenticators_config/features/authn_config.feature
@@ -125,3 +125,58 @@ Feature: Authenticator configuration
     """
     Errors::Authentication::AuthenticatorNotSupported
     """
+
+  Scenario: Authenticator without service-id is successfully configured
+    When I am the super-user
+    And I load a policy:
+    """
+    - !policy
+      id: conjur/authn-gcp
+      body:
+      - !webservice
+    """
+    And I save my place in the log file
+    And I PATCH "/authn-gcp/cucumber" with body:
+    """
+    enabled=true
+    """
+    Then the HTTP response status code is 204
+    And authenticator "cucumber:webservice:conjur/authn-gcp" is enabled
+
+    When I successfully PATCH "/authn-gcp/cucumber" with body:
+    """
+    enabled=false
+    """
+    Then the HTTP response status code is 204
+    And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled
+
+  Scenario: Authenticator without service-id and webservice does not exist
+    When I am the super-user
+    And I save my place in the log file
+    And I PATCH "/authn-gcp/cucumber" with body:
+    """
+    enabled=true
+    """
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::WebserviceNotFound
+    """
+    And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled
+
+    When I load a policy:
+    """
+    - !policy
+      id: conjur/authn-gcp
+    """
+    And I save my place in the log file
+    And I PATCH "/authn-gcp/cucumber" with body:
+    """
+    enabled=true
+    """
+    Then the HTTP response status code is 401
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::WebserviceNotFound
+    """
+    And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled

--- a/spec/app/domain/authentication/security/validate_webservice_is_authenticator_spec.rb
+++ b/spec/app/domain/authentication/security/validate_webservice_is_authenticator_spec.rb
@@ -60,4 +60,31 @@ RSpec.describe(Authentication::Security::ValidateWebserviceIsAuthenticator) do
       expect { subject }.to raise_error(Errors::Authentication::AuthenticatorNotSupported)
     end
   end
+
+  context "authenticator with no service id" do
+    let(:webservice) do
+      mock_webservice(test_account, fake_authenticator_name, "")
+    end
+    let(:configured_authenticators) do
+      [ "authn", fake_authenticator_name ]
+    end
+
+    let(:subject) do
+      Authentication::Security::ValidateWebserviceIsAuthenticator.new(
+        installed_authenticators_class: installed
+      ).call(
+        webservice: webservice
+      )
+    end
+
+    before do
+      allow(installed).to receive(:configured_authenticators)
+                            .and_return(configured_authenticators)
+    end
+
+    it "validates without error" do
+      expect { subject }.to_not raise_error
+    end
+  end
+
 end


### PR DESCRIPTION
### Desired Outcome
 I want to be able to enable GCP authenticator on Conjur, so I could authenticate using authn-gcp authenticator, to authenticate securely on GCP platform.

Currently to enable authenticator, the user needs to run REST API request to enable the authenticator. The REST doesn't support authenticator that doesn't have serviceid.

We should add the ability to enable authenticator that missing service-id.


### Implemented Changes

We want to use the existing REST API endpoint, and update service-id to be optional parameter in the URL
Before change:
patch '/:authenticator/:service_id/:account' => 'authenticate#update_config'


After change:
patch '/:authenticator/(:service_id)/:account' => 'authenticate#update_config'


### Connected Issue/Story

Resolves #[2389](https://github.com/cyberark/conjur/issues/2389)


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
