### PR TITLE
Bumped nokogiri to 1.13.3 and commonmarker to 0.23.4 in docs Gemfile.lock

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.8)
     dnsruby (1.61.5)

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.12.5)
+    nokogiri (1.13.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     octokit (4.20.0)


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Bumps nokogiri to 1.13.3 in the docs Gemfile.lock
Bumps commonmarker to 0.23.4 in the docs Gemfile.lock