### PR TITLE
Use the ShardedThreadedConnectionPool to disconnect after policy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added configuration for default value for maximum number of results return to `/resources` request
   [cyberark/conjur#2510](https://github.com/cyberark/conjur/pull/2510)
 
+### Fixed
+- Previously, the temporary schemas used to modify Conjur policy
+  caused the Postgres database catalog cache to leak memory over time,
+  leading to an eventual crash. Now, we recycle the database
+  connection after modifying policy to free this cache and prevent
+  the memory leak from occurring.
+  [cyberark/conjur#2584](https://github.com/cyberark/conjur/pull/2584)
+
 ### Security
 - Update rack to 2.2.3.1 to resolve CVE-2022-3023
   [cyberark/conjur#2564](https://github.com/cyberark/conjur/pull/2564)

--- a/app/models/loader/create_policy.rb
+++ b/app/models/loader/create_policy.rb
@@ -17,6 +17,8 @@ module Loader
       @loader.delete_shadowed_and_duplicate_rows
 
       @loader.store_policy_in_db
+
+      @loader.release_db_connection
     end
 
     def new_roles

--- a/app/models/loader/modify_policy.rb
+++ b/app/models/loader/modify_policy.rb
@@ -19,6 +19,8 @@ module Loader
       @loader.update_changed
 
       @loader.store_policy_in_db
+
+      @loader.release_db_connection
     end
 
     def new_roles

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -373,5 +373,18 @@ module Loader
     def db
       Sequel::Model.db
     end
+    
+    # PostgreSQL has many types of caches, one of which is the "catalog cache". 
+    # When a connection is established to the database, this cache is initialized alongside it, and persists for the duration of the connection. 
+    # This cache contains references to Database Objects, such as indexes, etc. (not data records themselves). 
+    # This cache is not cleaned up by the system automatically. However, if the connection is disconnected, the cache is dumped.
+    # further reading: Postgres community email thread: https://www.postgresql.org/message-id/flat/20161219.201505.11562604.horiguchi.kyotaro@lab.ntt.co.jp.
+    # The default connection pool does not support closing connections.We must be able to close connections on demand
+    # to clear the connection cache after policy loads [cyberark/conjur#2584](https://github.com/cyberark/conjur/pull/2584)
+    # The ShardedThreadedConnectionPool does support closing connections on-demand
+    # [docs](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel/ShardedThreadedConnectionPool)
+    def release_db_connection
+      Sequel::Model.db.disconnect
+    end  
   end
 end

--- a/app/models/loader/replace_policy.rb
+++ b/app/models/loader/replace_policy.rb
@@ -21,6 +21,8 @@ module Loader
       @loader.update_changed
 
       @loader.store_policy_in_db
+
+      @loader.release_db_connection
     end
 
     def new_roles

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,15 @@ module Conjur
       Sequel.extension(:core_extensions, :postgres_schemata)
       Sequel::Model.db.extension(:pg_array, :pg_inet)
     end
-
+    
+    #The default connection pool does not support closing connections.
+    # We must be able to close connections on demand to clear the connection cache
+    # after policy loads [cyberark/conjur#2584](https://github.com/cyberark/conjur/pull/2584)
+    # The [ShardedThreadedConnectionPool](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel/ShardedThreadedConnectionPool) does support closing connections on-demand.
+    # Sequel is configured to use the ShardedThreadedConnectionPool by setting the servers configuration on
+    # the database connection [docs](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel%2FShardedThreadedConnectionPool:servers)
+    config.sequel.servers = {}
+    
     config.encoding = "utf-8"
     config.active_support.escape_html_entities_in_json = true
 


### PR DESCRIPTION
### Desired Outcome
The desired outcome of this PR is to resolve the memory leak in the postgres container causing it to OOM.

### Implemented Changes
This PR:

Makes use of [ShardedThreadedConnectionPool](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel/ShardedThreadedConnectionPool) in Sequel so that active connections can be closed.
Closing active connections from conjur ensures that memory consumption in postgres stays low and a new connection for conjur is established every-time on policy load instead of using the existing connection.

### - Connected Issue/Story
- In support of [ONYX-18692](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-18692)

### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
        CHANGELOG update

### Test coverage
 
- [ ] This PR includes new unit and integration tests to go with the code
        changes, or
- [x] The changes in this PR do not require tests

### Documentation

- [ ] Docs (e.g. READMEs) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID](https://github.com/cyberark/conjur/pull/2582)
- [x] This PR does not require updating any documentation

### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x]  No behavior was changed with this PR

### Security
 
- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes