### PR TITLE
New `ca_cert` parameter in FetchJwksUriSigningKey class

### DIFF
--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -11,6 +11,7 @@ module Authentication
         def initialize(
           authenticator_input:,
           fetch_signing_key:,
+          ca_cert: nil,
           fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
           http_lib: Net::HTTP,
           create_jwks_from_http_response: CreateJwksFromHttpResponse.new,
@@ -23,6 +24,7 @@ module Authentication
 
           @authenticator_input = authenticator_input
           @fetch_signing_key = fetch_signing_key
+          @ca_cert = ca_cert
         end
 
         def call(force_fetch:)
@@ -36,6 +38,7 @@ module Authentication
         def fetch_signing_key
           fetch_jwks_uri
           fetch_jwks_keys
+          create_jwks_from_http_response
         end
 
         private
@@ -58,19 +61,63 @@ module Authentication
         end
 
         def fetch_jwks_keys
-          begin
-            uri = URI(jwks_uri)
-            @logger.info(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(jwks_uri))
-            response = @http_lib.get_response(uri)
-            @logger.debug(LogMessages::Authentication::AuthnJwt::FetchJwtUriKeysSuccess.new)
-          rescue => e
+          jwks_keys
+        end
+
+        def jwks_keys
+          return @jwks_keys if defined?(@jwks_keys)
+
+          uri = URI(jwks_uri)
+          @logger.info(LogMessages::Authentication::AuthnJwt::FetchingJwksFromProvider.new(jwks_uri))
+          @jwks_keys = net_http_start(
+            uri.host,
+            uri.port,
+            uri.scheme == 'https'
+          ) { |http| http.get(uri) }
+          @logger.debug(LogMessages::Authentication::AuthnJwt::FetchJwtUriKeysSuccess.new)
+        rescue => e
+          raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(
+            jwks_uri,
+            e.inspect
+          )
+        end
+
+        def net_http_start(host, port, use_ssl, &block)
+          if @ca_cert && !use_ssl
             raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(
               jwks_uri,
-              e.inspect
+              "TLS misconfiguration - ca-cert is provided but jwks-uri URI scheme is http"
             )
           end
 
-          @create_jwks_from_http_response.call(http_response: response)
+          if @ca_cert
+            net_http_start_with_ca_cert(host, port, use_ssl, &block)
+          else
+            net_http_start_without_ca_cert(host, port, use_ssl, &block)
+          end
+        end
+
+        def net_http_start_with_ca_cert(host, port, use_ssl, &block)
+          @http_lib.start(
+            host,
+            port,
+            use_ssl: use_ssl,
+            cert_store: @ca_cert,
+            &block
+          )
+        end
+
+        def net_http_start_without_ca_cert(host, port, use_ssl, &block)
+          @http_lib.start(
+            host,
+            port,
+            use_ssl: use_ssl,
+            &block
+          )
+        end
+
+        def create_jwks_from_http_response
+          @create_jwks_from_http_response.call(http_response: jwks_keys)
         end
       end
     end


### PR DESCRIPTION
### Desired Outcome

Allow FetchJwksUriSigningKey class fetch JWKS data from endpoints are providing self-signed certificate or certificate signed by 3rd party CA.

### Implemented Changes

Add new `ca_cert` parameter to FetchJwksUriSigningKey class

### Connected Issue/Story

[ONYX-15871](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15871)

### Definition of Done

- [X] Desired outcome is achieved

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
