### PR TITLE
Rename the TrustedProxyFilter class to IsIpTrusted

### DIFF
--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   disable_cache = config.respond_to?(:conjur_disable_trusted_proxies_cache) &&
     config.conjur_disable_trusted_proxies_cache
 
-  Rack::Request.ip_filter = Conjur::TrustedProxyFilter.new(
+  Rack::Request.ip_filter = Conjur::IsIpTrusted.new(
     config: Rails.application.config.conjur_config,
     disable_cache: disable_cache
   )

--- a/lib/conjur/is_ip_trusted.rb
+++ b/lib/conjur/is_ip_trusted.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Conjur
-  # TrustedProxyFilter wraps the default Rack IP filtering. This allows
+  # IsIpTrusted wraps the default Rack IP filtering. This allows
   # the trusted proxies to be configured using the environment variable,
   # `TRUSTED_PROXIES`.
   #
@@ -9,7 +9,7 @@ module Conjur
   # addresses or IP address ranges using CIDR notation.
   #
   # Example: TRUSTED_PROXIES=4.4.4.4,192.168.100.0/24
-  class TrustedProxyFilter
+  class IsIpTrusted
     def initialize(config:, disable_cache: true)
       @config = config
       @disable_cache = disable_cache
@@ -47,8 +47,8 @@ module Conjur
 
       return [] unless trusted_proxies
 
-      Set.new(trusted_proxies).
-        map { |cidr| IPAddr.new(cidr.strip) }
+      Set.new(trusted_proxies)
+        .map { |cidr| IPAddr.new(cidr.strip) }
     end
   end
 end

--- a/spec/lib/conjur/is_ip_trusted_spec.rb
+++ b/spec/lib/conjur/is_ip_trusted_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-describe Conjur::TrustedProxyFilter do
+describe Conjur::IsIpTrusted do
   it "does not raise an exception when created with valid IP addresses" do
     config = Conjur::ConjurConfig.new(trusted_proxies: '127.0.0.1')
 
     expect {
-      Conjur::TrustedProxyFilter.new(config: config)
+      Conjur::IsIpTrusted.new(config: config)
     }.not_to raise_error
   end
 end


### PR DESCRIPTION
Desired Outcome
This change renames the TrustedProxyFilter class to IsIPTrusted. The new name better describes what the class does.
This issue addresses https://github.com/cyberark/conjur/issues/2176

Implemented Changes
The TrustedProxyFilter class has been renamed to a more apt name IsIpTrusted.
The RSpec tests for this have been changed to reflect the same
The config initializer now refers to the new class name.

Connected Issue/Story
Issue https://github.com/cyberark/conjur/issues/2176

Definition of Done
The new class name reflects in all the places where the old class name was used.