### PR TITLE
Fixup conjur source image location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.17.4] - 2022-04-07
+
+### Changed
+- Fixed promotion behavior
+
 ## [1.17.3] - 2022-04-04
 
 ### Changed
@@ -835,7 +840,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/conjur/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur/compare/v1.17.3...HEAD
+[1.17.4]: https://github.com/cyberark/conjur/compare/v1.17.3...v1.17.4
+[1.17.3]: https://github.com/cyberark/conjur/compare/v1.16.0...v1.17.3
 [1.16.0]: https://github.com/cyberark/conjur/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/cyberark/conjur/compare/v1.14.2...v1.15.0
 [1.14.2]: https://github.com/cyberark/conjur/compare/v1.14.1...v1.14.2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,10 @@ properties([
 // Performs release promotion.  No other stages will be run
 if (params.MODE == "PROMOTE") {
   release.promote(params.VERSION_TO_PROMOTE) { sourceVersion, targetVersion, assetDirectory ->
-    sh "docker pull registry.tld/conjur:${sourceVersion}"
+    sh "docker pull registry.tld/cyberark/conjur:${sourceVersion}"
+    sh "docker tag registry.tld/cyberark/conjur:${sourceVersion} conjur:${sourceVersion}"
     sh "docker pull registry.tld/conjur-ubi:${sourceVersion}"
+    sh "docker tag registry.tld/conjur-ubi:${sourceVersion} conjur-ubi:${sourceVersion}"
     sh "summon -f ./secrets.yml ./publish-images.sh --promote --redhat --base-version=${sourceVersion} --version=${targetVersion}"
 
     // Trigger Conjurops build to push newly promoted releases of conjur to ConjurOps Staging


### PR DESCRIPTION
### Desired Outcome

During promotion it tried to pull from the incorrect image locations and reference images that weren't local.  This fixes up the issue and makes images available during promotion

### Implemented Changes

- Update image pull names
- Re-tag for locally expected names

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
