### PR TITLE
JWT Authenticator supports `public-keys` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added an ability to JWT generic vendor configuration to receive signing keys for
+  JWT token verification from a variable. Variable name is `public-keys`
+  ([#2463](https://github.com/cyberark/conjur/pull/2463)
+  [#2461](https://github.com/cyberark/conjur/pull/2461)
+  [#2456](https://github.com/cyberark/conjur/pull/2456)
+  [#2455](https://github.com/cyberark/conjur/pull/2455)
+  [#2454](https://github.com/cyberark/conjur/pull/2454)
+  [#2450](https://github.com/cyberark/conjur/pull/2450)
+  [#2447](https://github.com/cyberark/conjur/pull/2447)
+  [#2437](https://github.com/cyberark/conjur/pull/2437))
+
 ## [1.15.1] - 2022-01-12
 
 ### Changed

--- a/app/domain/authentication/authn_jwt/signing_key/create_signing_key_provider.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/create_signing_key_provider.rb
@@ -18,6 +18,7 @@ module Authentication
           build_signing_key_settings: Authentication::AuthnJwt::SigningKey::SigningKeySettingsBuilder.new,
           fetch_provider_uri_signing_key_class: Authentication::AuthnJwt::SigningKey::FetchProviderUriSigningKey,
           fetch_jwks_uri_signing_key_class: Authentication::AuthnJwt::SigningKey::FetchJwksUriSigningKey,
+          fetch_public_keys_signing_key_class: Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey,
           logger: Rails.logger
         },
         inputs: %i[authenticator_input]
@@ -52,6 +53,8 @@ module Authentication
             fetch_jwks_uri_signing_key
           when PROVIDER_URI_INTERFACE_NAME
             fetch_provider_uri_signing_key
+          when PUBLIC_KEYS_INTERFACE_NAME
+            fetch_public_keys_signing_key
           else
             raise Errors::Authentication::AuthnJwt::InvalidSigningKeyType, signing_key_settings.type
           end
@@ -74,6 +77,15 @@ module Authentication
           @fetch_jwks_uri_signing_key ||= @fetch_jwks_uri_signing_key_class.new(
             jwks_uri: signing_key_settings.uri,
             fetch_signing_key: @fetch_signing_key
+          )
+        end
+
+        def fetch_public_keys_signing_key
+          @logger.info(
+            LogMessages::Authentication::AuthnJwt::SelectedSigningKeyInterface.new(PUBLIC_KEYS_INTERFACE_NAME)
+          )
+          @fetch_public_keys_signing_key ||= @fetch_public_keys_signing_key_class.new(
+            signing_keys: signing_key_settings.signing_keys
           )
         end
       end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_public_keys_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_public_keys_signing_key.rb
@@ -5,19 +5,19 @@ module Authentication
       class FetchPublicKeysSigningKey
 
         def initialize(
-          public_keys:,
+          signing_keys:,
           logger: Rails.logger
         )
           @logger = logger
-          @public_keys = public_keys
+          @signing_keys = signing_keys
         end
 
         def call(*)
           @logger.info(LogMessages::Authentication::AuthnJwt::ParsingStaticSigningKeys.new)
-          signing_keys = Authentication::AuthnJwt::SigningKey::PublicSigningKeys.new(JSON.parse(@public_keys))
-          signing_keys.validate!
+          public_signing_keys = Authentication::AuthnJwt::SigningKey::PublicSigningKeys.new(JSON.parse(@signing_keys))
+          public_signing_keys.validate!
           @logger.debug(LogMessages::Authentication::AuthnJwt::ParsedStaticSigningKeys.new)
-          { keys: JSON::JWK::Set.new(signing_keys.value) }
+          { keys: JSON::JWK::Set.new(public_signing_keys.value) }
         end
       end
     end

--- a/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
@@ -368,7 +368,6 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'incorrect.com'). Reason: '#<AttrRequired::AttrMissing: 'host' required.>'
     """
 
-  @skip
   Scenario: ONYX-15323: public-keys with invalid issuer variable
     Given I extend the policy with:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
@@ -659,7 +659,6 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::DecodeError: No key id (kid) found from token headers>')
     """
 
-  @skip
   @sanity
   Scenario: ONYX-15322: public-keys happy path
     Given I load a policy:
@@ -709,7 +708,6 @@ Feature: JWT Authenticator - Fetch signing key
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
-  @skip
   Scenario: ONYX-15325: public-keys value is in invalid format
     Given I load a policy:
      """

--- a/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
@@ -77,7 +77,6 @@ Feature: JWT Authenticator - Validate And Decode
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')>
     """
 
-  @skip
   Scenario: ONYX-15324: public-keys with valid issuer, token is signed by other key
     Given I extend the policy with:
     """

--- a/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_provider_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/create_signing_key_provider_spec.rb
@@ -34,11 +34,18 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
       type: "provider-uri"
     )
   }
+  let(:mocked_signing_key_settings_type_public_keys) {
+    Authentication::AuthnJwt::SigningKey::SigningKeySettings.new(
+      signing_keys: "public_keys",
+      type: "public-keys"
+    )
+  }
 
   let(:mocked_fetch_signing_key_parameters) { double("MockedFetchSigningKeyParameters") }
   let(:mocked_build_signing_key_settings_type_is_wrong) { double("MockedBuildSigningKeySettingsTypeIsWrong") }
   let(:mocked_build_signing_key_settings_type_jwks_uri) { double("MockedBuildSigningKeySettingsTypeJwksUri") }
   let(:mocked_build_signing_key_settings_type_provider_uri) { double("MockedBuildSigningKeySettingsTypeProviderUri") }
+  let(:mocked_build_signing_key_settings_type_public_keys) { double("MockedBuildSigningKeySettingsTypePublicKeys") }
 
   let(:mocked_logger) { double("Mocked logger")  }
 
@@ -73,6 +80,12 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
       receive(:call)
         .with(signing_key_parameters: mocked_signing_key_parameters)
         .and_return(mocked_signing_key_settings_type_provider_uri)
+    )
+
+    allow(mocked_build_signing_key_settings_type_public_keys).to(
+      receive(:call)
+        .with(signing_key_parameters: mocked_signing_key_parameters)
+        .and_return(mocked_signing_key_settings_type_public_keys)
     )
   end
 
@@ -118,6 +131,26 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider')
         expect(log_output.string.split("\n")).to eq([
                                                       "DEBUG,CONJ00075D Selecting signing key interface...",
                                                       "INFO,CONJ00076I Selected signing key interface: 'provider-uri'"
+                                                    ])
+      end
+    end
+
+    context "Signing key settings type is public-keys" do
+      subject do
+        ::Authentication::AuthnJwt::SigningKey::CreateSigningKeyProvider.new(
+          fetch_signing_key_parameters: mocked_fetch_signing_key_parameters,
+          build_signing_key_settings: mocked_build_signing_key_settings_type_public_keys,
+          logger: logger
+        ).call(
+          authenticator_input: mocked_authenticator_input
+        )
+      end
+
+      it "returns FetchProviderUriSigningKey instance and writes appropriate logs" do
+        expect(subject).to be_a(Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey)
+        expect(log_output.string.split("\n")).to eq([
+                                                      "DEBUG,CONJ00075D Selecting signing key interface...",
+                                                      "INFO,CONJ00076I Selected signing key interface: 'public-keys'"
                                                     ])
       end
     end

--- a/spec/app/domain/authentication/authn-jwt/signing_key/fetch_public_keys_signing_key_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/signing_key/fetch_public_keys_signing_key_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey'
     context "fails when the value is not a JSON" do
       subject do
         ::Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey.new(
-          public_keys: string_value
+          signing_keys: string_value
         ).call(force_fetch: false)
       end
 
@@ -46,7 +46,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey'
     context "fails when the value is not valid" do
       subject do
         ::Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey.new(
-          public_keys: invalid_public_keys_value
+          signing_keys: invalid_public_keys_value
         ).call(force_fetch: false)
       end
 
@@ -59,7 +59,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey'
     context "returns a JWKS object" do
       subject do
         ::Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey.new(
-          public_keys: valid_public_keys_value
+          signing_keys: valid_public_keys_value
         ).call(force_fetch: false)
       end
 
@@ -79,7 +79,7 @@ RSpec.describe('Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey'
     context "writes logs" do
       subject do
         ::Authentication::AuthnJwt::SigningKey::FetchPublicKeysSigningKey.new(
-          public_keys: valid_public_keys_value,
+          signing_keys: valid_public_keys_value,
           logger: logger
         ).call(force_fetch: false)
         log_output.string.split("\n")


### PR DESCRIPTION
### Desired Outcome

Enable JWT authenticator to receive static signing keys via `public-keys` variable.

### Implemented Changes

- `CreateSigningKeyProvider` creates and returns `FetchPublicKeysSigningKey` class
- Enable relevant integration tests

### Connected Issue/Story

[ONYX-15388](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-15388)

### Definition of Done

- [X] Desired outcome is achieved
- [X] No integration tests are broken
#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [X] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
