### PR TITLE
Collect API metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,7 +1,21 @@
-  # If using Prometheus telemetry, we want to ensure that the middleware
+if Rails.application.config.conjur_config.telemetry_enabled 
+  require 'monitoring/prometheus'
+  require 'monitoring/metrics'
+  require 'monitoring/pub_sub'
+  # Require all defined metrics
+  Dir.glob(Rails.root + 'lib/monitoring/metrics/*.rb', &method(:require))
+
+  # Register new metrics and setup the Prometheus client store
+  metrics = [
+    Monitoring::Metrics::ApiRequestCounter.new,
+    Monitoring::Metrics::ApiRequestHistogram.new,
+    Monitoring::Metrics::ApiExceptionCounter.new
+  ]
+  Monitoring::Prometheus.setup(metrics: metrics)
+
+  # Initialize Prometheus middleware. We want to ensure that the middleware
   # which collects and exports metrics is loaded at the start of the 
-  # middleware chain to prevent any modifications to the incoming requests
-  if Rails.application.config.conjur_config.telemetry_enabled 
-    Monitoring::Prometheus.setup
-    Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
-  end
+  # middleware chain to prevent any modifications to incoming HTTP requests
+  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
+  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusCollector, pubsub: Monitoring::PubSub.instance)
+end

--- a/lib/monitoring/metrics.rb
+++ b/lib/monitoring/metrics.rb
@@ -1,0 +1,59 @@
+module Monitoring
+  module Metrics
+    extend self
+
+    def create_metric(metric, type) 
+      case type.to_sym
+      when :counter
+        create_counter_metric(metric)
+      when :gauge
+        create_gauge_metric(metric)
+      when :histogram
+        create_histogram_metric(metric)
+      else
+        raise Exception.new "Invalid or missing metric type."
+      end
+    end
+
+    private
+
+    def create_gauge_metric(metric) 
+      gauge = ::Prometheus::Client::Gauge.new(
+        metric.metric_name,
+        docstring: metric.docstring,
+        labels: metric.labels,
+        store_settings: {
+          aggregation: :most_recent
+        }
+      )
+      metric.registry.register(gauge)
+      setup_subscriber(metric)
+    end
+
+    def create_counter_metric(metric) 
+      counter = ::Prometheus::Client::Counter.new(
+        metric.metric_name,
+        docstring: metric.docstring,
+        labels: metric.labels
+      )
+      metric.registry.register(counter)
+      setup_subscriber(metric)
+    end
+
+    def create_histogram_metric(metric) 
+      histogram = ::Prometheus::Client::Histogram.new(
+        metric.metric_name,
+        docstring: metric.docstring,
+        labels: metric.labels
+      )
+      metric.registry.register(histogram)
+      setup_subscriber(metric)
+    end
+
+    def setup_subscriber(metric)
+      metric.pubsub.subscribe(metric.sub_event_name) do |payload|
+        metric.update(payload)
+      end
+    end
+  end
+end

--- a/lib/monitoring/metrics/api_exception_counter.rb
+++ b/lib/monitoring/metrics/api_exception_counter.rb
@@ -1,0 +1,29 @@
+module Monitoring
+  module Metrics
+    class ApiExceptionCounter
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_http_server_request_exceptions_total
+        @docstring = 'The total number of API exceptions raised by Conjur.'
+        @labels = %i[operation exception message]
+        @sub_event_name = 'conjur.request_exception'
+
+        # Create/register the metric
+        Metrics.create_metric(self, :counter)
+      end
+
+      def update(payload)
+        metric = @registry.get(@metric_name)
+        update_labels = {
+          operation: payload[:operation],
+          exception: payload[:exception],
+          message: payload[:message]
+        }
+        metric.increment(labels: update_labels)
+      end
+    end
+  end
+end

--- a/lib/monitoring/metrics/api_request_counter.rb
+++ b/lib/monitoring/metrics/api_request_counter.rb
@@ -1,0 +1,28 @@
+module Monitoring
+  module Metrics
+    class ApiRequestCounter
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_http_server_requests_total
+        @docstring = 'The total number of HTTP requests handled by Conjur.'
+        @labels = %i[code operation]
+        @sub_event_name = 'conjur.request'
+
+        # Create/register the metric
+        Metrics.create_metric(self, :counter)
+      end
+
+      def update(payload)
+        metric = @registry.get(@metric_name)
+        update_labels = {
+          code: payload[:code],
+          operation: payload[:operation]
+        }
+        metric.increment(labels: update_labels)
+      end
+    end
+  end
+end

--- a/lib/monitoring/metrics/api_request_histogram.rb
+++ b/lib/monitoring/metrics/api_request_histogram.rb
@@ -1,0 +1,27 @@
+module Monitoring
+  module Metrics
+    class ApiRequestHistogram
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_http_server_request_duration_seconds
+        @docstring = 'The HTTP response duration of requests handled by Conjur.'
+        @labels = %i[operation]
+        @sub_event_name = 'conjur.request'
+
+        # Create/register the metric
+        Metrics.create_metric(self, :histogram)
+      end
+
+      def update(payload)
+        metric = @registry.get(@metric_name)
+        update_labels = {
+          operation: payload[:operation]
+        }
+        metric.observe(payload[:duration], labels: update_labels)
+      end
+    end
+  end
+end

--- a/lib/monitoring/middleware/prometheus_collector.rb
+++ b/lib/monitoring/middleware/prometheus_collector.rb
@@ -1,0 +1,60 @@
+require 'benchmark'
+require_relative '../operations.rb'
+
+module Monitoring
+  module Middleware
+    class PrometheusCollector
+      attr_reader :app
+
+      def initialize(app, options = {})
+        @app = app
+        @pubsub = options[:pubsub]
+      end
+
+      def call(env) # :nodoc:
+        trace(env) { @app.call(env) }
+      end
+
+      protected
+
+      # Trace HTTP requests
+      def trace(env)
+        response = nil
+        duration = Benchmark.realtime { response = yield }
+        record(env, response.first.to_s, duration)
+        return response
+      rescue => exception
+        operation = find_operation(env['REQUEST_METHOD'], env['PATH_INFO'])
+        @pubsub.publish(
+          "conjur.request_exception", 
+          operation: operation,
+          exception: exception.class.name,
+          message: exception
+        )
+        raise
+      end
+
+      def record(env, code, duration)
+        operation = find_operation(env['REQUEST_METHOD'], env['PATH_INFO'])
+        @pubsub.publish(
+          "conjur.request", 
+          code: code,
+          operation: operation,
+          duration: duration
+        )
+      rescue
+        # TODO: log unexpected exception during request recording
+        nil
+      end
+
+      def find_operation(method, path)
+        Monitoring::Metrics::OPERATIONS.each do |op|
+          if op[:method] == method && op[:pattern].match?(path)
+            return op[:operation]
+          end
+        end
+        return "unknown"
+      end
+    end
+  end
+end

--- a/lib/monitoring/middleware/prometheus_exporter.rb
+++ b/lib/monitoring/middleware/prometheus_exporter.rb
@@ -10,7 +10,7 @@ module Monitoring
     # under `/metrics`. Use the `:registry` and `:path` options to change the
     # defaults.
     class PrometheusExporter
-      attr_reader :app, :path, :registry
+      attr_reader :app
 
       FORMATS  = [::Prometheus::Client::Formats::Text].freeze
       FALLBACK = ::Prometheus::Client::Formats::Text

--- a/lib/monitoring/operations.rb
+++ b/lib/monitoring/operations.rb
@@ -1,0 +1,227 @@
+module Monitoring
+  module Metrics
+    OPERATIONS = [
+      # AccountsApi (undocumented)
+      {
+        method: "POST",
+        pattern: /^(\/accounts)$/,
+        operation: "createAccount"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/accounts)$/,
+        operation: "getAccounts"
+      },
+      {
+        method: "DELETE",
+        pattern: /^(\/accounts)(\/[^\/]+)$/,
+        operation: "deleteAccount"
+      },
+
+      # AuthenticationApi
+      {
+        method: "PUT",
+        pattern: /^(\/authn)(\/[^\/]+)(\/password)$/,
+        operation: "changePassword"
+      },
+      {
+        method: "PATCH",
+        pattern: /^(\/authn-)([^\/]+)(\/[^\/]+){2,3}$/,
+        operation: "enableAuthenticatorInstance"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/authn)(\/[^\/]+)(\/login)$/,
+        operation: "getAPIKey"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/authn-ldap)(\/[^\/]+){2}(\/login)$/,
+        operation: "getAPIKeyViaLDAP"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn)(\/[^\/]+){2}(\/authenticate)$/,
+        operation: "getAccessToken"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-iam)(\/[^\/]+){3}(\/authenticate)$/,
+        operation: "getAccessTokenViaAWS"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-azure)(\/[^\/]+){3}(\/authenticate)$/,
+        operation: "getAccessTokenViaAzure"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-gcp)(\/[^\/]+)(\/authenticate)$/,
+        operation: "getAccessTokenViaGCP"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-k8s)(\/[^\/]+){3}(\/authenticate)$/,
+        operation: "getAccessTokenViaKubernetes"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-ldap)(\/[^\/]+){3}(\/authenticate)$/,
+        operation: "getAccessTokenViaLDAP"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-oidc)(\/[^\/]+){2}(\/authenticate)$/,
+        operation: "getAccessTokenViaOIDC"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-jwt)(\/[^\/]+){2,3}(\/authenticate)$/,
+        operation: "getAccessTokenViaJWT"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/authn-k8s)(\/[^\/]+)(\/inject_client_cert)$/,
+        operation: "k8sInjectClientCert"
+      },
+      {
+        method: "PUT",
+        pattern: /^(\/authn)(\/[^\/]+)(\/api_key)$/,
+        operation: "rotateAPIKey"
+      },
+
+      # CertificateAuthorityApi
+      {
+        method: "POST",
+        pattern: /^(\/ca)(\/[^\/]+){2}(\/sign)$/,
+        operation: "sign"
+      },
+
+      # HostFactoryApi
+      {
+        method: "POST",
+        pattern: /^(\/host_factories\/hosts)$/,
+        operation: "createHost"
+      },
+      {
+        method: "POST",
+        pattern: /^(\/host_factory_tokens)$/,
+        operation: "createToken"
+      },
+      {
+        method: "DELETE",
+        pattern: /^(\/host_factory_tokens)(\/[^\/]+)$/,
+        operation: "revokeToken"
+      },
+
+      # MetricsApi
+      {
+        method: "GET",
+        pattern: /^(\/metrics)$/,
+        operation: "getMetrics"
+      },
+
+      # PoliciesApi
+      {
+        method: "POST",
+        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        operation: "loadPolicy"
+      },
+      {
+        method: "PUT",
+        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        operation: "replacePolicy"
+      },
+      {
+        method: "PATCH",
+        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        operation: "updatePolicy"
+      },
+
+      # PublicKeysApi
+      {
+        method: "GET",
+        pattern: /^(\/public_keys)(\/[^\/]+){3}$/,
+        operation: "showPublicKeys"
+      },
+
+      # ResourcesApi
+      {
+        method: "GET",
+        pattern: /^(\/resources)(\/[^\/]+){3}(\/.*)$/,
+        operation: "showResource"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/resources)(\/[^\/]+){1}$/,
+        operation: "showResourcesForAccount"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/resources$)/,
+        operation: "showResourcesForAllAccounts"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/resources)(\/[^\/]+){2}$/,
+        operation: "showResourcesForKind"
+      },
+
+      # RolesApi
+      {
+        method: "POST",
+        pattern: /^(\/roles)(\/[^\/]+){3}$/,
+        operation: "addMemberToRole"
+      },
+      {
+        method: "DELETE",
+        pattern: /^(\/roles)(\/[^\/]+){3}$/,
+        operation: "removeMemberFromRole"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/roles)(\/[^\/]+){3}$/,
+        operation: "showRole"
+      },
+
+      # SecretsApi
+      {
+        method: "POST",
+        pattern: /^(\/secrets)(\/[^\/]+){2}(\/.*)$/,
+        operation: "createSecret"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/secrets)(\/[^\/]+){3}$/,
+        operation: "getSecret"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/secrets)$/,
+        operation: "getSecrets"
+      },
+
+      # StatusApi
+      {
+        method: "GET",
+        pattern: /^(\/authenticators)$/,
+        operation: "getAuthenticators"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/authn-gcp)(\/[^\/]+)(\/status)$/,
+        operation: "getGCPAuthenticatorStatus"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/authn-)([^\/]+)(\/[^\/]+){2}(\/status)$/,
+        operation: "getServiceAuthenticatorStatus"
+      },
+      {
+        method: "GET",
+        pattern: /^(\/whoami)$/,
+        operation: "whoAmI"
+      },
+    ]
+  end
+end

--- a/lib/monitoring/prometheus.rb
+++ b/lib/monitoring/prometheus.rb
@@ -8,7 +8,6 @@ module Monitoring
 
     def setup(options = {})
       @registry = options[:registry] || ::Prometheus::Client::Registry.new
-      @metrics_prefix = options[:metrics_prefix] || "conjur_http_server"
       @metrics_dir_path = ENV['CONJUR_METRICS_DIR'] || '/tmp/prometheus'
       @pubsub = options[:pubsub] || PubSub.instance
 
@@ -24,10 +23,6 @@ module Monitoring
 
     def registry
       @registry
-    end
-
-    def metrics_prefix
-      @metrics_prefix
     end
 
     protected

--- a/spec/lib/monitoring/middleware/prometheus_collector_spec.rb
+++ b/spec/lib/monitoring/middleware/prometheus_collector_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+require 'monitoring/middleware/prometheus_collector'
+require 'monitoring/prometheus'
+require 'monitoring/metrics'
+Dir.glob(Rails.root + 'lib/monitoring/metrics/api_*.rb', &method(:require))
+
+
+describe Monitoring::Middleware::PrometheusCollector do
+
+  # Clear out any existing subscribers and reset the data store
+  before do
+    pubsub.unsubscribe('conjur.request_exception')
+    pubsub.unsubscribe('conjur.request')
+    Monitoring::Prometheus.setup(registry: Prometheus::Client::Registry.new, metrics: metrics)
+  end
+
+  let(:metrics) { [
+    Monitoring::Metrics::ApiRequestCounter.new,
+    Monitoring::Metrics::ApiRequestHistogram.new,
+    Monitoring::Metrics::ApiExceptionCounter.new
+  ] }
+
+  let(:registry) { Monitoring::Prometheus.registry }
+
+  let(:request_counter_metric) { registry.get(:conjur_http_server_requests_total) }
+
+  let(:request_duration_metric) { registry.get(:conjur_http_server_request_duration_seconds) }
+
+  let(:env) { Rack::MockRequest.env_for }
+
+  let(:app) do
+    app = ->(env) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
+  end
+
+  let(:pubsub) { Monitoring::PubSub.instance }
+
+  let(:options) { { pubsub: pubsub } }
+
+  subject { described_class.new(app, **options) }
+
+  it 'returns the app response' do
+    env['PATH_INFO'] = "/foo"
+    status, _headers, _response = subject.call(env)
+
+    expect(status).to eql(200)
+    expect(_response.first).to eql('OK')
+  end
+
+  it 'traces request information' do
+    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.2)
+
+    env['PATH_INFO'] = "/foo"
+    status, _headers, _response = subject.call(env)
+
+    labels = { operation: 'unknown', code: '200' }
+    expect(request_counter_metric.get(labels: labels)).to eql(1.0)
+
+    labels = { operation: 'unknown' }
+    expect(request_duration_metric.get(labels: labels)).to include("0.1" => 0, "0.25" => 1)
+  end
+
+  it 'stores a known operation ID in the metrics store' do
+    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.2)
+
+    env['PATH_INFO'] = "/whoami"
+    status, _headers, _response = subject.call(env)
+
+    labels = { operation: 'whoAmI', code: '200' }
+    expect(request_counter_metric.get(labels: labels)).to eql(1.0)
+
+    labels = { operation: 'whoAmI' }
+    expect(request_duration_metric.get(labels: labels)).to include("0.1" => 0, "0.25" => 1)
+  end
+
+  context 'when the app raises an exception' do
+
+    let(:dummy_error) { RuntimeError.new('Dummy error from tests') }
+
+    let(:request_exception_metric) { registry.get(:conjur_http_server_request_exceptions_total) }
+
+    let(:app) do
+      app = ->(env) { 
+        raise dummy_error if env['PATH_INFO'] == '/broken'
+        [200, { 'Content-Type' => 'text/html' }, ['OK']] 
+      }
+    end
+  
+    subject { described_class.new(app, **options) }
+
+    before do
+      subject.call(env)
+    end
+
+    it 'traces exceptions' do
+      env['PATH_INFO'] = '/broken'
+      expect { subject.call(env) }.to raise_error(RuntimeError)
+
+      labels = {
+        operation: 'unknown',
+        exception: 'RuntimeError',
+        message: 'Dummy error from tests'
+      }
+
+      expect(request_exception_metric.get(labels: labels)).to eql(1.0)
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

For this story we need to register REST API metrics onto the Prometheus client store. Consult the [solution design](https://github.com/cyberark/conjur/blob/040f5041fadf085e47087e4ef8286bc66e72ec74/design/telemetry/metrics_solution_design.md#conjur-http-requests) for details around the metric metadata. The general idea is to

1. Collect the metrics through custom Rack middleware. The prometheus client gem provides an [example Rack middleware](https://github.com/prometheus/client_ruby/blob/master/lib/prometheus/middleware/collector.rb) for tracing HTTP requests. This idea was used in the hackathon and expanded upon in the POC for the soluition design, so for the implementation we can crib from `lib/prometheus/custom_collector.rb` in the [diff from the POC branch](https://github.com/cyberark/conjur/compare/metrics-poc-kt#diff-963b0f7173b1dd7863e1c623cccdc5e03fba88c1ca33e1d3730ae571da2913ce).
2. Publish an event (e.g. `conjur.request`) with enough data that the subscriber can use to make the metrics updates.
3. The Prometheus subscriber for these metrics will interpret that event and make appropriate metric updates to the store. The act of adding the metrics onto the store, combined with the prior work to setup the Prometheus exporter should result in the metric being present in the scrape target endpoint `GET /metrics`.

NOTE: In the Rack middleware we need to ensure that our measurements take into account all other Rack middleware applied to a request. This means the metrics collection Rack middleware must be [first in the list](https://blog.appoptics.com/monitoring-rails-get-hidden-metrics-rails-app/#:~:text=Note%20that%20the%C2%A0Librato%3A%3ARack%C2%A0middleware%20is%20the%20very%20first%20item%20in%20the%20list%2C%20while%20my%20Rails%20app%20is%20the%20last).

A/C

e2e test cases:

lightweight test: requests made on the REST API are reflected in the response of the scrape target endpoint
pub/sub plumbing is unit tested so that when any relevant events are dispatched the expected changes are reflected on the store
