### PR TITLE
Add policy retention step for upgrade

### DIFF
--- a/cucumber/api/features/policy_versions_retention.feature
+++ b/cucumber/api/features/policy_versions_retention.feature
@@ -24,3 +24,14 @@ Feature: Limit the number of policy versions
     """
     Deleting policy version: {:version=>1, :resource_id=>"cucumber:policy:policy_test_version",
     """
+
+  Scenario: DB migration removes policy versions that exceed to limit
+    Given I save my place in the log file
+    And I successfully POST 21 times "/policies/cucumber/policy/policy_test_version" with body:
+    """
+      - !user bob
+    """    
+    And the HTTP response status code is 201
+    When I migrate the db
+    And I successfully GET "/resources/cucumber/policy/policy_test_version"
+    Then there are 20 "policy_versions" in the response

--- a/cucumber/api/features/step_definitions/policy_load_steps.rb
+++ b/cucumber/api/features/step_definitions/policy_load_steps.rb
@@ -53,6 +53,10 @@ When('I use curl to load a policy with special characters and no content type') 
   @command_result = $CHILD_STATUS.success?
 end
 
+When(/^I migrate the db/) do
+  system("rake db:migrate")
+end
+
 Then('the command is successful') do
   expect(@command_result).to be(true)
 end

--- a/db/migrate/20220104115357_policy_retention.rb
+++ b/db/migrate/20220104115357_policy_retention.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  up do
+    execute <<-DELETE
+      WITH
+        "ordered_versions" AS (
+          SELECT *, row_number() over( PARTITION BY "resource_id"
+            ORDER BY "version" DESC) as row_number 
+          FROM "policy_versions"
+        )
+      DELETE FROM "policy_versions" AS policies
+      WHERE EXISTS ( 
+        SELECT *
+        FROM  ordered_versions
+        WHERE row_number > 20 AND
+              resource_id = policies.resource_id AND 
+              version = policies.version)
+    DELETE
+  end
+end


### PR DESCRIPTION
### Desired Outcome

We want to leave just 20 versions for each policy on upgrade.

### Implemented Changes

Added a migration step for removing old versions (all except the last 20)

### Connected Issue/Story

CyberArk internal issue link [ONYX-15331](https://ca-il-jira.il.cyber-ark.com:8443/secure/RapidBoard.jspa?rapidView=1475&view=detail&selectedIssue=ONYX-15331)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [V ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ V] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
