### PR TITLE
Configurable metrics collectrion

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,12 +24,6 @@ require 'conjur_audit'
 # Must require because lib folder hasn't been loaded yet
 require './lib/conjur/conjur_config'
 
-# Require prometheus dependencies and metrics module
-# so that a clean data store can be initialized
-# This should be done dynamically depending on whether
-# metrics are enabled in the future
-require './lib/monitoring/prometheus'
-
 module Conjur
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -81,7 +75,5 @@ module Conjur
     # guaranteed to be available for other initializers to use.
     config.conjur_config = Conjur::ConjurConfig.new
 
-    # Initialize metrics and clean existing data
-    Monitoring::Prometheus.setup
   end
 end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,7 @@
+  # If using Prometheus telemetry, we want to ensure that the middleware
+  # which collects and exports metrics is loaded at the start of the 
+  # middleware chain to prevent any modifications to the incoming requests
+  if Rails.application.config.conjur_config.telemetry_enabled 
+    Monitoring::Prometheus.setup
+    Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
+  end

--- a/config/initializers/rack_middleware.rb
+++ b/config/initializers/rack_middleware.rb
@@ -27,11 +27,6 @@ Rails.application.configure do
   # to the start of the Rack middleware chain.
   config.middleware.insert_before(0, ::Rack::DefaultContentType)
 
-  # If using Prometheus telemetry, we want to ensure that the middleware
-  # which collects and exports metrics is loaded at the start of the 
-  # middleware chain to prevent any modifications to the incoming requests
-  config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
-
   # Deleting the RemoteIp middleware means that `request.remote_ip` will
   # always be the same as `request.ip`. This ensure that the Conjur request log
   # (using `remote_ip`) and the audit log (using `ip`) will have the same value

--- a/dev/start
+++ b/dev/start
@@ -36,6 +36,7 @@ ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
 ENABLE_AUDIT=false
+ENABLE_METRICS=false
 
 main() {
   unset COMPOSE_PROJECT_NAME
@@ -68,6 +69,7 @@ main() {
   init_jwt
   init_oidc
   init_rotators
+  init_metrics
 
   # Updates CONJUR_AUTHENTICATORS and restarts required services.
   start_auth_services
@@ -106,6 +108,8 @@ Usage: start [options]
 
     --audit         Starts with the audit engine and database enabled
 
+    --metrics       Starts with the prometheus telemetry features enabled
+
     -h, --help      Shows this help message.
 EOF
   exit
@@ -124,6 +128,7 @@ parse_options() {
       --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
       --rotators ) ENABLE_ROTATORS=true ; shift ;;
       --audit ) ENABLE_AUDIT=true ; shift ;;
+      --metrics ) ENABLE_METRICS=true ; shift ;;
       -h | --help ) print_help ; shift ;;
        * )
          if [ -z "$1" ]; then
@@ -399,6 +404,13 @@ init_iam() {
   docker-compose exec conjur \
     conjurctl policy load cucumber \
     "/src/conjur-server/dev/files/authn-iam/policy.yml"
+}
+
+init_metrics() {
+  if [[ $ENABLE_METRICS != true ]]; then
+    return
+  fi
+  env_args+=(-e "CONJUR_TELEMETRY_ENABLED=true")
 }
 
 start_auth_services() {

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -23,7 +23,8 @@ module Conjur
     attr_config(
       # Read TRUSTED_PROXIES before default to maintain backwards compatibility
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
-      authenticators: []
+      authenticators: [],
+      telemetry_enabled: false
     )
 
     def initialize(*args)
@@ -57,6 +58,7 @@ module Conjur
 
       invalid << "trusted_proxies" unless trusted_proxies_valid?
       invalid << "authenticators" unless authenticators_valid?
+      invalid << "telemetry_enabled" unless telemetry_enabled_valid?
 
       unless invalid.empty?
         msg = "Invalid values for configured attributes: #{invalid.join(',')}"
@@ -115,6 +117,10 @@ module Conjur
       end
     rescue
       false
+    end
+
+    def telemetry_enabled_valid?
+      [true, false].include? telemetry_enabled
     end
   end
 end

--- a/spec/lib/monitoring/metrics_spec.rb
+++ b/spec/lib/monitoring/metrics_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
 require 'prometheus/client/formats/text'
+require 'monitoring/prometheus'
 
 class SampleMetric
   def setup(registry, pubsub)

--- a/spec/lib/monitoring/pub_sub_spec.rb
+++ b/spec/lib/monitoring/pub_sub_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'monitoring/pub_sub'
 
 describe Monitoring::PubSub do
   let(:pubsub) { Monitoring::PubSub.instance }


### PR DESCRIPTION
### Desired Outcome
Prometheus telemetry should be configurable via the Conjur configuration system which leverages [Anyway Config](https://github.com/palkan/anyway_config). This includes the following two options for enabling the telemetry feature (in order of precedence):
- As an environment variable: 
  - CONJUR_TELEMETRY_ENABLED=true
- In the configuration file (/etc/conjur/config/conjur.yml): 
  - telemetry_enabled: true

NOTE: If neither of the above are configured it will default to 'false'

As with all configurations, at this time, this must be set for every instance of the Conjur OSS Server. It’s not replicated across instances. After making one of the two changes above, simply apply the updated configuration using conjurctl configuration apply (or by restarting the Conjur processes).

At this point, Conjur will be able to collect metrics and tally them in Prometheus client store. Also, the /metrics endpoint is enabled and will no longer report a 401.
