### PR TITLE
Update k8s test app base image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -616,9 +616,8 @@ pipeline {
             archiveFiles('coverage/.resultset*.json')
             archiveFiles('coverage/coverage.json')
             archiveFiles('coverage/codeclimate.json')
-            archiveFiles(
-              'ci/test_suites/authenticators_k8s/output/simplecov-resultset-authnk8s-gke.json'
-            )
+            archiveFiles('ci/test_suites/authenticators_k8s/output/simplecov-resultset-authnk8s-gke.json')
+            archiveFiles('ci/test_suites/authenticators_k8s/output/gke-authn-k8s-logs.txt')
             archiveFiles('cucumber/*/*.*')
 
             publishHTML([

--- a/ci/test_suites/authenticators_k8s/dev/Dockerfile.inventory_base
+++ b/ci/test_suites/authenticators_k8s/dev/Dockerfile.inventory_base
@@ -1,12 +1,17 @@
-FROM ruby:3.0
+FROM ruby:3.0-slim
 
-RUN gem install -N activesupport --version 6.1.4.4
-RUN gem install -N conjur-api --version 5.3.7
-RUN gem install -N conjur-cli --version 6.2.6
-RUN gem install -N sinatra
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y \
+    build-essential
+
+RUN gem install -N activesupport --version 6.1.4.4 && \
+    gem install -N conjur-api --version 5.3.7 && \
+    gem install -N conjur-cli --version 6.2.6 && \
+    gem install -N sinatra
 
 COPY inventory.rb usr/src/inventory.rb
 
-env PORT 80
+ENV PORT 80
 
 CMD [ "ruby", "/usr/src/inventory.rb" ]

--- a/ci/test_suites/authenticators_k8s/test_gke_entrypoint.sh
+++ b/ci/test_suites/authenticators_k8s/test_gke_entrypoint.sh
@@ -42,11 +42,6 @@ function finish {
         bash -c "cat /opt/conjur-server/log/test.log" >> \
         output/gke-authn-k8s-logs.txt
 
-      echo "Printing Logs from Conjur to the console"
-      echo "==========================="
-      cat output/gke-authn-k8s-logs.txt
-      echo "==========================="
-
       echo "Killing conjur so that coverage report is written"
       # The container is kept alive using an infinite sleep in the at_exit hook
       # (see .simplecov) so that the kubectl cp below works.

--- a/cucumber/authenticators_k8s/features/step_definitions/authenticate_steps.rb
+++ b/cucumber/authenticators_k8s/features/step_definitions/authenticate_steps.rb
@@ -69,7 +69,12 @@ Then(/^I( can)? authenticate pod matching "([^"]*)" with authn-k8s as "([^"]*)"(
     conjur_id = "#{hostid_prefix}/#{hostid_suffix}"
   end
 
-  cert = nocertkey ? nil : OpenSSL::X509::Certificate.new(@cert)
+  cert = nil
+  unless nocertkey
+    expect(@cert.to_s).not_to be_empty, "ERROR: Certificate fetched was empty or nil but was expected to be present!"
+    cert = OpenSSL::X509::Certificate.new(@cert)
+  end
+
   key = nocertkey ? nil : @pkey
 
   begin


### PR DESCRIPTION

### Implemented Changes

This PR switches the base image for the k8s test app to use the "slim" variant with fewer packages installed by default. Switching to the slim base image reduces the vulnerable package footprint of the app image.

This PR further cleans up the Dockerfile and aligns it with our current best practices.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
