### PR TITLE
Conjur tracing with jaeger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,11 @@ gem 'openid_connect'
 gem "anyway_config"
 gem 'i18n', '~> 1.8.11'
 
+# Opentelemetry tracing
+gem 'opentelemetry-common'
+gem 'opentelemetry-sdk'
+gem 'opentelemetry-exporter-jaeger'
+
 group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,23 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    opentelemetry-api (1.0.1)
+    opentelemetry-common (0.19.3)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-jaeger (0.20.1)
+      opentelemetry-api (~> 1.0)
+      opentelemetry-common (~> 0.19.2)
+      opentelemetry-sdk (~> 1.0)
+      thrift
+    opentelemetry-instrumentation-base (0.19.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-sdk (1.0.2)
+      opentelemetry-api (~> 1.0)
+      opentelemetry-common (~> 0.19.3)
+      opentelemetry-instrumentation-base (~> 0.19.0)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.8.0)
+      opentelemetry-api (~> 1.0)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
@@ -437,6 +454,7 @@ GEM
       ffi (~> 1.1)
     table_print (1.5.7)
     thor (1.2.1)
+    thrift (0.16.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -503,6 +521,9 @@ DEPENDENCIES
   net-ssh
   nokogiri (>= 1.8.2)
   openid_connect
+  opentelemetry-common
+  opentelemetry-exporter-jaeger
+  opentelemetry-sdk
   parallel
   pg
   pry-byebug
@@ -538,4 +559,4 @@ DEPENDENCIES
   websocket
 
 BUNDLED WITH
-   2.2.31
+   2.2.33

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,18 @@ class ApplicationController < ActionController::API
   include Authenticates
   include ::ActionView::Layouts
 
+  #Add tracing to all controller actions
+  if (Rails.application.config.conjur_config.tracing_enabled)
+    around_action :trace
+  end
+
+  def trace
+    tracer = Rails.application.config.tracer
+    tracer.in_span(request.env['PATH_INFO']) do |span|
+      yield
+    end
+  end
+
   class Unauthorized < RuntimeError
     attr_reader :return_message_in_response
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/jaeger'
 
 class AuthenticateController < ApplicationController
   include BasicAuthenticator

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger/formatter/conjur_formatter'
+require 'opentelemetry/sdk'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -39,4 +40,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  #Use for Opentelemtry tracing
+  config.tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger/formatter/conjur_formatter'
+require 'opentelemetry/sdk'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -65,4 +66,7 @@ Rails.application.configure do
   #Add support for asset compression in production
   # config.assets.css_compressor = :sass
   # config.assets.js_compressor = :uglifier
+
+  #Use for Opentelemtry tracing
+  config.tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
 end

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,0 +1,7 @@
+require 'opentelemetry'
+require 'opentelemetry/exporter/jaeger'
+require 'opentelemetry/sdk'
+
+OpenTelemetry::SDK.configure do |c|
+  c.use_all()
+end

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -40,6 +40,11 @@ services:
       RAILS_ENV:
       CONJUR_LOG_LEVEL: debug
       AUDIT_DATABASE_URL:
+      CONJUR_TRACING_ENABLED:
+      OTEL_SERVICE_NAME:
+      OTEL_PROPAGATORS:
+      OTEL_TRACES_EXPORTER:
+      OTEL_EXPORTER_JAEGER_ENDPOINT:
       # TODO: Where should we be running rspec tests from, ideally?
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
@@ -59,6 +64,7 @@ services:
     # TODO: authenticators_oidc/test has a dep on this
     - ../ci/oauth/keycloak:/oauth/keycloak/scripts
     - jwks-volume:/var/jwks
+    - ./files/conjur.yml:/etc/conjur/config/conjur.yml
     links:
     - pg:pg
     - ldap-server
@@ -178,6 +184,14 @@ services:
     volumes:
       - ../ci/jwt/:/usr/src/jwks/
 
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686"
+      - "14268:14268"
+
 volumes:
   authn-local:
   jwks-volume:
+  conjur-config:

--- a/dev/files/conjur.yml
+++ b/dev/files/conjur.yml
@@ -1,0 +1,2 @@
+trusted_proxies:
+- 1.2.3.4

--- a/dev/files/policy.yml
+++ b/dev/files/policy.yml
@@ -1,1 +1,3 @@
 - !user alice
+
+- !variable testvar

--- a/dev/start
+++ b/dev/start
@@ -36,6 +36,7 @@ ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
 ENABLE_AUDIT=false
+ENABLE_TRACING=false
 
 main() {
   unset COMPOSE_PROJECT_NAME
@@ -51,6 +52,7 @@ main() {
 
   init_data_key
   init_audit_service
+  init_tracing
 
   # Install gems, create DB, and create cucumber account.
   docker-compose up -d --no-deps "${services[@]}"
@@ -106,6 +108,8 @@ Usage: start [options]
 
     --audit         Starts with the audit engine and database enabled
 
+    --tracing       Starts with tracing enabled and a Jaeger container running
+
     -h, --help      Shows this help message.
 EOF
   exit
@@ -124,6 +128,7 @@ parse_options() {
       --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
       --rotators ) ENABLE_ROTATORS=true ; shift ;;
       --audit ) ENABLE_AUDIT=true ; shift ;;
+      --tracing ) ENABLE_TRACING=true ; shift ;;
       -h | --help ) print_help ; shift ;;
        * )
          if [ -z "$1" ]; then
@@ -260,6 +265,17 @@ init_audit_service() {
   if [[ $ENABLE_AUDIT == true ]]; then
     services+=(audit)
     export AUDIT_DATABASE_URL=postgres://postgres@audit
+  fi
+}
+
+init_tracing() {
+  if [[ $ENABLE_TRACING == true ]]; then
+    export CONJUR_TRACING_ENABLED=true
+    export OTEL_SERVICE_NAME=Conjur
+    export OTEL_PROPAGATORS=jaeger
+    export OTEL_TRACES_EXPORTER=jaeger
+    export OTEL_EXPORTER_JAEGER_ENDPOINT="http://jaeger:14268/api/traces"
+    docker-compose up -d --no-deps jaeger
   fi
 }
 

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -23,7 +23,8 @@ module Conjur
     attr_config(
       # Read TRUSTED_PROXIES before default to maintain backwards compatibility
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
-      authenticators: []
+      authenticators: [],
+      tracing_enabled: false,
     )
 
     def initialize(*args)


### PR DESCRIPTION
### Desired Outcome

The desired outcome for this PR is add observability tracing into Conjur.

### Implemented Changes

The incoming changes add the Open Telemetry ruby gem to add traces in the codebase and to send these traces to a specified Jaeger container. The changes include an all-in-one Jaeger container in the docker-compose file which can be boot up using a feature flag that has been added to the start script. 

### Connected Issue/Story

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
