### PR TITLE
Change Scenario names on binary batch secret tests

### DIFF
--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -102,7 +102,7 @@ Feature: Batch retrieval of secrets
     { "cucumber:variable:secret1": "v3", "cucumber:variable:secret2": "v5", "cucumber:variable:secret3": "v6" }
     """
 
-  Scenario: Returns the correct result for binary secrets
+  Scenario: Returns Base64 encoded secrets with Accept-Encoding header base64
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
     And I set the "Accept-Encoding" header to "base64"
@@ -110,20 +110,22 @@ Feature: Batch retrieval of secrets
     Then the binary data is preserved for "cucumber:variable:secret3"
     And the content encoding is "base64"
 
-  Scenario: Returns the correct result for binary secrets
+  Scenario: Returns Base64 encoded secrets with alternate heading capitalization
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I set the "Accept-Encoding" header to "Base64"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the binary data is preserved for "cucumber:variable:secret3"
 
-  Scenario: Returns the correct result for binary secrets
+  Scenario: Fails with 406 on retrieval of single binary secret with improper header
     Given I create a binary secret value for resource "cucumber:variable:secret3"
+    And I set the "Accept-Encoding" header to "*"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the HTTP response status code is 406
 
-  Scenario: Raises error on binary secret with no annotation
+  Scenario: Fails with 406 on retrieval of multiple secrets with improper header
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
+    And I set the "Accept-Encoding" header to "*"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
     Then the HTTP response status code is 406
 


### PR DESCRIPTION
### Desired Outcome

The integration tests relating to batch requests of binary secrets had vague/identical scenario names.

### Implemented Changes
The Scenario names were updated and some new detail was added to the tests in order to make them more clear

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
