### PR TITLE
Delete policy versions

### DIFF
--- a/app/models/policy_version.rb
+++ b/app/models/policy_version.rb
@@ -84,6 +84,58 @@ class PolicyVersion < Sequel::Model(:policy_versions)
   def before_save
     require 'digest'
     self.policy_sha256 = Digest::SHA256.hexdigest(policy_text)
+    delete_stale_versions
+  end
+
+  def delete_stale_versions
+    log_policy_version_candidates_for_deletion
+    delete_stale_versions
+  end
+
+  def delete_stale_versions(limit = policies_version_limit)
+    Sequel::Model.db[<<-SQL, resource_id, limit, resource_id].delete
+    WITH
+      "ordered_versions" AS
+        (SELECT * FROM "policy_versions" WHERE ("resource_id" = ?) ORDER BY "version" DESC LIMIT ?),
+      "delete_versions" AS
+        (SELECT * FROM "policy_versions" LEFT JOIN "ordered_versions" USING ("resource_id", "version") 
+       WHERE (("ordered_versions"."resource_id" IS NULL) AND ("resource_id" = ?)))
+    DELETE FROM "policy_versions"
+    USING  "delete_versions" 
+    WHERE "policy_versions"."resource_id" = "delete_versions"."resource_id" AND
+      "policy_versions"."version" = "delete_versions"."version"
+    SQL
+  end
+
+  def log_policy_version_candidates_for_deletion
+    stale_policy_versions.all.each do | policy_version |
+      Rails.logger.info( "Policy version: #{policy_version} will be deleted" )
+    end
+  end
+
+  def stale_policy_versions(limit = policies_version_limit)
+    Sequel::Model.db[<<-SQL, resource_id, limit, resource_id]
+    WITH
+      "ordered_versions" AS
+        (SELECT * FROM "policy_versions" WHERE ("resource_id" = ?) ORDER BY "version" DESC LIMIT ?),
+      "delete_versions" AS
+        (SELECT * FROM "policy_versions" LEFT JOIN "ordered_versions" 
+       USING (
+         "resource_id", 
+         "version", 
+         "created_at", 
+         "finished_at", 
+         "client_ip", 
+         "role_id", 
+         "policy_text", 
+         "policy_sha256"
+       ) 
+       WHERE (("ordered_versions"."resource_id" IS NULL) AND ("resource_id" = ?)))
+    SELECT * FROM "policy_versions"
+    JOIN  "delete_versions" USING ("resource_id", "version") 
+    WHERE "policy_versions"."resource_id" = "delete_versions"."resource_id" AND
+      "policy_versions"."version" = "delete_versions"."version"
+    SQL
   end
 
   def before_update

--- a/config/initializers/limits.rb
+++ b/config/initializers/limits.rb
@@ -6,6 +6,6 @@ def secrets_version_limit
 end
 
 def policies_version_limit
-  ( ENV['POLICIES_VERSION_LIMIT'] || 1 ).to_i
+  ( ENV['POLICIES_VERSION_LIMIT'] || 20 ).to_i
 end
 

--- a/config/initializers/limits.rb
+++ b/config/initializers/limits.rb
@@ -4,3 +4,8 @@
 def secrets_version_limit
   ( ENV['SECRETS_VERSION_LIMIT'] || 20 ).to_i
 end
+
+def policies_version_limit
+  ( ENV['POLICIES_VERSION_LIMIT'] || 1 ).to_i
+end
+

--- a/cucumber/api/features/policy_versions_retention.feature
+++ b/cucumber/api/features/policy_versions_retention.feature
@@ -1,0 +1,29 @@
+Feature: Limit the number of policy versions
+
+  Each update of a policy creates a policy version record and policy log records. This feature limits
+  the number of versions in the database to default value of 20 version, older versions are deleted.
+
+  Background:
+    Given I am the super-user
+    And I successfully POST "/policies/cucumber/policy/root" with body:
+    """
+      - !policy policy_test_version
+    """
+  Scenario: I update a policy multiple times so it exceeds the default policy versions limit and get the default
+            limited number of versions in response when I retrieve the policy resource
+    Given I save my place in the log file
+    And I successfully POST 21 times "/policies/cucumber/policy/policy_test_version" with body:
+    """
+      - !user bob
+    """
+    Then the HTTP response status code is 201
+    And I successfully GET "/resources/cucumber/policy/policy_test_version"
+    Then there are 20 "policy_versions" in response
+    And The following appears in the log after my savepoint:
+    """
+    Deleting policy version: {:version=>1, :resource_id=>"cucumber:policy:policy_test_version",
+    """
+
+
+
+

--- a/cucumber/api/features/policy_versions_retention.feature
+++ b/cucumber/api/features/policy_versions_retention.feature
@@ -9,6 +9,7 @@ Feature: Limit the number of policy versions
     """
       - !policy policy_test_version
     """
+
   Scenario: I update a policy multiple times so it exceeds the default policy versions limit and get the default
             limited number of versions in response when I retrieve the policy resource
     Given I save my place in the log file
@@ -16,14 +17,10 @@ Feature: Limit the number of policy versions
     """
       - !user bob
     """
-    Then the HTTP response status code is 201
+    And the HTTP response status code is 201
     And I successfully GET "/resources/cucumber/policy/policy_test_version"
-    Then there are 20 "policy_versions" in response
+    Then there are 20 "policy_versions" in the response
     And The following appears in the log after my savepoint:
     """
     Deleting policy version: {:version=>1, :resource_id=>"cucumber:policy:policy_test_version",
     """
-
-
-
-

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -124,9 +124,13 @@ When(/^I( (?:successfully|can))? authenticate Alice (?:(\d+) times? in (\d+) thr
   )
 end
 
-When(/^I( (?:can|successfully))? POST "([^"]*)" with body:$/) do |can, path, body|
-  try_request can do
-    post_json path, body
+When(/^I( (?:can|successfully))? POST(( \d+) times)? "([^"]*)" with body:$/) do |can, requests_num, path, body|
+  requests_num ||= 1
+
+  (1..requests_num.to_i).each do |i|
+    try_request can do
+      post_json path, body
+    end
   end
 end
 

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -127,7 +127,7 @@ end
 When(/^I( (?:can|successfully))? POST(( \d+) times)? "([^"]*)" with body:$/) do |can, requests_num, path, body|
   requests_num ||= 1
 
-  (1..requests_num.to_i).each do |i|
+  (1..requests_num.to_i).each do
     try_request can do
       post_json path, body
     end

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -12,7 +12,7 @@ Then(/^the resource list should include the newest resources$/) do
   expect(@result.map{|r| r['id']}).to include(*@resources.values.map{|r| r.id})
 end
 
-Then(/^there are (\d+) "([^"]*)" in response$/) do |occurrences, key|
+Then(/^there are (\d+) "([^"]*)" in the response$/) do |occurrences, key|
   expect(@result[key].count).to eq(occurrences)
 end
 

--- a/cucumber/api/features/step_definitions/response_steps.rb
+++ b/cucumber/api/features/step_definitions/response_steps.rb
@@ -12,6 +12,10 @@ Then(/^the resource list should include the newest resources$/) do
   expect(@result.map{|r| r['id']}).to include(*@resources.values.map{|r| r.id})
 end
 
+Then(/^there are (\d+) "([^"]*)" in response$/) do |occurrences, key|
+  expect(@result[key].count).to eq(occurrences)
+end
+
 Then(/^the resource list should only include the searched resource$/) do
   expect(@result.map{|r| r['id']}).to eq([@current_resource.id])
 end


### PR DESCRIPTION
### Desired Outcome
Limit the number of Policy Versions

### Implemented Changes
Old version beyond the limit of 20 records are deleted.

*Describe how the desired outcome above has been achieved with this PR.
PolicyVersion model after save deleted old version beyond the limit of 20 records.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()
[ONYX-13335 Default number of policy version](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13335)
[Task ONYX-15328](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15328)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*
- [x] Upon policy version creation versions limit is checked and enforced
- [x] Deleted versions are written to log at info level
- [x] The versions limit can be set using an environment variable


#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
