### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,33 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.17.2] - 2022-02-13
 
-### Fixed
-- IAM Authn bug fix - Take rexml gem to production configuration [#2493](https://github.com/cyberark/conjur/pull/2493)
-
-### Security
-- Updated Rails to 6.1.4.4 to resolve CVE-2021-44528 (Medium, Not Vulnerable)
-  [cyberark/conjur#2486](https://github.com/cyberark/conjur/pull/2486)
-- Updated Rails to 6.1.4.6 to resolve CVE-2022-23633
-  Updated Puma to 5.6.2 to resolve CVE-2022-23634
-  [cyberark/conjur#2492](https://github.com/cyberark/conjur/pull/2492)  
-
-## [1.17.1] - 2022-02-09
-
-### Added
-- Added support for SNI certificates when talking to the Kubernetes API 
-  server through the web socket client.
-  [ONYX-14386](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14386)
-- Added support for http(s)_proxy for Kubernetes client in Kubernetes
-  authenticator
-  [ONYX-16433](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16433)
-
-## [1.17.0] - 2022-02-09
-
-### Changed
-- Upgrade to Ruby 3. [#2444](https://github.com/cyberark/conjur/pull/2444)
-
-## [1.16.0] - 2022-01-25
-
 ### Added
 - Added the ability to fetch signing keys from JWKS endpoints that use a self-signed
   certificate or a certificate signed by a third-party CA for JWT generic vendor
@@ -59,15 +32,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#2450](https://github.com/cyberark/conjur/pull/2450)
   [#2447](https://github.com/cyberark/conjur/pull/2447)
   [#2437](https://github.com/cyberark/conjur/pull/2437))
-
-### Changed
-- Proper error message appears when JWT Authenticator gets HTTP code error
-  while trying to fetch JWKS data from `jwks-uri` [#2474](https://github.com/cyberark/conjur/pull/2474)
-
-## [1.15.1] - 2022-01-12
+- Added support for SNI certificates when talking to the Kubernetes API 
+  server through the web socket client.
+  [ONYX-14386](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14386)
+- Added support for http(s)_proxy for Kubernetes client in Kubernetes
+  authenticator
+  [ONYX-16433](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16433)
 
 ### Changed
 - Update to automated release process
+- Proper error message appears when JWT Authenticator gets HTTP code error
+  while trying to fetch JWKS data from `jwks-uri` [#2474](https://github.com/cyberark/conjur/pull/2474)
+- Upgrade to Ruby 3. [#2444](https://github.com/cyberark/conjur/pull/2444)
+
+### Fixed
+- IAM Authn bug fix - Take rexml gem to production configuration [#2493](https://github.com/cyberark/conjur/pull/2493)
+
+### Security
+- Updated Rails to 6.1.4.4 to resolve CVE-2021-44528 (Medium, Not Vulnerable)
+  [cyberark/conjur#2486](https://github.com/cyberark/conjur/pull/2486)
+- Updated Rails to 6.1.4.6 to resolve CVE-2022-23633
+  Updated Puma to 5.6.2 to resolve CVE-2022-23634
+  [cyberark/conjur#2492](https://github.com/cyberark/conjur/pull/2492)  
 
 ## [1.15.0] - 2021-12-21
 


### PR DESCRIPTION
### Desired Outcome

Recent CHANGELOG changes resulted in creation of multiple `.pre` releases of conjur, an undesired behavior.
This PR unifies all un-promoted versions (which are classified as pre-release) into one CHANGELOG entry.

### Implemented Changes

All CHANGELOG entries `> 1.15.0` are unified into 1.17.2 entry.

### Definition of Done
CHANGELOG has only one entry `1.17.2` which consists of previous `1.17.2`, `1.17.1`, `1.17.0` and `1.16.0` pre-releases.
Reviewed and approved by at least one core team member who is well familiar with the new automated release process.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
