### PR TITLE
Add SYSLOG capability to a dev conjur container

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       BUNDLE_GEMFILE: /src/conjur-server/Gemfile
+    cap_add:
+      - SYSLOG
     ports:
       - "3000:3000"
       - "1234:1234"


### PR DESCRIPTION
### Desired Outcome && Implemented Changes

After upgrading docker desktop to 4.4.2 I failed to start conjur dev environment. The following errors appear in conjur container logs:
```
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/10_syslog-ng.init...
syslog-ng: Error setting capabilities, capability management disabled; error='Operation not permitted'
[2022-01-19T11:45:33.675517] Error opening file for reading; filename='/proc/kmsg', error='Operation not permitted (1)'
[2022-01-19T11:45:33.675556] Error initializing message pipeline; plugin name='file', location='source generator system:8:1'
*** /etc/my_init.d/10_syslog-ng.init failed with status 1
```

Adding SYSLOG ([CAP_SYSLOG](https://man7.org/linux/man-pages/man7/capabilities.7.html)) is solving the issue and allows conjur container to start.

During investigation I've found that sysylog-ng [removed](https://github.com/balabit/syslog-ng-docker/pull/36) container detection check staring 3.17.2 version. However conjur dev container is using only syslog-ng version 3.13.2. It looks a latest available version for `cyberark/phusion-ruby-fips:latest` container image that by itself is based on very old (more than 3 years old) [phusion/baseimage:0.11](https://hub.docker.com/r/phusion/baseimage/tags?page=1&name=0.11) container image. The effort of upgrading phusion image to latest or using ubuntu based container for dev environment suggested to be significantly larger than adding a capability.

### Connected Issue/Story

[ONYX-16358](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16358)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
