### PR TITLE
Limiting user creation per flag

### DIFF
--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -201,15 +201,11 @@ module Loader
 
       # Below is a sample method verifying policy data validity
       def verify
-
-	userCreationAllowed = ENV['CONJUR_ALLOW_USER_CREATION']
-
-        if userCreationAllowed == 'false'
-          Rails.logger.info("Explicit user creation disallowed")
-          if resourceid.include? "@"  # not under root
-              Rails.logger.info("user = #{self.id} is not under root")
-              message = "User '#{self.id}' creation is disallowed - please address administator"
-              raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
+        user_creation_allowed = ENV['CONJUR_ALLOW_USER_CREATION']
+        if user_creation_allowed == 'false'
+          if (resourceid.include? "@")  # not under root
+            message = "User creation is disallowed - please address administator"
+            raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
           end
         end
 

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -201,6 +201,18 @@ module Loader
 
       # Below is a sample method verifying policy data validity
       def verify
+
+	userCreationAllowed = ENV['CONJUR_ALLOW_USER_CREATION']
+
+        if userCreationAllowed == 'false'
+          Rails.logger.info("Explicit user creation disallowed")
+          if resourceid.include? "@"  # not under root
+              Rails.logger.info("user = #{self.id} is not under root")
+              message = "User '#{self.id}' creation is disallowed - please address administator"
+              raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
+          end
+        end
+
         # if self.uidnumber == 8
         #  message = "User '#{self.id}' has wrong params"
         #  raise Exceptions::InvalidPolicyObject.new(self.id, message: message)

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -202,11 +202,9 @@ module Loader
       # Below is a sample method verifying policy data validity
       def verify
         user_creation_allowed = ENV['CONJUR_ALLOW_USER_CREATION']
-        if user_creation_allowed == 'false'
-          if resourceid.include?('@')  # not under root
-            message = "User creation is disallowed - please address administator"
-            raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
-          end
+        if user_creation_allowed == 'false' && resourceid.include?('@')  # not under root
+          message = "User creation is disallowed - please address administator"
+          raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
         end
 
         # if self.uidnumber == 8

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -203,7 +203,7 @@ module Loader
       def verify
         user_creation_allowed = ENV['CONJUR_ALLOW_USER_CREATION']
         if user_creation_allowed == 'false'
-          if (resourceid.include? "@")  # not under root
+          if resourceid.include? "@"  # not under root
             message = "User creation is disallowed - please address administator"
             raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
           end

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -203,7 +203,7 @@ module Loader
       def verify
         user_creation_allowed = ENV['CONJUR_ALLOW_USER_CREATION']
         if user_creation_allowed == 'false'
-          if resourceid.include? "@"  # not under root
+          if resourceid.include?('@')  # not under root
             message = "User creation is disallowed - please address administator"
             raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
           end

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       CONJUR_DATA_KEY:
       RAILS_ENV:
       CONJUR_LOG_LEVEL: debug
-      CONJUR_ALLOW_USER_CREATION: false
+      # CONJUR_ALLOW_USER_CREATION: false
       AUDIT_DATABASE_URL:
       # TODO: Where should we be running rspec tests from, ideally?
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       CONJUR_DATA_KEY:
       RAILS_ENV:
       CONJUR_LOG_LEVEL: debug
+      CONJUR_ALLOW_USER_CREATION: false
       AUDIT_DATABASE_URL:
       # TODO: Where should we be running rspec tests from, ideally?
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards

--- a/dev/start
+++ b/dev/start
@@ -18,7 +18,7 @@ fi
 # Minimal set of services.  We add to this list based on cmd line flags.
 services=(pg conjur client)
 
-# Authenticators to enable. 
+# Authenticators to enable.
 default_authenticators="authn,authn-k8s/test"
 enabled_authenticators="$default_authenticators"
 
@@ -72,6 +72,7 @@ main() {
   # Updates CONJUR_AUTHENTICATORS and restarts required services.
   start_auth_services
   create_alice
+
   kill_conjur # so dev's can restart it manually
   enter_container
 }
@@ -83,7 +84,7 @@ the Conjur container.  To start the application server, run:
     # conjurctl server
 
 Usage: start [options]
-    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable 
+    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable
                     authentication via:
                     'curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate'
     --rotators      Starts a cucumber and test postgres container.
@@ -354,7 +355,7 @@ init_jwt() {
 
 init_oidc() {
   # ADFS and OKTA make no sense without OIDC.
-  if [[ $ENABLE_AUTHN_OIDC = false && 
+  if [[ $ENABLE_AUTHN_OIDC = false &&
     ($ENABLE_OIDC_ADFS = true || $ENABLE_OIDC_OKTA = true) ]]
   then
     echo "Error: --oidc-adfs and --oidc-okta both require --authn-oidc"
@@ -415,9 +416,21 @@ start_auth_services() {
   fi
 }
 
+create_ben() {
+  echo "Creating user ben"
+  docker-compose exec client \
+    conjur policy load root "/src/conjur-server/dev/files/policy_ofira_ben1.yml"
+  docker-compose exec client \
+    conjur policy load root "/src/conjur-server/dev/files/policy_pas_data.yml"
+  docker-compose exec client \
+    conjur policy load pas-data "/src/conjur-server/dev/files/policy_ofira_ben2.yml"
+}
+
 create_alice() {
   echo "Creating user alice"
   client_load_policy "/src/conjur-server/dev/files/policy.yml"
+
+  create_ben
 }
 
 kill_conjur() {

--- a/dev/start
+++ b/dev/start
@@ -416,21 +416,10 @@ start_auth_services() {
   fi
 }
 
-create_ben() {
-  echo "Creating user ben"
-  docker-compose exec client \
-    conjur policy load root "/src/conjur-server/dev/files/policy_ofira_ben1.yml"
-  docker-compose exec client \
-    conjur policy load root "/src/conjur-server/dev/files/policy_pas_data.yml"
-  docker-compose exec client \
-    conjur policy load pas-data "/src/conjur-server/dev/files/policy_ofira_ben2.yml"
-}
-
 create_alice() {
   echo "Creating user alice"
   client_load_policy "/src/conjur-server/dev/files/policy.yml"
 
-  create_ben
 }
 
 kill_conjur() {

--- a/spec/models/loader_fixtures/non_root_user.yml
+++ b/spec/models/loader_fixtures/non_root_user.yml
@@ -1,0 +1,4 @@
+- !policy
+  id: users-tree
+  body:
+    - !user ben_1

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -147,7 +147,7 @@ describe Loader::Orchestrate do
       ensure
         ENV['CONJUR_ALLOW_USER_CREATION'] = 'true'
       end
-      expect(status).to eq('falure')
+      expect(status).to eq('failure')
     end
   end
 end

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -135,9 +135,19 @@ describe Loader::Orchestrate do
       verify_data 'base/empty.txt'
     end
     it "applies the policy update with non-root user" do
-      ENV['CONJUR_ALLOW_USER_CREATION'] = 'false'
-      replace_policy_with 'non_root_user.yml'
-      verify_data 'updated/simple.txt'
+      status='none'
+      begin
+        ENV['CONJUR_ALLOW_USER_CREATION'] = 'false'
+        replace_policy_with 'non_root_user.yml'
+        # verify_data 'updated/simple.txt'
+      rescue Exceptions::InvalidPolicyObject =>
+        status='failure'
+      else
+        status='sucess'
+      ensure
+        ENV['CONJUR_ALLOW_USER_CREATION'] = 'true'
+      end
+      expect(status).to eq('falure')
     end
   end
 end

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -110,7 +110,7 @@ describe Loader::Orchestrate do
         replace_policy_with 'extended.yml'
         verify_data 'updated/extended.txt'
       end
-      it "removed records are kept" do 
+      it "removed records are kept" do
         modify_policy_with 'simple.yml'
         modify_policy_with 'extended.yml'
         verify_data 'updated/extended_without_deletion.txt'
@@ -125,6 +125,19 @@ describe Loader::Orchestrate do
         replace_policy_with 'extended.yml'
         verify_data 'updated/extended_simple_base.txt'
       end
+    end
+  end
+
+  context "with non-root user policy" do
+    let(:base_policy_path) { 'empty.yml' }
+    it "loads the minimal policy" do
+      expect(resource_policy).to be
+      verify_data 'base/empty.txt'
+    end
+    it "applies the policy update with non-root user" do
+      ENV['CONJUR_ALLOW_USER_CREATION'] = 'false'
+      replace_policy_with 'non_root_user.yml'
+      verify_data 'updated/simple.txt'
     end
   end
 end

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -135,15 +135,13 @@ describe Loader::Orchestrate do
       verify_data 'base/empty.txt'
     end
     it "applies the policy update with non-root user" do
-      status='none'
+      status='sucess'
       begin
         ENV['CONJUR_ALLOW_USER_CREATION'] = 'false'
         replace_policy_with 'non_root_user.yml'
         # verify_data 'updated/simple.txt'
       rescue Exceptions::InvalidPolicyObject =>
         status='failure'
-      else
-        status='sucess'
       ensure
         ENV['CONJUR_ALLOW_USER_CREATION'] = 'true'
       end

--- a/spec/models/loader_orchestrate_spec.rb
+++ b/spec/models/loader_orchestrate_spec.rb
@@ -140,7 +140,7 @@ describe Loader::Orchestrate do
         ENV['CONJUR_ALLOW_USER_CREATION'] = 'false'
         replace_policy_with 'non_root_user.yml'
         # verify_data 'updated/simple.txt'
-      rescue Exceptions::InvalidPolicyObject =>
+      rescue Exceptions::InvalidPolicyObject => exc
         status='failure'
       ensure
         ENV['CONJUR_ALLOW_USER_CREATION'] = 'true'


### PR DESCRIPTION
### Desired Outcome

The direct outcome of this PR is to limit users creation to be allowed only under root if the environment variable CONJUR_ALLOW_USER_CREATION is false.
If the CONJUR_ALLOW_USER_CREATION is undefined user creation behaviour is allowed (does not change)

### Implemented Changes

Logics has beed added in types.rb under User verification - throwing exception when user creation fails

### Connected Issue/Story


### Definition of Done

Validation fully implemented and testes

#### Changelog


#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
