### PR TITLE
Collect role metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -11,7 +11,8 @@ if Rails.application.config.conjur_config.telemetry_enabled
     Monitoring::Metrics::ApiRequestCounter.new,
     Monitoring::Metrics::ApiRequestHistogram.new,
     Monitoring::Metrics::ApiExceptionCounter.new,
-    Monitoring::Metrics::PolicyResourceGauge.new
+    Monitoring::Metrics::PolicyResourceGauge.new,
+    Monitoring::Metrics::PolicyRoleGauge.new
   ]
   Monitoring::Prometheus.setup(metrics: metrics)
 

--- a/lib/monitoring/metrics/policy_role_gauge.rb
+++ b/lib/monitoring/metrics/policy_role_gauge.rb
@@ -1,0 +1,30 @@
+module Monitoring
+  module Metrics
+    class PolicyRoleGauge
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_role_count
+        @docstring = 'Number of roles in Conjur database'
+        @labels = %i[kind]
+        @sub_event_name = 'conjur.role_count_update'
+        @throttle = true
+        
+        # Create/register the metric
+        Metrics.create_metric(self, :gauge)
+
+        # Run update to set the initial counts on startup
+        update
+      end
+
+      def update(*payload)
+        metric = @registry.get(@metric_name)
+        Monitoring::QueryHelper.instance.policy_role_counts.each do |kind, value|
+          metric.set(value, labels: { kind: kind })
+        end
+      end
+    end
+  end
+end

--- a/lib/monitoring/query_helper.rb
+++ b/lib/monitoring/query_helper.rb
@@ -4,7 +4,7 @@ module Monitoring
   class QueryHelper
     include Singleton
 
-    def policy_resource_counts()
+    def policy_resource_counts
       counts = {}
       kind = ::Sequel.function(:kind, :resource_id)
       Resource.group_and_count(kind).each do |record|
@@ -13,5 +13,13 @@ module Monitoring
       counts
     end
 
+    def policy_role_counts
+      counts = {}
+      kind = ::Sequel.function(:kind, :role_id)
+      Role.group_and_count(kind).each do |record|
+        counts[record[:kind]] = record[:count]
+      end
+      counts
+    end
   end
 end

--- a/spec/lib/monitoring/query_helper_spec.rb
+++ b/spec/lib/monitoring/query_helper_spec.rb
@@ -8,4 +8,9 @@ describe Monitoring::QueryHelper do
     expect(resource_counts).not_to be_empty
   end
 
+  it 'returns policy role counts' do
+    role_counts = queryhelper.policy_role_counts
+    expect(role_counts).not_to be_empty
+  end
+
 end


### PR DESCRIPTION
NOTE: this is policy roles, NOT policy resources!

For this we need to register policy roles counts metrics onto the Prometheus client store. Consult the solution design for the policy roles counts metric definitions. The general idea is to:

1. Publish an event (e.g. conjur_policy_load) the subscriber can use to make the metrics updates. In this case there really isn't any data for the event to pass along with the event since at policy load time we only know that the policy resouce count has potentially changed, and not what the changes were. This event is published on policy load, which we believes takes place exclusively at load_policy in the PolicyController. NOTE that the method load_policy returns created_roles, perhaps this can be used to determine avoid unnecessarily querying the database for policy roles counts changes.

2. The Prometheus subscriber for these metrics will interpret that event and make appropriate metric updates to the store. In this case the subscriber is responsible for determining the latest policy roles counts by querying the database.

The act of adding the metrics onto the store, combined with the prior work to setup the Prometheus exporter should result in the metric being present in the scrape target endpoint GET /metrics.

For the end-to-end tests:

lightweight test: make policy updates by invoking the policy endpoints, and ensure that any changes are reflected in the response of the scrape target endpoint
pub/sub plumbing is unit tested so that when policy is loaded (1) an event is dispatched, (2) an event dispatched results in the correct subscriber logic running, (3) the subsciber logic grabs the latest policy roles counts and writes them onto the Prometheus store