### PR TITLE
Ofira host api key

### DIFF
--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -134,8 +134,22 @@ module Loader
     end
 
     class Host < Record
-      def verify; end
-      def_delegators :@policy_object, :restricted_to
+
+      def_delegators :@policy_object, :restricted_to, :apikey
+
+      def verify;
+        if self.annotations.nil?
+          apiKey = false
+        else
+          apiKey = self.annotations["authn/api-key"]
+        end
+        if Rails.application.config.conjur_config.mandatory_api_key
+          message = "Api key required for host."
+          raise Exceptions::InvalidPolicyObject.new(self.id, message: message) unless apiKey == true
+        end
+
+      end
+
 
       def create!
         self.handle_restricted_to(self.roleid, restricted_to)
@@ -146,7 +160,17 @@ module Loader
     class HostFactory < Record
       def_delegators :@policy_object, :layers
 
-      def verify; end
+      def verify;
+        if self.annotations.nil?
+          apiKey = false
+        else
+          apiKey = self.annotations["authn/api-key"]
+        end
+        if Rails.application.config.conjur_config.mandatory_api_key
+          message = "Api key required for host factory."
+          raise Exceptions::InvalidPolicyObject.new(self.id, message: message) unless apiKey == true
+        end
+      end
 
       def create!
         super

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -25,6 +25,7 @@ module Conjur
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
       user_authorization_token_ttl: 480, # The default TTL of User is 8 minutes
       host_authorization_token_ttl: 480, # The default TTL of Host is 8 minutes
+      mandatory_api_key: true,
       authenticators: []
     )
 

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -25,7 +25,7 @@ module Conjur
       trusted_proxies: (ENV['TRUSTED_PROXIES'] || []),
       user_authorization_token_ttl: 480, # The default TTL of User is 8 minutes
       host_authorization_token_ttl: 480, # The default TTL of Host is 8 minutes
-      mandatory_api_key: true,
+      mandatory_api_key: false,
       authenticators: []
     )
 

--- a/spec/models/loader/types.rb
+++ b/spec/models/loader/types.rb
@@ -87,15 +87,11 @@ describe Loader::Types::User do
 end
 
 describe Loader::Types::Host do
-  let(:user) do
-    #role = Conjur::PolicyParser::Types::Role.new
-    #role.id = role_id
-    #role.kind = role_kind
-    #role.account = 'default'
+  let(:host) do
     host = Conjur::PolicyParser::Types::Host.new
     host.id = resource_id
     if api_key != ''
-      host.annotations =  { "authn/api-key" => api_key } #["auth/api-key"] = api_key
+      host.annotations =  { "authn/api-key" => api_key }
     end
     Loader::Types.wrap(host, self)
   end
@@ -110,19 +106,19 @@ describe Loader::Types::Host do
       context 'when creating host with api-key annotation true' do
         let(:resource_id) { 'myhost@admin' }
         let(:api_key) { true }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
 
       context 'when creating host with api-key annotation false' do
         let(:resource_id) { 'myhost@cyberark' }
         let(:api_key) { false }
-        it { expect { user.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
+        it { expect { host.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
       end
 
       context 'when creating host without api-key annotation' do
         let(:resource_id) { 'myhost@cyberark' }
         let(:api_key) { '' }
-        it { expect { user.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
+        it { expect { host.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
       end
     end
 
@@ -135,19 +131,19 @@ describe Loader::Types::Host do
       context 'when creating host with api-key annotation true' do
         let(:resource_id) { 'myhost@admin' }
         let(:api_key) { true }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
 
       context 'when creating host with api-key annotation false' do
         let(:resource_id) { 'alice@cyberark' }
         let(:api_key) { false }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
 
       context 'when creating host without api-key annotation' do
         let(:resource_id) { 'alice@cyberark' }
         let(:api_key) { '' }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
     end
 
@@ -155,19 +151,107 @@ describe Loader::Types::Host do
       context 'when creating host with api-key annotation true' do
         let(:resource_id) { 'myhost@admin' }
         let(:api_key) { true }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
 
       context 'when creating host with api-key annotation false' do
         let(:resource_id) { 'alice@cyberark' }
         let(:api_key) { false }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
       end
 
       context 'when creating host without api-key annotation' do
         let(:resource_id) { 'alice@cyberark' }
         let(:api_key) { '' }
-        it { expect { user.verify }.to_not raise_error }
+        it { expect { host.verify }.to_not raise_error }
+      end
+    end
+  end
+
+  describe Loader::Types::HostFactory do
+    let(:hostFactory) do
+      hostFactory = Conjur::PolicyParser::Types::HostFactory.new
+      hostFactory.id = resource_id
+      if api_key != ''
+        hostFactory.annotations =  { "authn/api-key" => api_key }
+      end
+      Loader::Types.wrap(hostFactory, self)
+    end
+
+    describe '.verify' do
+      context 'when CONJUR_MANDATORY_API_KEY is true' do
+        before do
+          allow(ENV).to receive(:[]).with('CONJUR_MANDATORY_API_KEY').and_return('true')
+          Rails.application.config.conjur_config.mandatory_api_key = true
+        end
+
+        context 'when creating host factory with api-key annotation true' do
+          let(:resource_id) { 'myhostfactory@admin' }
+          let(:api_key) { true }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+
+        context 'when creating host factory with api-key annotation false' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { false }
+          it { expect { hostFactory.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
+        end
+
+        context 'when creating host factory without api-key annotation' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { '' }
+          it { expect { hostFactory.verify }.to raise_error(Exceptions::InvalidPolicyObject) }
+        end
+      end
+
+      context 'when CONJUR_MANDATORY_API_KEY is false' do
+        before do
+          allow(ENV).to receive(:[]).with('CONJUR_MANDATORY_API_KEY').and_return('false')
+          Rails.application.config.conjur_config.mandatory_api_key = false
+        end
+
+        context 'when creating host factory with api-key annotation true' do
+          let(:resource_id) { 'myhostfactory@admin' }
+          let(:api_key) { true }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+
+        context 'when creating host factory with api-key annotation false' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { false }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+
+        context 'when creating host factory without api-key annotation' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { '' }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+      end
+
+      context 'when CONJUR_MANDATORY_API_KEY is not set' do
+
+        before do
+          Rails.application.config.conjur_config.mandatory_api_key = false
+        end
+
+        context 'when creating host with api-key annotation true' do
+          let(:resource_id) { 'myhostfactory@admin' }
+          let(:api_key) { true }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+
+        context 'when creating host factory with api-key annotation false' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { false }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
+
+        context 'when creating host factory without api-key annotation' do
+          let(:resource_id) { 'myhostfactory@cyberark' }
+          let(:api_key) { '' }
+          it { expect { hostFactory.verify }.to_not raise_error }
+        end
       end
     end
   end


### PR DESCRIPTION
### Desired Outcome

Adding mandatory ApiKEY annotation for host and host factory upon relevant env variable is set

### Implemented Changes

In order to implement it - we are going to add flag to conjur_config.rb. The flag is called 'mandatory_api_key' and its default value is 'false' in order to preserve existing functionality in conjur-oss.

Also - we are adding validation to Host and HostFactory objects in loader/types.rb. 

If the flag is provided as 'true' the validations are mandating annotation "authn/api-key" with value true

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
