### PR TITLE
Fix binary secrets values behavior in batch secrets retrieval api after ruby upgrade

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -72,6 +72,8 @@ class SecretsController < RestController
     end
 
     render(json: result)
+  rescue JSON::GeneratorError
+    raise Errors::Conjur::BadSecretEncoding, result
   rescue Encoding::UndefinedConversionError
     raise Errors::Conjur::BadSecretEncoding, result
   rescue Exceptions::RecordNotFound => e

--- a/cucumber/api/features/secrets_batch.feature
+++ b/cucumber/api/features/secrets_batch.feature
@@ -136,7 +136,7 @@ Feature: Batch retrieval of secrets
     When I GET "/secrets?variable_ids=cucumber:variable:secret3"
     Then the HTTP response status code is 406
 
-  @negative @acceptance
+  @negative @smoke
   Scenario: Fails with 406 on retrieval of multiple secrets with improper header
     Given I create a binary secret value for resource "cucumber:variable:secret3"
     And I add the secret value "v2" to the resource "cucumber:variable:secret2"


### PR DESCRIPTION
### Desired Outcome

Fix batch secrets retrieval API behavior when one of the secrets is binary data and `Acceptance-Encoding` header value has inappropriate value.

### Implemented Changes

- Catch `JSON::GeneratorError` exception and throw `Errors::Conjur::BadSecretEncoding` in secrets controller.
- Move one of tests are testing inappropriate `Acceptance-Encoding` from acceptance to smoke

### Connected Issue/Story

Part of [ONYX-9661](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-9661)

### Definition of Done

- [X] Desired outcome is achieved

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
