### PR TITLE
Adding configurable expiration time for Conjur token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.17.7] - 2022-05-19
 
+### Changed
+- Adding configuration for token TTL
+
 ### Security
 - Update nokogiri to 1.13.6 to resolve un-numbered libxml CVEs (both in main
   Gemfile.lock and in docs/Gemfile.lock)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.17.7] - 2022-05-19
 
 ### Changed
-- Adding configuration for token TTL
+- Added configuration for token TTL
+  [cyberark/conjur#2510](https://github.com/cyberark/conjur/pull/2510)
 
 ### Security
 - Update nokogiri to 1.13.6 to resolve un-numbered libxml CVEs (both in main

--- a/app/domain/token_factory.rb
+++ b/app/domain/token_factory.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date'
+
 class TokenFactory < Dry::Struct
 
   NoSigningKey = ::Util::ErrorClass.new(
@@ -10,9 +12,19 @@ class TokenFactory < Dry::Struct
   def signing_key(account)
     slosilo["authn:#{account}".to_sym] || raise(NoSigningKey, account)
   end
-    
+
+  def signed_host_key(account:, username:)
+    exp_t = Time.now + Rails.application.config.conjur_config.host_authorization_token_ttl.to_i
+    signing_key(account).issue_jwt(sub: username, exp: exp_t)
+  end
+
   def signed_token(account:, username:)
-    signing_key(account).issue_jwt(sub: username)
+    if username.starts_with?('host/')
+      signed_host_key(account: account, username: username)
+    else
+      exp_t = Time.now + Rails.application.config.conjur_config.user_authorization_token_ttl.to_i
+      signing_key(account).issue_jwt(sub: username, exp: exp_t)
+    end
   end
 
 end

--- a/app/domain/token_factory.rb
+++ b/app/domain/token_factory.rb
@@ -28,7 +28,7 @@ class TokenFactory < Dry::Struct
   end
 
   def offset(ttl:)
-    return ttl if ttl < MAXIMUM_AUTHENTICATION_TOKEN_EXPIRATION
+    return ttl.to_i if ttl.to_i < MAXIMUM_AUTHENTICATION_TOKEN_EXPIRATION
 
     MAXIMUM_AUTHENTICATION_TOKEN_EXPIRATION
   end

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -23,6 +23,8 @@ module Conjur
     attr_config(
       # Read TRUSTED_PROXIES before default to maintain backwards compatibility
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
+      user_authorization_token_ttl: 480, # default is 8 minutes
+      hosts_authorization_token_ttl: 480, # default is 8 minutes
       authenticators: []
     )
 

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -23,8 +23,8 @@ module Conjur
     attr_config(
       # Read TRUSTED_PROXIES before default to maintain backwards compatibility
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
-      user_authorization_token_ttl: 480, # default is 8 minutes
-      hosts_authorization_token_ttl: 480, # default is 8 minutes
+      user_authorization_token_ttl: 480, # The default TTL of User is 8 minutes
+      host_authorization_token_ttl: 480, # The default TTL of Host is 8 minutes
       authenticators: []
     )
 

--- a/spec/app/domain/token_factory_spec.rb
+++ b/spec/app/domain/token_factory_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe TokenFactory  do
+
+  before(:all) { Slosilo["authn:cucumber"] ||= Slosilo::Key.new }
+
+  it "should generate a token for user with 8 minutes expiration" do
+      Rails.application.config.conjur_config.user_authorization_token_ttl = 8.minutes
+      Rails.application.config.conjur_config.host_authorization_token_ttl = 0
+      token_expiration = Time.now + 8.minutes
+      token_factory = TokenFactory.new
+      token = token_factory.signed_token(account: "cucumber", username: "myuser")
+      expect(token.claims[:exp]).to be >= token_expiration.to_i
+      expect(token.claims[:exp]).to be < (Time.now + 8.minutes + 1.seconds).to_i
+    end
+
+    it "should generate a token for host with 8 minutes expiration" do
+      Rails.application.config.conjur_config.user_authorization_token_ttl = 0
+      Rails.application.config.conjur_config.host_authorization_token_ttl = 8.minutes
+      token_expiration = Time.now + 8.minutes
+      token_factory = TokenFactory.new
+      token = token_factory.signed_token(account: "cucumber", username: "host/demo-host")
+      expect(token.claims[:exp]).to be >= token_expiration.to_i
+      expect(token.claims[:exp]).to be < (Time.now + 8.minutes + 1.seconds).to_i
+    end
+
+    it "should generate maximum token expiration for user" do
+      Rails.application.config.conjur_config.user_authorization_token_ttl = 6.hours
+      Rails.application.config.conjur_config.host_authorization_token_ttl = 0
+      token_expiration = Time.now + 5.hours
+      token_factory = TokenFactory.new
+      token = token_factory.signed_token(account: "cucumber", username: "myuser")
+      expect(token.claims[:exp]).to be >= token_expiration.to_i
+      expect(token.claims[:exp]).to be < (Time.now + 5.hours + 1.second).to_i
+    end
+
+    it "should generate maximum token expiration for host" do
+      Rails.application.config.conjur_config.user_authorization_token_ttl = 0
+      Rails.application.config.conjur_config.host_authorization_token_ttl = 6.hours
+      token_expiration = Time.now + 5.hours
+      token_factory = TokenFactory.new
+      token = token_factory.signed_token(account: "cucumber", username: "host/demo-host")
+      expect(token.claims[:exp]).to be >= token_expiration.to_i
+      expect(token.claims[:exp]).to be < (Time.now + 5.hours + 1.second).to_i
+    end
+
+end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
### Desired Outcome

The desired outcome is that in there will be an option to configure conjur token expiration time for users
It will allow integrations of conjur with CLIs using MFA

### Implemented Changes

Current PR adds config / environment variable for TTL and reads it and sends to slosilo as a parameter upon token creation for users only

### Connected Issue/Story

CyberArk internal issue link: [ONYX-19655](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19655)

#### Behavior

Conjur OSS default product behavior does not change

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 

