### PR TITLE
Align error message in jwt status and authenticator error logs

### DIFF
--- a/app/domain/authentication/authn_jwt/validate_status.rb
+++ b/app/domain/authentication/authn_jwt/validate_status.rb
@@ -26,12 +26,12 @@ module Authentication
       def call
         @logger.info(LogMessages::Authentication::AuthnJwt::ValidatingJwtStatusConfiguration.new)
         validate_generic_status_validations
+        validate_signing_key
         validate_issuer
         validate_audience
         validate_enforced_claims
         validate_claim_aliases
         validate_identity_secrets
-        validate_signing_key
         @logger.info(LogMessages::Authentication::AuthnJwt::ValidatedJwtStatusConfiguration.new)
       end
 

--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -338,7 +338,7 @@ Feature: JWT Authenticator - Status Check
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00078E Issuer authenticator configuration is invalid"
+    And the authenticator status check fails with error "CONJ00086E Signing key URI configuration is invalid"
 
   Scenario: ONYX-9141: Identity is configured but empty, 500 Error
     Given I load a policy:
@@ -649,7 +649,7 @@ Feature: JWT Authenticator - Status Check
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00079E Failed to extract hostname from URI 'unknow-host.com'"
+    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'unknow-host.com'"
 
   @sanity
   Scenario: ONYX-9516: Identify-path is configured but empty, 500 Error


### PR DESCRIPTION
Currently when jwks-uri was wrong they showed different messages. Change of order in call function of validate_status.rb fixed that.

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
