### PR TITLE
Collect resource metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,7 +1,8 @@
+require 'monitoring/pub_sub'
+
 if Rails.application.config.conjur_config.telemetry_enabled 
   require 'monitoring/prometheus'
   require 'monitoring/metrics'
-  require 'monitoring/pub_sub'
   # Require all defined metrics
   Dir.glob(Rails.root + 'lib/monitoring/metrics/*.rb', &method(:require))
 
@@ -9,7 +10,8 @@ if Rails.application.config.conjur_config.telemetry_enabled
   metrics = [
     Monitoring::Metrics::ApiRequestCounter.new,
     Monitoring::Metrics::ApiRequestHistogram.new,
-    Monitoring::Metrics::ApiExceptionCounter.new
+    Monitoring::Metrics::ApiExceptionCounter.new,
+    Monitoring::Metrics::PolicyResourceGauge.new
   ]
   Monitoring::Prometheus.setup(metrics: metrics)
 

--- a/lib/monitoring/metrics.rb
+++ b/lib/monitoring/metrics.rb
@@ -54,6 +54,14 @@ module Monitoring
       metric.pubsub.subscribe(metric.sub_event_name) do |payload|
         metric.update(payload)
       end
+      throttle_policy_event(metric) unless !metric.throttle
+    end
+
+    def throttle_policy_event(metric)
+      # TODO: revisit throttling for metrics which execute DB queries
+      metric.pubsub.subscribe('conjur.policy_loaded') do
+        metric.pubsub.publish(metric.sub_event_name)
+      end
     end
   end
 end

--- a/lib/monitoring/metrics/api_exception_counter.rb
+++ b/lib/monitoring/metrics/api_exception_counter.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiExceptionCounter
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/api_request_counter.rb
+++ b/lib/monitoring/metrics/api_request_counter.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiRequestCounter
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/api_request_histogram.rb
+++ b/lib/monitoring/metrics/api_request_histogram.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiRequestHistogram
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/policy_resouce_gauge.rb
+++ b/lib/monitoring/metrics/policy_resouce_gauge.rb
@@ -1,0 +1,30 @@
+module Monitoring
+  module Metrics
+    class PolicyResourceGauge
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_resource_count
+        @docstring = 'Number of resources in Conjur database'
+        @labels = %i[kind]
+        @sub_event_name = 'conjur.resource_count_update'
+        @throttle = true
+        
+        # Create/register the metric
+        Metrics.create_metric(self, :gauge)
+
+        # Run update to set the initial counts on startup
+        update
+      end
+
+      def update(*payload)
+        metric = @registry.get(@metric_name)
+        Monitoring::QueryHelper.instance.policy_resource_counts.each do |kind, value|
+          metric.set(value, labels: { kind: kind })
+        end
+      end
+    end
+  end
+end

--- a/lib/monitoring/operations.rb
+++ b/lib/monitoring/operations.rb
@@ -124,17 +124,17 @@ module Monitoring
       # PoliciesApi
       {
         method: "POST",
-        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        pattern: /^(\/policies)(\/[^\/]+){2,3}(\/.*)$/,
         operation: "loadPolicy"
       },
       {
         method: "PUT",
-        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        pattern: /^(\/policies)(\/[^\/]+){2,3}(\/.*)$/,
         operation: "replacePolicy"
       },
       {
         method: "PATCH",
-        pattern: /^(\/policies)(\/[^\/]+){3}(\/.*)$/,
+        pattern: /^(\/policies)(\/[^\/]+){2,3}(\/.*)$/,
         operation: "updatePolicy"
       },
 

--- a/lib/monitoring/query_helper.rb
+++ b/lib/monitoring/query_helper.rb
@@ -1,0 +1,17 @@
+require 'singleton'
+
+module Monitoring
+  class QueryHelper
+    include Singleton
+
+    def policy_resource_counts()
+      counts = {}
+      kind = ::Sequel.function(:kind, :resource_id)
+      Resource.group_and_count(kind).each do |record|
+        counts[record[:kind]] = record[:count]
+      end
+      counts
+    end
+
+  end
+end

--- a/spec/lib/monitoring/metrics/policy_metrics_spec.rb
+++ b/spec/lib/monitoring/metrics/policy_metrics_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+require 'monitoring/query_helper'
+Dir.glob(Rails.root + 'lib/monitoring/metrics/policy_*.rb', &method(:require))
+
+describe 'policy metrics', type: :request  do
+
+  before do
+    pubsub.unsubscribe('conjur.policy_loaded')
+    pubsub.unsubscribe('conjur.resource_count_update')
+
+    @resource_metric = Monitoring::Metrics::PolicyResourceGauge.new
+
+    # Clear and setup the Prometheus client store
+    Monitoring::Prometheus.setup(
+      registry: Prometheus::Client::Registry.new, 
+      metrics: metrics
+    )
+
+    Slosilo["authn:rspec"] ||= Slosilo::Key.new
+  end
+  
+  def headers_with_auth(payload)
+    token_auth_header.merge({ 'RAW_POST_DATA' => payload })
+  end
+
+  let(:registry) { Monitoring::Prometheus.registry }
+
+  let(:metrics) { [ @resource_metric ] }
+
+  let(:pubsub) { Monitoring::PubSub.instance }
+
+  let(:policy_load_event_name) { 'conjur.policy_loaded' }
+
+  let(:policies_url) { '/policies/rspec/policy/root' }
+
+  let(:current_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+
+  let(:token_auth_header) do
+    bearer_token = Slosilo["authn:rspec"].signed_token(current_user.login)
+    token_auth_str =
+      "Token token=\"#{Base64.strict_encode64(bearer_token.to_json)}\""
+    { 'HTTP_AUTHORIZATION' => token_auth_str }
+  end
+
+  context 'when a policy is loaded' do
+
+    it 'publishes a policy load event (POST)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@resource_metric.sub_event_name)
+      post(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'publishes a policy load event (PUT)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@resource_metric.sub_event_name)
+      put(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'publishes a policy load event (PATCH)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@resource_metric.sub_event_name)
+      patch(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'calls update on the correct metric' do
+      expect(@resource_metric).to receive(:update)
+      post(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'updates the registry' do
+      post(policies_url, env: headers_with_auth('[!variable added]'))
+
+      gauge_metric = registry.get(:conjur_resource_count)
+      expect(gauge_metric.get(labels: { kind: 'variable' })).to eql(1.0)
+    end
+
+  end
+
+  context 'when multiple policies are loaded' do
+
+    # Revisit this test when update throttling has been implemented
+    xit 'throttles policy events' do
+      expect(@resource_metric).to receive(:update).at_most(2).times
+      post(policies_url, env: headers_with_auth('[!variable test1]'))
+      post(policies_url, env: headers_with_auth('[!variable test2]'))
+      post(policies_url, env: headers_with_auth('[!variable test3]'))
+      post(policies_url, env: headers_with_auth('[!variable test4]'))
+      post(policies_url, env: headers_with_auth('[!variable test5]'))
+    end
+    
+  end
+end

--- a/spec/lib/monitoring/query_helper_spec.rb
+++ b/spec/lib/monitoring/query_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'monitoring/query_helper'
+
+describe Monitoring::QueryHelper do
+  let(:queryhelper) { Monitoring::QueryHelper.instance }
+
+  it 'returns policy resource counts' do
+    resource_counts = queryhelper.policy_resource_counts
+    expect(resource_counts).not_to be_empty
+  end
+
+end


### PR DESCRIPTION
NOTE: this is policy resources, NOT policy roles!

For this we need to register policy resources counts metrics onto the Prometheus client store. Consult the solution design for the policy resource count metric definitions. The general idea is to

Publish an event (e.g. conjur_policy_load) the subscriber can use to make the metrics updates. In this case there really isn't any data for the event to pass along with the event since at policy load time we only know that the policy resouce count has potentially changed, and not what the changes were. This event is published on policy load, which we believes takes place exclusively at load_policy in the PolicyController.

The Prometheus subscriber for these metrics will interpret that event and make appropriate metric updates to the store. In this case the subscriber is responsible for determining the latest policy resources counts by querying the database.

The act of adding the metrics onto the store, combined with the prior work to setup the Prometheus exporter should result in the metric being present in the scrape target endpoint GET /metrics.

For end to end test cases:

lightweight test: make policy updates by invoking the policy endpoints, and ensure that any changes are reflected in the response of the scrape target endpoint
pub/sub plumbing is unit tested so that when policy is loaded (1) an event is dispatched, (2) an event dispatched results in the correct subscriber logic running, (3) the subsciber logic grabs the latest policy resources counts and writes them onto the Prometheus store