### PR TITLE
Fix conjur wait in dev start script

### DIFF
--- a/dev/start
+++ b/dev/start
@@ -172,30 +172,9 @@ wait_for_conjur() {
       conjurctl role retrieve-key cucumber:user:admin | tr -d '\r'
   )
 
-  for i in {1..5}; do
-    sleep=10
-    echo "Try to login to conjur server:"
+  docker-compose exec -T conjur conjurctl wait
 
-    if ( 
-      # Use subshell to disable pipefail, since we expect grep failures here.
-      set +o pipefail
-      # We need 2>&1 because some versions docker-compose before 2 output to
-      # stdout, while 2 outputs to stderr.
-      docker-compose exec client \
-        conjur authn login -u admin -p "$api_key" 2>&1 | 
-        grep "Failed to open TCP connection"
-    )
-    then
-      echo "Conjur not ready yet. Sleep number $i for $sleep seconds."
-      sleep $sleep
-    else
-      echo "Conjur is up and ready."
-      return 0;
-    fi
-  done
-
-  echo "Conjur server failed to come up in time."
-  return 1
+  docker-compose exec client conjur authn login -u admin -p "$api_key"
 }
 
 configure_oidc_authenticators() {


### PR DESCRIPTION
### Desired Outcome

Use native conjur wait mechanism in `./dev/start` script instead of try catch from client approach.

### Implemented Changes

Client side try catch replaced by `conjurctl wait` command.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
