### PR TITLE
Remove redhat-rpm-config package from UBI image

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -25,7 +25,6 @@ RUN INSTALL_PKGS="gcc \
                   libxslt-devel \
                   make \
                   openldap-clients \
-                  redhat-rpm-config \
                   tzdata" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
### Desired Outcome

The UBI Conjur image currently installs the `redhat-rpm-config` package. This is
causing a current build failure because of `glibc` version conflicts. However, upon
further investigation it appears this package is used for building RH RPMs. We 
don't create RPMs in this image, so this package shouldn't be necessary.

### Implemented Changes

Removed the `redhat-rpm-config` package from the UBI Dockerfile.

### Connected Issue/Story

This is in support of: 
https://github.com/cyberark/conjur/pull/2565

Progress on that PR is currently blocked on the build failures caused
by this image build.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
