### PR TITLE
Add Prometheus Metrics endpoint and client store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,8 @@ gem 'openid_connect'
 gem "anyway_config"
 gem 'i18n', '~> 1.8.11'
 
+gem 'prometheus-client'
+
 group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,7 @@ GEM
       ast (~> 2.4.1)
     pg (1.2.3)
     powerpack (0.1.3)
+    prometheus-client (3.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -505,6 +506,7 @@ DEPENDENCIES
   openid_connect
   parallel
   pg
+  prometheus-client
   pry-byebug
   pry-rails
   puma (~> 5.5, >= 5.6.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,12 @@ require 'conjur_audit'
 # Must require because lib folder hasn't been loaded yet
 require './lib/conjur/conjur_config'
 
+# Require prometheus dependencies and metrics module
+# so that a clean data store can be initialized
+# This should be done dynamically depending on whether
+# metrics are enabled in the future
+require './lib/monitoring/prometheus'
+
 module Conjur
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -74,5 +80,8 @@ module Conjur
     # We create this in application.rb instead of an initializer so that it's
     # guaranteed to be available for other initializers to use.
     config.conjur_config = Conjur::ConjurConfig.new
+
+    # Initialize metrics and clean existing data
+    Monitoring::Prometheus.setup
   end
 end

--- a/config/initializers/rack_middleware.rb
+++ b/config/initializers/rack_middleware.rb
@@ -27,6 +27,11 @@ Rails.application.configure do
   # to the start of the Rack middleware chain.
   config.middleware.insert_before(0, ::Rack::DefaultContentType)
 
+  # If using Prometheus telemetry, we want to ensure that the middleware
+  # which collects and exports metrics is loaded at the start of the 
+  # middleware chain to prevent any modifications to the incoming requests
+  config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
+
   # Deleting the RemoteIp middleware means that `request.remote_ip` will
   # always be the same as `request.ip`. This ensure that the Conjur request log
   # (using `remote_ip`) and the audit log (using `ip`) will have the same value

--- a/lib/monitoring/middleware/prometheus_exporter.rb
+++ b/lib/monitoring/middleware/prometheus_exporter.rb
@@ -1,0 +1,89 @@
+require 'prometheus/client'
+require 'prometheus/client/formats/text'
+
+module Monitoring
+  module Middleware
+    # Exporter is a Rack middleware that provides a sample implementation of a
+    # Prometheus HTTP exposition endpoint.
+    #
+    # By default it will export the state of the global registry and expose it
+    # under `/metrics`. Use the `:registry` and `:path` options to change the
+    # defaults.
+    class PrometheusExporter
+      attr_reader :app, :path, :registry
+
+      FORMATS  = [::Prometheus::Client::Formats::Text].freeze
+      FALLBACK = ::Prometheus::Client::Formats::Text
+
+      def initialize(app, options = {})
+        @app = app
+        @path = options[:path]
+        @registry = options[:registry]
+        @acceptable = build_dictionary(FORMATS, FALLBACK)
+      end
+
+      def call(env)
+        if env['PATH_INFO'] == @path
+          format = negotiate(env, @acceptable)
+          format ? respond_with(format) : not_acceptable(FORMATS)
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+
+      def negotiate(env, formats)
+        parse(env.fetch('HTTP_ACCEPT', '*/*')).each do |content_type, _|
+          return formats[content_type] if formats.key?(content_type)
+        end
+
+        nil
+      end
+
+      def parse(header)
+        header.split(/\s*,\s*/).map do |type|
+          attributes = type.split(/\s*;\s*/)
+          quality = extract_quality(attributes)
+
+          [attributes.join('; '), quality]
+        end.sort_by(&:last).reverse
+      end
+
+      def extract_quality(attributes, default = 1.0)
+        quality = default
+
+        attributes.delete_if do |attr|
+          quality = attr.split('q=').last.to_f if attr.start_with?('q=')
+        end
+
+        quality
+      end
+
+      def respond_with(format)
+        [
+          200,
+          { 'Content-Type' => format::CONTENT_TYPE },
+          [format.marshal(@registry)]
+        ]
+      end
+
+      def not_acceptable(formats)
+        types = formats.map { |format| format::MEDIA_TYPE }
+
+        [
+          406,
+          { 'Content-Type' => 'text/plain' },
+          ["Supported media types: #{types.join(', ')}"]
+        ]
+      end
+
+      def build_dictionary(formats, fallback)
+        formats.each_with_object('*/*' => fallback) do |format, memo|
+          memo[format::CONTENT_TYPE] = format
+          memo[format::MEDIA_TYPE] = format
+        end
+      end
+    end
+  end
+end

--- a/lib/monitoring/prometheus.rb
+++ b/lib/monitoring/prometheus.rb
@@ -1,0 +1,47 @@
+require 'prometheus/client'
+require 'prometheus/client/data_stores/direct_file_store'
+
+module Monitoring
+  module Prometheus
+    extend self
+
+    def setup(options = {})
+      @registry = options[:registry] || ::Prometheus::Client::Registry.new
+      @metrics_prefix = options[:metrics_prefix] || "conjur_http_server"
+      @metrics_dir_path = ENV['CONJUR_METRICS_DIR'] || '/tmp/prometheus'
+
+      clear_data_store
+      configure_data_store
+      init_metrics
+    end
+
+    def registry
+      @registry
+    end
+
+    def metrics_prefix
+      @metrics_prefix
+    end
+
+    protected
+
+    def clear_data_store
+      Dir[File.join(@metrics_dir_path, '*.bin')].each do |file_path|
+        File.unlink(file_path)
+      end
+    end
+
+    def configure_data_store
+      ::Prometheus::Client.config.data_store = ::Prometheus::Client::DataStores::DirectFileStore.new(
+        dir: @metrics_dir_path
+      )
+    end
+
+    def init_metrics
+      # Test a random gauge metric
+      gauge = registry.gauge(:test_gauge, docstring: '...', labels: [:test_label])
+      gauge.set(1234.567, labels: { test_label: 'gauge metric test' })
+    end
+
+  end
+end

--- a/spec/monitoring/metrics_spec.rb
+++ b/spec/monitoring/metrics_spec.rb
@@ -1,0 +1,15 @@
+require 'rack/test'
+require 'prometheus/client/formats/text'
+require 'monitoring/prometheus'
+
+describe Monitoring::Prometheus do
+  include Rack::Test::Methods
+
+  it 'creates a valid registry and allows metrics' do
+    Monitoring::Prometheus.setup(registry: Prometheus::Client::Registry.new)
+    gauge = Monitoring::Prometheus.registry.gauge(:foo, docstring: '...', labels: [:bar])
+    gauge.set(21.534, labels: { bar: 'test' })
+
+    expect(gauge.get(labels: { bar: 'test' })).to eql(21.534)
+  end
+end

--- a/spec/monitoring/middleware/prometheus_exporter_spec.rb
+++ b/spec/monitoring/middleware/prometheus_exporter_spec.rb
@@ -1,0 +1,107 @@
+require 'rack/test'
+require 'monitoring/middleware/prometheus_exporter'
+
+describe Monitoring::Middleware::PrometheusExporter do
+  include Rack::Test::Methods
+
+  # Reset the data store
+  before do
+    Monitoring::Prometheus.setup(registry: Prometheus::Client::Registry.new)
+  end
+  
+  let(:registry) do
+    Monitoring::Prometheus.registry
+  end
+
+  let(:path) { '/metrics' }
+
+  let(:options) { { registry: registry, path: path} }
+
+  let(:app) do
+    app = ->(_) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
+    described_class.new(app, **options)
+  end
+
+  context 'when requesting app endpoints' do
+    it 'returns the app response' do
+      get '/foo'
+
+      expect(last_response).to be_ok
+      expect(last_response.body).to eql('OK')
+    end
+  end
+
+  context 'when requesting /metrics' do
+    text = Prometheus::Client::Formats::Text
+
+    shared_examples 'ok' do |headers, fmt|
+      it "responds with 200 OK and Content-Type #{fmt::CONTENT_TYPE}" do
+        registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
+
+        get '/metrics', nil, headers
+
+        expect(last_response.status).to eql(200)
+        expect(last_response.header['Content-Type']).to eql(fmt::CONTENT_TYPE)
+        expect(last_response.body).to eql(fmt.marshal(registry))
+      end
+    end
+
+    shared_examples 'not acceptable' do |headers|
+      it 'responds with 406 Not Acceptable' do
+        message = 'Supported media types: text/plain'
+
+        get '/metrics', nil, headers
+
+        expect(last_response.status).to eql(406)
+        expect(last_response.header['Content-Type']).to eql('text/plain')
+        expect(last_response.body).to eql(message)
+      end
+    end
+
+    context 'when client does not send a Accept header' do
+      include_examples 'ok', {}, text
+    end
+
+    context 'when client accepts any media type' do
+      include_examples 'ok', { 'HTTP_ACCEPT' => '*/*' }, text
+    end
+
+    context 'when client requests application/json' do
+      include_examples 'not acceptable', 'HTTP_ACCEPT' => 'application/json'
+    end
+
+    context 'when client requests text/plain' do
+      include_examples 'ok', { 'HTTP_ACCEPT' => 'text/plain' }, text
+    end
+
+    context 'when client uses different white spaces in Accept header' do
+      accept = 'text/plain;q=1.0  ; version=0.0.4'
+
+      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    end
+
+    context 'when client does not include quality attribute' do
+      accept = 'application/json;q=0.5, text/plain'
+
+      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    end
+
+    context 'when client accepts some unknown formats' do
+      accept = 'text/plain;q=0.3, proto/buf;q=0.7'
+
+      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    end
+
+    context 'when client accepts only unknown formats' do
+      accept = 'fancy/woo;q=0.3, proto/buf;q=0.7'
+
+      include_examples 'not acceptable', 'HTTP_ACCEPT' => accept
+    end
+
+    context 'when client accepts unknown formats and wildcard' do
+      accept = 'fancy/woo;q=0.3, proto/buf;q=0.7, */*;q=0.1'
+
+      include_examples 'ok', { 'HTTP_ACCEPT' => accept }, text
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

Create the groundwork for Conjur Telemetry and metrics collection using Prometheus. For more details on this feature, see the [Solution Design.](https://github.com/cyberark/conjur/blob/metrics-solution-design/design/telemetry/metrics_solution_design.md#solution-design---conjur-metrics-telemetry)

### Implemented Changes
Added middleware (ConjurExporter) to expose a /metrics endpoint to be used by Prometheus, as well as initialization methods to create a client store for metric collection, and relevant unit tests.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16193](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16193)

### Definition of Done

- [x] Create a Prometheus client store
- [x] Expose the Prometheus client store via the GET /metrics scrape target
- [x] Add test cases to ensure the scrape target works as expected

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
