### PR TITLE
Fix: authn-k8s websocket client SNI

### DIFF
--- a/app/domain/authentication/authn_k8s/execute_command_in_container.rb
+++ b/app/domain/authentication/authn_k8s/execute_command_in_container.rb
@@ -47,7 +47,6 @@ module Authentication
           ws_exec_url,
           {
             headers: headers,
-            verify_mode: OpenSSL::SSL::VERIFY_PEER,
             cert_store: @k8s_object_lookup.cert_store
           }
         )

--- a/app/domain/authentication/authn_k8s/web_socket_client.rb
+++ b/app/domain/authentication/authn_k8s/web_socket_client.rb
@@ -1,7 +1,9 @@
 ## This code is based on github.com/shokai/websocket-client-simple (MIT License)
 
-require "event_emitter"
+require 'event_emitter'
 require 'websocket'
+require 'resolv'
+require 'openssl'
 
 # Utility class for processing WebSocket messages.
 module Authentication
@@ -17,6 +19,7 @@ module Authentication
         client
       end
 
+      # connect provides options :hostname, :headers, :ssl_version, :cert_store, :verify_mode
       def connect(url, options = {})
         return if @socket
 
@@ -28,13 +31,17 @@ module Authentication
           ctx = OpenSSL::SSL::SSLContext.new
           ssl_version = options[:ssl_version]
           ctx.ssl_version = ssl_version if ssl_version
-          ctx.verify_mode = options[:verify_mode] || OpenSSL::SSL::VERIFY_NONE # use VERIFY_PEER for verification
+          ctx.verify_mode = options[:verify_mode] || OpenSSL::SSL::VERIFY_PEER # use VERIFY_PEER for verification
           cert_store = options[:cert_store]
+
           unless cert_store
             cert_store = OpenSSL::X509::Store.new
             cert_store.set_default_paths
           end
           ctx.cert_store = cert_store
+
+          use_sni = false
+          ssl_host_address =  options[:hostname] || uri.host # use the param :hostname or default to the host of the url argument
 
           case uri.host
           when Resolv::IPv4::Regex, Resolv::IPv6::Regex
@@ -44,18 +51,18 @@ module Authentication
             # Avoid openssl warning
             ctx.verify_hostname = false
           else
-            ssl_host_address =  options[:hostname] || uri.host 
+            use_sni = true
           end
 
           @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)
 
           # support SNI, see https://www.cloudflare.com/en-gb/learning/ssl/what-is-sni/
-          @socket.hostname = ssl_host_address if ssl_host_address
+          @socket.hostname = ssl_host_address if use_sni
 
           @socket.connect
 
-          # TODO: it's good that we are now doing this but should we explicitly call this out?
-          @socket.post_connection_check(@socket.hostname) if @socket.hostname
+          # mandatory hostname verification applicable to both hostnames and IP addresses
+          @socket.post_connection_check(ssl_host_address)
         end
         @handshake = ::WebSocket::Handshake::Client.new(url: url, headers: options[:headers])
         @handshaked = false
@@ -81,6 +88,8 @@ module Authentication
                 end
               else
                 @handshake << recv_data
+
+                # completed handshake
                 if @handshake.finished?
                   @handshaked = true
                   emit(:open)

--- a/spec/app/domain/authentication/authn_k8s/web_socket_client_spec_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/web_socket_client_spec_spec.rb
@@ -1,498 +1,202 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+# Run this file by calling:
+# bundle exec rspec spec/app/domain/authentication/authn_k8s/web_socket_client_spec_spec.rb --format documentation
 
-class TestServer
-  attr_reader(:handshake)
-  attr_reader(:ca)
-  attr_reader(:message)
+require 'openssl'
 
-  def initialize(port)
-    @port = port
-    @server = TCPServer.open("localhost", port)
-  end
+require 'domain/authentication/authn_k8s/web_socket_client'
 
-  def add_old_ssl(host)
-    build_ca
-    @server = OpenSSL::SSL::SSLServer.new(@server, build_ssl_context(:SSLv23, build_cert(host)))
-  end
+require_relative './web_socket_test_server.rb'
+require_relative '../../../../../config/initializers/openssl.rb'
 
-  def add_tls_without_sni(host)
-    build_ca
-    @server = OpenSSL::SSL::SSLServer.new(@server, build_ssl_context(:TLSv1, build_cert(host)))
-  end
-
-  def add_tls_with_sni
-    build_ca
-    testing_com_cert = build_cert("testing.com")
-    another_site_com_cert = build_cert("another-site.com")
-    ssl_context = OpenSSL::SSL::SSLContext.new
-
-    # Default context when there is no SNI (for example connection via IP or no servername is sent)
-    ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    ssl_context.ssl_version = :TLSv1
-    ssl_context.key = OpenSSL::PKey::RSA.new(@ca.key)
-    ssl_context.cert = OpenSSL::X509::Certificate.new(another_site_com_cert)
-
-    # Create context depending on SNI
-    ssl_context.servername_cb = proc { |ssl_socket, hostname|
-      new_context = OpenSSL::SSL::SSLContext.new
-      new_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      new_context.ssl_version = :TLSv1
-      new_context.key = OpenSSL::PKey::RSA.new(@ca.key)
-
-      case hostname
-      when "testing.com"
-        new_context.cert = OpenSSL::X509::Certificate.new(testing_com_cert)
-      else
-        new_context.cert = OpenSSL::X509::Certificate.new(another_site_com_cert)
-      end
-
-      new_context
-    }
-    @server = OpenSSL::SSL::SSLServer.new(@server, ssl_context)
-  end
-
-  def add_websocket
-    @handshake = WebSocket::Handshake::Server.new(host: "localhost", port: @port)
-  end
-
-  def add_bad_websocket
-    @handshake = WebSocket::Handshake::Server.new(host: "localhost", port: @port)
-    @bad_handshake = true
-  end
-
-  def run
-    @thread = Thread.new do
-      client = @server.accept
-      string = ""
-      while part = client.gets
-        string = string + part
-        break if string =~ /Sec-WebSocket-Key/
-      end
-      if @handshake
-        @handshake << string + "\r\n"
-        if @bad_handshake
-          client.puts("bad handshake")
-        else
-          client.puts(@handshake.to_s)
-        end
-      end
+describe 'Authentication::AuthnK8s::WebSocketClient' do
+  context 'server not running' do
+    it 'fails to connect' do
+      expect {
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("https://127.0.0.1:91239") # Strange issue where if "localhost" is used the error becomes EADDRNOTAVAIL
+      }.to raise_error(Errno::ECONNREFUSED)
     end
-  end
-
-  def close
-    @thread.kill if @thread
-    @server.close
-  end
-
-  private
-
-  def build_cert(common_name)
-    @ca.signed_cert(
-      Util::OpenSsl::X509::SmartCsr.new(
-        Util::OpenSsl::X509::QuickCsr.new(common_name: common_name, rsa_key: @ca.key).request
-      )
-    )
-  end
-
-  def build_ca
-    @ca ||= Util::OpenSsl::CA.from_subject("/CN=testing.com/OU=Conjur Kubernetes CA/O=user")
-  end
-
-  def build_ssl_context(ssl_version, cert)
-    ssl_context = OpenSSL::SSL::SSLContext.new
-    ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    ssl_context.ssl_version = ssl_version
-    ssl_context.key = OpenSSL::PKey::RSA.new(@ca.key)
-    ssl_context.cert = OpenSSL::X509::Certificate.new(cert)
-    ssl_context
   end
 end
 
 describe 'Authentication::AuthnK8s::WebSocketClient' do
-  context 'no server running' do
-    before(:example) do
+  context 'server running' do  
+    context 'without TLS' do
+      before(:example) do
+        @test_server = WebSocketTestServer.new
+        @client = nil
+      end
+  
+      after(:example) do
+        @test_server.close
+        @client && @client.close
+        @test_server = nil
+        @client = nil
+      end
+  
+      it 'has good handshake with no options' do
+        @test_server.add_websocket
+        @test_server.run
+        @client  = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost:#{@test_server.port}")
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
+  
+      it 'has good handshake with options' do
+        @test_server.add_websocket
+        @test_server.run
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost:#{@test_server.port}",
+                                                                   cert_store: OpenSSL::X509::Store.new)
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
+  
+      it 'is not open for communication without a good handshake' do
+        @test_server.add_bad_websocket
+        @test_server.run
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost:#{@test_server.port}")
+        sleep(1)
+        expect(@client.open?).to be_falsey
+      end
     end
 
-    after(:example) do
+    context 'with TLS and no SNI' do
+      before(:example) do
+        @test_server = WebSocketTestServer.new
+        @test_server.add_tls_without_sni("good.com")
+        @client = nil
+      end
+
+      after(:example) do
+        @client.close if @client
+        @test_server.close
+        @test_server = nil
+        @client = nil
+      end
+
+      it 'fails cert verification without options' do
+        @test_server.add_websocket
+        @test_server.run
+        expect { 
+          @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}")
+        }.to raise_error(OpenSSL::SSL::SSLError, nil) {  |error|
+           expect(error.message).to eq("SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)") 
+        }
+      end
+  
+      it 'passes all TLS verifications with good options' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}",
+                                                                   cert_store: cert_store,
+                                                                   hostname: "good.com")
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
+
+      it 'fails hostname verification with bad hostname' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+
+        expect { @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}",
+                                                                   cert_store: cert_store)
+        }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+          |error| expect(error.message).to eq("hostname \"localhost\" does not match the server certificate")
+        }
+      end
+
+      it 'fails hostname verification for bad ip' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://0.0.0.0:#{@test_server.port}",
+                                                                   cert_store: cert_store)
+        }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+          |error| expect(error.message).to eq("hostname \"0.0.0.0\" does not match the server certificate")
+        }
+      end
+
+      it 'passes hostname verification for good ip' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1:#{@test_server.port}",
+          cert_store: cert_store)
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
     end
 
-    it 'fails to connect' do
-      expect {
-        Authentication::AuthnK8s::WebSocketClient.connect("https://127.0.0.1")
-      }.to raise_error(Errno::ECONNREFUSED)
-    end
-  end
+    context 'with TLS and SNI' do
+      before(:example) do
+        @test_server = WebSocketTestServer.new
+        @test_server.add_tls_with_sni
+      end
 
-  context 'server running - no web socket' do
-    before(:example) do
-      @test_server = TestServer.new(80)
-    end
+      after(:example) do
+        @test_server.close
+        @test_server = nil
+      end
 
-    after(:example) do
-      @test_server.close
-      @test_server = nil
-    end
+      it 'fails cert verification without options' do
+        @test_server.add_websocket
+        @test_server.run
+        expect { 
+          @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}")
+        }.to raise_error(OpenSSL::SSL::SSLError, nil) {  |error|
+           expect(error.message).to eq("SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)") 
+        }
+      end
 
-    it 'fails to connect - no web socket server' do
-      client = Authentication::AuthnK8s::WebSocketClient.connect("http://localhost")
-      expect(client.open?).to be_falsey
-    end
-  end
+      it 'passes all TLS verifications with options for default SNI cert with good hostname' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}",
+                                                                   cert_store: cert_store,
+                                                                   hostname: "default.com")
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
 
-  context 'server running - no security' do
-    before(:example) do
-      @test_server = TestServer.new(80)
-    end
+      it 'fails hostname verification with options for default SNI cert with bad hostname' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        expect { @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}",
+                                                                            cert_store: cert_store)
+        }.to raise_error(OpenSSL::SSL::SSLError, nil) {
+          |error| expect(error.message).to eq("hostname \"localhost\" does not match the server certificate")
+        }
+      end
 
-    after(:example) do
-      @test_server.close
-      @test_server = nil
-    end
-
-    it 'connects with no options' do
-      @test_server.add_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'connects with options' do # because the options are ignored!
-      @test_server.add_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost",
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "testing.com")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'does not connect with a bad handshake' do # bad handshake means failure always
-      @test_server.add_bad_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("ws://localhost")
-      sleep(1)
-      expect(client.open?).to be_falsey
-      client.close
-    end
-  end
-
-  context 'server running - with old security' do
-    before(:example) do
-      @test_server = TestServer.new(443)
-      @test_server.add_old_ssl("localhost")
-    end
-
-    after(:example) do
-      @test_server.close
-      @test_server = nil
-    end
-
-    it 'does not connect with a bad handshake' do # bad handshake means failure always
-      @test_server.add_bad_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_falsey
-      client.close
-    end
-
-    it 'connects properly without options' do # uses defaults which include no TLS verification
-      @test_server.add_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'connects properly with options' do # verification and cert_store. without the cert_store there is failure
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                #  ssl_version: :SSLv23,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER
-                                                                )
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'fails when cert is not in cert_store' do # 
-      @test_server.add_websocket
-      @test_server.run
-
-      expect { 
-        Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-          verify_mode: OpenSSL::SSL::VERIFY_PEER
-        )
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)")
-      }
-    end
-
-    it 'connects properly on hostname match' do # verifies hostname
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'fails on hostname mismatch' do # verifies hostname
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      expect { 
-        Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-          cert_store: cert_store,
-          verify_mode: OpenSSL::SSL::VERIFY_PEER,
-          hostname: "localxhost")
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("hostname \"localxhost\" does not match the server certificate")
-      }
-    end
-  end
-
-  context 'server running - with tls security - no SNI' do
-    before(:example) do
-      @test_server = TestServer.new(443)
-      @test_server.add_tls_without_sni("localhost")
-    end
-
-    after(:example) do
-      @test_server.close
-      @test_server = nil
-    end
-
-    it 'does not connect with a bad handshake' do
-      @test_server.add_bad_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_falsey
-      client.close
-    end
-
-    it 'connects properly without options' do
-      @test_server.add_websocket
-      @test_server.run
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'connects properly with options' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                #  ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER)
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'connects properly with hostname' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                #  ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "localhost")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'does not connect properly with bad hostname' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                #  ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "bad.com")
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("hostname \"bad.com\" does not match the server certificate")
-      }
+      it 'passes all TLS verifications with options for non-default SNI cert' do
+        @test_server.add_websocket
+        @test_server.run
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.add_cert(@test_server.ca.cert)
+        @client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost:#{@test_server.port}",
+                                                                   cert_store: cert_store,
+                                                                   hostname: "testing.com")
+        sleep(1)
+        expect(@test_server.good_handshake?).to be_truthy
+        expect(@client.open?).to be_truthy
+      end
     end
   end
 
-  context 'server running - with tls security - with SNI' do
-    before(:example) do
-      @test_server = TestServer.new(443)
-      @test_server.add_tls_with_sni
-    end
-
-    after(:example) do
-      @test_server.close
-      @test_server = nil
-    end
-
-    it 'does not connect with a bad handshake' do
-      @test_server.add_bad_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                 ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "testing.com")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_falsey
-      client.close
-    end
-
-    it 'does not connect properly without options, no cert available for "localhost"' do
-      @test_server.add_websocket
-      @test_server.run
-      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost")
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("hostname \"localhost\" does not match the server certificate")
-      }
-    end
-
-    it 'does not connect properly missing the hostname and no cert available for "localhost"' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      expect { client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                          # ssl_version: :TLSv1,
-                                                                          cert_store: cert_store,
-                                                                          verify_mode: OpenSSL::SSL::VERIFY_PEER)
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("hostname \"localhost\" does not match the server certificate")
-      }
-    end
-
-    it 'connects properly with hostname' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                 ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "testing.com")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'connects properly with a different hostname' do
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                 ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "another-site.com")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-
-    it 'fails verification on hostname mismatch' do # this is when a hostname has no associated certificate so the default is used. the default doesn't have this hostname
-      # a case could be done for when the hostname results in the default cert but passes verification too. this proves that SNI fallsback to the default
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      expect { Authentication::AuthnK8s::WebSocketClient.connect("wss://localhost",
-                                                                 ssl_version: :TLSv1,
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "bad.com")
-      }.to raise_error(OpenSSL::SSL::SSLError, nil) {
-        |error| expect(error.message).to eq("hostname \"bad.com\" does not match the server certificate")
-      }
-    end
-
-    it 'not hostname verification for IP' do # this is when a hostname has no associated certificate so the default is used. the default doesn't have this hostname
-      # a case could be done for when the hostname results in the default cert but passes verification too. this proves that SNI fallsback to the default
-      @test_server.add_websocket
-      @test_server.run
-      cert_store = OpenSSL::X509::Store.new
-      cert_store.add_cert(@test_server.ca.cert)
-      client = Authentication::AuthnK8s::WebSocketClient.connect("wss://127.0.0.1",
-                                                                 cert_store: cert_store,
-                                                                 verify_mode: OpenSSL::SSL::VERIFY_PEER,
-                                                                 hostname: "bad.com")
-      sleep(1)
-      expect(@test_server.handshake).to be_truthy
-      expect(@test_server.handshake.valid?).to be_truthy
-      expect(@test_server.handshake.finished?).to be_truthy
-      expect(client.open?).to be_truthy
-      client.close
-    end
-  end
 end
-
-
-#  TODO: it feels like we're not testing the right thing here. THink about what the uni tests ought to really test!
-
-#  TODO: add test cases for equivalence classes for params. hostname verificaton fails or succeeds, hostname is ip, cert store is set etc.

--- a/spec/app/domain/authentication/authn_k8s/web_socket_test_server.rb
+++ b/spec/app/domain/authentication/authn_k8s/web_socket_test_server.rb
@@ -1,0 +1,141 @@
+require 'socket'
+require 'openssl'
+require 'websocket'
+
+require "domain/util/open_ssl/ca"
+require "domain/util/open_ssl/x509/quick_csr"
+require "domain/util/open_ssl/x509/smart_csr"
+
+class WebSocketTestServer
+    attr_reader(:handshake)
+    attr_reader(:ca)
+    attr_reader(:port)
+    attr_reader(:message)
+    attr_accessor(:should_log)
+
+    def initialize(port = 0)
+      @should_log = false
+      @port = port
+      @server = TCPServer.open("0.0.0.0", @port)
+  
+      if @port == 0
+        @port = @server.addr[1]
+      end
+
+      @server
+    end
+
+    def add_tls_without_sni(host)
+      build_ca
+      @server = OpenSSL::SSL::SSLServer.new(@server, build_ssl_context(:TLSv1_2_server, build_cert(host)))
+    end
+
+    def add_tls_with_sni
+      build_ca
+      default_site_com_cert = build_cert("default.com")
+      testing_com_cert = build_cert("testing.com")
+
+      ssl_context = OpenSSL::SSL::SSLContext.new(:TLSv1_2_server)
+  
+      # default context when there is no SNI (for example connection via IP or no servername is sent)
+      ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ssl_context.key = OpenSSL::PKey::RSA.new(@ca.key)
+      ssl_context.cert = OpenSSL::X509::Certificate.new(default_site_com_cert)
+  
+      # create context depending on SNI
+      ssl_context.servername_cb = proc { |ssl_socket, hostname|
+        new_context = OpenSSL::SSL::SSLContext.new(:TLSv1_2_server)
+
+        new_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        new_context.key = OpenSSL::PKey::RSA.new(@ca.key)
+        case hostname
+        when "testing.com"
+          new_context.cert = OpenSSL::X509::Certificate.new(testing_com_cert)
+        else
+          new_context.cert = OpenSSL::X509::Certificate.new(default_site_com_cert)
+        end
+  
+        new_context
+      }
+      @server = OpenSSL::SSL::SSLServer.new(@server, ssl_context)
+    end
+
+    def add_websocket
+      @handshake = WebSocket::Handshake::Server.new(host: "localhost", port: @port)
+    end
+
+    def good_handshake?
+      @handshake && @handshake.finished? && @handshake.valid?
+    end
+
+    def add_bad_websocket
+      @handshake = WebSocket::Handshake::Server.new(host: "localhost", port: @port)
+      @bad_handshake = true
+    end
+
+    def run
+      return if @thread
+      log "test server: running server at #{@port}"
+
+      @thread = Thread.new do
+        log "test server: waiting for connection"
+        begin
+            client = @server.accept
+        rescue => e 
+          log "test server: failed to accept connection", e
+            @thread.kill
+        end
+
+        log "test server: accepted connection"
+        string = ""
+        while part = client.gets
+          string = string + part
+          break if string =~ /Sec-WebSocket-Key/
+        end
+        if @handshake
+          @handshake << string + "\r\n"
+          if @bad_handshake
+            client.puts("bad handshake")
+          else
+            client.puts(@handshake.to_s)
+          end
+        end
+      end
+      @thread.abort_on_exception = true
+    end
+
+    def close
+      @thread.kill if @thread
+      @server.close
+    end
+
+    private
+
+    def log(*args, &block)
+      return unless @should_log
+
+      puts(*args, &block)
+    end
+
+    def build_cert(common_name)
+      @ca.signed_cert(
+        Util::OpenSsl::X509::SmartCsr.new(
+          Util::OpenSsl::X509::QuickCsr.new(common_name: common_name, rsa_key: @ca.key).request
+        ),
+        subject_altnames: ["DNS:#{common_name}", "IP:127.0.0.1"] # because verification is either CN or SAN, not both :()
+      )
+    end
+  
+    def build_ca
+      @ca ||= Util::OpenSsl::CA.from_subject("/CN=ca-testing.com/OU=Conjur Kubernetes CA/O=user")
+    end
+
+    def build_ssl_context(ssl_version, cert)
+      ssl_context = OpenSSL::SSL::SSLContext.new()
+      ssl_context.ssl_version = ssl_version if ssl_version
+      ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ssl_context.key = OpenSSL::PKey::RSA.new(@ca.key)
+      ssl_context.cert = OpenSSL::X509::Certificate.new(cert)
+      ssl_context
+    end
+end


### PR DESCRIPTION
### Context

Link to initial [SNI PR](https://github.com/cyberark/conjur/pull/2432)

I'm working with a Rancher deployment based off https://github.com/rancher/quickstart. My understanding is that the deployment uses Traefik (with SNI) to expose a public endpoint. In this case to connect to the Rancher API (for the purposes of consuming the Kubernetes API of an underlying cluster) requires a client that supports SNI. The Kubernetes authenticator in Conjur fails to connect to this Rancher API. 

I did some digging and found out what was causing the issue. It appears that SNI is only applied when the  `ssl_version` parameter (of `Authentication::AuthnK8s::WebSocketClient`) is set to something other than the default  `:SSLv23`. The unit tests for `Authentication::AuthnK8s::WebSocketClient` validate this behavior by setting the value of the `ssl_version` parameter to `:TLSv1` . However, in actual usage of `Authentication::AuthnK8s::WebSocketClient` within the Kubernetes authenticator controller the `ssl_version` parameter is never set, is therefore always set to the default and therefore Conjur at present has no SNI support.

This begs the question "what about the E2E tests?". The E2E tests are not actually validating anything at all, since they are passing even though the implementation is borked.

I couldn't make sense of why we have the `ssl_version` parameter at all if it never explicitly set in actual usage, or why it defaults to `:SSLv23`. I did some digging and landed on the understanding that we sort of just copied that from [https://github.com/shokai/websocket-client-simple/blob/master/lib/websocket-client-simple/client.rb#L22-L31](https://github.com/shokai/websocket-client-simple/blob/master/lib/websocket-client-simple/client.rb#L22-L31 "https://github.com/shokai/websocket-client-simple/blob/master/lib/websocket-client-simple/client.rb#l22-l31"). 

To better make sense of things, I looked to Ruby's standard library's  `Net::HTTP`  for a canonical implementation of establishing a TLS connection that supports SNI. See the code at https://github.com/ruby/net-http/blob/master/lib/net/http.rb#L982-L1084. This guided the changes I have made.

My intended changes are, though I might not get to all of them:
 
 1. I removed the default `ssl_version`  of `:SSLv23`. My understanding is that leaving the  `ssl_version` parameter without a default results in the socket assuming the `OpenSSL` defaults specified at https://github.com/cyberark/conjur/blob/master/config/initializers/openssl.rb. We retain the `ssl_version` parameter to facilitate testing.
 2. I do not apply SNI to IP addresses since you can not use IP addresses with SNI as per the spec
 3. I updated unit tests to better reflected the usage, AND removed parameters where they are not needed. Unused parameters means creating unit tests for what might never be
 4. Remove any loading of certs from `ENV['SSL_CERT_DIRECTORY']`?
    + I'm still not sure why this was added at all. I can understand if the idea here is that this directory is the shared location for the roots any Conjur-wide (e.g. in authenticators or anywhere elsewhere certs are needed) custom certs. This would be a static setup that requires restarting the Conjur server to be restarted to acknowledge updates. This would be separate from the `ca_cert` Conjur secret field which is configuration that is local to the Kubernetes authenticator. Though in the case of the Kubernetes authenticator the ca_cert field is a required field.
    + This envvar is undocumented as far as I can tell and I don't see usage of it anywhere else in the org
 6. Fix the integration tests? For me the integration tests are a bit of a mystery right now. 
     + I think the cucumber test for SNI failure ([https://github.com/cyberark/conjur/blob/master/cucumber/authenticators_k8s/features/sni.feature#L5-L7](https://github.com/cyberark/conjur/blob/master/cucumber/authenticators_k8s/features/sni.feature#L5-L7)) is testing a case that will always return a 401. It should test a case that would otherwise return a 200. 
     + For development there are env vars  $SNI_FQDN=sni-test.dev.conjur.net and $SNI_PORT=6443 , which are sort of magical and need explanation!. These are not defined in CI

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
