### PR TITLE
Change the order of the params in authn audit so user will come first

### DIFF
--- a/app/models/audit/event/authn.rb
+++ b/app/models/audit/event/authn.rb
@@ -83,9 +83,9 @@ module Audit
       end
 
       def auth_stuctured_data
-        { authenticator: @authenticator_name }.tap do |sd|
+        { user: sanitized_role_id }.tap do |sd|
+          sd[:authenticator] = @authenticator_name
           sd[:service] = service_id if @service
-          sd[:user] = sanitized_role_id
         end
       end
 

--- a/cucumber/api/features/authenticate.feature
+++ b/cucumber/api/features/authenticate.feature
@@ -19,7 +19,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -34,7 +34,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:host:app"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:host:app"]
+      [auth@43868 user="cucumber:host:app" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:host:app successfully authenticated with authenticator authn
@@ -50,7 +50,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -67,7 +67,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -84,7 +84,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -101,7 +101,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -116,7 +116,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="authenticate"]
       cucumber:user:alice successfully authenticated with authenticator authn
@@ -137,7 +137,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="authenticate"]
       cucumber:user:alice failed to authenticate with authenticator authn
@@ -152,7 +152,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:host:app"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:host:app"]
+      [auth@43868 user="cucumber:host:app" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="authenticate"]
       cucumber:host:app failed to authenticate with authenticator authn
@@ -167,7 +167,7 @@ Feature: Exchange a role's API key for a signed authentication token
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="authenticate"]
       cucumber:user:alice failed to authenticate with authenticator authn

--- a/cucumber/api/features/login.feature
+++ b/cucumber/api/features/login.feature
@@ -19,7 +19,7 @@ Feature: Exchange a role's password for its API key
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="login"]
       cucumber:user:alice successfully logged in with authenticator authn service cucumber:webservice:conjur/authn
@@ -36,7 +36,7 @@ Feature: Exchange a role's password for its API key
     """
       <86>1 * * conjur * authn
       [subject@43868 role="cucumber:host:app"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:host:app"]
+      [auth@43868 user="cucumber:host:app" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="success" operation="login"]
       cucumber:host:app successfully logged in with authenticator authn service cucumber:webservice:conjur/authn
@@ -51,7 +51,7 @@ Feature: Exchange a role's password for its API key
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:user:alice"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:user:alice"]
+      [auth@43868 user="cucumber:user:alice" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="login"]
       cucumber:user:alice failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00002E Invalid credentials
@@ -66,7 +66,7 @@ Feature: Exchange a role's password for its API key
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:host:app"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="cucumber:host:app"]
+      [auth@43868 user="cucumber:host:app" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="login"]
       cucumber:host:app failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00002E Invalid credentials
@@ -81,7 +81,7 @@ Feature: Exchange a role's password for its API key
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:user:non-exist"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="not-found"]
+      [auth@43868 user="not-found" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="login"]
       cucumber:user:non-exist failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00007E 'non-exist' not found
@@ -106,7 +106,7 @@ Feature: Exchange a role's password for its API key
     """
       <84>1 * * conjur * authn
       [subject@43868 role="cucumber:host:non-exist"]
-      [auth@43868 authenticator="authn" service="cucumber:webservice:conjur/authn" user="not-found"]
+      [auth@43868 user="not-found" authenticator="authn" service="cucumber:webservice:conjur/authn"]
       [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
       [action@43868 result="failure" operation="login"]
       cucumber:host:non-exist failed to login with authenticator authn service cucumber:webservice:conjur/authn: CONJ00007E 'host/non-exist' not found

--- a/cucumber/authenticators_ldap/features/authn_ldap.feature
+++ b/cucumber/authenticators_ldap/features/authn_ldap.feature
@@ -136,5 +136,5 @@ Feature: Users can login with LDAP credentials from an authorized LDAP server
     Then it is unauthorized
     And The following matches the audit log after my savepoint:
     """
-    <84>1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z - conjur \d+ authn \[subject@43868 role="cucumber:user:alice"]\[auth@43868 authenticator="authn-ldap" service="cucumber:webservice:conjur/authn-ldap/test" user="cucumber:user:alice"]\[client@43868 ip="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"]\[action@43868 result="failure" operation="login"] cucumber:user:alice failed to login with authenticator authn-ldap service cucumber:webservice:conjur/authn-ldap/test: CONJ00002E Invalid credentials
+    <84>1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z - conjur \d+ authn \[subject@43868 role="cucumber:user:alice"]\[auth@43868 user="cucumber:user:alice" authenticator="authn-ldap" service="cucumber:webservice:conjur/authn-ldap/test"]\[client@43868 ip="\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"]\[action@43868 result="failure" operation="login"] cucumber:user:alice failed to login with authenticator authn-ldap service cucumber:webservice:conjur/authn-ldap/test: CONJ00002E Invalid credentials
     """


### PR DESCRIPTION
### What does this PR do?
Change for the audits to make the user field come first. See [ONYX-16002](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16002).
Also, adjust tests to new format.

### Checklists

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
