### PR TITLE
Fixing user creation check

### DIFF
--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -200,10 +200,12 @@ module Loader
       def_delegators :@policy_object, :public_keys, :account, :role_kind, :uidnumber, :restricted_to
 
       def check_user_creation_allowed(resource_id:)
-        return unless resource_id.include?('@') # if under root
-
         if ENV['CONJUR_USERS_IN_ROOT_POLICY_ONLY'] == 'true'
-          message = "User creation through policy is disabled."
+          # Users loaded into the `root` namespace are by default owned by the account's admin user.
+          # If CONJUR_USERS_IN_ROOT_POLICY_ONLY is set the users creation is allowed only into the `root` namespace
+          return if owner.role_kind == 'user' && owner.id == 'admin'
+
+          message = "User creation is disabled."
           raise Exceptions::InvalidPolicyObject.new(resource_id, message: message)
         end
       end

--- a/spec/models/loader/types.rb
+++ b/spec/models/loader/types.rb
@@ -2,9 +2,14 @@ require 'spec_helper'
 
 describe Loader::Types::User do
   let(:user) do
+    role = Conjur::PolicyParser::Types::Role.new
+    role.id = role_id
+    role.kind = role_kind
+    role.account = 'default'
     user = Conjur::PolicyParser::Types::User.new
     user.id = resource_id
     user.account = 'default'
+    user.owner = role
     Loader::Types.wrap(user, self)
   end
 
@@ -14,40 +19,67 @@ describe Loader::Types::User do
         allow(ENV).to receive(:[]).with('CONJUR_USERS_IN_ROOT_POLICY_ONLY').and_return('true')
       end
 
-      context 'when the user is loaded in the "my_sub_tree" policy' do
-        let(:resource_id) { 'alice@my_sub_tree' }
+      context 'when creating user in the "admin" sub-policy' do
+        let(:resource_id) { 'alice@admin' }
+        let(:role_kind) { 'policy' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
       end
 
-      context 'when the user is loaded in the "root" policy' do
-        let(:resource_id) { 'alice' }
+      context 'when non admin user creating user in the "root" policy' do
+        let(:resource_id) { 'alice@cyberark' }
+        let(:role_kind) { 'user' }
+        let(:role_id) { 'myuser' }
+        it { expect { user.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
+      end
+
+      context 'when admin user creating user in the "root" policy' do
+        let(:resource_id) { 'alice@cyberark' }
+        let(:role_kind) { 'user' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to_not raise_error }
       end
     end
+
     context 'when CONJUR_USERS_IN_ROOT_POLICY_ONLY is false' do
       before do
         allow(ENV).to receive(:[]).with('CONJUR_USERS_IN_ROOT_POLICY_ONLY').and_return('false')
       end
 
-      context 'when the user is loaded in the "my_sub_tree" policy' do
-        let(:resource_id) { 'alice@my_sub_tree' }
+      context 'when creating user in the "admin" sub-policy' do
+        let(:resource_id) { 'alice@admin' }
+        let(:role_kind) { 'policy' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to_not raise_error }
       end
 
-      context 'when the user is loaded in the "root" policy' do
-        let(:resource_id) { 'alice' }
+      context 'when non admin user creating user in the "root" policy' do
+        let(:role_kind) { 'user' }
+        let(:resource_id) { 'alice@cyberark' }
+        let(:role_id) { 'myuser' }
+        it { expect { user.verify }.to_not raise_error }
+      end
+
+      context 'when admin user creating user in the "root" policy' do
+        let(:role_kind) { 'user' }
+        let(:resource_id) { 'alice@cyberark' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to_not raise_error }
       end
     end
 
     context 'when CONJUR_USERS_IN_ROOT_POLICY_ONLY is not set' do
-      context 'when the user is loaded in the "my_sub_tree" policy' do
-        let(:resource_id) { 'alice@my_sub_tree' }
+      context 'when creating user in the "admin" sub-policy' do
+        let(:resource_id) { 'alice@admin' }
+        let(:role_kind) { 'policy' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to_not raise_error }
       end
 
-      context 'when the user is loaded in the "root" policy' do
-        let(:resource_id) { 'alice' }
+      context 'when admin user creating user in the "root" policy' do
+        let(:resource_id) { 'alice@cyberark' }
+        let(:role_kind) { 'user' }
+        let(:role_id) { 'admin' }
         it { expect { user.verify }.to_not raise_error }
       end
     end


### PR DESCRIPTION
### Desired Outcome
Follow up this [PR](https://github.com/cyberark/conjur/pull/2537), it block creation of user contains '@' in the root policy.
The desired outcome of this PR is to be able to handle allowing user creation when the username contains '@' and loading under root policy.

### Implemented Changes

The implementation of it change is to allow only conjur admin user to create user if the CONJUR_USERS_IN_ROOT_POLICY_ONLY is set 

### Connected Issue/Story

Resolves #[ONYX-19651](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19651)

Jira bug #[ONYX-21061](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21061)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] 
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
