### PR TITLE
Bug Fix - IAM Authn Fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.17.2] - 2022-02-13
 
+### Fixed
+- IAM Authn bug fix - Take rexml gem to production configuration [#2493](https://github.com/cyberark/conjur/pull/2493)
+
 ### Security
 - Updated Rails to 6.1.4.4 to resolve CVE-2021-44528 (Medium, Not Vulnerable)
   [cyberark/conjur#2486](https://github.com/cyberark/conjur/pull/2486)

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'base32-crockford'
 gem 'bcrypt'
 gem 'gli', require: false
 gem 'listen'
+gem 'rexml', '~> 3.2'
 gem 'slosilo', '~> 3.0'
 
 # Explicitly required as there are vulnerabilities in older versions
@@ -97,7 +98,6 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rails_layout'
   gem 'rake_shared_context'
-  gem 'rexml', '~> 3.2'
   gem 'rspec'
   gem 'rspec-core'
   gem 'rspec-rails'


### PR DESCRIPTION
### Desired Outcome

As part of Ruby 3 support, `rexml` gem was isolated in `:test` `:development` gem environments.
This gem is required in production for IAM authentication (at least).
The Root cause for the separation is that Ruby 3 gem is external, comparing to 2.5 where it comes with the Ruby itself.
[Documentation for this separation.](https://github.com/xhsdf/rtile/issues/5)

**This bug reconstructs only during manual tests, automatic tests do not exist for IAM authenticator.**

### Implemented Changes

Move rexml in Gemfile to production environment.

### Definition of Done
Authentication succeeds in prod environment - reconstructs in manual tests only.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
