### PR TITLE
Conjur tracing with jaeger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,11 @@ gem 'openid_connect'
 gem "anyway_config"
 gem 'i18n', '~> 1.8.11'
 
+# Opentelemetry tracing
+gem 'opentelemetry-common'
+gem 'opentelemetry-exporter-jaeger'
+gem 'opentelemetry-sdk'
+
 group :development, :test do
   gem 'aruba'
   gem 'ci_reporter_rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,23 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    opentelemetry-api (1.0.1)
+    opentelemetry-common (0.19.3)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-jaeger (0.20.1)
+      opentelemetry-api (~> 1.0)
+      opentelemetry-common (~> 0.19.2)
+      opentelemetry-sdk (~> 1.0)
+      thrift
+    opentelemetry-instrumentation-base (0.19.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-sdk (1.0.2)
+      opentelemetry-api (~> 1.0)
+      opentelemetry-common (~> 0.19.3)
+      opentelemetry-instrumentation-base (~> 0.19.0)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.8.0)
+      opentelemetry-api (~> 1.0)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
@@ -437,6 +454,7 @@ GEM
       ffi (~> 1.1)
     table_print (1.5.7)
     thor (1.2.1)
+    thrift (0.16.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -503,6 +521,9 @@ DEPENDENCIES
   net-ssh
   nokogiri (>= 1.8.2)
   openid_connect
+  opentelemetry-common
+  opentelemetry-exporter-jaeger
+  opentelemetry-sdk
   parallel
   pg
   pry-byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,9 @@ class ApplicationController < ActionController::API
   include Authenticates
   include ::ActionView::Layouts
 
+  # Add tracing to all controller actions
+  include Tracing
+
   class Unauthorized < RuntimeError
     attr_reader :return_message_in_response
 

--- a/app/controllers/concerns/tracing.rb
+++ b/app/controllers/concerns/tracing.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# A concern that adds OpenTelemetry tracing to controller methods.
+module Tracing
+  extend ActiveSupport::Concern
+  
+  included do
+    around_action :trace
+  end
+  
+  # rubocop:disable Style/ExplicitBlockArgument
+  def trace
+    return unless Tracing.tracing_enabled?
+
+    Rails.application.config.tracer.in_span(request.env['PATH_INFO']) do
+      yield
+    end
+  end
+  # rubocop:enable Style/ExplicitBlockArgument
+
+  def self.tracing_enabled?
+    Rails.application.config.conjur_config.tracing_enabled
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger/formatter/conjur_formatter'
+require 'opentelemetry/sdk'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger/formatter/conjur_formatter'
+require 'opentelemetry/sdk'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -1,0 +1,14 @@
+if Rails.application.config.conjur_config.tracing_enabled
+  require 'opentelemetry'
+  require 'opentelemetry/exporter/jaeger'
+  require 'opentelemetry/sdk'
+
+  OpenTelemetry::SDK.configure do |c|
+    c.use_all()
+  end
+
+  Rails.application.configure do
+    #Use for Opentelemtry tracing
+    config.tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
+  end
+end

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -40,6 +40,11 @@ services:
       RAILS_ENV:
       CONJUR_LOG_LEVEL: debug
       AUDIT_DATABASE_URL:
+      CONJUR_TRACING_ENABLED:
+      OTEL_SERVICE_NAME:
+      OTEL_PROPAGATORS:
+      OTEL_TRACES_EXPORTER:
+      OTEL_EXPORTER_JAEGER_ENDPOINT:
       # TODO: Where should we be running rspec tests from, ideally?
       # See https://github.com/DatabaseCleaner/database_cleaner#safeguards
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
@@ -178,6 +183,14 @@ services:
     volumes:
       - ../ci/jwt/:/usr/src/jwks/
 
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686"
+      - "14268:14268"
+
 volumes:
   authn-local:
   jwks-volume:
+  conjur-config:

--- a/dev/start
+++ b/dev/start
@@ -36,6 +36,7 @@ ENABLE_OIDC_ADFS=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
 ENABLE_AUDIT=false
+ENABLE_TRACING=false
 
 main() {
   unset COMPOSE_PROJECT_NAME
@@ -51,6 +52,7 @@ main() {
 
   init_data_key
   init_audit_service
+  init_tracing
 
   # Install gems, create DB, and create cucumber account.
   docker-compose up -d --no-deps "${services[@]}"
@@ -106,6 +108,8 @@ Usage: start [options]
 
     --audit         Starts with the audit engine and database enabled
 
+    --tracing       Starts with tracing enabled and a Jaeger container running
+
     -h, --help      Shows this help message.
 EOF
   exit
@@ -124,6 +128,7 @@ parse_options() {
       --oidc-okta ) ENABLE_OIDC_OKTA=true ; shift ;;
       --rotators ) ENABLE_ROTATORS=true ; shift ;;
       --audit ) ENABLE_AUDIT=true ; shift ;;
+      --tracing ) ENABLE_TRACING=true ; shift ;;
       -h | --help ) print_help ; shift ;;
        * )
          if [ -z "$1" ]; then
@@ -260,6 +265,17 @@ init_audit_service() {
   if [[ $ENABLE_AUDIT == true ]]; then
     services+=(audit)
     export AUDIT_DATABASE_URL=postgres://postgres@audit
+  fi
+}
+
+init_tracing() {
+  if [[ $ENABLE_TRACING == true ]]; then
+    export CONJUR_TRACING_ENABLED=true
+    export OTEL_SERVICE_NAME=Conjur
+    export OTEL_PROPAGATORS=jaeger
+    export OTEL_TRACES_EXPORTER=jaeger
+    export OTEL_EXPORTER_JAEGER_ENDPOINT="http://jaeger:14268/api/traces"
+    docker-compose up -d --no-deps jaeger
   fi
 }
 

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -23,7 +23,8 @@ module Conjur
     attr_config(
       # Read TRUSTED_PROXIES before default to maintain backwards compatibility
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
-      authenticators: []
+      authenticators: [],
+      tracing_enabled: false
     )
 
     def initialize(*args)

--- a/spec/controllers/concerns/tracing_spec.rb
+++ b/spec/controllers/concerns/tracing_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Tracing do
+  let!(:orig_tracing_enabled) { Rails.application.config.conjur_config.tracing_enabled }
+
+  let(:tracer) { double(::OpenTelemetry::Trace::Tracer) }
+  
+  before do
+    @controller = StatusController.new
+    
+    Rails.application.config.conjur_config.tracing_enabled = true
+
+    allow(Rails.application.config).to receive(:tracer).and_return(tracer)
+  end
+
+  after do
+    Rails.application.config.conjur_config.tracing_enabled = orig_tracing_enabled
+  end
+  
+  it "performs trace" do
+    expect(tracer).to receive(:in_span).with("/").once
+
+    get("index")
+  end
+end

--- a/spec/lib/conjur/conjur_config_spec.rb
+++ b/spec/lib/conjur/conjur_config_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 describe Conjur::ConjurConfig do
   it "uses default value if not set by environment variable or config file" do
     expect(Conjur::ConjurConfig.new.trusted_proxies).to eq([])
+    expect(Conjur::ConjurConfig.new.tracing_enabled).to eq(false)
   end
 
   it "reports the attribute source as :defaults" do
     expect(Conjur::ConjurConfig.new.attribute_sources[:trusted_proxies]).
+      to eq(:defaults)
+      expect(Conjur::ConjurConfig.new.attribute_sources[:tracing_enabled]).
       to eq(:defaults)
   end
 
@@ -98,6 +101,7 @@ describe Conjur::ConjurConfig do
     context "with prefixed env var" do
       before do
         ENV['CONJUR_TRUSTED_PROXIES'] = "5.6.7.8"
+        ENV['CONJUR_TRACING_ENABLED'] = "true"
 
         # Anyway Config caches prefixed env vars at the class level so we must
         # clear the cache to have it pick up the new var with a reload.
@@ -106,17 +110,20 @@ describe Conjur::ConjurConfig do
 
       after do
         ENV.delete('CONJUR_TRUSTED_PROXIES')
-
+        ENV.delete('CONJUR_TRACING_ENABLED')
         # Clear again to make sure we don't affect future tests.
         Anyway.env.clear
       end
 
       it "overrides the config file value" do
         expect(Conjur::ConjurConfig.new.trusted_proxies).to eq(["5.6.7.8"])
+        expect(Conjur::ConjurConfig.new.tracing_enabled).to eq(true)
       end
 
       it "reports the attribute source as :env" do
         expect(Conjur::ConjurConfig.new.attribute_sources[:trusted_proxies]).
+          to eq(:env)
+        expect(Conjur::ConjurConfig.new.attribute_sources[:tracing_enabled]).
           to eq(:env)
       end
     end


### PR DESCRIPTION
### Desired Outcome

The desired outcome for this PR is add observability tracing into Conjur.

### Implemented Changes

The incoming changes add the Open Telemetry ruby gem to add traces into the codebase and to send these traces to a specified Jaeger container. The changes include an all-in-one Jaeger container in the docker-compose file which can be boot up using a feature flag that has been added to the start script. 

### Connected Issue/Story

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
