### PR TITLE
Unskip Azure cuke

### DIFF
--- a/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
+++ b/cucumber/authenticators_azure/features/authn_azure_bad_configuration.feature
@@ -35,8 +35,6 @@ Feature: Azure Authenticator - Bad authenticator configuration leads to an error
     Errors::Conjur::RequiredResourceMissing
     """
 
-  # TODO: add this test when issue #1085 is done
-  @skip
   @negative @acceptance
   Scenario: provider-uri variable without value is denied
     Given I load a policy:


### PR DESCRIPTION
### Desired Outcome
* Unskip `provider-uri variable without value is denied` cucumber test in `authn_azure_bad_configuration.feature`

### Implemented Changes
* Remove the `skip` tag so that this test is run

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14954](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14954)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
