### PR TITLE
Expand CI Pipeline Cucumber Test Tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ demo/run/load
 coverage
 .DS_Store
 demo/run/*.yml
+container_logs
+cucumber/*/*_results.*
 
 apidocs/node_modules
 *.config

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -607,6 +607,7 @@ pipeline {
                 authenticators_jwt/cucumber_results.html,
                 authenticators_gcp/cucumber_results.html,
                 authenticators_status/cucumber_results.html,
+                kubernetes/cucumber_results.html,
                 policy/cucumber_results.html,
                 rotators/cucumber_results.html
               ''',

--- a/ci/authn-k8s/test.sh
+++ b/ci/authn-k8s/test.sh
@@ -12,7 +12,7 @@ function main() {
   setupTestEnvironment $PLATFORM
 
   createNginxCert
-    
+
   buildDockerImages
 
   case "$PLATFORM" in
@@ -84,7 +84,7 @@ function buildDockerImages() {
 
   # cukes will be run from this image
   docker tag $DOCKER_REGISTRY_PATH/conjur-test:$conjur_version $CONJUR_TEST_AUTHN_K8S_TAG
-  
+
   docker build -t $INVENTORY_BASE_TAG -f dev/Dockerfile.inventory_base dev
   docker build \
     --build-arg INVENTORY_BASE_TAG=$INVENTORY_BASE_TAG \
@@ -113,6 +113,7 @@ function test_gke() {
     -v $GCLOUD_SERVICE_KEY:/tmp$GCLOUD_SERVICE_KEY \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$PWD":/src \
+    -v "$PWD/../../cucumber/kubernetes:/cucumber/kubernetes" \
     $CONJUR_AUTHN_K8S_TESTER_TAG bash -c "./test_gke_entrypoint.sh"
 }
 

--- a/ci/authn-k8s/test.sh
+++ b/ci/authn-k8s/test.sh
@@ -100,6 +100,7 @@ function buildDockerImages() {
 
 function test_gke() {
   docker run --rm \
+    -e CUCUMBER_FILTER_TAGS \
     -e CONJUR_AUTHN_K8S_TAG \
     -e CONJUR_TEST_AUTHN_K8S_TAG \
     -e INVENTORY_TAG \
@@ -119,6 +120,7 @@ function test_gke() {
 
 function test_openshift() {
   docker run --rm \
+    -e CUCUMBER_FILTER_TAGS \
     -e CONJUR_AUTHN_K8S_TAG \
     -e CONJUR_TEST_AUTHN_K8S_TAG \
     -e INVENTORY_TAG \

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -274,6 +274,14 @@ function runTests() {
 
   conjurcmd mkdir -p /opt/conjur-server/output
 
+  # THE CUCUMBER_FILTER_TAGS environment variable is not natively
+  # implemented in cucumber-ruby, so we pass it as a CLI argument
+  # if the variable is set.
+  local cucumber_tags_arg="--tags \"not @skip\""
+  if [[ -n "$CUCUMBER_FILTER_TAGS" ]]; then
+    cucumber_tags_arg="--tags \"not @skip and $CUCUMBER_FILTER_TAGS\""
+  fi
+
   echo "./bin/cucumber \
     K8S_VERSION=1.7 \
     PLATFORM=kubernetes \
@@ -285,7 +293,8 @@ function runTests() {
     -r ./cucumber/kubernetes/features/support/world.rb \
     -r ./cucumber/kubernetes/features/support/hooks.rb \
     -r ./cucumber/kubernetes/features/support/conjur_token.rb \
-    --tags ~@skip ./cucumber/kubernetes/features" | cucumbercmd -i bash
+    $cucumber_tags_arg \
+    ./cucumber/kubernetes/features" | cucumbercmd -i bash
 }
 
 retrieve_pod() {

--- a/ci/authn-k8s/test_gke_entrypoint.sh
+++ b/ci/authn-k8s/test_gke_entrypoint.sh
@@ -27,18 +27,18 @@ function finish {
   echo '-----'
 
   {
-    pod_name=$(retrieve_pod conjur-authn-k8s)
-    if [[ "$pod_name" != "" ]]; then
-      echo "Grabbing output from $pod_name"
+    conjur_pod_name=$(retrieve_pod conjur-authn-k8s)
+    if [[ "$conjur_pod_name" != "" ]]; then
+      echo "Grabbing output from $conjur_pod_name"
       echo '-----'
       mkdir -p output
-      kubectl cp "$pod_name:/opt/conjur-server/output" output
+      kubectl cp "$conjur_pod_name:/opt/conjur-server/output" output
 
-      echo "Logs from Conjur Pod $pod_name:"
-      kubectl logs "$pod_name" > output/gke-authn-k8s-logs.txt
+      echo "Logs from Conjur Pod $conjur_pod_name:"
+      kubectl logs "$conjur_pod_name" > output/gke-authn-k8s-logs.txt
 
       # Rails.logger writes the logs to the environment log file
-      kubectl exec "$pod_name" -- \
+      kubectl exec "$conjur_pod_name" -- \
         bash -c "cat /opt/conjur-server/log/test.log" >> \
         output/gke-authn-k8s-logs.txt
 
@@ -50,17 +50,37 @@ function finish {
       echo "Killing conjur so that coverage report is written"
       # The container is kept alive using an infinite sleep in the at_exit hook
       # (see .simplecov) so that the kubectl cp below works.
-      kubectl exec "${pod_name}" -- bash -c "pkill -f 'puma 5'"
+      kubectl exec "${conjur_pod_name}" -- bash -c "pkill -f 'puma 5'"
 
       echo "Retrieving coverage report"
       kubectl cp \
-        "$pod_name:/opt/conjur-server/coverage/.resultset.json" \
+        "$conjur_pod_name:/opt/conjur-server/coverage/.resultset.json" \
         output/simplecov-resultset-authnk8s-gke.json
     fi
   } || {
-    echo "Logs could not be extracted from $pod_name"
+    echo "Logs could not be extracted from $conjur_pod_name"
     # So Jenkins artifact collection doesn't fail.
     touch output/gke-authn-k8s-logs.txt
+  }
+
+  {
+    cucumber_pod_name=$(retrieve_pod cucumber-authn-k8s)
+    if [[ "$conjur_pod_name" != "" ]]; then
+      echo "Retrieving cucumber reports"
+      kubectl cp \
+        "$cucumber_pod_name:/opt/conjur-server/cucumber/kubernetes/cucumber_results.json" \
+        "/cucumber/kubernetes/cucumber_results.json"
+
+      kubectl cp \
+        "$cucumber_pod_name:/opt/conjur-server/cucumber/kubernetes/cucumber_results.html" \
+        "/cucumber/kubernetes/cucumber_results.html"
+
+      kubectl cp \
+        "$cucumber_pod_name:/opt/conjur-server/cucumber/kubernetes/features/reports" \
+        "/cucumber/kubernetes/features/reports"
+    fi
+  } || {
+    echo "Results could not be extracted from $cucumber_pod_name"
   }
 
   echo "Removing namespace $CONJUR_AUTHN_K8S_TEST_NAMESPACE"
@@ -85,19 +105,19 @@ export API_VERSION=rbac.authorization.k8s.io/v1
 function main() {
   sourceFunctions
   renderResourceTemplates
-  
+
   initialize_gke
   createNamespace
 
   pushDockerImages
 
   launchConjurMaster
-  
+
   copyNginxSSLCert
-  
+
   copyConjurPolicies
   loadConjurPolicies
-  
+
   launchInventoryServices
 
   runTests
@@ -191,7 +211,7 @@ function launchConjurMaster() {
   local wait_command="while ! curl --silent --head --fail \
     localhost:80 > /dev/null; do sleep 1; done"
   kubectl exec "$conjur_pod" -- bash -c "$wait_command"
-  
+
   API_KEY=$(
     kubectl exec "$conjur_pod" -- \
       conjurctl account create cucumber | tail -n 1 | awk '{ print $NF }'
@@ -221,7 +241,7 @@ function loadConjurPolicies() {
 
   # kubectl wait not needed -- already done in copyConjurPolicies.
   cli_pod=$(retrieve_pod conjur-cli)
-  
+
   kubectl exec "$cli_pod" -- conjur init -u conjur -a cucumber
   sleep 5
   kubectl exec "$cli_pod" -- conjur authn login -u admin -p "$API_KEY"
@@ -257,8 +277,10 @@ function runTests() {
   echo "./bin/cucumber \
     K8S_VERSION=1.7 \
     PLATFORM=kubernetes \
-    --no-color --format pretty --format junit \
-    --out /opt/conjur-server/output \
+    --no-color --format pretty --strict \
+    --format json --out \"./cucumber/kubernetes/cucumber_results.json\" \
+    --format html --out \"./cucumber/kubernetes/cucumber_results.html\" \
+    --format junit --out \"./cucumber/kubernetes/features/reports\" \
     -r ./cucumber/kubernetes/features/step_definitions/ \
     -r ./cucumber/kubernetes/features/support/world.rb \
     -r ./cucumber/kubernetes/features/support/hooks.rb \

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   audit:
     image: postgres:10.16
-    environment: 
+    environment:
       # See description on `pg` service for use of POSTGRES_HOST_AUTH_METHOD
       POSTGRES_HOST_AUTH_METHOD: trust
 
@@ -81,6 +81,7 @@ services:
       CONJUR_DATA_KEY:
       REPORT_ROOT:
       CUCUMBER_NETWORK:
+      CUCUMBER_FILTER_TAGS:
       # TODO: Where should we be running rspec tests from, ideally?
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"

--- a/cucumber/README.md
+++ b/cucumber/README.md
@@ -1,0 +1,32 @@
+# Conjur Cucumber Tests
+
+## Tag Descriptions
+
+- Feature Area (`@api`, `@authenticators_azure`, etc.)
+
+    These tags are added to each feature file and correspond to the feature
+    sub-directory name.
+
+- `@smoke`
+
+    Indicates a "happy-path" test for a given feature in its simplest form.
+
+- `@acceptance`
+
+    Tests for a feature that verify its acceptance criteria. These include
+    edge cases, unique data, etc..
+
+- `@negative`
+
+    A negative scenario is where invalid data/values/behavior are entered to
+    generate an error condition.
+
+    Example: entering a bad username and password should result in error/401
+    unauthorized status
+
+    Note: For negative AC - these should still be tagged as negative but also
+    be included as part of acceptance tests
+
+- `@performance`
+
+    Indicates a time-based measurement test to verify feature performance.

--- a/cucumber/api/features/account_create.feature
+++ b/cucumber/api/features/account_create.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Create a new account
 
   Conjur supports multiple accounts in a single database. Each account is a
@@ -9,6 +10,7 @@ Feature: Create a new account
   Accounts are managed through a standard REST interface.  The "accounts" routes
   are authorized via privileges on the resource "!:webservice:accounts".
 
+  @smoke
   Scenario: POST /accounts to create a new account.
 
     "execute" privilege on "!:webservice:accounts" is required.
@@ -16,7 +18,7 @@ Feature: Create a new account
     The response is JSON which contains:
 
     1. **id** The account id.
-    2. **api_key** The API key of the account "admin" user. 
+    2. **api_key** The API key of the account "admin" user.
 
     # Note: "!" is the default account
     Given I create a new user "admin" in account "!"
@@ -29,6 +31,7 @@ Feature: Create a new account
     And the JSON should have "id"
     And the JSON should have "api_key"
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: POST /accounts requires "execute" privilege.
 
@@ -43,6 +46,7 @@ Feature: Create a new account
     Then the HTTP response status code is 403
     And the result is empty
 
+  @negative @acceptance
   Scenario: An account cannot be created if it already exists.
 
     Given I create a new user "admin" in account "!"
@@ -73,6 +77,7 @@ Feature: Create a new account
     }
     """
 
+  @acceptance
   Scenario: An account can be created with an owner
 
     Given I create a new user "admin" in account "!"
@@ -85,6 +90,7 @@ Feature: Create a new account
     And the JSON should have "id"
     And the JSON should have "api_key"
 
+  @acceptance
   Scenario: An account can be created with a '.' in its name
 
     Given I create a new user "admin" in account "!"
@@ -96,6 +102,7 @@ Feature: Create a new account
     """
     And I can authenticate with the admin API key for the account "new_account@example.com"
 
+  @negative @acceptance
   Scenario: Creating account with : or space in the name fails
 
     Given I create a new user "admin" in account "!"
@@ -131,6 +138,7 @@ Feature: Create a new account
     }
     """
 
+  @smoke
   @create_account
   Scenario: Creating account with predefined password and login with it
     Given I create an account with the name "demo" and the password "MySecretP,@SS1()!" using conjurctl

--- a/cucumber/api/features/account_delete.feature
+++ b/cucumber/api/features/account_delete.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Delete an account
 
   Accounts can be deleted through the API.
@@ -18,6 +19,7 @@ Feature: Delete an account
     id=new.account
     """
 
+  @smoke
   Scenario: DELETE /accounts/:id to delete an account.
 
     "update" privilege on "!:webservice:accounts" is required.
@@ -27,6 +29,7 @@ Feature: Delete an account
     And I successfully GET "/accounts"
     And the JSON should not include "new.account"
 
+  @acceptance
   Scenario: DELETE /accounts requires "update" privilege.
 
     Without "update" privilege the request is forbidden.
@@ -36,6 +39,7 @@ Feature: Delete an account
     Then the HTTP response status code is 403
     And the result is empty
 
+  @acceptance
   Scenario: Root policy can be reloaded after DELETE
 
     Given I login as "new.account:user:admin"

--- a/cucumber/api/features/account_list.feature
+++ b/cucumber/api/features/account_list.feature
@@ -1,3 +1,4 @@
+@api
 Feature: List accounts
 
   The list of accounts, excluding the "!" special account, is available through the
@@ -12,6 +13,7 @@ Feature: List accounts
     id=new-account
     """
 
+  @smoke
   Scenario: GET /accounts to list accounts.
 
     "read" privilege on "!:webservice:accounts" is required.
@@ -24,6 +26,7 @@ Feature: List accounts
     And the JSON should include "new-account"
     And the JSON should not include "!"
 
+  @acceptance 
   @logged-in-admin
   Scenario: GET /accounts requires "read" privilege.
 

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -1,15 +1,17 @@
+@api
 Feature: Exchange a role's API key for a signed authentication token
 
   A role's API key can be used to obtain a signed authentication token.
 
-  The token is a signed JSON structure that contains the role id. The 
+  The token is a signed JSON structure that contains the role id. The
   token can be sent as the `Authorization` header to other Conjur REST
   functions as proof of authentication.
   Background:
     Given I create a new user "alice"
     And I have host "app"
 
-  Scenario: A role's API can be used to authenticate
+  @smoke
+  Scenario: A role's API key can be used to authenticate
     Given I save my place in the audit log file for remote
     Then I can POST "/authn/cucumber/alice/authenticate" with plain text body ":cucumber:user:alice_api_key"
     And the HTTP response content type is "application/json"
@@ -23,7 +25,8 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
-  Scenario: A host's API can be used to authenticate
+  @smoke
+  Scenario: A host's API key can be used to authenticate
     Given I save my place in the audit log file for remote
     Then I can POST "/authn/cucumber/host%2Fapp/authenticate" with plain text body ":cucumber:host:app_api_key"
     And the HTTP response content type is "application/json"
@@ -37,6 +40,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:host:app successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: X-Request-Id is set and visible in the audit record
     Given I set the "X-Request-Id" header to "TestMyApp"
     And I save my place in the audit log file for remote
@@ -52,6 +56,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: Authenticate response should be encoded if Accept-Encoding equals base64
     Given I save my place in the audit log file for remote
     When I successfully authenticate Alice with Accept-Encoding header "base64"
@@ -68,6 +73,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: Authenticate response should be encoded if Accept-Encoding includes base64
     Given I save my place in the audit log file for remote
     When I successfully authenticate Alice with Accept-Encoding header "base64,gzip,defalte,br"
@@ -84,6 +90,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: Authenticate response should be encoded if Accept-Encoding includes base64 with mixed case and spaces
     Given I save my place in the audit log file for remote
     When I successfully authenticate Alice with Accept-Encoding header "gzip      ,  bASe64 ,defalte,br"
@@ -100,6 +107,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: Authenticate response should be json if Accept-Encoding doesn't include base64
     Given I save my place in the audit log file for remote
     When I successfully authenticate Alice with Accept-Encoding header "gzip,defalte,br"
@@ -114,11 +122,13 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice successfully authenticated with authenticator authn
     """
 
+  @acceptance
   Scenario: Authenticating with no Content-Type header succeeds without writing API key to the logs
     And I save my place in the log file
     And I can authenticate Alice with no Content-Type header
     Then Alice's API key does not appear in the log
 
+  @negative @acceptance
   Scenario: Attempting to use an invalid API key to authenticate result in 401 error
     Given I save my place in the audit log file for remote
     When I POST "/authn/cucumber/alice/authenticate" with plain text body "wrong-api-key"
@@ -133,6 +143,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice failed to authenticate with authenticator authn
     """
 
+  @negative @acceptance
   Scenario: Attempting to use an invalid host API key to authenticate result in 401 error
     Given I save my place in the audit log file for remote
     When I POST "/authn/cucumber/host%2Fapp/authenticate" with plain text body "wrong-api-key"
@@ -147,6 +158,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:host:app failed to authenticate with authenticator authn
     """
 
+  @negative @acceptance
   Scenario: Attempting to use an invalid API key to authenticate with Accept-Encoding base64 result in 401 error
     Given I save my place in the audit log file for remote
     When I authenticate Alice with Accept-Encoding header "base64" with plain text body "wrong-api-key"
@@ -161,6 +173,7 @@ Feature: Exchange a role's API key for a signed authentication token
       cucumber:user:alice failed to authenticate with authenticator authn
     """
 
+  @negative @acceptance
   Scenario: User cannot login as a same-named user in a different account
 
     User logins are scoped per account. Conjur cannot be tricked into authenticating a user
@@ -170,15 +183,17 @@ Feature: Exchange a role's API key for a signed authentication token
     When I POST "/authn/second-account/alice/authenticate" with plain text body ":cucumber:user:alice_api_key"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   Scenario: Auth tokens cannot be refreshed
 
     The API key is required to authenticate. An authentication token is not a sufficient
-    credential to re-authenticate. 
+    credential to re-authenticate.
 
     Given I login as "alice"
     When I POST "/authn/cucumber/alice/authenticate"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: Roles cannot authenticate as any role other than themselves.
 
@@ -187,6 +202,7 @@ Feature: Exchange a role's API key for a signed authentication token
     When I POST "/authn/cucumber/alice/authenticate" with plain text body "wrong-api-key"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   Scenario: A non existing user cannot authenticate
     Given I save my place in the log file
     When I POST "/authn/cucumber/non-existing/authenticate"

--- a/cucumber/api/features/authn_local.feature
+++ b/cucumber/api/features/authn_local.feature
@@ -1,5 +1,7 @@
+@api
 Feature: Custom Authenticators can obtain access tokens for any role
 
+  @smoke
   Scenario: Obtain an access token for a user
     When I request from authn-local:
     """
@@ -7,6 +9,7 @@ Feature: Custom Authenticators can obtain access tokens for any role
     """
     Then I obtain an access token for "alice" in account "cucumber"
 
+  @smoke
   Scenario: Obtain an access token for a host
     When I request from authn-local:
     """
@@ -14,6 +17,7 @@ Feature: Custom Authenticators can obtain access tokens for any role
     """
     Then I obtain an access token for "host/myapp-01" in account "cucumber"
 
+  @acceptance
   Scenario: Custom expiration time can be specified.
     When I request from authn-local:
     """
@@ -21,6 +25,7 @@ Feature: Custom Authenticators can obtain access tokens for any role
     """
     Then the access token expires at 1512664254
 
+  @negative @acceptance
   Scenario: Sending invalid input results in an empty response
     When I request from authn-local:
     """

--- a/cucumber/api/features/authn_restricted_to.feature
+++ b/cucumber/api/features/authn_restricted_to.feature
@@ -1,14 +1,16 @@
+@api
 Feature: User and Host authentication can be network restricted
 
   Background:
     Given I am the super-user
     And I load a network-restricted policy
 
-
+  @negative @acceptance
   Scenario: Request origin can deny access
     When I authenticate as "alice" with account "cucumber"
     Then the HTTP response status code is 401
 
+  @smoke
   Scenario: When the request origin is correct, then access is allowed
     When I authenticate as "bob" with account "cucumber"
     Then the HTTP response status code is 200

--- a/cucumber/api/features/certificate_authority.feature
+++ b/cucumber/api/features/certificate_authority.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Conjur signs certificates using a configured CA
 
   Background:
@@ -60,19 +61,23 @@ Feature: Conjur signs certificates using a configured CA
     And I add the "dining-room" intermediate CA cert chain to the resource "cucumber:variable:conjur/dining-room/ca/cert-chain"
     And I add the secret value "secret" to the resource "cucumber:variable:conjur/dining-room/ca/private-key-password"
 
+  @negative @acceptance
   Scenario: A non-existent ca returns a 404
     When I POST "/ca/cucumber/living-room/sign"
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: A login that isn't a host returns a 403
     When I POST "/ca/cucumber/kitchen/sign"
     Then the HTTP response status code is 403
 
+  @negative @acceptance
   Scenario: The service returns 403 Forbidden if the host doesn't have sign privileges
     Given I login as "cucumber:host:toast"
     When I send a CSR for "toast" to the "kitchen" CA with a ttl of "P6M" and CN of "toast"
     Then the HTTP response status code is 403
 
+  @smoke
   Scenario: I can sign a valid CSR with a configured Conjur CA
     Given I login as "cucumber:host:bacon"
     When I send a CSR for "bacon" to the "kitchen" CA with a ttl of "P6M" and CN of "bacon"
@@ -80,9 +85,10 @@ Feature: Conjur signs certificates using a configured CA
     And the HTTP response content type is "application/json"
     And the resulting json certificate is valid according to the "kitchen" intermediate CA
 
+  @acceptance
   Scenario: I can receive the result directly as a PEM formatted certificate
     Given I login as "cucumber:host:bacon"
-    And I set the "Accept" header to "application/x-pem-file" 
+    And I set the "Accept" header to "application/x-pem-file"
     When I send a CSR for "bacon" to the "kitchen" CA with a ttl of "P6M" and CN of "bacon"
     Then the HTTP response status code is 201
     And the HTTP response content type is "application/x-pem-file"
@@ -91,6 +97,7 @@ Feature: Conjur signs certificates using a configured CA
     And the subject alternative names contain "DNS:bacon"
     And the subject alternative names contain "URI:spiffe://conjur/cucumber/kitchen/host/bacon"
 
+  @acceptance
   Scenario: I can sign a CSR using an encrypted CA private key
     Given I login as "cucumber:host:table"
     When I send a CSR for "table" to the "dining-room" CA with a ttl of "P6M" and CN of "table"

--- a/cucumber/api/features/change_password.feature
+++ b/cucumber/api/features/change_password.feature
@@ -1,13 +1,15 @@
+@api
 Feature: Change the password of a role
 
   Each role can have a password. This is typically used for human users, not for machine roles.
 
-  The password can be set or changed by providing either the current password or the API key as 
+  The password can be set or changed by providing either the current password or the API key as
   the credential.
 
   Background:
     Given I create a new user "alice"
 
+  @smoke
   Scenario: With basic authentication, users can update their own password using the current password.
 
     Given I set the password for "alice" to "My-Password1"
@@ -24,6 +26,7 @@ Feature: Change the password of a role
       cucumber:user:alice successfully changed their password
     """
 
+  @smoke
   Scenario: With basic authentication, user admin update their own password using the current password.
 
     Given I set the password for "admin" to "My-Password1"
@@ -40,17 +43,20 @@ Feature: Change the password of a role
       cucumber:user:admin successfully changed their password
     """
 
+  @smoke
   Scenario: With basic authentication, users can update their own password using the current API key.
 
     When I successfully PUT "/authn/cucumber/password" with username "alice" and password ":cucumber:user:alice_api_key" and plain text body "New-Password1"
     Then I can GET "/authn/cucumber/login" with username "alice" and password "New-Password1"
 
+  @acceptance
   Scenario: Succeed to set password with escaped special character applying to password complexity.
 
     Given I set the password for "alice" to "My-Password1"
     When I successfully PUT "/authn/cucumber/password" with username "alice" and password "My-Password1" and plain text body "NewPassword1/"
     Then I can GET "/authn/cucumber/login" with username "alice" and password "NewPassword1/"
 
+  @negative @acceptance
   Scenario: Fail to set password with 11 characters not applying to password complexity.
 
     Given I set the password for "alice" to "My-Password1"
@@ -68,6 +74,7 @@ Feature: Change the password of a role
       password CONJ00046E *
     """
 
+  @negative @acceptance
   Scenario: Bearer token cannot be used to change the password
 
     An authentication token is insufficient to change a role's password.
@@ -76,6 +83,7 @@ Feature: Change the password of a role
     When I PUT "/authn/cucumber/password" with plain text body "new-password"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: "Super" users cannot update user passwords
     Users cannot change the passwords of other users. However, if a role has `update` privilege

--- a/cucumber/api/features/check_permission.feature
+++ b/cucumber/api/features/check_permission.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Check whether a role has a privilege on a resource
 
   An RBAC transaction involves a role, a privilege, and a resource. A permission
@@ -9,6 +10,7 @@ Feature: Check whether a role has a privilege on a resource
     And I create a new user "bob"
     And I permit user "bob" to "fry" it
 
+  @smoke
   Scenario: I confirm that I can perform the granted action
     If a role is granted a privilege on a resource, then a permission check will pass.
 
@@ -28,6 +30,7 @@ Feature: Check whether a role has a privilege on a resource
       cucumber:user:charlie successfully checked if they can fry cucumber:chunky:bacon
     """
 
+  @smoke
   Scenario: I confirm that the role can perform the granted action
     If a role is granted a privilege on a resource, then a permission check will pass.
 
@@ -48,6 +51,7 @@ Feature: Check whether a role has a privilege on a resource
       cucumber:user:charlie successfully checked if cucumber:user:bob can fry cucumber:chunky:bacon
     """
 
+  @smoke
   Scenario: I confirm that the role cannot perform ungranted actions
     If a role is not granted a privilege, then a permission check will fail.
 
@@ -69,6 +73,7 @@ Feature: Check whether a role has a privilege on a resource
       cucumber:user:charlie failed to check if cucumber:user:bob can freeze cucumber:chunky:bacon
     """
 
+  @smoke
   Scenario: The new role can confirm that it may perform the granted action
 
     A role which is authenticated can use `check` parameter to determine whether it
@@ -81,6 +86,7 @@ Feature: Check whether a role has a privilege on a resource
     privilege: fry
     """
 
+  @negative @acceptance
   Scenario: I confirm that the non-existing role permission check will fail
     If a role is not existing, then a permission check will fail.
 
@@ -92,6 +98,7 @@ Feature: Check whether a role has a privilege on a resource
     """
     Then the HTTP response status code is 403
 
+  @acceptance
   Scenario: I confirm that the role cannot perform actions on nonexistent resources
 
     If permission check is for not existing variable it will fail.
@@ -104,6 +111,7 @@ Feature: Check whether a role has a privilege on a resource
     """
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: I confirm that the role cannot perform actions on resources it doesn't have permission
 
   If a role is not granted a permission, then a permission check will fail.

--- a/cucumber/api/features/export.feature
+++ b/cucumber/api/features/export.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Export Conjur Open Source data
 
    The database and data key from Conjur can be exported to import
@@ -6,11 +7,13 @@ Feature: Export Conjur Open Source data
    Background:
    Given I create a new user "admin" in account "export_account"
 
+   @smoke
    Scenario: Export using `conjurctl`
    When I run conjurctl export
    Then the export file exists
    And the accounts file contains "export_account"
 
+   @acceptance
    Scenario: Export with chosen label
    When I run conjurctl export with label "my_export"
    Then the export file exists with label "my_export"

--- a/cucumber/api/features/host_factory_create_host.feature
+++ b/cucumber/api/features/host_factory_create_host.feature
@@ -1,9 +1,11 @@
+@api
 Feature: Create a host using the host factory.
 
   Background:
     Given I create a host factory for layer "the-layer"
     And I create a host factory token
-    
+
+  @smoke
   Scenario: The host factory token authenticates and authorizes a request
     to create a new host.
 
@@ -21,6 +23,7 @@ Feature: Create a host using the host factory.
     }
     """
 
+  @acceptance
   Scenario: Creating a host with parameters in POST body
     Given I authorize the request with the host factory token
     When I successfully POST "/host_factories/hosts" with body:
@@ -39,6 +42,7 @@ Feature: Create a host using the host factory.
     }
     """
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: Invalid tokens are rejected.
 
@@ -48,6 +52,7 @@ Feature: Create a host using the host factory.
     When I POST "/host_factories/hosts?id=host-01"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   Scenario: Attempting to create a host without id argument
     Given I authorize the request with the host factory token
     When I POST "/host_factories/hosts"

--- a/cucumber/api/features/host_factory_create_token.feature
+++ b/cucumber/api/features/host_factory_create_token.feature
@@ -1,3 +1,4 @@
+@api
 @logged-in
 Feature: Create a host factory token.
 
@@ -5,19 +6,21 @@ Feature: Create a host factory token.
     Given I create a new user "alice"
     And I create a host factory for layer "the-layer"
 
-
+  @negative @acceptance
   Scenario: A host factory is invisible without some permission on it
     Given I login as "alice"
 
     When I POST "/host_factory_tokens?host_factory=cucumber:host_factory:the-layer-factory&expiration=2050-12-31" with in-body params
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: Unauthorized users cannot create host factory tokens.
     Given I permit user "alice" to "read" it
     And I login as "alice"
     When I POST "/host_factory_tokens?host_factory=cucumber:host_factory:the-layer-factory&expiration=2050-12-31"
     Then the HTTP response status code is 403
 
+  @smoke
   Scenario: A host factory token can be created by specifying an expiration time.
     Given I permit user "alice" to "execute" it
     And I login as "alice"
@@ -36,6 +39,7 @@ Feature: Create a host factory token.
     ]
     """
 
+  @acceptance
   Scenario: A host factory token can be created by specifying an expiration time and CIDR.
     Given I permit user "alice" to "execute" it
     And I login as "alice"
@@ -54,6 +58,7 @@ Feature: Create a host factory token.
     ]
     """
 
+  @negative @acceptance
   Scenario: A host factory token cannot be created with invalid CIDR
     Given I permit user "alice" to "execute" it
     And I login as "alice"

--- a/cucumber/api/features/host_factory_delete_token.feature
+++ b/cucumber/api/features/host_factory_delete_token.feature
@@ -1,3 +1,4 @@
+@api
 @logged-in
 Feature: Delete (revoke) a host factory token.
 
@@ -6,6 +7,7 @@ Background:
   And I create a host factory for layer "the-layer"
   And I create a host factory token
 
+  @negative @acceptance
   Scenario: Unauthorized users cannot delete host factory tokens.
     When I try to DELETE "/host_factory_tokens/@host_factory_token@"
     Then the HTTP response status code is 404
@@ -15,13 +17,15 @@ Background:
     And I try to DELETE "/host_factory_tokens/@host_factory_token@"
     Then the HTTP response status code is 403
 
-  Scenario: "delete" privilege on the host factory allows a user to delete 
+  @smoke
+  Scenario: "delete" privilege on the host factory allows a user to delete
     tokens.
 
     Given I permit user "alice" to "update" it
     When I login as "alice"
     Then I do DELETE "/host_factory_tokens/@host_factory_token@"
 
+  @negative @acceptance
   Scenario: Once the token has been deleted, subsequent attempts return 404 Not Found.
 
     Given I permit user "alice" to "update" it

--- a/cucumber/api/features/host_factory_rotate_host.feature
+++ b/cucumber/api/features/host_factory_rotate_host.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Rotate a host api key using the host factory.
 
   Background:
@@ -22,7 +23,11 @@ Feature: Rotate a host api key using the host factory.
     []
     """
 
-  Scenario: The host factory can rotate the host api key
+  @negative @acceptance
+  Scenario: The host factory cannot rotate the host api key that previously existed
+
+    If a host role already exists, but there is no corresponding resource to check,
+    the host builder will now return 403 forbidden because we cannot verify ownership.
 
     Given I am the super-user
     And I successfully PUT "/policies/cucumber/policy/root" with body:
@@ -40,6 +45,7 @@ Feature: Rotate a host api key using the host factory.
     And I POST "/host_factories/hosts?id=brand-new-host"
     Then the HTTP response status code is 403
 
+  @smoke
   Scenario: The host factory can rotate the host api key
 
     Given I am the super-user
@@ -53,7 +59,7 @@ Feature: Rotate a host api key using the host factory.
           id: users
           layers: [ !layer users ]
 
-    - !host 
+    - !host
       id: brand-new-host
       owner: !host-factory database/users
     """

--- a/cucumber/api/features/host_factory_show.feature
+++ b/cucumber/api/features/host_factory_show.feature
@@ -1,3 +1,4 @@
+@api
 @logged-in
 Feature: Display information about a host factory.
 
@@ -7,6 +8,7 @@ Feature: Display information about a host factory.
     And I permit user "alice" to "read" it
     And I login as "alice"
 
+  @acceptance
   Scenario: The host factory displays the normal resource fields, plus
     the list of layers and tokens. 
     

--- a/cucumber/api/features/login.feature
+++ b/cucumber/api/features/login.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Exchange a role's password for its API key
 
   Roles which have passwords can use the `login` method to obtain their API key.
@@ -7,6 +8,7 @@ Feature: Exchange a role's password for its API key
     Given I create a new user "alice"
     And I have host "app"
 
+  @smoke
   Scenario: Password can be used to obtain API key
     Given I set the password for "alice" to "My-Password1"
     And I save my place in the audit log file for remote
@@ -23,6 +25,7 @@ Feature: Exchange a role's password for its API key
       cucumber:user:alice successfully logged in with authenticator authn service cucumber:webservice:conjur/authn
     """
 
+  @smoke
   Scenario: Password can be used by host to obtain API key
     Given I set the password for "host/app" to "My-Password1"
     And I save my place in the audit log file for remote
@@ -39,6 +42,7 @@ Feature: Exchange a role's password for its API key
       cucumber:host:app successfully logged in with authenticator authn service cucumber:webservice:conjur/authn
     """
 
+  @negative @acceptance
   Scenario: Wrong password cannot be used to obtain API key
     Given I save my place in the audit log file for remote
     When I GET "/authn/cucumber/login" with username "alice" and password "Wrong-Password"
@@ -53,6 +57,7 @@ Feature: Exchange a role's password for its API key
       cucumber:user:alice failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00002E Invalid credentials
     """
 
+  @negative @acceptance
   Scenario: Wrong password cannot be used by host to obtain API key
     Given I save my place in the audit log file for remote
     When I GET "/authn/cucumber/login" with username "host/app" and password "Wrong-Password"
@@ -67,6 +72,7 @@ Feature: Exchange a role's password for its API key
       cucumber:host:app failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00002E Invalid credentials
     """
 
+  @negative @acceptance
   Scenario: Wrong username cannot be used to obtain API key
     Given I save my place in the audit log file for remote
     When I GET "/authn/cucumber/login" with username "non-exist" and password "My-Password1"
@@ -81,14 +87,17 @@ Feature: Exchange a role's password for its API key
       cucumber:user:non-exist failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00007E 'non-exist' not found
     """
 
+  @negative @acceptance
   Scenario: Empty username results in 401 response
     When I GET "/authn/cucumber/login" with username "" and password "My-Password1"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   Scenario: Invalid username with non-alpha characters results in 401 response
     When I GET "/authn/cucumber/login" with username "!@#$%^&*(){}" and password "My-Password1"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   Scenario: Wrong hostname cannot be used to obtain API key
     Given I save my place in the audit log file for remote
     When I GET "/authn/cucumber/login" with username "host/non-exist" and password "My-Password1"
@@ -103,6 +112,7 @@ Feature: Exchange a role's password for its API key
       cucumber:host:non-exist failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00007E 'host/non-exist' not found
     """
 
+  @negative @acceptance
   @logged-in
   Scenario: Bearer token cannot be used to login
     The login method requires the password; login cannot be performed using the auth token
@@ -112,6 +122,7 @@ Feature: Exchange a role's password for its API key
     When I GET "/authn/cucumber/login"
     Then the HTTP response status code is 401
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: "Super" users cannot login as other users
 

--- a/cucumber/api/features/member_list.feature
+++ b/cucumber/api/features/member_list.feature
@@ -1,3 +1,4 @@
+@api
 Feature: List and filter members of a role
 
 The members of a role can be listed, searched, and paged.
@@ -28,6 +29,7 @@ The members of a role can be listed, searched, and paged.
       members: !user alice
     """
 
+  @smoke
   Scenario: List role members
     When I successfully GET "/roles/cucumber/group/dev?members"
     Then the JSON should be:
@@ -71,9 +73,10 @@ The members of a role can be listed, searched, and paged.
         ]
         """
 
+  @smoke
   Scenario: Search role members
     When I successfully GET "/roles/cucumber/group/dev?members&search=alice"
-    Then the JSON should be: 
+    Then the JSON should be:
         """
         [
         {
@@ -86,13 +89,15 @@ The members of a role can be listed, searched, and paged.
         ]
         """
 
+  @acceptance
   Scenario: Search for non-existant member
      When I successfully GET "/roles/cucumber/group/dev?members&search=non_existent_user"
-     Then the JSON should be: 
+     Then the JSON should be:
          """
          []
-         """      
-  
+         """
+
+  @smoke
   Scenario: Page role members
     When I successfully GET "/roles/cucumber/group/dev?members&limit=3"
     Then the JSON should be:
@@ -139,16 +144,17 @@ The members of a role can be listed, searched, and paged.
             "ownership": false,
             "policy": "cucumber:policy:root",
             "role": "cucumber:group:dev"
-        }         
+        }
         ]
         """
 
+  @smoke
   Scenario: Counting role members
     When I successfully GET "/roles/cucumber/group/dev?members&count=true"
     Then the JSON should be:
     """
     {
-        "count": 5 
+        "count": 5
     }
     """
 
@@ -156,10 +162,11 @@ The members of a role can be listed, searched, and paged.
     Then the JSON should be:
     """
     {
-        "count": 5 
+        "count": 5
     }
     """
 
+  @smoke
   Scenario: Filter role members by kind
     When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group&kind[]=user"
     Then the JSON should be:

--- a/cucumber/api/features/members.feature
+++ b/cucumber/api/features/members.feature
@@ -1,3 +1,4 @@
+@api
 Feature: List direct members of a role
 
   If a role A is granted to a role B, then role A is said to have role B as a 
@@ -9,6 +10,7 @@ Feature: List direct members of a role
     Given I create a new user "bob"
     And I am a user named "alice"
 
+  @smoke
   Scenario: Initial roles members is just the initial role admin.
 
     At the time a new role ("alice") is created, the role is granted
@@ -28,6 +30,7 @@ Feature: List direct members of a role
     ]
     """
 
+  @smoke
   Scenario: New member roles appear in the role list.
 
     Granting a role ("alice") to a new role ("bob") results in 

--- a/cucumber/api/features/membership_entitlements.feature
+++ b/cucumber/api/features/membership_entitlements.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Manage the role entitlements through the API
 
   As an affordance for users to manage the entitlements for group membership,
@@ -12,7 +13,7 @@ Feature: Manage the role entitlements through the API
 
     - !policy
       id: dev
-      body:     
+      body:
       - !group developers
 
     - !grant
@@ -25,6 +26,7 @@ Feature: Manage the role entitlements through the API
       roles: !user alice
     """
 
+  @smoke
   Scenario: Add a group membership through the API
     Given I save my place in the audit log file for remote
     When I successfully POST "/roles/cucumber/group/dev%2Fdevelopers?members&member=cucumber:user:bob"
@@ -64,8 +66,9 @@ Feature: Manage the role entitlements through the API
       cucumber:user:admin added membership of cucumber:user:bob in cucumber:group:dev/developers
     """
 
+  @smoke
   Scenario: Revoke a group membership through the API
-    
+
     Given I login as "alice"
     And I save my place in the audit log file for remote
     When I successfully DELETE "/roles/cucumber/group/dev%2Fdevelopers?members&member=cucumber:user:alice"
@@ -91,12 +94,14 @@ Feature: Manage the role entitlements through the API
       cucumber:user:alice removed membership of cucumber:user:alice in cucumber:group:dev/developers
     """
 
+  @negative @acceptance
   Scenario: Add a membership without permissions
 
     Given I login as "bob"
     When I POST "/roles/cucumber/group/dev%2Fdevelopers?members&member=cucumber:user:bob"
     Then the HTTP response status code is 403
 
+  @acceptance
   Scenario: Attempt to add a member twice
 
     When I successfully POST "/roles/cucumber/group/dev%2Fdevelopers?members&member=cucumber:user:bob"

--- a/cucumber/api/features/memberships.feature
+++ b/cucumber/api/features/memberships.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Obtain the memberships of a role
 
   If a role A is granted to a role B, then role B is said to "have" role A.
@@ -19,6 +20,7 @@ Feature: Obtain the memberships of a role
     Given I am the super-user
     And I create a new user "alice"
 
+  @smoke
   Scenario: The initial memberships of a role is just the role itself.
     When I successfully GET "/roles/cucumber/user/alice?all"
     Then the JSON should be:
@@ -28,6 +30,7 @@ Feature: Obtain the memberships of a role
     ]
     """
 
+  @smoke
   Scenario: A newly granted role is listed in the grantee's memberships.
     Given I create a new user "bob"
     And I grant user "bob" to user "alice"
@@ -40,6 +43,7 @@ Feature: Obtain the memberships of a role
     ]
     """
 
+  @smoke
   Scenario: Memberships can be counted
     Given I create a new user "bob"
     And I grant user "bob" to user "alice"
@@ -51,6 +55,7 @@ Feature: Obtain the memberships of a role
     }
     """
 
+  @smoke
   Scenario: Direct memberships can be listed
     Given I create a new user "bob"
     And I create a new user "carol"
@@ -69,6 +74,7 @@ Feature: Obtain the memberships of a role
     ]
     """
 
+  @smoke
   Scenario: Direct memberships can be counted
     Given I create a new user "bob"
     And I create a new user "carol"
@@ -82,6 +88,7 @@ Feature: Obtain the memberships of a role
     }
     """
 
+  @smoke
   Scenario: Direct memberships can be searched
     Given I create a new user "bob"
     And I create a new user "carol"
@@ -100,6 +107,7 @@ Feature: Obtain the memberships of a role
     ]
     """
 
+  @smoke
   Scenario: The role memberships list can be filtered.
 
     The `filter` parameter can be used to select just a subset of the

--- a/cucumber/api/features/permitted_roles.feature
+++ b/cucumber/api/features/permitted_roles.feature
@@ -1,3 +1,4 @@
+@api
 Feature: List roles which have a specific permission on a resource
 
   The `permitted_roles` query parameter can be used to list all the roles which have
@@ -7,6 +8,7 @@ Feature: List roles which have a specific permission on a resource
     Given I am a user named "alice"
     And I create a new resource
 
+  @smoke
   Scenario: Initial permitted roles is just the owner, and the roles which have the owner.
     When I successfully GET "/resources/cucumber/:resource_kind/:resource_id" with parameters:
     """
@@ -21,6 +23,7 @@ Feature: List roles which have a specific permission on a resource
     ]
     """
 
+  @smoke
   Scenario: An additional user with the specified privilege is included in the list
     Given I create a new user "bob"
     And I permit user "bob" to "fry" it
@@ -38,6 +41,7 @@ Feature: List roles which have a specific permission on a resource
     ]
     """
 
+  @acceptance
   Scenario: An additional user with an unrelated privilege is not included in the list
     Given I create a new user "bob"
     And I permit user "bob" to "freeze" it
@@ -54,6 +58,7 @@ Feature: List roles which have a specific permission on a resource
     ]
     """
 
+  @smoke
   Scenario: An additional owner role is included in the list
     Given I create a new user "bob"
     And I grant my role to user "bob"

--- a/cucumber/api/features/policy_load.feature
+++ b/cucumber/api/features/policy_load.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Updating policies
 
   The initial policy is loaded using the `conjurctl` command line tool,
@@ -35,6 +36,7 @@ Feature: Updating policies
       role: !user eve
     """
 
+  @smoke
   Scenario: A role with "update" privilege can update a policy.
     When I login as "bob"
     And I save my place in the audit log file for remote
@@ -74,6 +76,7 @@ Feature: Updating policies
       cucumber:user:bob added ownership of cucumber:policy:dev/db in cucumber:layer:dev/db
     """
 
+  @negative @acceptance
   Scenario: A role without any privilege cannot update a policy.
     When I login as "eve"
     When I PUT "/policies/cucumber/policy/dev/db" with body:
@@ -82,10 +85,12 @@ Feature: Updating policies
     """
     Then the HTTP response status code is 403
 
+  @acceptance
   Scenario: A policy with special characters and no content type header
     When I use curl to load a policy with special characters and no content type
     Then the command is successful
 
+  @acceptance
   Scenario: A large policy with no content type header
     When I clear the "Content-Type" header
     And I load a large policy with POST

--- a/cucumber/api/features/policy_load_big.feature
+++ b/cucumber/api/features/policy_load_big.feature
@@ -1,7 +1,9 @@
+@api
 Feature: Loading big policies
 
   The API can be used to load large policies
 
+  @acceptance
   Scenario: I load a policy with 1k users, 1k groups
     Given I am the super-user
     Then I can PUT "/policies/cucumber/policy/root" with body from file "1k-users-1k-groups.yml"

--- a/cucumber/api/features/policy_load_errors.feature
+++ b/cucumber/api/features/policy_load_errors.feature
@@ -1,5 +1,7 @@
+@api
 Feature: Policy loading error messages
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: A policy which references a non-existing resource reports the error.
 
@@ -40,6 +42,7 @@ Feature: Policy loading error messages
       Failed to load policy: User 'bob' not found in account 'cucumber'
     """
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: A policy with a blank resource id reports the error.
     Given I save my place in the audit log file for remote
@@ -79,6 +82,7 @@ Feature: Policy loading error messages
       Failed to load policy: policy_text resource has a blank id
     """
 
+  @negative @acceptance
   @logged-in-admin
   Scenario: Posting a policy without a body
     Given I save my place in the audit log file for remote

--- a/cucumber/api/features/policy_load_modes.feature
+++ b/cucumber/api/features/policy_load_modes.feature
@@ -1,10 +1,11 @@
+@api
 Feature: Updating policies
 
   Policy updates can be performed in any of three modes: PUT, PATCH, and POST.
 
-  * **PUT** The policy is completely replaced. Records which exist in the database but not in 
+  * **PUT** The policy is completely replaced. Records which exist in the database but not in
   the submitted policy are deleted.
-  * **PATCH** The policy is appended and updated. Records which exist in the database but not in 
+  * **PATCH** The policy is appended and updated. Records which exist in the database but not in
   the submitted policy are not deleted. Policy statements `!delete`, `!deny`, and `!revoke` can be
   used to perform destructive actions.
   * **POST** The policy is appended. No deletion is allowed.
@@ -36,6 +37,7 @@ Feature: Updating policies
       kind: password
     """
 
+  @smoke
   Scenario: PUT replaces the policy completely.
     Given I save my place in the audit log file for remote
     When I successfully PUT "/policies/cucumber/policy/dev/db" with body:
@@ -56,6 +58,7 @@ Feature: Updating policies
       cucumber:user:alice removed resource cucumber:variable:dev/db/a
     """
 
+  @acceptance
   Scenario: Modifying annotations with PATCH
     Given I save my place in the audit log file for remote
     When I successfully PATCH "/policies/cucumber/policy/dev/db" with body:
@@ -86,6 +89,7 @@ Feature: Updating policies
       cucumber:user:alice changed annotation conjur/kind on cucumber:variable:dev/db/b
     """
 
+  @acceptance
   Scenario: PATCH does not remove existing records
     When I successfully PATCH "/policies/cucumber/policy/dev/db" with body:
     """
@@ -95,6 +99,7 @@ Feature: Updating policies
     Then the resource list should contain "variable" "dev/db/a"
     Then the resource list should contain "variable" "dev/db/c"
 
+  @acceptance
   Scenario: PATCH can explicitly delete records
     When I successfully PATCH "/policies/cucumber/policy/dev/db" with body:
     """
@@ -104,6 +109,7 @@ Feature: Updating policies
     And I successfully GET "/resources/cucumber/variable"
     Then the resource list should not contain "variable" "dev/db/a"
 
+  @acceptance
   Scenario: PATCH can perform a permission grant on existing roles and resources.
     Given I save my place in the audit log file for remote
     When I successfully PATCH "/policies/cucumber/policy/dev/db" with body:
@@ -133,6 +139,7 @@ Feature: Updating policies
       cucumber:user:alice added permission of cucumber:group:everyone to read on cucumber:variable:dev/db/a
     """
 
+  @acceptance
   Scenario: PATCH can perform a role grant on existing roles.
     Given I save my place in the audit log file for remote
     When I successfully PATCH "/policies/cucumber/policy/dev/db" with body:
@@ -163,6 +170,7 @@ Feature: Updating policies
       cucumber:user:alice added membership of cucumber:group:dev/db/secrets-managers in cucumber:group:dev/db/secrets-users
     """
 
+  @acceptance
   Scenario: POST cannot update existing policy records
     When I successfully POST "/policies/cucumber/policy/dev/db" with body:
     """
@@ -182,6 +190,7 @@ Feature: Updating policies
     ]
     """
 
+  @negative @acceptance
   Scenario: POST cannot remove existing records
     When I POST "/policies/cucumber/policy/dev/db" with body:
     """

--- a/cucumber/api/features/policy_load_permissions.feature
+++ b/cucumber/api/features/policy_load_permissions.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Updating policies
 
   Policy updates can be performed in any of three modes: PUT, PATCH, and POST.
@@ -30,6 +31,7 @@ Feature: Updating policies
       role: !user carol
     """
 
+  @acceptance
   Scenario: a policy is invisible without some permission on it
     When I login as "sam"
     And I POST "/policies/cucumber/policy/dev/db" with body:
@@ -38,6 +40,7 @@ Feature: Updating policies
     """
     Then the HTTP response status code is 404
 
+  @acceptance
   Scenario: `create` privilege is sufficient to add records to a policy via POST.
     When I login as "alice"
     Then I successfully POST "/policies/cucumber/policy/dev/db" with body:

--- a/cucumber/api/features/policy_load_response.feature
+++ b/cucumber/api/features/policy_load_response.feature
@@ -1,5 +1,7 @@
+@api
 Feature: Policy load response
 
+  @smoke
   @logged-in-admin
   Scenario: API keys of users and hosts created by a new policy are returned in the JSON response.
     When I successfully POST "/policies/cucumber/policy/root" with body:

--- a/cucumber/api/features/policy_versions_retention.feature
+++ b/cucumber/api/features/policy_versions_retention.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Limit the number of policy versions
 
   Each update of a policy creates a policy version record and policy log records. This feature limits
@@ -10,6 +11,7 @@ Feature: Limit the number of policy versions
       - !policy policy_test_version
     """
 
+  @acceptance
   Scenario: I update a policy multiple times so it exceeds the default policy versions limit and get the default
             limited number of versions in response when I retrieve the policy resource
     Given I save my place in the log file
@@ -25,6 +27,7 @@ Feature: Limit the number of policy versions
     Deleting policy version: {:version=>1, :resource_id=>"cucumber:policy:policy_test_version",
     """
 
+  @acceptance
   Scenario: DB migration removes policy versions that exceed to limit
     Given I save my place in the log file
     And I successfully POST 21 times "/policies/cucumber/policy/policy_test_version" with body:

--- a/cucumber/api/features/public_keys.feature
+++ b/cucumber/api/features/public_keys.feature
@@ -1,3 +1,4 @@
+@api
 @logged-in
 Feature: List a role's public keys
 
@@ -6,6 +7,7 @@ Feature: List a role's public keys
     And I create a new "public_key" resource called "user/alice/workstation"
     And I create a new "public_key" resource called "user/alice/laptop"
 
+  @smoke
   Scenario: Public keys can be added and queried through the REST API.
 
     Adding a public key for a role requires `update` privilege on the `public_key` resource.

--- a/cucumber/api/features/resource_list.feature
+++ b/cucumber/api/features/resource_list.feature
@@ -1,9 +1,11 @@
+@api
 @logged-in
 Feature: List resources with various types of filtering
 
   Background:
     Given I create 3 new resources
 
+  @smoke
   Scenario: The resource list includes a new resource.
 
     The most basic resource listing route returns all resources in an account.
@@ -11,102 +13,121 @@ Feature: List resources with various types of filtering
     When I successfully GET "/resources/cucumber"
     Then the resource list should include the newest resources
 
+  @smoke
   Scenario: The resource list can be filtered by resource kind.
     Given I create a new "custom" resource
     When I successfully GET "/resources/cucumber/custom"
     Then the resource list should include the newest resource
 
+  @acceptance
   Scenario: The resource list, when filtered by a different resource kind, does not include the newest resource.
     Given I create a new "custom" resource
     When I successfully GET "/resources/cucumber/uncreated-resource-kind"
     Then the resource list should not include the newest resource
 
+  @smoke
   Scenario: The resource list is searched and contains a resource with a matching resource id.
     Given I create a new resource called "target"
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resource
 
+  @smoke
   Scenario: The resource list is searched and contains a resource with a matching annotation.
     Given I create a new resource
     And I add an annotation value of "target" to the resource
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resource
 
+  @acceptance
   Scenario: The resource list is searched and the matched resource id contains a period.
     Given I create a new resource called "target.resource"
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resource
 
+  @acceptance
   Scenario: The resource list is searched and the matched resource id contains a slash separator.
     Given I create a new resource called "target/resource"
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resource
 
+  @acceptance
   Scenario: The resource list is searched and the matched resource id contains a dash separator.
     Given I create a new resource called "target-resource"
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resource
 
+  @smoke
   Scenario: The resource list is searched and contains multiple resources with matching resource ids.
     Given I create a new searchable resource called "target_1"
     And I create a new searchable resource called "target_2"
     When I successfully GET "/resources/cucumber/test-resource?search=target"
     Then the resource list should only include the searched resources
 
+  @smoke
   Scenario: The resource list is limited to a certain number of results.
     When I successfully GET "/resources/cucumber/test-resource?limit=1"
     Then I receive 1 resources
 
+  @negative @acceptance
   Scenario: The resource list cannot be limited with non numeric value
     When I GET "/resources/cucumber/test-resource?limit=abc"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
 
+  @negative @acceptance
   Scenario: The resource list cannot be limited with zero
     When I GET "/resources/cucumber/test-resource?limit=0"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
 
+  @negative @acceptance
   Scenario: The resource list cannot be limited with negative integer
     When I GET "/resources/cucumber/test-resource?limit=-10"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
 
+  @smoke
   Scenario: The resource list is retrieved starting from a specific offset.
     When I successfully GET "/resources/cucumber/test-resource?offset=1"
     Then I receive 2 resources
 
+  @negative @acceptance
   Scenario: The resource list cannot be retrieved starting from a specific offset with non numeric value
     When I GET "/resources/cucumber/test-resource?offset=abc"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
 
+  @negative @acceptance
   Scenario: The resource list cannot be retrieved starting from a specific offset with negative integer
     When I GET "/resources/cucumber/test-resource?offset=-10"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
 
+  @smoke
   Scenario: The resource list is retrieved starting from a specific offset and is limited
     When I successfully GET "/resources/cucumber/test-resource?offset=1&limit=1"
     Then I receive 1 resources
 
+  @negative @acceptance
   Scenario: The resource list cannot be retrieved with non numeric limit delimiter
     When I GET "/resources/cucumber/test-resource?offset=1&limit=abc"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'limit' contains an invalid value. 'limit' must be a positive integer."
 
+  @negative @acceptance
   Scenario: The resource list cannot be retrieved with non numeric offset delimiter
     When I GET "/resources/cucumber/test-resource?offset=abc&limit=1"
     Then the HTTP response status code is 422
     And there is an error
     And the error message includes "'offset' contains an invalid value. 'offset' must be an integer greater than or equal to 0."
 
+  @smoke
   Scenario: The resource list is counted.
     When I successfully GET "/resources/cucumber/test-resource?count=true"
     Then I receive a count of 3

--- a/cucumber/api/features/resource_list_by_role.feature
+++ b/cucumber/api/features/resource_list_by_role.feature
@@ -1,3 +1,4 @@
+@api
 @logged-in
 Feature: List resources for another role
   Background:
@@ -18,16 +19,19 @@ Feature: List resources for another role
         - !variable prod-var
     """
 
+  @smoke
   Scenario: The resource list can be retrieved for a different role, specified the query parameter role
     When I successfully GET "/resources?role=cucumber:user:alice"
     Then the resource list should contain "variable" "dev/dev-var"
     And the resource list should not contain "variable" "prod/prod-var"
 
+  @smoke
   Scenario: The resource list can be retrieved for a different role, specified the query parameter acting_as
     When I successfully GET "/resources?acting_as=cucumber:user:alice"
     Then the resource list should contain "variable" "dev/dev-var"
     And the resource list should not contain "variable" "prod/prod-var"
 
+  @negative @acceptance
   Scenario: Attempting to retrieve the resource list for a different role but without giving the account in the ID results in a 403
     When I GET "/resources?acting_as=user:alice"
     Then the HTTP response status code is 403

--- a/cucumber/api/features/resource_show.feature
+++ b/cucumber/api/features/resource_show.feature
@@ -1,9 +1,11 @@
+@api
 Feature: Fetch resource details.
 
   Background:
     Given I am a user named "alice"
     And I create a new "variable" resource called "@namespace@/app-01.mycorp.com"
 
+  @smoke
   Scenario: Showing a resource provides information about privileges, annotations and secrets on the resource
 
     Given I successfully POST "/secrets/cucumber/:resource_kind/:resource_id" with body:
@@ -41,6 +43,7 @@ Feature: Fetch resource details.
     }
     """
 
+  @negative @acceptance
   Scenario: Trying to show a resource that does not exist
     When I GET "/resources/cucumber/santa/claus"
     Then the HTTP response status code is 404

--- a/cucumber/api/features/resource_visibility.feature
+++ b/cucumber/api/features/resource_visibility.feature
@@ -1,6 +1,8 @@
+@api
 @logged-in
 Feature: Rules which govern the visibility of resources to roles.
 
+  @acceptance
   Scenario: Resources from a foreign account are not visible without a permission
     Given I create a new resource in a foreign account
     And I create a new user "alice"
@@ -10,6 +12,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     Then the resource list should not include the newest resource
 
+  @acceptance
   Scenario: Resources from a foreign account can be visible
     Given I create a new resource in a foreign account
     And I create a new user "alice"
@@ -22,6 +25,7 @@ Feature: Rules which govern the visibility of resources to roles.
     When I successfully GET "/resources/cucumber"
     Then the resource list should not include the newest resource
 
+  @acceptance
   Scenario: Resources without permissions or ownership are not visible
     Given I create a new resource called "probe"
     And I create a new user "alice"
@@ -31,6 +35,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     Then the resource list should not include the newest resource
 
+  @smoke
   Scenario: Resources with permissions are visible
     Given I create a new resource called "probe"
     And I create a new user "alice"
@@ -41,6 +46,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     Then the resource list should include the newest resource
 
+  @smoke
   Scenario: Resources with transitive permissions are visible
 
     Note: A role has a "transitive permission" on a resource if it's a member of a role that has a permission.
@@ -58,6 +64,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     Then the resource list should include the newest resource
 
+  @smoke
   Scenario: Owned resources are visible even without explicit permissions
     Given I create a new user "alice"
     And I login as "alice"
@@ -66,6 +73,7 @@ Feature: Rules which govern the visibility of resources to roles.
     When I successfully GET "/resources/cucumber"
     Then the resource list should include the newest resource
 
+  @smoke
   Scenario: Transitively owned resources are visible even without explicit permissions
 
     Note: a resource is "transitively owned" if the user holds a role that is the owner.
@@ -82,6 +90,7 @@ Feature: Rules which govern the visibility of resources to roles.
     And I can GET "/resources/cucumber"
     And the resource list should include the newest resource
 
+  @negative @acceptance
   Scenario: Showing a resource without permissions
     If the user doesn't have a permission or ownership of a resource, showing
     that resource should return 404.
@@ -94,6 +103,7 @@ Feature: Rules which govern the visibility of resources to roles.
 
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: Fetching a secret without any permission on it
     If the user doesn't have any permission or ownership of a secret, fetching
     it should return 404 (not 403) even if it exists.

--- a/cucumber/api/features/retrieve_api_key.feature
+++ b/cucumber/api/features/retrieve_api_key.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Retrieving an API key with conjurctl
 
   Background:
@@ -5,10 +6,12 @@ Feature: Retrieving an API key with conjurctl
     Given I set environment variable "RAILS_ENV" to "production"
     And I set environment variable "CONJUR_LOG_LEVEL" to "info"
 
+  @smoke
   Scenario: Retrieve an API key
     When I retrieve an API key for user "cucumber:user:admin" using conjurctl
     Then the API key is correct
 
+  @negative @acceptance
   Scenario: Retrieve an API key of a non-existing user fails
     When I retrieve an API key for user "cucumber:user:non-existing-user" using conjurctl
     Then the stderr includes the error "role does not exist"

--- a/cucumber/api/features/role_graph.feature
+++ b/cucumber/api/features/role_graph.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Retrieve the role graph for a given role
 
   The full graph of ancestor and descendent roles for a given
@@ -26,6 +27,7 @@ Feature: Retrieve the role graph for a given role
       member: !user alice
     """
 
+  @smoke
   Scenario: Retrieve role graph
     When I successfully GET "/roles/cucumber/group/internal?graph"
     Then the JSON should be:

--- a/cucumber/api/features/rotate_api_key.feature
+++ b/cucumber/api/features/rotate_api_key.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Rotate the API key of a role
 
   The API key of a role can be automatically changed ("rotated") to a new random string.
@@ -54,117 +55,131 @@ Feature: Rotate the API key of a role
     And I log out
 
   # Bob rotating his own API key
-
+  @smoke
   Scenario: Bob's password CAN be used to rotate own API key
     Given I set the password for "bob" to "My-Password1"
     When I can PUT "/authn/cucumber/api_key?role=user:bob" with username "bob" and password "My-Password1"
     Then the HTTP response status code is 200
     And the result is the API key for user "bob"
 
+  @smoke
   Scenario: Bob's API key CAN be used to rotate own API key
     When I can PUT "/authn/cucumber/api_key" with username "bob" and password ":cucumber:user:bob_api_key"
     Then the HTTP response status code is 200
     And the result is the API key for user "bob"
 
-  Scenario: Bob's access token CAN NOT be used to rotate own API key
+  @negative @acceptance
+  Scenario: Bob's access token CANNOT be used to rotate own API key
     Given I login as "bob"
     When I PUT "/authn/cucumber/api_key"
     Then the HTTP response status code is 401
 
-  Scenario: Bob's access token CAN NOT be used to rotate own API key using role parameter with self role value
+  @negative @acceptance
+  Scenario: Bob's access token CANNOT be used to rotate own API key using role parameter with self role value
     Given I login as "bob"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 
   # A user without update permission rotating Bob's API key
-
-  Scenario: User without permissions CAN NOT rotate Bob's API key using their own API key
+  @negative @acceptance
+  Scenario: User without permissions CANNOT rotate Bob's API key using their own API key
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "unprivileged_user" and password ":cucumber:user:unprivileged_user_api_key"
     Then the HTTP response status code is 401
 
-  Scenario: User without permissions CAN NOT rotate Bob's API key using their password
+  @negative @acceptance
+  Scenario: User without permissions CANNOT rotate Bob's API key using their password
     Given I set the password for "unprivileged_user" to "Passw0rd-Unprivileged"
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "unprivileged_user" and password "Passw0rd-Unprivileged"
     Then the HTTP response status code is 401
 
-  Scenario: User without permissions CAN NOT rotate Bob's API key using an access token
+  @negative @acceptance
+  Scenario: User without permissions CANNOT rotate Bob's API key using an access token
     Given I login as "unprivileged_user"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 
   # A user with update permission rotating Bob's API key
-
+  @smoke
   Scenario: A User with update privilege CAN rotate Bob's API key using an access token
     Given I login as "privileged_user"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 200
     And the result is the API key for user "bob"
 
-  Scenario: A User with update privilege CAN NOT rotate another user's API key using their own API key
+  @negative @acceptance
+  Scenario: A User with update privilege CANNOT rotate another user's API key using their own API key
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "privileged_user" and password ":cucumber:user:privileged_user_api_key"
     Then the HTTP response status code is 401
 
-  Scenario: A User with update privilege CAN NOT rotate another user's API key using their password
+  @negative @acceptance
+  Scenario: A User with update privilege CANNOT rotate another user's API key using their password
     Given I set the password for "privileged_user" to "Passw0rd-Privileged"
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "privileged_user" and password "Passw0rd-Privileged"
     Then the HTTP response status code is 401
 
   # A host rotating their own API key
-
+  @smoke
   Scenario: A Host CAN rotate their own API key using their API key
     When I PUT "/authn/cucumber/api_key?role=host:privileged_host" with username "host/privileged_host" and password ":cucumber:host:privileged_host_api_key"
     Then the HTTP response status code is 200
     And the result is the API key for host "privileged_host"
 
-  Scenario: A Host CAN NOT rotate their own API key using an access token
+  @negative @acceptance
+  Scenario: A Host CANNOT rotate their own API key using an access token
     Given I login as "host/privileged_host"
     When I PUT "/authn/cucumber/api_key"
     Then the HTTP response status code is 401
 
-  Scenario: A Host CAN NOT rotate their own API key using an access token and a role parameter with self role value
+  @negative @acceptance
+  Scenario: A Host CANNOT rotate their own API key using an access token and a role parameter with self role value
     Given I login as "host/privileged_host"
     When I PUT "/authn/cucumber/api_key?role=host:privileged_host"
     Then the HTTP response status code is 401
 
   # A host with update permission rotating Bob's API key
-
+  @smoke
   Scenario: A Host with update privilege CAN rotate Bob's API key with an access token
     Given I login as "host/privileged_host"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 200
     And the result is the API key for user "bob"
 
-  Scenario: A Host with update privilege CAN NOT rotate Bob's API key with their own API key
+  @negative @acceptance
+  Scenario: A Host with update privilege CANNOT rotate Bob's API key with their own API key
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "host/privileged_host" and password ":cucumber:host:privileged_host_api_key"
     Then the HTTP response status code is 401
 
   # A host without update permission rotating Bob's API key
-
-  Scenario: A Host without update privilege CAN NOT rotate Bob's API key with an access token
+  @negative @acceptance
+  Scenario: A Host without update privilege CANNOT rotate Bob's API key with an access token
     Given I login as "host/unprivileged_host"
     When I PUT "/authn/cucumber/api_key?role=user:bob"
     Then the HTTP response status code is 401
 
-  Scenario: A Host without update privilege CAN NOT rotate a user's API key with their own API key
+  @negative @acceptance
+  Scenario: A Host without update privilege CANNOT rotate a user's API key with their own API key
     When I PUT "/authn/cucumber/api_key?role=user:bob" with username "host/unprivileged_host" and password ":cucumber:host:unprivileged_host_api_key"
     Then the HTTP response status code is 401
 
   # Test rotation against nonexistent user
-
-  Scenario: Bob CAN NOT rotate a nonexistent user's API key using basic auth and an API key, RESULTS IN 401
+  @negative @acceptance
+  Scenario: Bob CANNOT rotate a nonexistent user's API key using basic auth and an API key, RESULTS IN 401
     When I PUT "/authn/cucumber/api_key?role=user:does_not_exist" with username "bob" and password ":cucumber:user:bob_api_key"
     Then the HTTP response status code is 401
 
-  Scenario: Bob CAN NOT rotate a nonexistent user's API key using basic auth and a password, RESULTS IN 401
+  @negative @acceptance
+  Scenario: Bob CANNOT rotate a nonexistent user's API key using basic auth and a password, RESULTS IN 401
     Given I set the password for "bob" to "Passw0rd-Bob"
     When I PUT "/authn/cucumber/api_key?role=user:does_not_exist" with username "bob" and password "Passw0rd-Bob"
     Then the HTTP response status code is 401
 
-  Scenario: Bob CAN NOT rotate a nonexistent user's API key using an access token, RESULTS IN 401
+  @negative @acceptance
+  Scenario: Bob CANNOT rotate a nonexistent user's API key using an access token, RESULTS IN 401
     Given I login as "bob"
     When I PUT "/authn/cucumber/api_key?role=user:does_not_exist"
     Then the HTTP response status code is 401
 
-  Scenario: Bob CAN NOT rotate API key for user in nonexistent account, RESULTS IN 401
+  @negative @acceptance
+  Scenario: Bob CANNOT rotate API key for user in nonexistent account, RESULTS IN 401
     When I PUT "/authn/cucumber/api_key?role=nonexistent_account:user:bob" with username "bob" and password ":cucumber:user:bob_api_key"
     Then the HTTP response status code is 401

--- a/cucumber/api/features/secrets.feature
+++ b/cucumber/api/features/secrets.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Adding and fetching secrets
 
   Each resource in Conjur has an associated list of "secrets", each of which is
@@ -17,6 +18,7 @@ Feature: Adding and fetching secrets
     Given I am a user named "eve"
     Given I create a new "variable" resource called "probe"
 
+  @negative @acceptance
   Scenario: Update a secret for a resource with no permissions
 
     When I am a user named "alice"
@@ -26,11 +28,13 @@ Feature: Adding and fetching secrets
     """
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: Fetching a resource with no name provided return a 404 error.
 
     When I GET "/secrets/cucumber/variable/"
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: Fetching a resource with no secret values return a 404 error.
 
     When I GET "/secrets/cucumber/variable/probe"
@@ -38,6 +42,7 @@ Feature: Adding and fetching secrets
     And there is an error
     And the error message is "CONJ00076E Variable cucumber:variable:probe is empty or not found."
 
+  @negative @acceptance
   Scenario: Fetching a secret for a nonexistent resource
 
     When I GET "/secrets/cucumber/variable/non-existent"
@@ -45,6 +50,7 @@ Feature: Adding and fetching secrets
     And there is an error
     And the error message is "CONJ00076E Variable cucumber:variable:non-existent is empty or not found."
 
+  @negative @acceptance
   Scenario: Update a secret of a nonexistent resource
 
     When I POST "/secrets/cucumber/variable/non-existent" with body:
@@ -53,6 +59,7 @@ Feature: Adding and fetching secrets
     """
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: Fetching a secret for a resource with no permissions
 
     When I POST "/secrets/cucumber/variable/probe" with body:
@@ -63,11 +70,12 @@ Feature: Adding and fetching secrets
     And I GET "/secrets/cucumber/variable/probe"
     Then the HTTP response status code is 404
 
+  @acceptance
   Scenario: The 'conjur/mime_type' annotation is used in the value response.
 
     If the annotation `conjur/mime_type` exists on a resource, then when a
     secret value is fetched from the resource, that mime type is used as the
-    `Content-Type` header in the response. 
+    `Content-Type` header in the response.
 
     Given I set annotation "conjur/mime_type" to "application/json"
     And I save my place in the audit log file for remote
@@ -91,12 +99,14 @@ Feature: Adding and fetching secrets
     """
     And the HTTP response content type is "application/json"
 
+  @acceptance
   Scenario: Secrets can contain any binary data.
 
     Given I create a binary secret value
     When I successfully GET "/secrets/cucumber/variable/probe"
     Then the binary result is preserved
 
+  @smoke
   Scenario: The last secret is the default one returned.
 
     Adding a new secret appends to a list of values on the resource. When
@@ -124,6 +134,7 @@ Feature: Adding and fetching secrets
       cucumber:user:eve fetched cucumber:variable:probe
     """
 
+  @acceptance
   Scenario: When fetching a secret, a specific secret index can be specified.
 
     The `version` parameter can be used to select a specific secret value from
@@ -150,6 +161,7 @@ Feature: Adding and fetching secrets
       cucumber:user:eve fetched version 1 of cucumber:variable:probe
     """
 
+  @negative @acceptance
   Scenario: Fetching with a non-existant secret version returns a 404 error.
 
     Given I successfully POST "/secrets/cucumber/variable/probe" with body:
@@ -159,6 +171,7 @@ Feature: Adding and fetching secrets
     When I GET "/secrets/cucumber/variable/probe?version=2"
     Then the HTTP response status code is 404
 
+  @negative @acceptance
   Scenario: When creating a secret, the value parameter is required.
     Given I save my place in the audit log file for remote
     When I POST "/secrets/cucumber/variable/probe" with body:
@@ -175,8 +188,9 @@ Feature: Adding and fetching secrets
       cucumber:user:eve tried to update cucumber:variable:probe: 'value' may not be empty
     """
 
+  @negative @acceptance
   Scenario: Only the last 20 versions of a secret are stored.
-  
+
     Given I create 20 secret values
     And I successfully POST "/secrets/cucumber/variable/probe" with body:
     """

--- a/cucumber/api/features/secrets_authorization.feature
+++ b/cucumber/api/features/secrets_authorization.feature
@@ -1,3 +1,4 @@
+@api
 Feature: RBAC privileges control whether a role can update and/or fetch a secret.
 
   Background:
@@ -6,6 +7,7 @@ Feature: RBAC privileges control whether a role can update and/or fetch a secret
     And I permit user "bob" to "read" it
     And I create 1 secret values
 
+  @negative @acceptance
   Scenario: Fetching a secret as an unauthorized user results in a 403 error.
 
     Given I login as "bob"
@@ -22,6 +24,7 @@ Feature: RBAC privileges control whether a role can update and/or fetch a secret
       cucumber:user:bob tried to fetch cucumber:variable:probe: Forbidden
     """
 
+  @negative @acceptance
   Scenario: Updating a secret as an unauthorized user results in a 403 error.
 
     Given I login as "bob"
@@ -41,6 +44,7 @@ Feature: RBAC privileges control whether a role can update and/or fetch a secret
       cucumber:user:bob tried to update cucumber:variable:probe: Forbidden
     """
 
+  @acceptance
   Scenario: A foreign role can be granted permission to fetch a secret.
 
     The `execute` privilege can be granted to any role to allow it to fetch a secret.
@@ -49,10 +53,11 @@ Feature: RBAC privileges control whether a role can update and/or fetch a secret
     And I login as "bob"
     Then I can GET "/secrets/cucumber/:resource_kind/:resource_id"
 
+  @acceptance
   Scenario: A foreign role can be granted permission to update a secret.
 
     The `update` privilege can be granted to any role to allow it to update a secret.
- 
+
     Given I permit user "bob" to "update" it
     When I login as "bob"
     Then I can POST "/secrets/cucumber/:resource_kind/:resource_id" with parameters:
@@ -60,6 +65,7 @@ Feature: RBAC privileges control whether a role can update and/or fetch a secret
     v-1
     """
 
+  @negative @acceptance
   Scenario: Fetching a secret without any permission on it
     If the user doesn't have any permission or ownership of a secret, fetching
     it should return 404 (not 403) even if it exists.

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Batch retrieval of secrets
   Background:
     Given I am a user named "bob"
@@ -8,6 +9,7 @@ Feature: Batch retrieval of secrets
     And I create a new "variable" resource called "secret3"
     And I add the secret value "s3" to the resource "cucumber:variable:secret3"
 
+  @smoke
   Scenario: Returns a JSON hash mapping resource id to value
     Given I save my place in the audit log file for remote
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,cucumber:variable:secret2"
@@ -34,41 +36,49 @@ Feature: Batch retrieval of secrets
       cucumber:user:bob fetched cucumber:variable:secret2
     """
 
+  @negative @acceptance
   Scenario: Fails with 422 if variable_ids param is missing
     When I GET "/secrets"
     Then the HTTP response status code is 422
 
+  @negative @acceptance
   Scenario: Fails with 422 if variable_ids param is empty
     When I GET "/secrets?variable_ids="
     Then the HTTP response status code is 422
 
+  @negative @acceptance
   Scenario: Fails with 422 if variable_ids param has only blank items
     When I GET "/secrets?variable_ids=,,,"
     Then the HTTP response status code is 422
 
+  @negative @acceptance
   Scenario: Fails with 403 if execute privilege is not held
     When I am a user named "someone-else"
     And I GET "/secrets?variable_ids=cucumber:variable:secret1"
     Then the HTTP response status code is 403
 
+  @negative @acceptance
   Scenario: Fails with 404 if variable_ids param has some blank items
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,,,cucumber:variable:secret2"
     Then the HTTP response status code is 422
     And there is an error
     And the error message is "variable_ids"
 
+  @negative @acceptance
   Scenario: Fails with 404 if a variable_id param is of an incorrect format
     When I GET "/secrets?variable_ids=1,2,3"
     Then the HTTP response status code is 404
     And there is an error
     And the error message is "CONJ00076E Variable 1 is empty or not found."
 
+  @negative @acceptance
   Scenario: Fails with 404 if a resource doesn't exist
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,cucumber:variable:not-a-secret"
     Then the HTTP response status code is 404
     And there is an error
     And the error message is "CONJ00076E Variable cucumber:variable:not-a-secret is empty or not found."
 
+  @negative @acceptance
   Scenario: Fails with 404 if a resource doesn't have a value
     Given I create a new "variable" resource called "secret-no-value"
     When I GET "/secrets?variable_ids=cucumber:variable:secret1,cucumber:variable:secret-no-value"
@@ -79,6 +89,7 @@ Feature: Batch retrieval of secrets
   # This test explicitly tests an error case that was discovered in Conjur v4 where
   # resource IDs were matched with incorrect variable values in the JSON response.
   # It was fixed in: https://github.com/conjurinc/core/pull/46/files
+  @smoke
   Scenario: Returns a correct mapping of resource ids to secret values
     Given I add the secret value "v1" to the resource "cucumber:variable:secret1"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
@@ -102,6 +113,7 @@ Feature: Batch retrieval of secrets
     { "cucumber:variable:secret1": "v3", "cucumber:variable:secret2": "v5", "cucumber:variable:secret3": "v6" }
     """
 
+  @smoke
   Scenario: Returns Base64 encoded secrets with Accept-Encoding header base64
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
@@ -110,18 +122,21 @@ Feature: Batch retrieval of secrets
     Then the binary data is preserved for "cucumber:variable:secret3"
     And the content encoding is "base64"
 
+  @smoke
   Scenario: Returns Base64 encoded secrets with alternate heading capitalization
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I set the "Accept-Encoding" header to "Base64"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the binary data is preserved for "cucumber:variable:secret3"
 
+  @negative @acceptance
   Scenario: Fails with 406 on retrieval of single binary secret with improper header
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I set the "Accept-Encoding" header to "*"
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the HTTP response status code is 406
 
+  @negative @acceptance
   Scenario: Fails with 406 on retrieval of multiple secrets with improper header
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"
@@ -129,6 +144,7 @@ Feature: Batch retrieval of secrets
     When I GET "/secrets?variable_ids=cucumber:variable:secret3,cucumber:variable:secret2"
     Then the HTTP response status code is 406
 
+  @acceptance
   Scenario: Omit the Accept-Encoding header entirely from batch secrets request
     Given I add the secret value "v2" to the resource "cucumber:variable:secret2"
     When I GET "/secrets?variable_ids=cucumber:variable:secret2" with no default headers

--- a/cucumber/api/features/status_page.feature
+++ b/cucumber/api/features/status_page.feature
@@ -1,7 +1,9 @@
+@api
 Feature: Status page
 
   The root route is a simple "status page" that verifies that the API is reachable
 
+  @smoke
   Scenario: GET / is reachable.
 
     When I GET the root route

--- a/cucumber/api/features/whoami.feature
+++ b/cucumber/api/features/whoami.feature
@@ -1,5 +1,7 @@
+@api
 Feature: Who Am I
 
+  @acceptance
   Scenario: Audit entry
 
     Given I am a user named "alice"

--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -1,3 +1,4 @@
+@authenticators_azure
 Feature: Azure Authenticator - Bad authenticator configuration leads to an error
 
   In this feature we define an Azure Authenticator with a configuration
@@ -5,6 +6,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
   and log the relevant error for the user to re-configure the authenticator
   properly
 
+  @negative @acceptance
   Scenario: provider-uri variable missing in policy is denied
     Given I load a policy:
     """
@@ -35,6 +37,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
 
   # TODO: add this test when issue #1085 is done
   @skip
+  @negative @acceptance
   Scenario: provider-uri variable without value is denied
     Given I load a policy:
     """
@@ -66,6 +69,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     Errors::Conjur::RequiredSecretMissing
     """
 
+  @negative @acceptance
   Scenario: webservice missing in policy is denied
     Given I load a policy:
     """
@@ -92,6 +96,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     Errors::Authentication::Security::WebserviceNotFound
     """
 
+  @negative @acceptance
   Scenario: Webservice with read and no authenticate permission in policy is denied
     Given I load a policy:
     """
@@ -124,6 +129,7 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
+  @negative @acceptance
   Scenario: Unauthorized is raised in case of an invalid ID Provider hostname
     Given I load a policy:
     """

--- a/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_basic_host.feature
@@ -1,3 +1,4 @@
+@authenticators_azure
 Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
 
   In this feature we define an Azure authenticator in policy and perform authentication
@@ -30,6 +31,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
 
+  @smoke
   Scenario: Hosts can authenticate with Azure authenticator and fetch secret
     Given I have a "variable" resource called "test-variable"
     And I permit host "test-app" to "execute" it
@@ -44,6 +46,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     cucumber:host:test-app successfully authenticated with authenticator authn-azure service cucumber:webservice:conjur/authn-azure/prod
     """
 
+  @acceptance
   Scenario: A valid provider-uri without trailing slash works
     Given I have a "variable" resource called "test-variable"
     And I permit host "test-app" to "execute" it
@@ -54,6 +57,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     Then host "test-app" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
 
+  @acceptance
   Scenario: Changing provider-uri dynamically reflects on the ID Provider endpoint
     Given I fetch a non-assigned-identity Azure access token from inside machine
     And I authenticate via Azure with token as host "test-app"
@@ -74,6 +78,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     And I authenticate via Azure with token as host "test-app"
     And host "test-app" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: Missing Azure access token is a bad request
     Given I save my place in the log file
     When I authenticate via Azure with no token as host "test-app"
@@ -83,6 +88,7 @@ Feature: Azure Authenticator - Hosts can authenticate with Azure authenticator
     Errors::Authentication::RequestBody::MissingRequestParam
     """
 
+  @negative @acceptance
   Scenario: Empty Azure access token is a bad request
     Given I save my place in the log file
     When I authenticate via Azure with empty token as host "test-app"

--- a/cucumber/authenticators_azure/features/authn_azure_hosts.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_hosts.feature
@@ -1,3 +1,4 @@
+@authenticators_azure
 Feature: Azure Authenticator - Different Hosts can authenticate with Azure authenticator
 
   In this feature we define an Azure authenticator in policy, define different
@@ -24,6 +25,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     And I am the super-user
     And I successfully set Azure provider-uri variable with the correct values
 
+  @smoke
   Scenario: Host with user-assigned-identity annotation is authorized
     And I have host "user-assigned-identity-app"
     And I set subscription-id annotation to host "user-assigned-identity-app"
@@ -34,6 +36,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     When I authenticate via Azure with token as host "user-assigned-identity-app"
     Then host "user-assigned-identity-app" has been authorized by Conjur
 
+  @smoke
   Scenario: Host with system-assigned-identity annotation is authorized
     And I have host "system-assigned-identity-app"
     And I set subscription-id annotation to host "system-assigned-identity-app"
@@ -44,6 +47,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     When I authenticate via Azure with token as host "system-assigned-identity-app"
     Then host "system-assigned-identity-app" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: Host without resource-group annotation is denied
     And I have host "no-resource-group-app"
     And I set subscription-id annotation to host "no-resource-group-app"
@@ -57,6 +61,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::Constraints::RoleMissingConstraints: CONJ00057E Role does not have the required constraints: '["resource-group"]'
     """
 
+  @negative @acceptance
   Scenario: Host without subscription-id annotation is denied
     And I have host "no-subscription-id-app"
     And I set resource-group annotation to host "no-subscription-id-app"
@@ -70,6 +75,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::Constraints::RoleMissingConstraints: CONJ00057E Role does not have the required constraints: '["subscription-id"]'
     """
 
+  @negative @acceptance
   Scenario: Host without any Azure annotation is denied
     And I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"
@@ -82,6 +88,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::Constraints::RoleMissingConstraints
     """
 
+  @negative @acceptance
   Scenario: Host with both identity Azure annotations is denied
     And I have host "illegal-combination-app"
     And I set resource-group annotation to host "illegal-combination-app"
@@ -98,6 +105,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::Constraints::IllegalConstraintCombinations
     """
 
+  @negative @acceptance
   Scenario: Host with incorrect subscription-id Azure annotation is denied
     And I have host "incorrect-subscription-id-app"
     And I set resource-group annotation to host "incorrect-subscription-id-app"
@@ -112,6 +120,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::ResourceRestrictions::InvalidResourceRestrictions
     """
 
+  @negative @acceptance
   Scenario: Host with incorrect resource-group Azure annotation is denied
     And I have host "incorrect-resource-group-app"
     And I set subscription-id annotation to host "incorrect-resource-group-app"
@@ -126,6 +135,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::ResourceRestrictions::InvalidResourceRestrictions
     """
 
+  @negative @acceptance
   Scenario: Host with incorrect user-assigned-identity annotation is denied
     And I have host "incorrect-user-assigned-identity-app"
     And I set subscription-id annotation to host "incorrect-user-assigned-identity-app"
@@ -141,6 +151,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::ResourceRestrictions::InvalidResourceRestrictions
     """
 
+  @negative @acceptance
   Scenario: Host with incorrect system-assigned-identity annotation is denied
     And I have host "incorrect-system-assigned-identity-app"
     And I set subscription-id annotation to host "incorrect-system-assigned-identity-app"
@@ -156,6 +167,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     Errors::Authentication::ResourceRestrictions::InvalidResourceRestrictions
     """
 
+  @negative @acceptance
   Scenario: Non-existing host is denied
     And I fetch a non-assigned-identity Azure access token from inside machine
     And I save my place in the log file
@@ -170,6 +182,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
     cucumber:host:non-existing-app failed to authenticate with authenticator authn-azure service cucumber:webservice:conjur/authn-azure/prod
     """
 
+  @negative @acceptance
   Scenario: Host that is not in the permitted group is denied
     And I have host "non-permitted-app"
     And I set Azure annotations to host "non-permitted-app"
@@ -185,6 +198,7 @@ Feature: Azure Authenticator - Different Hosts can authenticate with Azure authe
   # This test runs a failing authentication request that is already
   # tested in another scenario (Host without resource-group annotation is denied).
   # We run it again here to verify that we write a message to the audit log
+  @acceptance
   Scenario: Authentication failure is written to the audit log
     And I have host "no-resource-group-app"
     And I set subscription-id annotation to host "no-resource-group-app"

--- a/cucumber/authenticators_azure/features/authn_azure_performance.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_performance.feature
@@ -1,3 +1,4 @@
+@authenticators_azure
 Feature: Azure Authenticator - Performance tests
 
   In this feature we test that Azure Authenticator performance is meeting
@@ -29,21 +30,25 @@ Feature: Azure Authenticator - Performance tests
     And I set Azure annotations to host "test-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "test-app"
 
+  @performance
   Scenario: successful requests
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app"
     Then The avg authentication request responds in less than 0.75 seconds
 
+  @performance
   Scenario: successful requests with Accept-Encoding base64
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with token as host "test-app" with Accept-Encoding header "base64"
     Then The avg authentication request responds in less than 0.75 seconds
 
+  @performance @negative
   Scenario: Unsuccessful requests with an invalid token
     And I fetch a non-assigned-identity Azure access token from inside machine
     When I authenticate 1000 times in 10 threads via Azure with invalid token as host "test-app"
     Then The avg authentication request responds in less than 0.75 seconds
 
+  @performance @negative
   Scenario: Unsuccessful requests with invalid resource restrictions
     Given I have host "no-azure-annotations-app"
     And I grant group "conjur/authn-azure/prod/apps" to host "no-azure-annotations-app"

--- a/cucumber/authenticators_azure/features/authn_status_azure.feature
+++ b/cucumber/authenticators_azure/features/authn_status_azure.feature
@@ -1,5 +1,7 @@
+@authenticators_azure
 Feature: Azure Authenticator - Status Check
 
+  @smoke
   Scenario: A properly configured Azure authenticator returns a successful response
     Given I load a policy:
     """
@@ -51,6 +53,7 @@ Feature: Azure Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @negative @acceptance
   Scenario: A non-responsive Azure AD provider returns a 500 response
     Given I load a policy:
     """
@@ -101,6 +104,7 @@ Feature: Azure Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "ProviderDiscoveryFailed: CONJ00011E"
 
+  @negative @acceptance
   Scenario: provider-uri variable is missing and a 500 error response is returned
     Given I load a policy:
      """

--- a/cucumber/authenticators_config/features/authn_config.feature
+++ b/cucumber/authenticators_config/features/authn_config.feature
@@ -1,3 +1,4 @@
+@authenticators_config
 Feature: Authenticator configuration
 
   Background:
@@ -43,11 +44,13 @@ Feature: Authenticator configuration
       member: !user authn-updater
     """
 
+  @smoke
   Scenario: Authenticator is not configured in database
     When I am the super-user
     And I retrieve the list of authenticators
     Then the enabled authenticators contains "authn-k8s/test"
 
+  @smoke
   Scenario: Authenticator is enabled in the environment and disabled in the database
     When I am the super-user
     And I successfully PATCH "/authn-k8s/test/cucumber" with body:
@@ -57,6 +60,7 @@ Feature: Authenticator configuration
     And I retrieve the list of authenticators
     Then the enabled authenticators contains "authn-k8s/test"
 
+  @smoke
   Scenario: Authenticator is successfully configured
     When I login as "authn-updater"
     And I successfully PATCH "/authn-k8s/db/cucumber" with body:
@@ -73,6 +77,7 @@ Feature: Authenticator configuration
     Then the HTTP response status code is 204
     And authenticator "cucumber:webservice:conjur/authn-k8s/db" is disabled
 
+  @negative @acceptance
   Scenario: Authenticator account does not exist
     When I am the super-user
     And I save my place in the log file
@@ -86,6 +91,7 @@ Feature: Authenticator configuration
     Errors::Authentication::Security::AccountNotDefined
     """
 
+  @negative @acceptance
   Scenario: Authenticator webservice does not exist
     When I am the super-user
     And I save my place in the log file
@@ -99,6 +105,7 @@ Feature: Authenticator configuration
     Errors::Authentication::Security::WebserviceNotFound
     """
 
+  @negative @acceptance
   Scenario: Authenticated user can not update authenticator
     When I login as "authn-viewer"
     And I save my place in the log file
@@ -113,6 +120,7 @@ Feature: Authenticator configuration
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
+  @negative @acceptance
   Scenario: Nested webservice can not be configured
     When I am the super-user
     And I save my place in the log file
@@ -126,6 +134,7 @@ Feature: Authenticator configuration
     Errors::Authentication::AuthenticatorNotSupported
     """
 
+  @smoke
   Scenario: Authenticator without service-id is successfully configured
     When I am the super-user
     And I load a policy:
@@ -150,6 +159,7 @@ Feature: Authenticator configuration
     Then the HTTP response status code is 204
     And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled
 
+  @negative @acceptance
   Scenario: Authenticator without service-id and webservice does not exist
     When I am the super-user
     And I save my place in the log file
@@ -181,6 +191,7 @@ Feature: Authenticator configuration
     """
     And authenticator "cucumber:webservice:conjur/authn-gcp" is disabled
 
+  @negative @acceptance
   Scenario: Unauthorized user can not update authenticator without service-id
     When I am the super-user
     And I load a policy:
@@ -203,6 +214,7 @@ Feature: Authenticator configuration
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
+  @negative @acceptance
   Scenario: Nested webservice can not be configured for authenticator without service-id
     When I am the super-user
     And I load a policy:

--- a/cucumber/authenticators_config/features/available_authn.feature
+++ b/cucumber/authenticators_config/features/available_authn.feature
@@ -1,7 +1,9 @@
+@authenticators_config
 Feature: The list of available authentication providers is discoverable
   through the API.
 
   @sanity
+  @smoke
   Scenario: ONYX-12104 - Verify installed authenticators
     When I retrieve the list of authenticators
     Then there are exactly 8 installed authenticators
@@ -14,6 +16,7 @@ Feature: The list of available authentication providers is discoverable
     And the installed authenticators contains "authn-ldap"
     And the installed authenticators contains "authn-oidc"
 
+  @smoke
   Scenario: List authenticators
     Given I load a policy:
     """

--- a/cucumber/authenticators_gcp/features/authn_gce.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authenticator
 
   In this feature we define a GCP authenticator in policy and perform authentication
@@ -26,6 +26,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     And I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
 
+  @smoke
   Scenario: Hosts can authenticate with GCP authenticator and fetch secret
     Given I have a "variable" resource called "test-variable"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
@@ -41,6 +42,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Host can authenticate with only project-id annotation set
     Given I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
@@ -55,6 +57,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Host can authenticate with only service-account-id annotation set
     Given I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
@@ -69,6 +72,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Host can authenticate with only service-account-email annotation set
     Given I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
@@ -83,6 +87,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Host can not authenticate with only instance-name annotation set
     Given I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
@@ -97,6 +102,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     CONJ00069E Role must have at least one of the following constraints: ["project-id", "service-account-id", "service-account-email"]
     """
 
+  @negative @acceptance
   Scenario: Non-existing account in token audience claim is denied
     Given I obtain a non_existing_account GCE identity token
     And I save my place in the log file
@@ -111,6 +117,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
+  @negative @acceptance
   Scenario: Non-existing account in URL request is denied
     Given I save my place in the log file
     When I authenticate with authn-gcp using obtained GCE token and non-existing account
@@ -124,6 +131,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     non-existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-gcp service
     """
 
+  @acceptance
   Scenario: Authenticate using token in standard format and host with only service-account-id annotation set
     Given I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
@@ -138,6 +146,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @negative @acceptance
   Scenario: Requests with an existing user ID in URL is responded with not found
     Given I save my place in the log file
     When I authenticate with authn-gcp using no token and user id "host%2Ftest-app" in the request
@@ -147,6 +156,7 @@ Feature: GCP Authenticator - GCE flow, hosts can authenticate with GCP authentic
     ActionController::RoutingError (No route matches [POST] "/authn-gcp/cucumber/host%2Ftest-app/authenticate")
     """
 
+  @negative @acceptance
   Scenario: Requests with a non-existing user ID in URL is responded with not found
     Given I save my place in the log file
     When I authenticate with authn-gcp using no token and user id "host%2Fnon-existing" in the request

--- a/cucumber/authenticators_gcp/features/authn_gce_bad_configuration.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce_bad_configuration.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCE flow, test malformed configuration
 
   In this feature we define a GCP authenticator with a malformed configuration.
@@ -9,6 +9,7 @@ Feature: GCP Authenticator - GCE flow, test malformed configuration
   Background:
     Given I obtain a valid GCE identity token
 
+  @negative @acceptance
   Scenario: Webservice is missing in policy gets denied
     Given I load a policy:
     """
@@ -29,6 +30,7 @@ Feature: GCP Authenticator - GCE flow, test malformed configuration
     CONJ00005E Webservice 'authn-gcp' not found
     """
 
+  @negative @acceptance
   Scenario: Webservice with read and no authenticate permission in policy is denied
     Given I load a policy:
     """

--- a/cucumber/authenticators_gcp/features/authn_gce_hosts.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce_hosts.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
 
   In this feature we define GCP authenticator in policy, test with different
@@ -23,7 +23,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     And I obtain a valid GCE identity token
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
 
-
+  @negative @acceptance
   Scenario: Host with all valid annotations except for project-id is denied
     Given I set invalid "authn-gcp/project-id" GCE annotation to host "test-app"
     And I set "authn-gcp/service-account-id" GCE annotation to host "test-app"
@@ -37,6 +37,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     CONJ00049E Resource restriction 'project-id' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Host with all valid annotations except for instance-name is denied
     Given I set invalid "authn-gcp/instance-name" GCE annotation to host "test-app"
     And I set "authn-gcp/project-id" GCE annotation to host "test-app"
@@ -50,6 +51,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     CONJ00049E Resource restriction 'instance-name' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Host with all valid annotations except for service-account-email is denied
     Given I set invalid "authn-gcp/service-account-email" GCE annotation to host "test-app"
     And I set "authn-gcp/project-id" GCE annotation to host "test-app"
@@ -63,6 +65,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     CONJ00049E Resource restriction 'service-account-email' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Host with all valid annotations except for service-account-id is denied
     Given I set invalid "authn-gcp/service-account-id" GCE annotation to host "test-app"
     And I set "authn-gcp/project-id" GCE annotation to host "test-app"
@@ -76,6 +79,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     CONJ00049E Resource restriction 'service-account-id' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Host with all valid annotations and an illegal annotation key is denied
     Given I set "authn-gcp/invalid-key" GCE annotation to host "test-app"
     And I set all valid GCE annotations to host "test-app"
@@ -87,6 +91,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     CONJ00050E Resource restrictions '["invalid-key"]' are not supported
     """
 
+  @smoke
   Scenario: Users can authenticate with GCP authenticator and fetch secret
     Given I have user "test-app"
     And I grant group "conjur/authn-gcp/apps" to user "test-app"
@@ -104,6 +109,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     cucumber:user:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @negative @acceptance
   Scenario: Non-existing host is denied
     Given I obtain a non_existing_host GCE identity token
     And I save my place in the log file
@@ -118,6 +124,7 @@ Feature: GCP Authenticator - GCE flow, test hosts can authentication scenarios
     cucumber:host:non-existing failed to authenticate with authenticator authn-gcp
     """
 
+  @smoke
   Scenario: Hosts defined outside of root can authenticate with GCP authenticator and fetch secret
     Given I have host "non-rooted/test-app"
     And I set all valid GCE annotations to host "non-rooted/test-app"

--- a/cucumber/authenticators_gcp/features/authn_gce_performance.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce_performance.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCE flow, Performance tests
 
   In this feature we test that GCP Authenticator performance is meeting
@@ -27,10 +27,12 @@ Feature: GCP Authenticator - GCE flow, Performance tests
     And I set all valid GCE annotations to host "test-app"
     And I obtain a valid GCE identity token
 
+  @performance
   Scenario: successful requests
     When I authenticate 1000 times in 10 threads with authn-gcp using valid GCE token and existing account
     Then The avg authentication request responds in less than 0.75 seconds
 
+  @performance @negative
   Scenario: Unsuccessful requests with invalid resource restrictions
     Given I have host "no-annotations-app"
     And I grant group "conjur/authn-gcp/apps" to host "no-annotations-app"

--- a/cucumber/authenticators_gcp/features/authn_gce_token_errors.feature
+++ b/cucumber/authenticators_gcp/features/authn_gce_token_errors.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCE flow, test token error handling
 
   In this feature we test authentication using malformed tokens.
@@ -24,6 +24,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
     And I set all valid GCE annotations to host "test-app"
 
+  @negative @acceptance
   Scenario: Authenticate using a self signed token is denied
     When I save my place in the log file
     And I authenticate with authn-gcp using self signed token and existing account
@@ -33,6 +34,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00035E Failed to decode token \(3rdPartyError ='#<JWT::DecodeError: Could not find public key for kid .*>'
     """
 
+  @negative @acceptance
   Scenario: Authenticate using a self signed token missing 'kid' header claim is denied
     When I save my place in the log file
     And I authenticate with authn-gcp using no kid token and existing account
@@ -42,6 +44,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::DecodeError: No key id (kid) found from token headers>')
     """
 
+  @negative @acceptance
   Scenario: Authenticate using token with an invalid audience claim is denied
     Given I obtain an invalid_audience GCE identity token
     And I save my place in the log file
@@ -52,6 +55,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00067E 'audience' token claim .* is invalid. The format should be 'conjur/<account-name>/<host-id>'
     """
 
+  @negative @acceptance
   Scenario: Missing GCP access token is a bad request
     Given I save my place in the log file
     When I authenticate with authn-gcp using no token and existing account
@@ -61,6 +65,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00009E Field 'jwt' is missing or empty in request body
     """
 
+  @negative @acceptance
   Scenario: Empty GCP access token is a bad request
     Given I save my place in the log file
     When I authenticate with authn-gcp using empty token and existing account
@@ -71,6 +76,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     """
 
   # "authn-gcp/project-id" annotation is set because at least one of the annotations is expected.
+  @negative @acceptance
   Scenario: Host not in permitted group is denied
     Given I load a policy:
     """
@@ -96,6 +102,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00006E 'host/test-app' does not have 'authenticate' privilege on cucumber:webservice:conjur/authn-gcp
     """
 
+  @negative @acceptance
   Scenario: Authenticate using token in standard format and host with only service-account-email annotation set is denied
     Given I have host "test-app"
     And I remove all annotations from host "test-app"
@@ -109,6 +116,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00068E Claim 'service-account-email' is missing from Google's JWT token. Verify that you configured the host with permitted restrictions. In case of Compute Engine token, verify that you requested the token using 'format=full'
     """
 
+  @negative @acceptance
   Scenario: Authenticate using token in standard format and host with only project-id annotation set is denied
     Given I have host "test-app"
     And I remove all annotations from host "test-app"
@@ -122,6 +130,7 @@ Feature: GCP Authenticator - GCE flow, test token error handling
     CONJ00068E Claim 'project-id' is missing from Google's JWT token. Verify that you configured the host with permitted restrictions. In case of Compute Engine token, verify that you requested the token using 'format=full'
     """
 
+  @negative @acceptance
   Scenario: Authenticate using token in standard format and host with only instance-name annotation set is denied
     Given I have host "test-app"
     And I remove all annotations from host "test-app"

--- a/cucumber/authenticators_gcp/features/authn_gcf.feature
+++ b/cucumber/authenticators_gcp/features/authn_gcf.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCF flow, hosts can authenticate with GCP authenticator
 
   In this feature we define a GCP authenticator in policy and perform authentication
@@ -25,6 +25,7 @@ Feature: GCP Authenticator - GCF flow, hosts can authenticate with GCP authentic
     And I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
 
+  @smoke
   Scenario: Hosts can authenticate with GCP authenticator and fetch secret
     Given I have a "variable" resource called "test-variable"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
@@ -41,6 +42,7 @@ Feature: GCP Authenticator - GCF flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Hosts can authenticate with GCP authenticator using service-account-id annotation only and fetch secret
     Given I have a "variable" resource called "test-variable"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
@@ -57,6 +59,7 @@ Feature: GCP Authenticator - GCF flow, hosts can authenticate with GCP authentic
     cucumber:host:test-app successfully authenticated with authenticator authn-gcp service cucumber:webservice:conjur/authn-gcp
     """
 
+  @acceptance
   Scenario: Hosts can authenticate with GCP authenticator using service-account-email annotation only and fetch secret
     Given I have a "variable" resource called "test-variable"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"

--- a/cucumber/authenticators_gcp/features/authn_gcf_token_errors.feature
+++ b/cucumber/authenticators_gcp/features/authn_gcf_token_errors.feature
@@ -1,4 +1,4 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - GCF flow, test token error hwahtandling
 
   In this feature we test authentication using malformed tokens.
@@ -23,6 +23,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     And I have host "test-app"
     And I grant group "conjur/authn-gcp/apps" to host "test-app"
 
+  @negative @acceptance
   Scenario: Token with service-account-id claim that does not match annotation is denied
     Given I remove all annotations from host "test-app"
     And I set "authn-gcp/service-account-id" annotation with value: "unknown-service-account-id" to host "test-app"
@@ -35,6 +36,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     CONJ00049E Resource restriction 'service-account-id' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Token with service-account-email claim that does not match annotation is denied
     Given I remove all annotations from host "test-app"
     And I set "authn-gcp/service-account-email" annotation with value: "unknown-service-account-email" to host "test-app"
@@ -47,6 +49,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     CONJ00049E Resource restriction 'service-account-email' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Token with valid service-account-id claim and service-account-email claim that does not match annotation is denied
     Given I remove all annotations from host "test-app"
     And I set "authn-gcp/service-account-id" GCF annotation to host "test-app"
@@ -60,6 +63,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     CONJ00049E Resource restriction 'service-account-email' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Token with valid service-account-email claim and service-account-id claim that does not match annotation is denied
     And I set "authn-gcp/service-account-email" GCF annotation to host "test-app"
     And I set "authn-gcp/service-account-id" annotation with value: "unknown-service-account-id" to host "test-app"
@@ -72,6 +76,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     CONJ00049E Resource restriction 'service-account-id' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: Token with project-id host annotation is denied
     And I set all valid GCF annotations to host "test-app"
     And I set "authn-gcp/project-id" GCF annotation to host "test-app"
@@ -84,6 +89,7 @@ Feature: GCP Authenticator - GCF flow, test token error hwahtandling
     CONJ00068E Claim 'project-id' is missing from Google's JWT token
     """
 
+  @negative @acceptance
   Scenario: Token with instance-name host annotation is denied
     And I set all valid GCF annotations to host "test-app"
     And I set "authn-gcp/instance-name" GCF annotation to host "test-app"

--- a/cucumber/authenticators_gcp/features/validate_status.feature
+++ b/cucumber/authenticators_gcp/features/validate_status.feature
@@ -1,6 +1,7 @@
-@gcp
+@authenticators_gcp
 Feature: GCP Authenticator - Status Check
 
+  @smoke
   Scenario: A properly configured GCP authenticator returns a successful response
     Given I load a policy:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - JWKs Basic sanity
 
   In this feature we define a JWT authenticator in policy and perform authentication
@@ -41,6 +42,7 @@ Feature: JWT Authenticator - JWKs Basic sanity
     And I successfully set authn-jwt "token-app-property" variable to value "host"
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-8598: Authenticator is not enabled
     Given I have a "variable" resource called "test-variable"
     And I am using file "authn-jwt-general" and alg "RS256" for remotely issue token:
@@ -58,6 +60,7 @@ Feature: JWT Authenticator - JWKs Basic sanity
     CONJ00004E 'authn-jwt/non-existing' is not enabled
     """
 
+  @negative @acceptance
   Scenario: ONYX-8821: Host that doesn't exist is denied
     Given I am using file "authn-jwt-general" and alg "RS256" for remotely issue token:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_ca_cert.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_ca_cert.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - ca-cert variable tests
 
   Validate the authenticator behavior when ca-cert variable is configured.
@@ -14,6 +15,7 @@ Feature: JWT Authenticator - ca-cert variable tests
       - !webservice status
     """
 
+  @negative @acceptance
   Scenario: ONYX-15311: Self-signed jwks-uri no ca-cert variable
     Given I initialize JWKS endpoint with file "ca-cert-ONYX-15311.json"
     And I am the super-user
@@ -23,6 +25,7 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://jwks/ca-cert-ONYX-15311.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>'>"
 
   @sanity
+  @acceptance
   Scenario: ONYX-15312: Self-signed jwks-uri with valid ca-cert variable value
     Given I initialize JWKS endpoint with file "ca-cert-ONYX-15312.json"
     And I am the super-user
@@ -38,6 +41,7 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @acceptance
   Scenario Outline: ONYX-15313/6: Self-signed jwks-uri with ca-cert contains bundle includes the valid certificate
     Given I initialize JWKS endpoint with file "ca-cert-ONYX-15313.json"
     And I initialize JWKS endpoint with file "ca-cert-ONYX-15316.json"
@@ -64,6 +68,7 @@ Feature: JWT Authenticator - ca-cert variable tests
       | https://jwks/ca-cert-ONYX-15313.json                    |
       | https://chained.mycompany.local/ca-cert-ONYX-15316.json |
 
+  @negative @acceptance
   Scenario: ONYX-15314: Chained jwks-uri no ca-cert variable
     Given I initialize JWKS endpoint with file "ca-cert-ONYX-15314.json"
     And I am the super-user
@@ -73,6 +78,7 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'https://chained.mycompany.local/ca-cert-ONYX-15314.json'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate in certificate chain)>'>"
 
   @sanity
+  @acceptance
   Scenario: ONYX-15315: Self-signed jwks-uri with valid ca-cert variable value
     Given I initialize JWKS endpoint with file "ca-cert-ONYX-15315.json"
     And I am the super-user
@@ -88,6 +94,7 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @acceptance
   Scenario: ONYX-15317: Google's jwks-uri no ca-cert variable
     Given I am the super-user
     And I successfully set authn-jwt "jwks-uri" variable to value "https://www.googleapis.com/oauth2/v3/certs"
@@ -97,6 +104,7 @@ Feature: JWT Authenticator - ca-cert variable tests
     And the authenticator status check succeeds
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-15318: Microsoft's jwks-uri with invalid ca-cert variable value
     Given I am the super-user
     And I extend the policy with:

--- a/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_check_standard_claims.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Check registered claim
 
   Verify the authenticator works correctly with the registered claims:
@@ -74,6 +75,7 @@ Feature: JWT Authenticator - Check registered claim
     And I permit host "myapp" to "execute" it
     And I permit host "alice" to "execute" it
 
+  @acceptance
   Scenario: ONYX-8727: Issuer configured with incorrect value, iss claim not exists in token, 200 ok
     Given I extend the policy with:
     """
@@ -104,6 +106,7 @@ Feature: JWT Authenticator - Check registered claim
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-8714: JWT token with past exp claim value, 401 Error
     Given I extend the policy with:
     """
@@ -130,6 +133,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00016E Token expired
     """
 
+  @negative @acceptance
   Scenario: ONYX-8711: Valid JWT token with no exp claim, 401 Error
     Given I extend the policy with:
     """
@@ -155,6 +159,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00091E Failed to validate token: mandatory claim 'exp' is missing.
     """
 
+  @negative @acceptance
   Scenario: ONYX-8715: JWT token with future iat claim, 401 Error
     Given I extend the policy with:
     """
@@ -181,6 +186,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::InvalidIatError: Invalid iat>')>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8716: JWT token with future nbf claim, 401 Error
     Given I extend the policy with:
     """
@@ -207,6 +213,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::ImmatureSignature: Signature nbf has not been reached>')>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8718: issuer configured but not set, iss claim exists in token, 401 Error
     Given I extend the policy with:
     """
@@ -236,6 +243,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/issuer
     """
 
+  @acceptance
   Scenario: ONYX-8719: issuer configured but not set, iss claim not exists in token, 200 ok
     Given I extend the policy with:
     """
@@ -264,6 +272,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/issuer
     """
 
+  @acceptance
   Scenario: ONYX-8728: jwks-uri configured with correct value, issuer configured with correct value, iss claim with correct value, 200 OK
     Given I extend the policy with:
     """
@@ -295,6 +304,7 @@ Feature: JWT Authenticator - Check registered claim
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-8728: jwks-uri configured with correct value, issuer configured with wrong value, iss claim with correct value, 401 Error
     Given I extend the policy with:
     """
@@ -325,6 +335,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::InvalidIssuerError: Invalid issuer. Expected incorrect.com, received http://jwks>')>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8728: jwks-uri configured with wrong value, issuer configured with wrong value, iss claim with correct value, 401 Error
     Given I extend the policy with:
     """
@@ -355,6 +366,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00087E Failed to fetch JWKS from 'incorrect.com'
     """
 
+  @negative @acceptance
   Scenario: ONYX-8728: provider-uri configured with wrong value, issuer configured with wrong value, iss claim with correct value, 502 Error
     Given I successfully set authn-jwt "provider-uri" variable in keycloack service to "incorrect.com"
     And I successfully set authn-jwt "token-app-property" variable with OIDC value from env var "ID_TOKEN_USER_PROPERTY"
@@ -368,6 +380,7 @@ Feature: JWT Authenticator - Check registered claim
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'incorrect.com'). Reason: '#<AttrRequired::AttrMissing: 'host' required.>'
     """
 
+  @negative @acceptance
   Scenario: ONYX-15323: public-keys with invalid issuer variable
     Given I extend the policy with:
     """
@@ -393,6 +406,7 @@ Feature: JWT Authenticator - Check registered claim
     """
 
   @sanity
+  @acceptance
   Scenario Outline: Audience tests
     Given I extend the policy with:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_configuration.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Configuration Check
 
   Tests to check failures because of misconfiguration of the JWT during runtime.
@@ -6,6 +7,7 @@ Feature: JWT Authenticator - Configuration Check
     Given I initialize remote JWKS endpoint with file "authn-jwt-configuration" and alg "RS256"
     And I have a "variable" resource called "test-variable"
 
+  @negative @acceptance
   Scenario: ONYX-8600: Webservice is missing in Authenticator policy
     Given I load a policy:
     """
@@ -46,6 +48,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00005E Webservice 'authn-jwt/raw' not found
     """
 
+  @negative @acceptance
   Scenario: ONYX-8601: Webservice with read and no authenticate permission in authenticator policy
     Given I load a policy:
     """
@@ -88,6 +91,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00006E 'host/myapp' does not have 'authenticate' privilege on cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-8694: Both provider-uri and jwks-uri are configured
     Given I load a policy:
     """
@@ -138,6 +142,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00122E Invalid signing key settings: jwks-uri and provider-uri cannot be defined simultaneously
     """
 
+  @negative @acceptance
   Scenario: ONYX-8826: provider-uri configured with correct value, jwks-uri configured with empty value, error
     Given I load a policy:
     """
@@ -188,6 +193,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00122E Invalid signing key settings: jwks-uri and provider-uri cannot be defined simultaneously
     """
 
+  @negative @acceptance
   Scenario: ONYX-8698: jwks-uri configured but variable not set
     Given I load a policy:
     """
@@ -233,6 +239,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/jwks-uri
     """
 
+  @negative @acceptance
   Scenario: ONYX-8697: provider-uri configured but variable not set
     Given I load a policy:
     """
@@ -278,6 +285,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/provider-uri
     """
 
+  @negative @acceptance
   Scenario: ONYX-8696: None of provider-uri or jwks-uri are configured
     Given I load a policy:
     """
@@ -320,6 +328,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00122E Invalid signing key settings: One of the following must be defined: jwks-uri, public-keys, or provider-uri
     """
 
+  @negative @acceptance
   Scenario: ONYX-8695: provider-uri configured with empty value, jwks-uri configured with correct value
     Given I load a policy:
     """
@@ -370,6 +379,7 @@ Feature: JWT Authenticator - Configuration Check
     CONJ00122E Invalid signing key settings: jwks-uri and provider-uri cannot be defined simultaneously
     """
 
+  @negative @acceptance
   Scenario: ONYX-8694: Both Token identity and host send in URL, error
     Given I load a policy:
     """
@@ -416,6 +426,7 @@ Feature: JWT Authenticator - Configuration Check
     Errors::Authentication::AuthnJwt::IdentityMisconfigured: CONJ00098E JWT identity configuration is invalid
     """
 
+  @negative @acceptance
   Scenario: ONYX-8602: Host in token not defined , and no host in URL, error
     Given I load a policy:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_fetch_identity_decoded_token.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_fetch_identity_decoded_token.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Fetch identity from decoded token
 
   Tests checking the fetch of identity from JWT token using these configurations from policy:
@@ -58,6 +59,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/identity-from-decoded-token/RS256" in service "raw"
 
   @sanity
+  @smoke
   Scenario: ONYX-8820: A valid JWT token with identity in the token
     Given I successfully set authn-jwt "token-app-property" variable to value "host"
     And I permit host "myapp" to "execute" it
@@ -79,6 +81,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-9522: User as Token identity is not supported, error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -107,6 +110,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     CONJ00007E 'host/myapp2' not found
     """
 
+  @negative @acceptance
   Scenario: ONYX-8825: Token identity configuration not matching any claim, error
     Given I am using file "identity-from-decoded-token" and alg "RS256" for remotely issue token:
     """
@@ -127,6 +131,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     CONJ00081E 'host_claim' field not found in the token
     """
 
+  @negative @acceptance
   Scenario: ONYX-8824: Token identity configuration with empty secret, no identity in URL, error
     Given I am using file "identity-from-decoded-token" and alg "RS256" for remotely issue token:
     """
@@ -143,6 +148,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-9524: Host with delimiter as Token identity, identity-path configured, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I successfully set authn-jwt "token-app-property" variable to value "host_claim"
@@ -174,6 +180,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-9523: Host without delimiter as Token identity, identity-path configured, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I successfully set authn-jwt "token-app-property" variable to value "host_claim"
@@ -205,6 +212,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-13707: Token-app-property from nested claim
     Given I successfully set authn-jwt "token-app-property" variable to value "account/project/id"
     And I am using file "identity-from-decoded-token" and alg "RS256" for remotely issue token:
@@ -228,6 +236,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-13711: Token-app-property does not accept array reference
     Given I successfully set authn-jwt "token-app-property" variable to value "account[0]/project/id"
     And I am using file "identity-from-decoded-token" and alg "RS256" for remotely issue token:
@@ -253,6 +262,7 @@ Feature: JWT Authenticator - Fetch identity from decoded token
     CONJ00117E Failed to parse 'token-app-property' value. Error: '#<Errors::Authentication::AuthnJwt::InvalidClaimPath: CONJ00116E
     """
 
+  @negative @acceptance
   Scenario: ONYX-13713: Token-app-property does not accept array reference
     Given I successfully set authn-jwt "token-app-property" variable to value "account/projects"
     And I am using file "identity-from-decoded-token" and alg "RS256" for remotely issue token:

--- a/cucumber/authenticators_jwt/features/authn_jwt_fetch_identity_from_url.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_fetch_identity_from_url.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Fetch identity from URL
 
   Tests for fetching identity from URL of the JWT authentication request.
@@ -60,6 +61,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     And I initialize remote JWKS endpoint with file "identity-from-url" and alg "RS256"
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/identity-from-url/RS256" in service "raw"
 
+  @acceptance
   Scenario: ONYX-9520: User send in URL, user not in root, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I permit user "user_test_from_url@some_policy" to "execute" it
@@ -79,6 +81,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     cucumber:user:user_test_from_url@some_policy successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @acceptance
   Scenario: ONYX-9519: User send in URL, user in root, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I permit user "user_test_from_url" to "execute" it
@@ -99,6 +102,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-9521: Host send in URL, host not in root, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I permit host "some_policy/host_test_from_url" to "execute" it
@@ -118,6 +122,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     cucumber:host:some_policy/host_test_from_url successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @acceptance
   Scenario: ONYX-9518: Host send in URL, host in root, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I permit host "myapp" to "execute" it
@@ -137,6 +142,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-8821: Host taken from URL but not defined in conjur, error
     Given I am using file "identity-from-url" and alg "RS256" for remotely issue token:
     """
@@ -152,6 +158,7 @@ Feature: JWT Authenticator - Fetch identity from URL
     CONJ00007E 'invalid_host' not found
     """
 
+  @acceptance
   Scenario: ONYX-9517: Host send in URL, host not in root, Identify-path with empty value is ignored, 200 ok
     Given I have a "variable" resource called "test-variable"
     And I permit host "some_policy/host_test_from_url" to "execute" it

--- a/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_fetch_signing_key.feature
@@ -1,9 +1,11 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Fetch signing key
 
   In this feature we define a JWT authenticator with various signing key
   configurations.
 
   @sanity
+  @smoke
   Scenario: ONYX-8702: provider-uri is configured with valid value
     Given I load a policy:
     """
@@ -46,6 +48,7 @@ Feature: JWT Authenticator - Fetch signing key
     When I authenticate via authn-jwt with the ID token
     Then host "alice" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: ONYX-8704: provider uri configured with bad value
     Given I load a policy:
     """
@@ -88,6 +91,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'unknown-host.com')
     """
 
+  @negative @acceptance
   Scenario: ONYX-8705: jwks uri configured with bad value
     Given I load a policy:
     """
@@ -137,6 +141,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00087E Failed to fetch JWKS from 'unknown-host.com'
     """
 
+  @acceptance
   Scenario: ONYX-8708: provider uri configured dynamically changed to jwks uri
     Given I load a policy:
     """
@@ -231,6 +236,7 @@ Feature: JWT Authenticator - Fetch signing key
     cucumber:host:alice successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/keycloak
     """
 
+  @acceptance
   Scenario: jwks uri configured dynamically changed to provider uri
     Given I load a policy:
     """
@@ -326,6 +332,7 @@ Feature: JWT Authenticator - Fetch signing key
     Then host "alice" has been authorized by Conjur
 
   @sanity
+  @acceptance
   Scenario: ONYX-8709: provider-uri dynamically changed, 502 ERROR resolves to 200 OK
     Given I load a policy:
     """
@@ -387,6 +394,7 @@ Feature: JWT Authenticator - Fetch signing key
     Then host "alice" has been authorized by Conjur
 
   @sanity
+  @acceptance
   Scenario: ONYX-8710: jwks-uri dynamically changed, 401 ERROR resolves 200 OK
     Given I initialize remote JWKS endpoint with file "authn-jwt-fetch-signing-key" and alg "RS256"
     And I load a policy:
@@ -448,6 +456,7 @@ Feature: JWT Authenticator - Fetch signing key
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-8853: jku is unfollowed - security check
     Given I initialize JWKS endpoint with file "myFirstJWKs.json"
     And I initialize JWKS endpoint "mySecondJWKs.json" with the same kid as "myFirstJWKs.json"
@@ -498,6 +507,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')
     """
 
+  @negative @acceptance
   Scenario: ONYX-8854: jwk is unfollowed - security check
     Given I initialize JWKS endpoint with file "myFirstJWKs.json"
     And I initialize JWKS endpoint "localRsaKey.json" with the same kid as "myFirstJWKs.json"
@@ -550,6 +560,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')
     """
 
+  @negative @acceptance
   Scenario: ONYX-8914: provider-uri with untrusted self sign certificate
     Given I load a policy:
     """
@@ -572,6 +583,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00011E Failed to discover Identity Provider (Provider URI: 'https://jwks'). Reason: '#<OpenIDConnect::Discovery::DiscoveryFailed: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8913: jwks-uri with untrusted self sign certificate
     Given I load a policy:
     """
@@ -601,6 +613,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00087E Failed to fetch JWKS from 'https://jwks'. Reason: '#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)>'>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8856: x5c header claim is ignored
     Given I load a policy:
     """
@@ -630,6 +643,7 @@ Feature: JWT Authenticator - Fetch signing key
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::DecodeError: No key id (kid) found from token headers>')
     """
 
+  @negative @acceptance
   Scenario: ONYX-8855: x5u header claim is ignored
     Given I load a policy:
     """
@@ -660,6 +674,7 @@ Feature: JWT Authenticator - Fetch signing key
     """
 
   @sanity
+  @smoke
   Scenario: ONYX-15322: public-keys happy path
     Given I load a policy:
     """
@@ -708,6 +723,7 @@ Feature: JWT Authenticator - Fetch signing key
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-15325: public-keys value is in invalid format
     Given I load a policy:
      """
@@ -726,6 +742,7 @@ Feature: JWT Authenticator - Fetch signing key
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00120E Failed to parse 'public-keys': Type can't be blank, Type '' is not a valid public-keys type. Valid types are: jwks, and Value can't be blank"
 
+  @negative @acceptance
   Scenario: JWKS URI with bad value and no issuer - Status And Authentication return same error
     Given I load a policy:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_input_validation.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_input_validation.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Input Validation
 
   Check scenarios with authentication request
@@ -34,6 +35,7 @@ Feature: JWT Authenticator - Input Validation
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-input-validation/RS256" in service "raw"
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-8594: Empty Token Given, 401 Error
     Given I save my place in the log file
     And I am using file "authn-jwt-input-validation" and alg "RS256" for remotely issue non exp token:
@@ -48,6 +50,7 @@ Feature: JWT Authenticator - Input Validation
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-8594: Invalid Token Given, 401 Error
     Given I save my place in the log file
     When I authenticate with string that is not token not-token-string-this-is-ivalid-token
@@ -58,6 +61,7 @@ Feature: JWT Authenticator - Input Validation
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-8594: No Token Given, 400 Error
     Given I save my place in the log file
     When I authenticate via authn-jwt with the JWT token
@@ -67,6 +71,7 @@ Feature: JWT Authenticator - Input Validation
     CONJ00009E Field 'jwt' is missing or empty in request body
     """
 
+  @negative @acceptance
   Scenario: ONYX-8579: URL not includes service-id, includes correct account
     Given I save my place in the log file
     And I am using file "authn-jwt-input-validation" and alg "RS256" for remotely issue non exp token:
@@ -82,6 +87,7 @@ Feature: JWT Authenticator - Input Validation
     CONJ00004E 'authn-jwt/myuser' is not enabled
     """
 
+  @negative @acceptance
   Scenario: ONYX-8579: URL includes valid service id, wrong account name
     Given I save my place in the log file
     And I am using file "authn-jwt-input-validation" and alg "RS256" for remotely issue token:
@@ -97,6 +103,7 @@ Feature: JWT Authenticator - Input Validation
     CONJ00007E 'wrong-account' not found
     """
 
+  @negative @acceptance
   Scenario: ONYX-8579: URL includes wrong service id, correct account name
     Given I save my place in the log file
     And I am using file "authn-jwt-input-validation" and alg "RS256" for remotely issue non exp token:

--- a/cucumber/authenticators_jwt/features/authn_jwt_security.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_security.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Security
 
   Tests checking that JWT authenticator stands against different attacks and security risks.
@@ -39,6 +40,7 @@ Feature: JWT Authenticator - Security
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
     And I permit host "myapp" to "execute" it
 
+  @negative @acceptance
   Scenario: ONYX-8851: None algorithm is unacceptable, 401 ERROR
     Given I initialize JWKS endpoint with file "myJWKs.json"
     And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
@@ -57,6 +59,7 @@ Feature: JWT Authenticator - Security
     CONJ00048I Authentication Error: #<Errors::Authentication::Jwt::RequestBodyMissingJWTToken: CONJ00077E The request body does not contain JWT token>
     """
 
+  @negative @acceptance
   Scenario: ONYX-8852: Test algorithm substitution attack, 401 ERROR
     Given I initialize JWKS endpoint with file "myJWKs.json"
     And I successfully set authn-jwt jwks-uri variable with value of "myJWKs.json" endpoint
@@ -75,6 +78,7 @@ Feature: JWT Authenticator - Security
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::IncorrectAlgorithm: Expected a different algorithm>')>
     """
 
+  @acceptance
   Scenario Outline: ONYX-8858: Algorithms sanity
     Given I initialize remote JWKS endpoint with file "ONYX-8858-<alg>" and alg "<alg>"
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/ONYX-8858-<alg>/<alg>" in service "raw"

--- a/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Token Schema
 
   Tests checking Enforced Claims and Claim Aliases
@@ -30,6 +31,7 @@ Feature: JWT Authenticator - Token Schema
     And I successfully set authn-jwt "token-app-property" variable to value "host"
 
   @sanity
+  @acceptance
   Scenario: ONYX-10471 - Enforced Claims Without Claim Aliases. Single enforced claim - 200 OK
     Given I extend the policy with:
     """
@@ -63,6 +65,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @acceptance
   Scenario: ONYX-10471 - Enforced Claims Without Claim Aliases. Two enforced claims - 200 OK
     Given I extend the policy with:
     """
@@ -98,6 +101,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-10759 - Enforced Claims Without Claim Aliases. Single enforced claim and wrong annotation - 401 Error
     Given I extend the policy with:
     """
@@ -128,6 +132,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00057E Role does not have the required constraints: '["ref"]'>
     """
 
+  @negative @acceptance
   Scenario: ONYX-10760 - Enforced Claims Without Claim Aliases. Single enforced claim but not in token - 401 Error
     Given I extend the policy with:
     """
@@ -157,6 +162,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00084E Claim 'ref' is missing from JWT token.
     """
 
+  @negative @acceptance
   Scenario Outline: ONYX-10470 - Standard claim in mandatory claims - 401 Error
     Given I extend the policy with:
     """
@@ -191,6 +197,7 @@ Feature: JWT Authenticator - Token Schema
     |   exp, iss    |  exp   |
     |   exp, branch |  exp   |
 
+  @negative @acceptance
   Scenario Outline: ONYX-10857 - Standard claim in annotation - 401 Error
     Given I extend the policy with:
     """
@@ -220,6 +227,7 @@ Feature: JWT Authenticator - Token Schema
     | claim   |
     |   iat   |
 
+  @negative @acceptance
   Scenario: ONYX-10860 - Enforced claims configured but not populated - 401 Error
     Given I extend the policy with:
     """
@@ -252,6 +260,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-10891 - Complex Case - Adding Enforced Claim after host configuration
     Given I extend the policy with:
     """
@@ -312,6 +321,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-10472 Unrelated alias
     Given I extend the policy with:
     """
@@ -345,11 +355,12 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-10473 Claim aliases with subsequent annotation
     Given I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/claim-aliases
-    
+
     - !host
       id: myapp
       annotations:
@@ -377,6 +388,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @acceptance
   Scenario: ONYX-10889 Complex Case - Adding Alias after host configuration
     Given I extend the policy with:
     """
@@ -416,6 +428,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-10705: Enforced Claims and Claim Aliases exist and host annotation are correct
     Given I extend the policy with:
     """
@@ -448,6 +461,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-10816 - Enforced Claims with Claim Aliases. Single enforced claim but not in token - 401 Error
     Given I extend the policy with:
     """
@@ -479,6 +493,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00084E Claim 'ref (annotation: branch)' is missing from JWT token. Verify that you configured the host with permitted restrictions
     """
 
+  @negative @acceptance
   Scenario: ONYX-10874 - Claim being mapped to another claim - 401 Error
     Given I extend the policy with:
     """
@@ -510,6 +525,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00049E Resource restriction 'sub' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: ONYX-10861 - Claim aliases configured but not populated - 401 Error
     Given I extend the policy with:
     """
@@ -542,6 +558,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-11117: Enforced Claims and Aliases with special allowed characters. Annotations are correct. 200 OK
     Given I extend the policy with:
     """
@@ -578,6 +595,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario Outline: ONYX-10873 - Broken claim aliases - 401 Error
     Given I extend the policy with:
     """
@@ -614,6 +632,7 @@ Feature: JWT Authenticator - Token Schema
       |   branch: ref, branch:sub   | CONJ00113E Failed to parse claim aliases: annotation name value 'branch' appears more than once |
       |   branch: sub, job: sub     | CONJ00113E Failed to parse claim aliases: claim name value 'sub' appears more than once   |
 
+  @negative @acceptance
   Scenario Outline: ONYX-10858 - Standard claim alias - 401 Error
     Given I extend the policy with:
     """
@@ -632,7 +651,7 @@ Feature: JWT Authenticator - Token Schema
 
     And I successfully set authn-jwt "claim-aliases" variable to value "<alias>"
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
-    
+
     """
     {
       "host":"myapp",
@@ -652,6 +671,7 @@ Feature: JWT Authenticator - Token Schema
       |   branch: exp  |
       |   exp: sub     |
 
+  @negative @acceptance
   Scenario: ONYX-10862 - Enforced claim invalid variable - 401 Error
     Given I extend the policy with:
     """
@@ -683,6 +703,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00104E Failed to validate claim: claim name '%@^#[{]}$~=-+_?.><&^@*@#*sdhj812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)'.>
     """
 
+  @negative @acceptance
   Scenario: ONYX-10863 - Claim aliases invalid variable - 401 Error
     Given I extend the policy with:
     """
@@ -714,6 +735,7 @@ Feature: JWT Authenticator - Token Schema
     CONJ00104E Failed to validate claim: claim name '%@^#&^[{]}$~=-+_?.><812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)'.
     """
 
+  @acceptance
   Scenario: ONYX-10941:  Complex Case - Add mapping of mandatory claims after host configuration
     Given I extend the policy with:
     """
@@ -788,6 +810,7 @@ Feature: JWT Authenticator - Token Schema
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @acceptance
   Scenario: ONYX-10896:  Authn JWT - Complex Case - Changing Aliases after host configuration
     Given I extend the policy with:
     """
@@ -845,6 +868,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-13716 Claim Alias nested annotation - 200 OK
     Given I extend the policy with:
     """
@@ -878,6 +902,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-13716 Claim Alias nested annotation - 401 Error Wrong Claim value
     Given I extend the policy with:
     """
@@ -911,6 +936,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-13717 Claim Alias and Enforced Claim nested annotation - 200 OK
     Given I extend the policy with:
     """
@@ -946,6 +972,7 @@ Feature: JWT Authenticator - Token Schema
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-13718 Claim Alias with invalid characters - 401 Error
     Given I extend the policy with:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_validate_and_decode.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Validate And Decode
 
   Tests checking tokens signed with wrong keys.
@@ -33,6 +34,7 @@ Feature: JWT Authenticator - Validate And Decode
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     And I initialize JWKS endpoint with file "myJWKs.json"
 
+  @negative @acceptance
   Scenario: ONYX-8732: Signature error, kid not found
     Given I extend the policy with:
     """
@@ -56,7 +58,8 @@ Feature: JWT Authenticator - Validate And Decode
 
 
   @sanity
-  Scenario: ONYX-8733: Signature error ,sign on a valid token header and content with your own key
+  @negative @acceptance
+  Scenario: ONYX-8733: Signature error, sign on a valid token header and content with your own key
     Given I extend the policy with:
     """
     - !variable conjur/authn-jwt/raw/jwks-uri
@@ -77,6 +80,7 @@ Feature: JWT Authenticator - Validate And Decode
     CONJ00035E Failed to decode token (3rdPartyError ='#<JWT::VerificationError: Signature verification raised>')>
     """
 
+  @negative @acceptance
   Scenario: ONYX-15324: public-keys with valid issuer, token is signed by other key
     Given I extend the policy with:
     """

--- a/cucumber/authenticators_jwt/features/authn_jwt_validate_restrictions.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_validate_restrictions.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Validate restrictions
 
   Tests to check that host annotations are validated correctly in jwt authenticator. Focusing on checking that only the vendor related annotations are being checked.
@@ -27,6 +28,7 @@ Feature: JWT Authenticator - Validate restrictions
     And I initialize remote JWKS endpoint with file "authn-jwt-validate-restrictions" and alg "RS256"
     And I successfully set authn-jwt "jwks-uri" variable value to "http://jwks_py:8090/authn-jwt-validate-restrictions/RS256" in service "raw"
 
+  @acceptance
   Scenario: ONYX-9069: Generals annotations with valid values, one annotation with valid service and valid value, one annotation with invalid service and valid value, 200 OK
     Given I have a "variable" resource called "test-variable"
     And I extend the policy with:
@@ -71,6 +73,7 @@ Feature: JWT Authenticator - Validate restrictions
     cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
+  @negative @acceptance
   Scenario: ONYX-9112: General annotation and without service specific annotations, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -101,6 +104,7 @@ Feature: JWT Authenticator - Validate restrictions
     CONJ00099E Role must have at least one relevant annotation
     """
 
+  @negative @acceptance
   Scenario: ONYX-9070: General annotations with valid values, annotation with correct service and valid value and annotation with correct service and wrong value, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -133,6 +137,7 @@ Feature: JWT Authenticator - Validate restrictions
     CONJ00049E Resource restriction 'ref' does not match with the corresponding value in the request
     """
 
+  @negative @acceptance
   Scenario: ONYX-9068: Host without annotations, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -160,6 +165,7 @@ Feature: JWT Authenticator - Validate restrictions
     CONJ00099E Role must have at least one relevant annotation
     """
 
+  @negative @acceptance
   Scenario: ONYX-8737: Validate multiple annotations with incorrect values but one, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -194,6 +200,7 @@ Feature: JWT Authenticator - Validate restrictions
     CONJ00049E Resource restriction
     """
 
+  @negative @acceptance
   Scenario: ONYX-8736: Validate multiple annotations with incorrect, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -226,6 +233,7 @@ Feature: JWT Authenticator - Validate restrictions
     CONJ00049E Resource restriction
     """
 
+  @negative @acceptance
   Scenario: ONYX-9113: Non existing field annotation, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:
@@ -254,6 +262,7 @@ Feature: JWT Authenticator - Validate restrictions
     """
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-8734: Annotation with empty value
     Given I extend the policy with:
     """
@@ -283,6 +292,7 @@ Feature: JWT Authenticator - Validate restrictions
     """
 
   @sanity
+  @acceptance
   Scenario: ONYX-8735: Ignore invalid annotations
     Given I extend the policy with:
     """
@@ -328,6 +338,7 @@ Feature: JWT Authenticator - Validate restrictions
       |CONJ00030D Resource restrictions validated                           |
       |CONJ00103D 'validate_restrictions' passed successfully               |
 
+  @negative @acceptance
   Scenario: ONYX-13722: Annotation with invalid claim path format, 401 Error
     And I successfully set authn-jwt "token-app-property" variable to value "host"
     Given I extend the policy with:

--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -1,3 +1,4 @@
+@authenticators_jwt
 Feature: JWT Authenticator - Status Check
 
   Checks status API of JWT authenticator. Status API should return error on each case of misconfiguration in
@@ -7,6 +8,7 @@ Feature: JWT Authenticator - Status Check
     Given I initialize remote JWKS endpoint with file "authn-jwt-configuration" and alg "RS256"
 
   @sanity
+  @smoke
   Scenario: ONYX-9122: A valid JWT status request, 200 OK
     Given I load a policy:
     """
@@ -70,6 +72,7 @@ Feature: JWT Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @negative @acceptance
   Scenario: ONYX-9138: Signing key is not configured, 500 Error
     Given I load a policy:
     """
@@ -124,6 +127,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00122E Invalid signing key settings: One of the following must be defined: jwks-uri, public-keys, or provider-uri"
 
+  @negative @acceptance
   Scenario: Signing key is configured with jwks-uri and provider-uri, 500 Error
     Given I load a policy:
     """
@@ -186,6 +190,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00122E Invalid signing key settings: jwks-uri and provider-uri cannot be defined simultaneously"
 
+  @negative @acceptance
   Scenario: ONYX-9142: User doesn't have permissions on webservice, 403 Error
     Given I load a policy:
     """
@@ -235,6 +240,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 403
     And the authenticator status check fails with error "CONJ00006E 'alice' does not have 'read' privilege on cucumber:webservice:conjur/authn-jwt/raw/status"
 
+  @acceptance @acceptance
   Scenario: ONYX-9139: Non existing issuer, and existing Signing key, 200 OK
     Given I load a policy:
     """
@@ -290,6 +296,7 @@ Feature: JWT Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @negative @acceptance
   Scenario: ONYX-9140: Non existing issuer and Signing key, 500 Error
     Given I load a policy:
     """
@@ -340,6 +347,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00122E Invalid signing key settings: One of the following must be defined: jwks-uri, public-keys, or provider-uri"
 
+  @negative @acceptance
   Scenario: ONYX-9141: Identity is configured but empty, 500 Error
     Given I load a policy:
     """
@@ -393,6 +401,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/token-app-property"
 
+  @negative @acceptance
   Scenario: ONYX-9143: Status webservice does not exist, 500 Error
     Given I load a policy:
     """
@@ -437,6 +446,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00005E Webservice 'authn-jwt/raw/status' not found"
 
+  @negative @acceptance
   Scenario: ONYX-9569: JWKS-uri is configured but empty, 500 Error
     Given I load a policy:
     """
@@ -490,6 +500,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/jwks-uri"
 
+  @negative @acceptance
   Scenario: ONYX-9570: Provider-uri is configured but empty, 500 Error
     Given I load a policy:
     """
@@ -543,6 +554,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/provider-uri"
 
+  @negative @acceptance
   Scenario: ONYX-9571: Provider-uri is configured with bad value, 500 Error
     Given I load a policy:
     """
@@ -597,6 +609,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00011E Failed to discover Identity Provider"
 
+  @negative @acceptance
   Scenario: ONYX-9572: JWKS-uri is configured with bad value, 500 Error
     Given I load a policy:
     """
@@ -652,6 +665,7 @@ Feature: JWT Authenticator - Status Check
     And the authenticator status check fails with error "CONJ00087E Failed to fetch JWKS from 'unknow-host.com'"
 
   @sanity
+  @negative @acceptance
   Scenario: ONYX-9516: Identify-path is configured but empty, 500 Error
     Given I load a policy:
     """
@@ -710,6 +724,7 @@ Feature: JWT Authenticator - Status Check
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/identity-path>"
 
   @sanity
+  @smoke
   Scenario: ONYX-9515: Valid status check, identify-path is configured with value, 200 OK
     Given I load a policy:
     """
@@ -778,6 +793,7 @@ Feature: JWT Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @acceptance
   Scenario: ONYX-10875: Status works fine with Enforced Claims and Aliases, 200 OK
     Given I load a policy:
     """
@@ -846,6 +862,7 @@ Feature: JWT Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @negative @acceptance
   Scenario: ONYX-11162: Audience is configured but empty, 500 Error
     Given I load a policy:
     """
@@ -903,6 +920,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/audience>"
 
+  @negative @acceptance
   Scenario: ONYX-10875: claim-aliases configured but secret not populated, 500 Error
     Given I load a policy:
     """
@@ -965,6 +983,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/claim-aliases>"
 
+  @negative @acceptance
   Scenario: ONYX-10876: enforced-claims configured but secret not populated, 500 Error
     Given I load a policy:
     """
@@ -1027,6 +1046,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "CONJ00037E Missing value for resource: cucumber:variable:conjur/authn-jwt/raw/enforced-claims>"
 
+  @negative @acceptance
   Scenario: ONYX-10960: enforced-claims configured with invalid value, 500 Error
     Given I load a policy:
     """
@@ -1090,6 +1110,7 @@ Feature: JWT Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)"
 
+  @negative @acceptance
   Scenario Outline: ONYX-10958: claim-aliases configured with invalid value, 500 Error
     Given I load a policy:
     """
@@ -1157,6 +1178,7 @@ Feature: JWT Authenticator - Status Check
       | SDsas213sda!!A!!$$@#$#:$@$@#sdasdasdq23asd32rdf  | does not match regular expression:                                      |
       | a/b:bbb                                          | Failed to parse claim aliases: the claim alias name 'a/b' contains '/'. |
 
+  @negative @acceptance
   Scenario: ONYX-13997:  Identity is configured not according format, 500 Error
     Given I load a policy:
     """

--- a/cucumber/authenticators_ldap/features/authn_ldap.feature
+++ b/cucumber/authenticators_ldap/features/authn_ldap.feature
@@ -1,3 +1,4 @@
+@authenticators_ldap
 Feature: Users can login with LDAP credentials from an authorized LDAP server
 
   Background:
@@ -54,11 +55,12 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     - !grant
       role: !group conjur/authn-ldap/secure/clients
       member: !user alice
-      
+
     """
     And I store the LDAP bind password in "conjur/authn-ldap/secure/bind-password"
     And I store the LDAP CA certificate in "conjur/authn-ldap/secure/tls-ca-cert"
 
+  @smoke
   Scenario: An LDAP user authorized in Conjur can login with a good password
     Given I save my place in the log file
     When I login via LDAP as authorized Conjur user "alice"
@@ -69,32 +71,39 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     cucumber:user:alice successfully authenticated with authenticator authn-ldap service cucumber:webservice:conjur/authn-ldap/test
     """
 
+  @smoke
   Scenario: An LDAP user authorized in Conjur can login with a good password using TLS
     When I login via secure LDAP as authorized Conjur user "alice"
     And I authenticate via secure LDAP as authorized Conjur user "alice" using key
     Then user "alice" has been authorized by Conjur
 
+  @smoke
   Scenario: An LDAP user authorized in Conjur can authenticate with a good password
     When I authenticate via LDAP as authorized Conjur user "alice"
     Then user "alice" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: An LDAP user authorized in Conjur can't login with a bad password
     When my LDAP password is wrong for authorized user "alice"
     Then it is unauthorized
 
+  @negative @acceptance
   Scenario: 'admin' cannot use LDAP authentication
     When I login via LDAP as authorized Conjur user "admin"
     Then it is unauthorized
 
+  @negative @acceptance
   Scenario: An valid LDAP user who's not in Conjur can't login
     When I login via LDAP as non-existent Conjur user "bob"
     Then it is forbidden
 
+  @negative @acceptance
   Scenario: An empty password may never be used to authenticate
     When my LDAP password for authorized Conjur user "alice" is empty
     Then it is unauthorized
 
-    #TODO Add an "is denied" for alice added to conjur but not entitled
+  #TODO Add an "is denied" for alice added to conjur but not entitled
+  @negative @acceptance
   Scenario: An LDAP user in Conjur but without authorization can't login
     Given I load a policy:
     """
@@ -120,6 +129,7 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
   # password). We run it again here to verify that we write a message to the
   # audit log in Syslog format.  This is our e2e test that the Syslog formatter
   # is working correctly.
+  @smoke
   Scenario: Authentication failure is logged in Syslog format
     Given I save my place in the audit log file
     When my LDAP password is wrong for authorized user "alice"

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -1,3 +1,4 @@
+@authenticators_oidc
 Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
 
   In this feature we define an OIDC authenticator in policy and perform authentication
@@ -37,6 +38,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And I am the super-user
     And I successfully set OIDC variables
 
+  @smoke
   Scenario: A valid id token to get Conjur access token
     # We want to verify the returned access token is valid for retrieving a secret
     Given I have a "variable" resource called "test-variable"
@@ -52,6 +54,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:alice successfully authenticated with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
     """
 
+  @smoke
   Scenario: A valid id token with email as id-token-user-property
     Given I extend the policy with:
     """
@@ -66,6 +69,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And I authenticate via OIDC with id token
     Then user "alice@conjur.net" has been authorized by Conjur
 
+  @smoke
   Scenario: Adding a group to keycloak/users group permits users to authenticate
     Given I extend the policy with:
     """
@@ -85,6 +89,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     When I authenticate via OIDC with id token
     Then user "bob" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: Non-existing username in ID token is denied
     Given I fetch an ID Token for username "not_in_conjur" and password "not_in_conjur"
     And I save my place in the log file
@@ -99,6 +104,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:not_in_conjur failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
     """
 
+  @negative @acceptance
   Scenario: User that is not permitted to webservice in ID token is denied
     Given I extend the policy with:
     """
@@ -113,6 +119,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
+  @negative @acceptance
   Scenario: ID token without value of variable id-token-user-property is denied
     When I add the secret value "non_existing_field" to the resource "cucumber:variable:conjur/authn-oidc/keycloak/id-token-user-property"
     And I fetch an ID Token for username "alice" and password "alice"
@@ -124,6 +131,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty
     """
 
+  @negative @acceptance
   Scenario: Missing id token is a bad request
     Given I save my place in the log file
     When I authenticate via OIDC with no id token
@@ -137,6 +145,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
+  @negative @acceptance
   Scenario: Empty id token is a bad request
     Given I save my place in the log file
     When I authenticate via OIDC with empty id token
@@ -150,6 +159,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
+  @negative @acceptance
   Scenario: non-existing account in request is denied
     Given I save my place in the log file
     When I authenticate via OIDC with id token and account "non-existing"
@@ -163,6 +173,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     non-existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
+  @negative @acceptance
   Scenario: admin user is denied
     And I fetch an ID Token for username "admin" and password "admin"
     And I save my place in the log file
@@ -177,6 +188,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
     """
 
+  @smoke
   Scenario: provider-uri dynamic change
     And I fetch an ID Token for username "alice" and password "alice"
     And I authenticate via OIDC with id token
@@ -191,6 +203,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And I authenticate via OIDC with id token
     Then user "alice" has been authorized by Conjur
 
+  @negative @acceptance
   Scenario: Unauthenticated is raised in case of an invalid OIDC Provider hostname
     Given I fetch an ID Token for username "alice" and password "alice"
     And I authenticate via OIDC with id token
@@ -208,6 +221,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
   # This test runs a failing authentication request that is already
   # tested in another scenario (User that is not permitted to webservice in ID token is denied).
   # We run it again here to verify that we write a message to the audit log
+  @acceptance
   Scenario: Authentication failure is written to the audit log
     Given I extend the policy with:
     """
@@ -222,6 +236,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     cucumber:user:bob failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
     """
 
+  @negative @acceptance
   Scenario: Request with an existing user ID in URL is responded with not found
     Given I save my place in the log file
     When I authenticate via OIDC with no id token and user id "alice" in the request
@@ -231,6 +246,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     ActionController::RoutingError (No route matches [POST] "/authn-oidc/keycloak/cucumber/alice/authenticate")
     """
 
+  @negative @acceptance
   Scenario: Request with a non-existing user ID in URL is responded with not found
     Given I save my place in the log file
     When I authenticate via OIDC with no id token and user id "non-exist" in the request

--- a/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
@@ -1,3 +1,4 @@
+@authenticators_oidc
 Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
 
   In this feature we define an OIDC Authenticator with a configuration
@@ -5,6 +6,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
   and log the relevant error for the user to re-configure the authenticator
   properly
 
+  @negative @acceptance
   Scenario: id-token-user-property variable missing in policy is denied
     Given I load a policy:
     """
@@ -42,6 +44,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     Errors::Conjur::RequiredResourceMissing
     """
 
+  @negative @acceptance
   Scenario: provider-uri variable missing in policy is denied
     Given I load a policy:
     """
@@ -78,7 +81,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     """
     Errors::Conjur::RequiredResourceMissing
     """
-
+  @negative @acceptance
   Scenario: webservice missing in policy is denied
     Given I load a policy:
     """
@@ -111,6 +114,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     Errors::Authentication::Security::WebserviceNotFound
     """
 
+  @negative @acceptance
   Scenario: webservice with read and no authenticate permission in policy is denied
     Given I load a policy:
     """
@@ -151,6 +155,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     Errors::Authentication::Security::RoleNotAuthorizedOnResource
     """
 
+  @negative @acceptance
   Scenario: An authenticator without a service id
     Given I load a policy:
     """

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -1,3 +1,4 @@
+@authenticators_oidc
 Feature: OIDC Authenticator - Performance tests
 
   In this feature we test that OIDC Authenticator performance is meeting
@@ -37,11 +38,13 @@ Feature: OIDC Authenticator - Performance tests
     And I am the super-user
     And I successfully set OIDC variables
 
+  @performance
   Scenario: successful requests
     And I fetch an ID Token for username "alice" and password "alice"
     When I authenticate 1000 times in 10 threads via OIDC with id token
     Then The avg authentication request responds in less than 0.75 seconds
 
+  @performance
   Scenario: Unsuccessful requests with an invalid token
     When I authenticate 1000 times in 10 threads via OIDC with invalid id token
     Then The avg authentication request responds in less than 0.75 seconds

--- a/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
@@ -1,3 +1,4 @@
+@authenticators_oidc
 Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authenticators
 
   In this feature we define an OIDC authenticator and LDAP authenticator
@@ -56,6 +57,7 @@ Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authentica
       member: !user alice
     """
 
+  @acceptance
   Scenario: Users can authenticate with 2 authenticators
     # We want to verify the returned access token is valid for retrieving a secret
     Given I have a "variable" resource called "test-variable"

--- a/cucumber/authenticators_oidc/features/authn_status_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_status_oidc.feature
@@ -1,5 +1,7 @@
+@authenticators_oidc
 Feature: OIDC Authenticator - Status Check
 
+  @smoke
   Scenario: A properly configured OIDC authenticator returns a successful response
     Given I load a policy:
     """
@@ -56,6 +58,7 @@ Feature: OIDC Authenticator - Status Check
     And the HTTP response content type is "application/json"
     And the authenticator status check succeeds
 
+  @negative @acceptance
   Scenario: A non-responsive OIDC provider returns a 500 response
     Given I load a policy:
     """
@@ -112,6 +115,7 @@ Feature: OIDC Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "ProviderDiscoveryFailed: CONJ00011E"
 
+  @negative @acceptance
   Scenario: provider-uri variable is missing and a 500 error response is returned
     Given I load a policy:
      """
@@ -164,6 +168,7 @@ Feature: OIDC Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "RequiredResourceMissing: CONJ00036E"
 
+  @negative @acceptance
   Scenario: id-token-user-property variable is missing and a 500 error response is returned
     Given I load a policy:
      """
@@ -216,6 +221,7 @@ Feature: OIDC Authenticator - Status Check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "RequiredResourceMissing: CONJ00036E"
 
+  @negative @acceptance
   Scenario: service-id missing and a 500 error response is returned
     Given I load a policy:
     """

--- a/cucumber/authenticators_status/features/authn_status.feature
+++ b/cucumber/authenticators_status/features/authn_status.feature
@@ -1,3 +1,4 @@
+@authenticators_status
 Feature: Authenticator status check
 
   Conjur supports a Status check where users can get immediate feedback
@@ -14,6 +15,7 @@ Feature: Authenticator status check
   implements the Status check but all these test are not OIDC-specific and do
   not require a running OIDC Provider in order to run.
 
+  @negative @acceptance
   Scenario: An unauthorized user is responded with 403
     Given I load a policy:
     """
@@ -64,6 +66,7 @@ Feature: Authenticator status check
     Then the HTTP response status code is 403
     And the authenticator status check fails with error "RoleNotAuthorizedOnResource: CONJ00006E"
 
+  @negative @acceptance
   Scenario: An authenticator without an implemented status check returns 501
     Given I load a policy:
     """
@@ -74,6 +77,7 @@ Feature: Authenticator status check
     Then the HTTP response status code is 501
     And the authenticator status check fails with error "StatusNotSupported: CONJ00056E"
 
+  @negative @acceptance
   Scenario: A non-existing authenticator status check returns 404
     Given I load a policy:
     """
@@ -84,6 +88,7 @@ Feature: Authenticator status check
     Then the HTTP response status code is 404
     And the authenticator status check fails with error "AuthenticatorNotSupported: CONJ00001E"
 
+  @negative @acceptance
   Scenario: A missing status webservice returns 500
     Given I load a policy:
     """
@@ -123,6 +128,7 @@ Feature: Authenticator status check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "WebserviceNotFound: CONJ00005E"
 
+  @negative @acceptance
   Scenario: A non-existing account name in the status request returns 500
     Given I load a policy:
     """
@@ -177,6 +183,7 @@ Feature: Authenticator status check
     Then the HTTP response status code is 500
     And the authenticator status check fails with error "AccountNotDefined: CONJ00008E"
 
+  @negative @acceptance
   Scenario: An authenticator webservice doesn't exist in policy
     Given I load a policy:
     """

--- a/cucumber/kubernetes/features/authenticate.feature
+++ b/cucumber/kubernetes/features/authenticate.feature
@@ -1,33 +1,42 @@
+@authenticators_k8s
 Feature: A permitted Conjur host can authenticate with a valid resource restrictions
   that is defined in the id
 
+  @smoke
   Scenario: Authenticate as a Pod.
     Given I login to authn-k8s as "pod/inventory-pod"
     Then I can authenticate with authn-k8s as "pod/inventory-pod"
 
+  @smoke
   Scenario: Authenticate as a Namespace.
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "*/*"
 
+  @smoke
   Scenario: Authenticate as a ServiceAccount.
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "service_account/inventory-pod-only"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "service_account/inventory-pod-only"
 
+  @smoke
   Scenario: Authenticate as a Deployment.
     Given I login to authn-k8s as "deployment/inventory-deployment"
     Then I can authenticate with authn-k8s as "deployment/inventory-deployment"
 
+  @smoke
   Scenario: Authenticate as a StatefulSet.
     Given I login to authn-k8s as "stateful_set/inventory-stateful"
     Then I can authenticate with authn-k8s as "stateful_set/inventory-stateful"
 
+  @acceptance
   Scenario: Authenticate using a certificate signed by a different CA
     Then I cannot authenticate with pod matching "pod/inventory-pod" as "service_account/inventory-pod-only" using a cert signed by a different CA
 
+  @acceptance
   Scenario: Authenticate as a host defined under the root policy
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "@namespace@/*/*" with prefix "host"
 
+  @acceptance
   Scenario: Authenticate without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"

--- a/cucumber/kubernetes/features/authenticate_errors.feature
+++ b/cucumber/kubernetes/features/authenticate_errors.feature
@@ -1,18 +1,22 @@
+@authenticators_k8s
 Feature: Errors emitted by the authenticate method.
 
   # Skip this test as we're not currently doing IP verification.
   @skip
+  @negative @acceptance
   Scenario: it raises an error when authenticating as a different host than the one that sent the request.
     Given I login to authn-k8s as "stateful_set/inventory-stateful"
     And I use the IP address of a pod in "pod/inventory-pod"
     When I authenticate with authn-k8s as "stateful_set/inventory-stateful"
     Then the HTTP status is "401"
 
-  Scenario: it raises an error when authenticating as a host which does not hold "authenticate" privilege 
+  @negative @acceptance
+  Scenario: it raises an error when authenticating as a host which does not hold "authenticate" privilege
     on the webservice.
     When I authenticate with authn-k8s as "pod/inventory-unauthorized" without cert and key
     Then the HTTP status is "403"
 
+  @negative @acceptance
   Scenario: it raises an error when authenticating without providing a cert and key.
     When I authenticate with authn-k8s as "pod/inventory-pod" without cert and key
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/authenticate_with_annotations.feature
+++ b/cucumber/kubernetes/features/authenticate_with_annotations.feature
@@ -1,47 +1,59 @@
+@authenticators_k8s
 Feature: A permitted Conjur host can login with a valid resource restrictions
   that is defined in annotations
 
+  @smoke
   Scenario: Authenticate as a Pod.
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-pod" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Authenticate as a Pod with long host prefix.
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy/second-layer"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-pod" with prefix "host/some-policy/second-layer"
 
+  @acceptance
   Scenario: Authenticate as a Pod with medium host prefix.
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "second-layer/test-app-pod" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "second-layer/test-app-pod" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Authenticate as a Pod with short host prefix.
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "some-policy/second-layer/test-app-pod" with prefix "host"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "some-policy/second-layer/test-app-pod" with prefix "host"
 
+  @smoke
   Scenario: Authenticate as a Namespace.
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-namespace" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Authenticate as a ServiceAccount.
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-account" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-service-account" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Authenticate as a Deployment.
     Given I can login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-deployment" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-deployment" with authn-k8s as "test-app-deployment" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Authenticate as a StatefulSet.
     Given I can login to pod matching "app=inventory-stateful" to authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-stateful" with authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
 
   @k8s_skip
+  @smoke
   Scenario: Authenticate as a DeploymentConfig.
     Given I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-deployment-cfg" with authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Authenticate as a host defined under the root policy
     Given I login to pod matching "app=inventory-pod" to authn-k8s as "root-based-app" with prefix "host"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "root-based-app" with prefix "host"
 
+  @acceptance
   Scenario: Authenticate without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
     Given I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"
     Then I can authenticate pod matching "pod/inventory-pod" with authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"

--- a/cucumber/kubernetes/features/backpressure.feature
+++ b/cucumber/kubernetes/features/backpressure.feature
@@ -1,7 +1,9 @@
+@authenticators_k8s
 Feature: Backpressure in response to load.
 
   # Not worth worrying about this yet.
   @skip
+  @negative @acceptance
   Scenario: Login overload causes a 503 Service Unavailable.
     When I launch many concurrent login requests
     Then at least one response status is 503

--- a/cucumber/kubernetes/features/login.feature
+++ b/cucumber/kubernetes/features/login.feature
@@ -1,30 +1,40 @@
+@authenticators_k8s
 Feature: A permitted Conjur host can login with a valid resource restrictions
   that is defined in the id
 
+  @smoke
   Scenario: Login as the namespace a pod belongs to.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
 
+  @smoke
   Scenario: Login as a Pod.
     Then I can login to authn-k8s as "pod/inventory-pod"
 
+  @smoke
   Scenario: Login as a ServiceAccount.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "service_account/inventory-pod-only"
 
   @k8s_skip
+  @smoke
   Scenario: Login as a DeploymentConfig.
     Then I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "deployment_config/inventory-deployment-cfg"
 
+  @smoke
   Scenario: Login as a Deployment.
     Then I can login to authn-k8s as "deployment/inventory-deployment"
 
+  @smoke
   Scenario: Login as a StatefulSet.
     Then I can login to authn-k8s as "stateful_set/inventory-stateful"
 
+  @acceptance
   Scenario: Login with a custom prefix.
     Then I can login to authn-k8s as "@namespace@/pod/inventory-pod" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login with a host defined in the root policy
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host"
 
+  @acceptance
   Scenario: Login without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/host-without-container-name"

--- a/cucumber/kubernetes/features/login_errors.feature
+++ b/cucumber/kubernetes/features/login_errors.feature
@@ -1,35 +1,43 @@
+@authenticators_k8s
 Feature: Errors emitted by the login method.
 
+  @negative @acceptance
   Scenario: Login for unsupported resource type identity scope throws an AuthenticationError .
     Given I login to pod matching "app=inventory-deployment" to authn-k8s as "node/inventory-node"
     Then the HTTP status is "401"
 
   # Skip this test as we're not currently doing IP verification.
   @skip
+  @negative @acceptance
   Scenario: it raises an error when logging in as a different host than the one that sent the request.
     Given I login to authn-k8s as "stateful_set/inventory-stateful"
     And I use the IP address of "pod/inventory-pod"
     When I login to authn-k8s as "stateful_set/inventory-stateful"
     Then the HTTP status is "401"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in as a host which does not hold "authenticate" privilege
     on the webservice.
     When I login to authn-k8s as "pod/inventory-unauthorized"
     Then the HTTP status is "403"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in with a custom prefix as a host which does not
     hold "authenticate" privilege on the webservice.
     When I login to authn-k8s as "@namespace@/pod/inventory-unauthorized" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "403"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in with a service account which does not match the calling pod.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "service_account/inventory-pod-only"
     Then the HTTP status is "401"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in from a namespace which does not match the one configured in the host.
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "incorrect-namespace/*/*" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the HTTP status is "401"
 
+  @acceptance
   Scenario: Cert injection errors are written to a file in the client container
     When I login to pod matching "app=inventory-no-ssl-dir" to authn-k8s as "*/*"
     Then the cert injection logs exist in the client container

--- a/cucumber/kubernetes/features/login_with_annotations.feature
+++ b/cucumber/kubernetes/features/login_with_annotations.feature
@@ -1,73 +1,95 @@
+@authenticators_k8s
 Feature: A permitted Conjur host can login with a valid resource restrictions
   that is defined in annotations
 
+  @smoke
   Scenario: Login as the namespace a pod belongs to.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-namespace" with prefix "host/some-policy"
 
+  @negative @acceptance
   Scenario: Login for unsupported resource type identity scope throws an AuthenticationError .
     Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @smoke
   Scenario: Login as a Pod.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-pod" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Login as a ServiceAccount.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-account" with prefix "host/some-policy"
 
   @k8s_skip
+  @smoke
   Scenario: Login as a DeploymentConfig.
     Then I can login to pod matching "app=inventory-deployment-cfg" to authn-k8s as "test-app-deployment-config" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Login as a Deployment.
     Then I can login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-deployment" with prefix "host/some-policy"
 
+  @smoke
   Scenario: Login as a StatefulSet.
     Then I can login to pod matching "app=inventory-stateful" to authn-k8s as "test-app-stateful-set" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login as a Pod and a ServiceAccount
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-multiple-constraints" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login as the namespace a pod belongs to when the constraint is on the authenticator.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-constraint" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login as the namespace a pod belongs to when a constraint defined twice: on the authenticator and granular.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-and-general-constraint" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login with a host defined in the root policy
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "root-based-app" with prefix "host"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in with a host that has an unsupported resource type
     Given I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-non-permited-scope" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in from a namespace which does not match the one configured in the host
     When I login to pod matching "app=inventory-deployment" to authn-k8s as "test-app-incorrect-namespace" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in with a non-existing K8s resource
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-non-existing-resource" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @negative @acceptance
   Scenario: it raises an error when logging in from a K8s resource which does not match the one configured in the host
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-resource" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @acceptance
   Scenario: Login without the "authentication-container-name" annotation defaults to "authenticator" and succeeds
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-no-container-annotation" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login with "kubernetes/authentication-container-name" annotation and succeeds
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-kubernetes-container-annotation" with prefix "host/some-policy"
 
+  @negative @acceptance
   Scenario: It raises an error when logging in from a container which does not match the one configured in the host
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-container-annotation" with prefix "host/some-policy"
     Then the HTTP status is "401"
 
+  @acceptance
   Scenario: Login when the "authentication-container-name" annotation defined twice: on the authenticator and granular.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-service-id-and-granular-container-annotation" with prefix "host/some-policy"
 
+  @acceptance
   Scenario: Login when the "authentication-container-name" annotation defined twice: granular and with 'kubernetes' prefix.
     Then I can login to pod matching "app=inventory-pod" to authn-k8s as "test-app-authn-and-kubernetes-container-annotation" with prefix "host/some-policy"
 
+  @negative @acceptance
   Scenario: It raises an error when logging in from a container which does not match the one configured in the host for the service-id, although it is configured correctly for both granular and with 'kubernetes' prefix.
     When I login to pod matching "app=inventory-pod" to authn-k8s as "test-app-incorrect-service-id-container-annotation" with prefix "host/some-policy"
     Then the HTTP status is "401"

--- a/cucumber/kubernetes/features/pki.feature
+++ b/cucumber/kubernetes/features/pki.feature
@@ -1,17 +1,22 @@
+@authenticators_k8s
 Feature: Certificates issued by the login method.
 
+  @acceptance
   Scenario: The subject name is the dot-separated, with hard-coded apps prefix, Conjur host ID when the "Host-Id-Prefix" header isn't present.
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
     Then the certificate subject name is "/CN=host.conjur.authn-k8s.minikube.apps.@namespace@.*.*"
 
+  @acceptance
   Scenario: The subject name is the dot-separated given Conjur host ID in apps when the "Host-Id-Prefix" header is present
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/conjur/authn-k8s/minikube/apps"
     Then the certificate subject name is "/CN=host.conjur.authn-k8s.minikube.apps.@namespace@.*.*"
 
+  @acceptance
   Scenario: The subject name is the dot-separated given Conjur host ID outside of apps when the "Host-Id-Prefix" header is present
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "@namespace@/*/*" with prefix "host/some-policy"
     Then the certificate subject name is "/CN=host.some-policy.@namespace@.*.*"
 
+  @acceptance
   Scenario: The TTL of the certificate is 3 days.
     When I can login to pod matching "app=inventory-pod" to authn-k8s as "*/*"
     Then the certificate is valid for 3 days

--- a/cucumber/policy/features/bulk_actions.feature
+++ b/cucumber/policy/features/bulk_actions.feature
@@ -1,5 +1,7 @@
+@policy
 Feature: YAML anchors can be used for bulk actions
 
+  @smoke
   Scenario: Group records for bulk actions
     Sometimes you will want to grant privileges or perform actions on a group
     of roles or resources.  In this policy, two AWS-related variables (secrets)

--- a/cucumber/policy/features/cidr_restrictions.feature
+++ b/cucumber/policy/features/cidr_restrictions.feature
@@ -1,8 +1,10 @@
+@policy
 Feature: Users and Hosts can be CIDR restricted
 
 Users and Hosts can be restricted to only allow authentication
 from a particular network, defined by a CIDR in the policy
 
+  @smoke
   Scenario: Loading users and hosts with CIDR restrictions
 
     Given I load a policy:
@@ -38,6 +40,7 @@ from a particular network, defined by a CIDR in the policy
        ["192.168.0.1/32", "192.168.1.10/32"]
     """
 
+  @negative @acceptance
   Scenario: Invalid CIDR restriction string
 
     When I load a policy:
@@ -51,6 +54,7 @@ from a particular network, defined by a CIDR in the policy
     And the error message includes "Invalid IP address or CIDR range 'an_invalid_cidr_string'"
 
 
+  @negative @acceptance
   Scenario: Domain name as CIDR restriction string
 
     When I load a policy:
@@ -63,6 +67,7 @@ from a particular network, defined by a CIDR in the policy
     And the error code is "validation_failed"
     And the error message includes "Invalid IP address or CIDR range 'dap.my-company.net'"
 
+  @negative @acceptance
   Scenario: Load policy with invalid CIDR (Bits to the right of the mask)
   Conjur strips the extra bits before storing the CIDR in the database.
 
@@ -76,6 +81,7 @@ from a particular network, defined by a CIDR in the policy
     And the error code is "validation_failed"
     And the error message includes "Invalid IP address or CIDR range '10.0.0.1/24': Value has bits set to right of mask. Did you mean '10.0.0.0/24'"
 
+  @acceptance
   Scenario: Change CIDR restriction value
     Given I load a policy:
     """

--- a/cucumber/policy/features/deletion.feature
+++ b/cucumber/policy/features/deletion.feature
@@ -1,8 +1,10 @@
+@policy
 Feature: Deleting objects and relationships.
 
   Objects and relationships can be explicitly deleted using the !delete,
   !revoke, and !deny statements.
 
+  @smoke
   Scenario: The !delete statement can be used to delete an object.
     Given I load a policy:
     """
@@ -16,6 +18,7 @@ Feature: Deleting objects and relationships.
     """
     Then group "developers" does not exist
 
+  @acceptance
   Scenario: Deleting variable value is unrecoverable.
     Given I load a policy:
     """
@@ -47,6 +50,7 @@ Feature: Deleting objects and relationships.
     Then variable "test/db-password" exists
     And variable resource "test/db-password" does not have a secret value
 
+  @acceptance
   Scenario: Deleting variable value is unrecoverable even if we add same variable with the delete policy
     Given I load a policy:
     """
@@ -72,6 +76,7 @@ Feature: Deleting objects and relationships.
     Then variable "test/db-password" exists
     And variable resource "test/db-password" does not have a secret value
 
+  @acceptance
   Scenario: Deleting variable value is unrecoverable when we delete the policy itself and then add it again
     Given I load a policy:
     """
@@ -100,6 +105,7 @@ Feature: Deleting objects and relationships.
     Then variable "test/db-password" exists
     And variable resource "test/db-password" does not have a secret value
 
+  @smoke
   Scenario: The !revoke statement can be used to revoke a role grant.
     Given I load a policy:
     """
@@ -120,7 +126,7 @@ Feature: Deleting objects and relationships.
     And I show the group "employees"
     Then group "developers" is not a role member
 
-
+  @smoke
   Scenario: The !deny statement can be used to revoke a permission.
     Given I load a policy:
     """

--- a/cucumber/policy/features/group_members.feature
+++ b/cucumber/policy/features/group_members.feature
@@ -1,5 +1,7 @@
+@policy
 Feature: Users and groups can be added to groups
 
+  @smoke
   Scenario: Create a group of groups
   
     In this example we are giving the `group:employees` role to groups
@@ -25,6 +27,7 @@ Feature: Users and groups can be added to groups
     Then group "developers" is a role member
     And group "operations" is a role member
 
+  @smoke
   Scenario: Add an administrator to a group
 
     In this example, a group `ci-admin` gets an admin grant on the group `ci`.

--- a/cucumber/policy/features/host_factory.feature
+++ b/cucumber/policy/features/host_factory.feature
@@ -1,87 +1,91 @@
+@policy
 Feature: Host Factories can be managed through policies.
 
+  @smoke
   Scenario: Create a host factory on a layer.
-    
+
     The layer is added to the "layers" field.
     The "tokens" field is empty.
 
     Given I load a policy:
-    """
-    - !layer
-      id: myapp
-    
-    - !host-factory
-      id: myapp
-      layers: [ !layer myapp ]
-    """
+      """
+      - !layer
+        id: myapp
+
+      - !host-factory
+        id: myapp
+        layers: [ !layer myapp ]
+      """
     Then there is a host_factory resource "myapp"
     And I show the host_factory "myapp"
     Then the "layers" should be:
-    """
-    [
-      "cucumber:layer:myapp"
-    ]
-    """
+      """
+      [
+        "cucumber:layer:myapp"
+      ]
+      """
     And the "tokens" should be:
-    """
-    [
-    ]
-    """
+      """
+      []
+      """
 
+  @acceptance
   Scenario: Layers which are not under the management of the policy cannot
     be added to the host factory.
-    
+
     Given I try to load a policy with an unresolvable reference:
-    """
-    - !layer default
-    
-    - !policy
-      id: myapp
-      body:
-      - !host-factory
-        layers: [ !layer ../default ]
-    """
+      """
+      - !layer default
+
+      - !policy
+        id: myapp
+        body:
+        - !host-factory
+          layers: [ !layer ../default ]
+      """
     Then there's an error
     And the error code is "not_found"
     And the error message is "Layer 'myapp/../default' not found in account 'cucumber'"
 
-    Scenario: The host factory can be defined in a separate policy load event from the creation
-      of the layer.
-      
-      Given I load a policy:
+  @acceptance
+  Scenario: The host factory can be defined in a separate policy load event from the creation
+    of the layer.
+
+    Given I load a policy:
       """
       - !layer
         id: myapp
       """
-      And I extend the policy with:
+    And I extend the policy with:
       """
       - !host-factory
         id: myapp
         layers: [ !layer myapp ]
       """
-      Then there is a host_factory resource "myapp"
-      And I show the host_factory "myapp"
-      Then the "layers" should be:
+    Then there is a host_factory resource "myapp"
+    And I show the host_factory "myapp"
+    Then the "layers" should be:
       """
       [
         "cucumber:layer:myapp"
       ]
       """
 
-    Scenario: Load a Host Factory with no layers
-      Given I load a policy:
-        """ 
+  @acceptance
+  Scenario: Load a Host Factory with no layers
+    Given I load a policy:
+      """
+      - !policy
+        id: another-app
+        body:
         - !policy
-          id: another-app
+          id: hosts
+          annotations:
+            description: Layer & Host Factory for machines that can read secrets
           body:
-            - !policy
-              id: hosts
-              annotations:
-                description: Layer & Host Factory for machines that can read secrets
-              body:
-                - !layer
-                - !host-factory
-        """
-      Then there's an error
-      And the error code is "policy_invalid"
-      And the error message is "Host factory 'another-app/hosts' does not include any layers"
+          - !layer
+          - !host-factory
+      """
+    Then there's an error
+    And the error code is "policy_invalid"
+    And the error message is "Host factory 'another-app/hosts' does not include any layers"

--- a/cucumber/policy/features/ownership.feature
+++ b/cucumber/policy/features/ownership.feature
@@ -1,3 +1,4 @@
+@policy
 Feature: Custom ownership can be assigned to a policy object.
 
   By default, each object in a policy is owned by the policy.
@@ -7,6 +8,7 @@ Feature: Custom ownership can be assigned to a policy object.
   However, ownership of each object can be assigned to a role other than the
   policy.
 
+  @smoke
   Scenario: The default owner of a policy-scoped object is the policy.
     Given I load a policy:
     """
@@ -20,6 +22,7 @@ Feature: Custom ownership can be assigned to a policy object.
     Then the owner of user "bob" is user "admin"
     And  the owner of variable "db/password" is policy "db"
 
+  @smoke
   Scenario: The owner of a policy-scoped object can be changed.
     Given I load a policy:
     """

--- a/cucumber/policy/features/policy_delegation.feature
+++ b/cucumber/policy/features/policy_delegation.feature
@@ -1,5 +1,7 @@
+@policy
 Feature: Policies can be organized into hierarchies with specific update permissions.
 
+  @acceptance
   Scenario: Define a root policy with sub-policies
   
     Given I load a policy:

--- a/cucumber/policy/features/policy_reference.feature
+++ b/cucumber/policy/features/policy_reference.feature
@@ -1,5 +1,7 @@
+@policies
 Feature: Policies can refer to each other by relative path.
 
+  @smoke
   Scenario: Two sibling policies can refer to each other by relative path.
 
     A policy can grant its own roles and permissions to roles in other policies.
@@ -40,6 +42,7 @@ Feature: Policies can refer to each other by relative path.
     When I log in as host "host-01"
     Then I can fetch a secret from variable resource "prod/database/password"
 
+  @acceptance
   Scenario: Policy references can be used across policy loader invocations.
     Given I load a policy:
     """

--- a/cucumber/policy/features/policy_scoping.feature
+++ b/cucumber/policy/features/policy_scoping.feature
@@ -1,5 +1,7 @@
+@policy
 Feature: Policies can be used to scope records by name and ownership.
 
+  @acceptance
   Scenario: Declare a scoped policy
   
     This example shows how to use a scoped policy to represent who can access credentials for a Jenkins master. 

--- a/cucumber/policy/features/public_keys.feature
+++ b/cucumber/policy/features/public_keys.feature
@@ -1,5 +1,7 @@
+@policy
 Feature: Public keys can be associated with user records.
 
+  @smoke
   Scenario: Public keys can be managed through policy.
     Conjur can store public keys for each of your users. To store a public key, use the
     `public_keys` attribute on the `!user` record. When you load a user policy containing
@@ -29,6 +31,7 @@ Feature: Public keys can be associated with user records.
 
     """
 
+  @smoke
   Scenario: The latest public key version is the one provided by the pubkeys API.
     Public keys that you load in policies use the form:
     

--- a/cucumber/policy/features/rake.feature
+++ b/cucumber/policy/features/rake.feature
@@ -1,9 +1,11 @@
+@policy
 Feature: Rake task to load Conjur policy
 
 Conjur includes a Rake task (`rake policy:load`) for loading policies from 
 within the Conjur container. This rake task is used by the `conjurctl policy 
 load`
 
+  @smoke
   Scenario: Load a simple policy using `rake policy:load`
   
     When I load a policy from file "policy.yml" using conjurctl

--- a/cucumber/policy/features/replace.feature
+++ b/cucumber/policy/features/replace.feature
@@ -1,7 +1,9 @@
+@policy
 Feature: Replacing a policy
 
 A policy can be reloaded using the --replace flag
 
+  @negative @acceptance
   Scenario: A multifile policy with one modified file fails on reload
 
     Given I load a policy:
@@ -49,6 +51,7 @@ A policy can be reloaded using the --replace flag
     And the error code is "not_found"
     And the error message is "Role cucumber:group:developers does not exist"
 
+  @negative @acceptance
   Scenario: Policy reload fails when group isn't defined in new policy
 
     Given I load a policy:
@@ -85,6 +88,7 @@ A policy can be reloaded using the --replace flag
     And the error code is "not_found"
     And the error message is "Role cucumber:group:security-admin does not exist"
 
+  @smoke
   Scenario: Removing variable declaration from policy deletes its value
     Given I load a policy:
     """
@@ -112,6 +116,7 @@ A policy can be reloaded using the --replace flag
     Then variable "test/db-password" exists
     And variable resource "test/db-password" does not have a secret value
 
+  @acceptance
   Scenario: Removing policy with variable declaration deletes its value
     Given I load a policy:
     """
@@ -138,6 +143,7 @@ A policy can be reloaded using the --replace flag
     Then variable "test/db-password" exists
     And variable resource "test/db-password" does not have a secret value
 
+  @acceptance
   Scenario: Replacing policy with variable declaration keeps variable's secret value
     Given I load a policy:
     """
@@ -160,6 +166,7 @@ A policy can be reloaded using the --replace flag
     Then variable "test/db-password" exists
     And I can fetch a secret from variable resource "test/db-password"
 
+  @acceptance
   Scenario: Replacing policy root with same policy tests replaces the variable
     Given I load a policy:
     """
@@ -182,6 +189,7 @@ A policy can be reloaded using the --replace flag
     Then variable "test/db-password" exists
     And I can fetch a secret from variable resource "test/db-password"
 
+  @smoke
   Scenario: A multifile policy successfully reloads when files are concatenated
 
     Given I load a policy:

--- a/cucumber/policy/features/secrets.feature
+++ b/cucumber/policy/features/secrets.feature
@@ -1,3 +1,4 @@
+@policy
 Feature: Secrets can be managed through policies.
 
   Each resource in Conjur can have an associated list of secrets. Secrets on a resource
@@ -12,6 +13,7 @@ Feature: Secrets can be managed through policies.
 
   By convention, secrets are stored in Conjur using a resource called a `variable`. 
 
+  @smoke
   Scenario: The owner of a secret has full privileges to it.
 
     Because the owner of a resource has all privileges on the resource, the owner of a resource
@@ -36,6 +38,7 @@ Feature: Secrets can be managed through policies.
     And I can add a secret to variable resource "db-password"
     And I can retrieve the same secret value from "db-password"
 
+  @smoke
   Scenario: Privilege grants can be used to delegate secrets permissions.
 
     The `update` privilege conveys the right to update a secret.
@@ -81,6 +84,7 @@ Feature: Secrets can be managed through policies.
     Then I can not add a secret to variable resource "db-password"
     And I can fetch a secret from variable resource "db-password"
 
+  @acceptance
   Scenario: Defining secrets which are available to a Layer
 
     A policy which is used to define an application will typically include a layer.

--- a/cucumber/rotators/features/aws.feature
+++ b/cucumber/rotators/features/aws.feature
@@ -25,6 +25,7 @@
 #       instantly.
 #
 @manual
+@rotators
 Feature: AWS Secret Access Key Rotation
 
   Background: Configure an AWS rotator
@@ -45,6 +46,7 @@ Feature: AWS Secret Access Key Rotation
     """
     And I ensure conjur has AWS test account credentials for policy "aws"
 
+  @smoke
   Scenario: Values are rotated according to the policy
     Given I moniter AWS variables in policy "aws" for 3 values in 50 seconds
     Then the last two sets of AWS credentials both work

--- a/cucumber/rotators/features/expiration.feature
+++ b/cucumber/rotators/features/expiration.feature
@@ -1,3 +1,4 @@
+@rotators
 Feature: Manually expiring a rotating variable
 
   This feature is an API endpoint allowing a rotating variable to be expired
@@ -25,6 +26,7 @@ Feature: Manually expiring a rotating variable
     And I add the value "secret" to variable "db-reports/password"
     And I create a db user "test" with password "secret"
 
+  @smoke
   Scenario: Expiring causes the secret to change
 
     # The initial password is rotated right away, and the subsequent rotation

--- a/cucumber/rotators/features/password.feature
+++ b/cucumber/rotators/features/password.feature
@@ -1,3 +1,4 @@
+@rotators
 Feature: Postgres password rotation
 
   Background: Configure a postgres rotator
@@ -27,6 +28,7 @@ Feature: Postgres password rotation
   #       some leeway, waiting for 3 rotations but allowing for more than
   #       3 seconds of time.
   #
+  @smoke
   Scenario: Values are rotated according to the policy
     Given I moniter "db-reports/password" and db user "test" for 3 values in 20 seconds
     Then we find at least 3 distinct matching passwords


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is to improve the experience and data reporting working with the Conjur cucumber tests.

### Implemented Changes

This PR:

- Extends the use of cucumber tags in the test suites. See `cucumber/README.md` for a list of the tags applied through the tests.

- Adds the authn-k8s test results to the Jenkins cucumber report.

- Updates the CI pipeline to only run `@smoke` tagged tests on branch builds by default. All test types run for `master` branch and tag builds.

**I recommend reviewing this PR by commit.** The majority of the line changes are adding test tags, which are all in the first commit. The other changes will be easier to review in the separate commits.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14790](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14790)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
