### PR TITLE
Restrict publishing to DockerHub

### DIFF
--- a/publish-images.sh
+++ b/publish-images.sh
@@ -75,6 +75,12 @@ REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6
 # Normalize version number in the case of '+' included
 VERSION="$(echo -n "${VERSION}" | tr "+" "_")"
 
+# Don't publish to DockerHub unless the build is in the main conjur repo
+if [[ "${JOB_NAME}" != cyberark--conjur/* ]];
+then
+  DOCKERHUB=false
+fi
+
 # Only push SHA images on internal
 if [[ "${PUBLISH_INTERNAL}" = true ]]; then
   echo "Pushing ${LOCAL_TAG} tagged images to registry.tld..."


### PR DESCRIPTION
### Desired Outcome

If the job is run from a security fork, images should not be published
to DockerHub.

### Implemented Changes

Restricts DockerHub publishing

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
