### PR TITLE
Mandate specific annotation on host creation under condition (currently true for Conjur Cloud)

### DIFF
--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -134,8 +134,36 @@ module Loader
     end
 
     class Host < Record
-      def verify; end
       def_delegators :@policy_object, :restricted_to
+
+      # This is a temporary policy validation check to ensure that we're not
+      # creating hosts that will fail API key-based authentication by default
+      # in the future.
+      def future_api_key_auth_will_fail?
+        # The default config value is to allow API key authentication, so if this is
+        # either the default or set to true, then future API key authentication will
+        # continue to work and we don't need to reject this policy.
+        return false if Rails.application.config.conjur_config.authn_api_key_default
+
+        # If the default API authentication config is to disallow it, and the host
+        # does not explicitly state the policy authors intentions with the
+        # `authn/api-key` annotation with value true, then we should reject this until the annotation
+        # is added to the policy object.
+        self.annotations&.[]("authn/api-key").nil? or self.annotations["authn/api-key"] == false
+      end
+
+      def verify
+        # If policy contains a host with annotation authn/api-key effectively false, either by explicit
+        # value or by default value, then policy load is blocked.
+        if future_api_key_auth_will_fail?
+          message = "API key authentication for hosts is disabled by default and " \
+              "will be removed in a future release. Add the 'authn/api-key' " \
+              "annotation to this host with the value 'true' to " \
+              "ensure authentication works as expected for this host in the " \
+              "future."
+          raise Exceptions::InvalidPolicyObject.new(self.id, message: message)
+        end
+      end
 
       def create!
         self.handle_restricted_to(self.roleid, restricted_to)

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -28,6 +28,7 @@ module Conjur
       api_resource_list_limit_max: 0,
       user_authorization_token_ttl: 480, # The default TTL of User is 8 minutes
       host_authorization_token_ttl: 480, # The default TTL of Host is 8 minutes
+      authn_api_key_default: true,
       authenticators: []
     )
 

--- a/spec/models/loader/types.rb
+++ b/spec/models/loader/types.rb
@@ -85,3 +85,67 @@ describe Loader::Types::User do
     end
   end
 end
+
+describe Loader::Types::Host do
+  let(:host) do
+    host = Conjur::PolicyParser::Types::Host.new
+    host.id = resource_id
+    if api_key != ''
+      host.annotations =  { "authn/api-key" => api_key }
+    end
+    Loader::Types.wrap(host, self)
+  end
+
+  describe '.verify' do
+    context 'when CONJUR_AUTHN_API_KEY_DEFAULT is true' do
+      before do
+        allow(ENV).to receive(:[]).with('CONJUR_AUTHN_API_KEY_DEFAULT').and_return('true')
+        Rails.application.config.conjur_config.authn_api_key_default = true
+      end
+
+      context 'when creating host with api-key annotation true' do
+        let(:resource_id) { 'myhost@admin' }
+        let(:api_key) { true }
+        it { expect { host.verify }.to_not raise_error }
+      end
+
+      context 'when creating host with api-key annotation false' do
+        let(:resource_id) { 'myhost@cyberark' }
+        let(:api_key) { false }
+        it { expect { host.verify }.to_not raise_error(Exceptions::InvalidPolicyObject) }
+      end
+
+      context 'when creating host without api-key annotation' do
+        let(:resource_id) { 'myhost@cyberark' }
+        let(:api_key) { '' }
+        it { expect { host.verify }.to_not raise_error(Exceptions::InvalidPolicyObject) }
+      end
+    end
+
+    context 'when CONJUR_AUTHN_API_KEY_DEFAULT is false' do
+      before do
+        allow(ENV).to receive(:[]).with('CONJUR_AUTHN_API_KEY_DEFAULT').and_return('false')
+        Rails.application.config.conjur_config.authn_api_key_default = false
+      end
+
+      context 'when creating host with api-key annotation true' do
+        let(:resource_id) { 'myhost@admin' }
+        let(:api_key) { true }
+        it { expect { host.verify }.to_not raise_error }
+      end
+
+      context 'when creating host with api-key annotation false' do
+        let(:resource_id) { 'alice@cyberark' }
+        let(:api_key) { false }
+        it { expect { host.verify }.to raise_error }
+      end
+
+      context 'when creating host without api-key annotation' do
+        let(:resource_id) { 'alice@cyberark' }
+        let(:api_key) { '' }
+        it { expect { host.verify }.to raise_error }
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
### Desired Outcome

Adding mandatory ApiKEY annotation for host upon relevant env variable is set to false

### Implemented Changes

In order to implement it - we are going to add flag to conjur_config.rb. The flag is called 'authn_api_key_default' and its default value is 'true' in order to preserve existing functionality in conjur-oss.

Also - we are adding validation to Host objects in loader/types.rb. 

If the flag is provided as 'false' the validations are mandating annotation "authn/api-key" with value true

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [[ONYX-22003](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22003)]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update. (OSS users are not impacted by this change)

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [X] This PR changes product behavior and has been reviewed by a PO, or (but only under a flag)
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
