### PR TITLE
Authn-k8s:websockets: support api endpoints with path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Previously, a stale puma pid file would prevent the Conjur server from starting 
   successfully. Conjur now removes a stale pid file at startup, if it exists.
   [#2498](https://github.com/cyberark/conjur/pull/2498)
+- Use entirety of configured Kubernetes endpoint URL in Kubernetes authenticator's
+  web socket client, instead of only host and port
+  [#2479](https://github.com/cyberark/conjur/pull/2479)
 
 ### Security
 - Updated rails to 6.1.4.7 to resolve CVE-2022-21831 (not vulnerable)

--- a/app/domain/authentication/authn_k8s/execute_command_in_container.rb
+++ b/app/domain/authentication/authn_k8s/execute_command_in_container.rb
@@ -44,7 +44,7 @@ module Authentication
 
       def ws_client
         @ws_client ||= @websocket_client.connect(
-          server_url,
+          ws_exec_url,
           {
             headers: headers,
             verify_mode: OpenSSL::SSL::VERIFY_PEER,
@@ -54,7 +54,7 @@ module Authentication
       end
 
       def ws_client_event_handler
-        @close_event_queue       = Queue.new
+        @close_event_queue = Queue.new
         @ws_client_event_handler ||= @ws_client_event_handler_class.new(
           close_event_queue: @close_event_queue,
           ws_client: ws_client,
@@ -72,14 +72,14 @@ module Authentication
         # the curly brackets it will look for such a member in the websocket_client
         # class
         ws_client_event_handler = @ws_client_event_handler
-        main_thread_tags        = @logger.formatter.current_tags
-        logger                  = @logger
+        main_thread_tags = @logger.formatter.current_tags
+        logger = @logger
 
         ws_client.on(:open) do
           # Add log tags (origin, thread id, etc.) to sub-thread as they are not
           # passed automatically. We append the sub-thread id to the main one so
           # we can easily know the flow from the logs and connect between the threads
-          tid             = syscall(186)
+          tid = syscall(186)
           sub_thread_tags = main_thread_tags.map do |x|
             x.start_with?("tid=") ? "#{x}=>#{tid}" : x
           end
@@ -112,19 +112,25 @@ module Authentication
         )
       end
 
-      def server_url
-        api_uri  = kube_client.api_endpoint
-        base_url = "wss://#{api_uri.host}:#{api_uri.port}"
-        path     = "/api/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
+      def ws_exec_url
+        api_uri = kube_client.api_endpoint.clone # contains /api path prefix
+        api_uri.scheme = "wss"
 
-        base_query_string_parts = %W[container=#{CGI.escape(@container)} stderr=true stdout=true]
-        stdin_part              = @stdin ? ['stdin=true'] : []
-        cmds_part               = @cmds.map { |cmd| "command=#{CGI.escape(cmd)}" }
-        query_string            = (
-        base_query_string_parts + stdin_part + cmds_part
-      ).join("&")
+        # append pod exec path
+        api_uri.path += "/v1/namespaces/#{@pod_namespace}/pods/#{@pod_name}/exec"
 
-        "#{base_url}#{path}?#{query_string}"
+        # populate query params
+        api_uri.query = ws_exec_query_params(String(api_uri.query))
+
+        api_uri.to_s
+      end
+
+      def ws_exec_query_params query
+        base_query_string_parts = [["container", @container], ["stderr", "true"], ["stdout", "true"]]
+        stdin_part = @stdin ? [['stdin', 'true']] : []
+        cmds_part = @cmds.map { |cmd| ["command", cmd] }
+        query_ar = URI.decode_www_form(query) + base_query_string_parts + stdin_part + cmds_part
+        URI.encode_www_form(query_ar)
       end
 
       def headers

--- a/app/domain/authentication/authn_k8s/web_socket_client.rb
+++ b/app/domain/authentication/authn_k8s/web_socket_client.rb
@@ -37,6 +37,7 @@ module Authentication
           ctx.cert_store = cert_store
 
           @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)
+          # support SNI, see https://www.cloudflare.com/en-gb/learning/ssl/what-is-sni/
           if ssl_version != 'SSLv23'
             @socket.hostname = options[:hostname] || uri.host
           end


### PR DESCRIPTION
### Desired Outcome

The Kubernetes API endpoint can include a path, as is the case with the Rancher API, the websocket implementation should take the URL as is instead of taking only host and port.
The commit originally included support for server name indication (SNI) on the the websocket client, which enables the client to be specific about the host it is trying to reach in the first step of the TLS handshake, preventing common name mismatch errors.
However, that commit was removed in favour of the more comprehensive work to support SNI at https://github.com/cyberark/conjur/pull/2432.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
