### PR TITLE
Remove the stale puma pidfile before starting the server process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - IAM Authn bug fix - Take rexml gem to production configuration [#2493](https://github.com/cyberark/conjur/pull/2493)
+- Previously, a stale puma pid file would prevent the Conjur server from starting 
+  successfully. Conjur now removes a stale pid file at startup, if it exists.
+  [#2498](https://github.com/cyberark/conjur/pull/2498)
 
 ### Security
 - Updated nokogiri to 1.13.3 to resolve CVE-2022-23308 and CVE-2021-30560

--- a/bin/conjur-cli/commands/server.rb
+++ b/bin/conjur-cli/commands/server.rb
@@ -31,6 +31,9 @@ module Commands
       create_account
       load_bootstrap_policy
 
+      # Remove a stale puma PID file, if it exists
+      cleanup_pidfile
+
       # Start the Conjur API and service
       # processes
       fork_server_process
@@ -83,6 +86,24 @@ module Commands
       system(
         "rake 'policy:load[#{@account},#{@file_name}]'"
       ) || exit(($CHILD_STATUS.exitstatus))
+    end
+
+    # This method is needed because in some versions of conjur server it has been observed that
+    # docker restart of the conjur server results in an error stating that the puma PID file is still present.
+    # Hence we check to see if this stale PID File exists and delete it, which ensures a smooth restart.
+    # This issue is described in detail in Issue 2381.
+
+    def cleanup_pidfile
+      # Get the path to conjurctl
+      conjurctl_path = `readlink -f $(which conjurctl)`
+    
+      # Navigate from its directory (/bin) to the root Conjur server directory
+      conjur_server_dir = Pathname.new(File.join(File.dirname(conjurctl_path), '..')).cleanpath
+      pid_file_path = File.join(conjur_server_dir, 'tmp/pids/server.pid')
+      return unless File.exist?(pid_file_path)
+      
+      puts("Removing existing PID file: #{pid_file_path}")
+      File.delete(pid_file_path)
     end
 
     def fork_server_process


### PR DESCRIPTION
#### Desired Outcome
- This changes ensures that the stale pidfile is removed before starting the conjur server process
This issue addresses https://github.com/cyberark/conjur/issues/2381

#### Implemented Changes
- A new method is added to conjur-cli to check if the stale puma pid file exists and deletes it if it exists.

#### Connected Issue/Story
- Issue https://github.com/cyberark/conjur/issues/2381

#### Definition of Done
- A new method checks if the stale pidfile exists and it is removed before the starting the conjur server. 

#### Changelog
- The CHANGELOG has been updated with the bug that was fixed.

#### Test coverage
- This PR includes two new unit tests to go with the code
  changes

#### Documentation
- This PR does not require updating any documentation

#### Behavior
-  No behavior was changed with this PR

#### Security
- There are no security aspects to these changes 
