### PR TITLE
Blocking User Creation

### DIFF
--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -202,8 +202,8 @@ module Loader
       # Below is a sample method verifying policy data validity
       def verify
         # if self.uidnumber == 8
-        #  message = "User '#{self.id}' has wrong params"
-        #  raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
+        #   message = "User '#{self.id}' has wrong params"
+        #   raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
         # end
       end
 


### PR DESCRIPTION
### Desired Outcome

The direct outcome of this PR is to limit users creation to be allowed only under root if the environment variable CONJUR_USERS_IN_ROOT_POLICY_ONLY is true.
If the CONJUR_USERS_IN_ROOT_POLICY_ONLY is undefined user creation behaviour is allowed (does not change)

### Implemented Changes

Logics has beed added in types.rb under User verification - throwing exception when user creation fails

### Connected Issue/Story

### Definition of Done

Validation fully implemented and testes

#### Changelog


#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
