### PR TITLE
Fix typo latent_creditials -> latent_roles

### DIFF
--- a/db/migrate/20210514185315_role_cascade_delete.rb
+++ b/db/migrate/20210514185315_role_cascade_delete.rb
@@ -66,8 +66,8 @@ Sequel.migration do
   
       $stderr.puts(
         "Deleting #{latent_roles.count} " \
-        "role#{'s' if latent_credentials.count > 1} that no longer " \
-        "exist#{'s' if latent_credentials.count == 1} in policy:"
+        "role#{'s' if latent_roles.count > 1} that no longer " \
+        "exist#{'s' if latent_roles.count == 1} in policy:"
       )
   
       # Print the ID for deleted roles


### PR DESCRIPTION
### Desired Outcome

Fixing a typo in migrations. The `delete_latent_credentials` function was duplicated for `delete_latent_roles` and two references to `credentials` weren't replaced with `roles`. If there are latent roles, it tries to clean them up, but aborts due to undefined `latent_credentials`.

```
NameError: undefined local variable or method `latent_credentials' for #<Sequel::Postgres::Database: "postgres://[snip]" {:test=>true, :url=>"postgres://[snip]"}>
Did you mean? latent_roles
```


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
