### PR TITLE
Integrate ca certificate flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added an ability to fetch signing keys from JWKS endpoints are using self-signed
+  certificate or certificate signed by 3rd party CA to JWT generic vendor configuration
+  ([#2462](https://github.com/cyberark/conjur/pull/2462)
+  [#2461](https://github.com/cyberark/conjur/pull/2461)
+  [#2456](https://github.com/cyberark/conjur/pull/2456)
+  [#2455](https://github.com/cyberark/conjur/pull/2455)
+  [#2457](https://github.com/cyberark/conjur/pull/2457)
+  [#2452](https://github.com/cyberark/conjur/pull/2452)
+  [#2437](https://github.com/cyberark/conjur/pull/2437))
 - Added an ability to JWT generic vendor configuration to receive signing keys for
   JWT token verification from a variable. Variable name is `public-keys`
   ([#2463](https://github.com/cyberark/conjur/pull/2463)

--- a/app/domain/authentication/authn_jwt/signing_key/create_signing_key_provider.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/create_signing_key_provider.rb
@@ -76,6 +76,7 @@ module Authentication
           )
           @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri_signing_key_class.new(
             jwks_uri: signing_key_settings.uri,
+            cert_store: signing_key_settings.cert_store,
             fetch_signing_key: @fetch_signing_key
           )
         end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_jwks_uri_signing_key.rb
@@ -11,7 +11,7 @@ module Authentication
         def initialize(
           jwks_uri:,
           fetch_signing_key:,
-          ca_cert: nil,
+          cert_store: nil,
           http_lib: Net::HTTP,
           create_jwks_from_http_response: CreateJwksFromHttpResponse.new,
           logger: Rails.logger
@@ -22,7 +22,7 @@ module Authentication
 
           @jwks_uri = jwks_uri
           @fetch_signing_key = fetch_signing_key
-          @ca_cert = ca_cert
+          @cert_store = cert_store
         end
 
         def call(force_fetch:)
@@ -63,14 +63,14 @@ module Authentication
         end
 
         def net_http_start(host, port, use_ssl, &block)
-          if @ca_cert && !use_ssl
+          if @cert_store && !use_ssl
             raise Errors::Authentication::AuthnJwt::FetchJwksKeysFailed.new(
               @jwks_uri,
               "TLS misconfiguration - ca-cert is provided but jwks-uri URI scheme is http"
             )
           end
 
-          if @ca_cert
+          if @cert_store
             net_http_start_with_ca_cert(host, port, use_ssl, &block)
           else
             net_http_start_without_ca_cert(host, port, use_ssl, &block)
@@ -82,7 +82,7 @@ module Authentication
             host,
             port,
             use_ssl: use_ssl,
-            cert_store: @ca_cert,
+            cert_store: @cert_store,
             &block
           )
         end

--- a/cucumber/authenticators_jwt/features/authn_jwt_ca_cert.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_ca_cert.feature
@@ -4,8 +4,7 @@ Feature: JWT Authenticator - ca-cert variable tests
   All tests are using status API for validation.
 
   Background:
-    Given I initialize JWKS endpoint with file "ca-cert.json"
-    And I load a policy:
+    Given I load a policy:
     """
     - !policy
       id: conjur/authn-jwt/raw
@@ -16,21 +15,22 @@ Feature: JWT Authenticator - ca-cert variable tests
     """
 
   Scenario: ONYX-15311: Self-signed jwks-uri no ca-cert variable
-    Given I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable to value "https://jwks/ca-cert.json"
+    Given I initialize JWKS endpoint with file "ca-cert-ONYX-15311.json"
+    And I am the super-user
+    And I successfully set authn-jwt "jwks-uri" variable to value "https://jwks/ca-cert-ONYX-15311.json"
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://jwks/ca-cert.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>'>"
+    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://jwks/ca-cert-ONYX-15311.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>'>"
 
-  @skip
   @sanity
   Scenario: ONYX-15312: Self-signed jwks-uri with valid ca-cert variable value
-    Given I am the super-user
+    Given I initialize JWKS endpoint with file "ca-cert-ONYX-15312.json"
+    And I am the super-user
     And I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/ca-cert
     """
-    And I successfully set authn-jwt "jwks-uri" variable to value "https://jwks/ca-cert.json"
+    And I successfully set authn-jwt "jwks-uri" variable to value "https://jwks/ca-cert-ONYX-15312.json"
     And I fetch root certificate from https://jwks endpoint as "self"
     And I successfully set authn-jwt "ca-cert" variable value to the "self" certificate
     When I GET "/authn-jwt/raw/cucumber/status"
@@ -38,9 +38,10 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
-  @skip
   Scenario Outline: ONYX-15313/6: Self-signed jwks-uri with ca-cert contains bundle includes the valid certificate
-    Given I am the super-user
+    Given I initialize JWKS endpoint with file "ca-cert-ONYX-15313.json"
+    And I initialize JWKS endpoint with file "ca-cert-ONYX-15316.json"
+    And I am the super-user
     And I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/ca-cert
@@ -59,26 +60,27 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
     Examples:
-      | jwks-uri                                     |
-      | https://jwks/ca-cert.json                    |
-      | https://chained.mycompany.local/ca-cert.json |
+      | jwks-uri                                                |
+      | https://jwks/ca-cert-ONYX-15313.json                    |
+      | https://chained.mycompany.local/ca-cert-ONYX-15316.json |
 
   Scenario: ONYX-15314: Chained jwks-uri no ca-cert variable
-    Given I am the super-user
-    And I successfully set authn-jwt "jwks-uri" variable to value "https://chained.mycompany.local/ca-cert.json"
+    Given I initialize JWKS endpoint with file "ca-cert-ONYX-15314.json"
+    And I am the super-user
+    And I successfully set authn-jwt "jwks-uri" variable to value "https://chained.mycompany.local/ca-cert-ONYX-15314.json"
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://chained.mycompany.local/ca-cert.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)>'>"
+    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://chained.mycompany.local/ca-cert-ONYX-15314.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)>'>"
 
-  @skip
   @sanity
   Scenario: ONYX-15315: Self-signed jwks-uri with valid ca-cert variable value
-    Given I am the super-user
+    Given I initialize JWKS endpoint with file "ca-cert-ONYX-15315.json"
+    And I am the super-user
     And I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/ca-cert
     """
-    And I successfully set authn-jwt "jwks-uri" variable to value "https://chained.mycompany.local/ca-cert.json"
+    And I successfully set authn-jwt "jwks-uri" variable to value "https://chained.mycompany.local/ca-cert-ONYX-15315.json"
     And I fetch root certificate from https://chained.mycompany.local endpoint as "chained"
     And I successfully set authn-jwt "ca-cert" variable value to the "chained" certificate
     When I GET "/authn-jwt/raw/cucumber/status"
@@ -94,17 +96,16 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
-  @skip
   @sanity
-  Scenario: ONYX-15318: Google's jwks-uri with invalid ca-cert variable value
+  Scenario: ONYX-15318: Microsoft's jwks-uri with invalid ca-cert variable value
     Given I am the super-user
     And I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/ca-cert
     """
-    And I successfully set authn-jwt "jwks-uri" variable to value "https://www.googleapis.com/oauth2/v3/certs"
+    And I successfully set authn-jwt "jwks-uri" variable to value "https://login.microsoftonline.com/common/discovery/v2.0/keys"
     And I fetch root certificate from https://chained.mycompany.local endpoint as "chained"
     And I successfully set authn-jwt "ca-cert" variable value to the "chained" certificate
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://www.googleapis.com/oauth2/v3/certs'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)>'>"
+    And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://login.microsoftonline.com/common/discovery/v2.0/keys'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)>'>"

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_jwks_signing_key_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
       context "when it present" do
         subject do
           ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(jwks_uri: jwks_uri_https,
-                                                                             ca_cert: cert_store_present,
+                                                                             cert_store: cert_store_present,
                                                                              fetch_signing_key: mocked_fetch_signing_key,
                                                                              logger: mocked_logger,
                                                                              http_lib: mocked_http_response_ca_cert_present,
@@ -142,7 +142,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey') d
       context "when it present but uri is http" do
         subject do
           ::Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey.new(jwks_uri: jwks_uri_http,
-                                                                             ca_cert: cert_store_present,
+                                                                             cert_store: cert_store_present,
                                                                              fetch_signing_key: mocked_fetch_signing_key,
                                                                              logger: mocked_logger,
                                                                              http_lib: mocked_http_response_ca_cert_present,


### PR DESCRIPTION
### Desired Outcome

Enable JWT Authenticator to work with new `ca-cert` variable.

### Implemented Changes

- `CreateSigningKeyProvider` class passes `cert_store` parameter into `FetchJwksUriSigningKey` instance
- Enable relevant integration tests

### Connected Issue/Story

[ONYX-15872](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15872)

### Definition of Done

- [X] Desired outcome achieved
- [X] All integration tests are passed

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [X] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
