### PR TITLE
Add gemfile comments and fix OCP test script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,12 @@ group :development, :test do
   gem 'rspec-core'
   gem 'rspec-rails'
   gem 'ruby-debug-ide'
+
+  # We use a post-coverage hook to sleep covered processes until we're ready to
+  # collect the coverage reports in CI. Because of this, we don't want bundler
+  # to auto-load simplecov. Rather we require it directly when we need it.
   gem 'simplecov', require: false
+
   gem 'spring'
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'

--- a/ci/test_suites/authenticators_k8s/test_oc_entrypoint.sh
+++ b/ci/test_suites/authenticators_k8s/test_oc_entrypoint.sh
@@ -294,7 +294,7 @@ function run_cucumber() {
     -r ./cucumber/authenticators_k8s/features/support/world.rb \
     -r ./cucumber/authenticators_k8s/features/support/hooks.rb \
     -r ./cucumber/authenticators_k8s/features/support/conjur_token.rb \
-    $cucumber_args ./cucumber/authenticators_k8s/features" | cucumbercmd -i bash || true
+    $cucumber_args ./cucumber/authenticators_k8s/features" | cucumbercmd -i bash
 }
 
 main


### PR DESCRIPTION

### Implemented Changes
This is a follow-up PR to https://github.com/cyberark/conjur/pull/2564

Specifically it:
- Adds comments to the gemfile to explain the use of `require: false` for simplecov
- Fixes the OCP test entrypoint in the same way GKE was fixed in the prior PR


### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
