### PR TITLE
Adds OIDC code workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.18.0] - 2022-07-12
+### Changed
+- Adds support for authentication using OIDC's code authorization flow
+  [cyberark/conjur#2595](https://github.com/cyberark/conjur/pull/2595)
+
 ## [1.17.8] - 2022-07-14
+
 ### Security
 - Updated rails to 6.1.6.1 to remove CVE-2022-32224
   [cyberark/conjurinc#2605](https://github.com/cyberark/conjur/pull/2605)
 
 ## [1.17.7] - 2022-06-29
-
 ### Changed
 - Made simplecov a dev/test dependency
-  [cyberark/conjur#2564](https://github.com/cyberark/conjur/pull/2564)  
+  [cyberark/conjur#2564](https://github.com/cyberark/conjur/pull/2564)
 - Added configuration for token TTL
   [cyberark/conjur#2510](https://github.com/cyberark/conjur/pull/2510)
 - Added configuration for default value for maximum number of results return to `/resources` request

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development, :test do
   gem 'debase', '~> 0.2.5.beta2'
   gem 'faye-websocket'
   gem 'json_spec', '~> 1.1'
+  gem 'faye-websocket'
   gem 'net-ssh'
   gem 'parallel'
   gem 'pry-byebug'
@@ -109,6 +110,8 @@ group :development, :test do
   gem 'spring-commands-cucumber'
   gem 'spring-commands-rspec'
   gem 'table_print'
+  gem 'vcr'
+  gem 'webmock'
   gem 'webrick'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     conjur-rack-heartbeat (2.2.0)
       rack
     contracts (0.17)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     csr (0.1.1)
     cucumber (7.1.0)
@@ -215,6 +217,7 @@ GEM
     globalid (1.0.0)
       activesupport (>= 5.0)
     haikunator (1.1.1)
+    hashdiff (1.0.1)
     highline (2.0.3)
     http (4.2.0)
       addressable (~> 2.3)
@@ -453,9 +456,14 @@ GEM
     validate_url (1.0.13)
       activemodel (>= 3.0.0)
       public_suffix
+    vcr (6.1.0)
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
@@ -539,6 +547,8 @@ DEPENDENCIES
   spring-commands-cucumber
   spring-commands-rspec
   table_print
+  vcr
+  webmock
   webrick
   websocket
 

--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -4,6 +4,25 @@ class AuthenticateController < ApplicationController
   include BasicAuthenticator
   include AuthorizeResource
 
+  def oidc_authenticate_code_redirect
+    # TODO: need a mechanism for an authenticator strategy to define the required
+    # params. This will likely need to be done via the Handler.
+    params.permit!
+
+    auth_token = Authentication::Handler::AuthenticationHandler.new(
+      authenticator_type: params[:authenticator]
+    ).call(
+      parameters: params.to_hash.symbolize_keys,
+      request_ip: request.ip
+    )
+
+    render_authn_token(auth_token)
+    Rails.logger.debug("AuthenticateController#authenticate_okta - authentication token: #{auth_token.inspect}")
+  rescue => e
+    log_backtrace(e)
+    raise e
+  end
+
   def index
     authenticators = {
       # Installed authenticator plugins
@@ -129,7 +148,6 @@ class AuthenticateController < ApplicationController
   else
     authenticate(input)
   end
-
   def authenticate_gcp
     params[:authenticator] = "authn-gcp"
     input = Authentication::AuthnGcp::UpdateAuthenticatorInput.new.(
@@ -273,8 +291,14 @@ class AuthenticateController < ApplicationController
     when Errors::Authentication::Security::RoleNotAuthorizedOnResource
       raise Forbidden
 
+    when Errors::Conjur::RequestedResourceNotFound
+      raise RecordNotFound.new(err.message)
+
     when Errors::Authentication::RequestBody::MissingRequestParam
       raise BadRequest
+
+    when Errors::Conjur::RequestedResourceNotFound
+      raise RecordNotFound.new(err.message)
 
     when Errors::Authentication::Jwt::TokenExpired
       raise Unauthorized.new(err.message, true)
@@ -285,6 +309,9 @@ class AuthenticateController < ApplicationController
     when Errors::Authentication::AuthnK8s::CSRMissingCNEntry,
       Errors::Authentication::AuthnK8s::CertMissingCNEntry
       raise ArgumentError
+
+    when Rack::OAuth2::Client::Error
+      raise BadRequest
 
     else
       raise Unauthorized

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ProvidersController < RestController
+  include FindResource
+  include AssumedRole
+  include CurrentUser
+
+  def index
+    namespace = Authentication::Util::NamespaceSelector.select(
+      authenticator_type: params[:authenticator]
+    )
+    render(
+      json: "#{namespace}::Views::ProviderContext".constantize.new.call(
+        authenticators: DB::Repository::AuthenticatorRepository.new(
+          data_object:  "#{namespace}::DataObjects::Authenticator".constantize
+        ).find_all(
+          account: params[:account],
+          type: params[:authenticator]
+        ).select { |authenticator| role&.allowed_to?(:read, ::Resource[authenticator.resource_id]) }
+      )
+    )
+  end
+
+  # The v5 API currently sends +acting_as+ when listing resources
+  # for a role other than the current user.
+  def role
+    assumed_role(params[:role].presence) || assumed_role(params[:acting_as].presence)
+  end
+end

--- a/app/db/repository/authenticator_repository.rb
+++ b/app/db/repository/authenticator_repository.rb
@@ -1,0 +1,68 @@
+module DB
+  module Repository
+    class AuthenticatorRepository
+      def initialize(data_object:, resource_repository: ::Resource, logger: Rails.logger)
+        @resource_repository = resource_repository
+        @data_object = data_object
+        @logger = logger
+      end
+
+      def find_all(type:, account:)
+        @resource_repository.where(
+          Sequel.like(
+            :resource_id,
+            "#{account}:webservice:conjur/#{type}/%"
+          )
+        ).all.map do |webservice|
+          load_authenticator(account: account, id: webservice.id.split(':').last, type: type)
+        end.compact
+      end
+
+      def find(type:, account:,  service_id:)
+        webservice =  @resource_repository.where(
+          Sequel.like(
+            :resource_id,
+            "#{account}:webservice:conjur/#{type}/#{service_id}"
+          )
+        ).first
+        return unless webservice
+
+        load_authenticator(account: account, id: webservice.id.split(':').last, type: type)
+      end
+
+      def exists?(type:, account:, service_id:)
+        @resource_repository.with_pk("#{account}:webservice:conjur/#{type}/#{service_id}") != nil
+      end
+
+      private
+
+      def load_authenticator(type:, account:, id:)
+        service_id = id.split('/')[2]
+        variables = @resource_repository.where(
+          Sequel.like(
+            :resource_id,
+            "#{account}:variable:conjur/#{type}/#{service_id}/%"
+          )
+        ).eager(:secrets).all
+
+        args_list = {}.tap do |args|
+          args[:account] = account
+          args[:service_id] = service_id
+          variables.each do |variable|
+            next unless variable.secret
+
+            args[variable.resource_id.split('/')[-1].underscore.to_sym] = variable.secret.value
+          end
+        end
+        @logger.debug("DB::Repository::AuthenticatorRepository.load_authenticator - arguments for initialization: #{args_list.inspect}")
+        begin
+          @data_object.new(**args_list)
+        rescue ArgumentError => e
+          @logger.debug("DB::Repository::AuthenticatorRepository.load_authenticator - exception: #{e}")
+          @logger.debug("DB::Repository::AuthenticatorRepository.load_authenticator - invalid: #{args_list.inspect}")
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -1,0 +1,97 @@
+module Authentication
+  module AuthnOidc
+    module V2
+      class Client
+        def initialize(
+          authenticator:,
+          client: ::OpenIDConnect::Client,
+          oidc_id_token: ::OpenIDConnect::ResponseObject::IdToken,
+          discovery_configuration: ::OpenIDConnect::Discovery::Provider::Config,
+          cache: Rails.cache,
+          logger: Rails.logger
+        )
+          @authenticator = authenticator
+          @client = client
+          @oidc_id_token = oidc_id_token
+          @discovery_configuration = discovery_configuration
+          @cache = cache
+          @logger = logger
+        end
+
+        def oidc_client
+          @oidc_client ||= begin
+            issuer_uri = URI(@authenticator.provider_uri)
+            @client.new(
+              identifier: @authenticator.client_id,
+              secret: @authenticator.client_secret,
+              redirect_uri: @authenticator.redirect_uri,
+              scheme: issuer_uri.scheme,
+              host: issuer_uri.host,
+              port: issuer_uri.port,
+              authorization_endpoint: URI(discovery_information.authorization_endpoint).path,
+              token_endpoint: URI(discovery_information.token_endpoint).path,
+              userinfo_endpoint: URI(discovery_information.userinfo_endpoint).path,
+              jwks_uri: URI(discovery_information.jwks_uri).path,
+              end_session_endpoint: URI(discovery_information.end_session_endpoint).path
+            )
+          end
+        end
+
+        def callback(code:)
+          unless code.present?
+            raise Errors::Authentication::RequestBody::MissingRequestParam, 'code'
+          end
+
+          oidc_client.authorization_code = code
+          bearer_token = oidc_client.access_token!(
+            scope: true,
+            client_auth_method: :basic,
+            nonce: @authenticator.nonce
+          )
+          id_token = bearer_token.id_token || bearer_token.access_token
+          @logger.debug("token: #{id_token.inspect}")
+
+          begin
+            attempts ||= 0
+            decoded_id_token = @oidc_id_token.decode(
+              id_token,
+              discovery_information.jwks
+            )
+          rescue Exception => e
+            attempts += 1
+            raise e if attempts > 1
+
+            # If the JWKS verification fails, blow away the existing cache and
+            # try again. This is intended to handle the case where the OIDC certificate
+            # changes, and we want to cache the new certificate without decode failing.
+            discovery_information(invalidate: true)
+            retry
+          end
+
+          decoded_id_token.verify!(
+            issuer: @authenticator.provider_uri,
+            client_id: @authenticator.client_id,
+            nonce: @authenticator.nonce
+          )
+          decoded_id_token
+        rescue OpenIDConnect::ValidationFailed => e
+          raise Errors::Authentication::AuthnOidc::TokenVerificationFailed, e.message
+        end
+
+        def discovery_information(invalidate: false)
+          @cache.fetch(
+            "#{@authenticator.account}/#{@authenticator.service_id}/#{URI::Parser.new.escape(@authenticator.provider_uri)}",
+            force: invalidate,
+            skip_nil: true
+          ) do
+            @discovery_configuration.discover!(@authenticator.provider_uri)
+          rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
+            raise Errors::Authentication::OAuth::ProviderDiscoveryTimeout.new(@authenticator.provider_uri, e.inspect)
+          rescue => e
+            raise Errors::Authentication::OAuth::ProviderDiscoveryFailed.new(@authenticator.provider_uri, e.inspect)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -1,0 +1,54 @@
+module Authentication
+  module AuthnOidc
+    module V2
+      module DataObjects
+        class Authenticator
+
+          # required
+          attr_reader :provider_uri, :client_id, :client_secret, :claim_mapping, :nonce, :state, :account
+          attr_reader :service_id, :redirect_uri, :response_type
+
+          def initialize(
+            provider_uri:,
+            client_id:,
+            client_secret:,
+            claim_mapping:,
+            nonce:,
+            state:,
+            account:,
+            service_id:,
+            redirect_uri: nil,
+            name: nil,
+            response_type: 'code',
+            provider_scope: nil
+          )
+            @account = account
+            @provider_uri = provider_uri
+            @client_id = client_id
+            @client_secret = client_secret
+            @claim_mapping = claim_mapping
+            @nonce = nonce
+            @response_type = response_type
+            @state = state
+            @service_id = service_id
+            @name = name
+            @provider_scope = provider_scope
+            @redirect_uri = redirect_uri
+          end
+
+          def scope
+            (%w[openid email profile] + [*@provider_scope]).uniq.join(' ')
+          end
+
+          def name
+            @name || @service_id.titleize
+          end
+
+          def resource_id
+            "#{account}:webservice:conjur/authn-oidc/#{service_id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/v2/resolve_identity.rb
+++ b/app/domain/authentication/authn_oidc/v2/resolve_identity.rb
@@ -1,0 +1,19 @@
+module Authentication
+  module AuthnOidc
+    module V2
+      class ResolveIdentity
+        def call(identity:, account:, allowed_roles:)
+          # make sure role has a resource (ex. user, host)
+          roles = allowed_roles.select(&:resource?)
+
+          roles.each do |role|
+            role_account, _, role_id = role.id.split(':')
+            return role if role_account == account && identity == role_id
+          end
+
+          raise(Errors::Authentication::Security::RoleNotFound, identity)
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -1,0 +1,41 @@
+
+module Authentication
+  module AuthnOidc
+    module V2
+      class Strategy
+        def initialize(
+          authenticator:,
+          client: Authentication::AuthnOidc::V2::Client,
+          logger: Rails.logger
+        )
+          @authenticator = authenticator
+          @client = client.new(authenticator: authenticator)
+          @logger = logger
+        end
+
+        # Don't love this name...
+        def callback(args)
+          @logger.info("-- args: #{args.inspect}")
+          # TODO: Check that `code` and `state` attributes are present
+          raise Errors::Authentication::AuthnOidc::StateMismatch unless args[:state] == @authenticator.state
+
+          identity = resolve_identity(
+            jwt: @client.callback(
+              code: args[:code]
+            )
+          )
+          unless identity.present?
+            raise Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty,
+                  @authenticator.claim_mapping
+          end
+          identity
+        end
+
+        def resolve_identity(jwt:)
+          @logger.info(jwt.raw_attributes.inspect)
+          jwt.raw_attributes.with_indifferent_access[@authenticator.claim_mapping]
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/authn_oidc/v2/views/provider_context.rb
+++ b/app/domain/authentication/authn_oidc/v2/views/provider_context.rb
@@ -1,0 +1,44 @@
+module Authentication
+  module AuthnOidc
+    module V2
+      module Views
+        class ProviderContext
+          def initialize(
+            client: Authentication::AuthnOidc::V2::Client,
+            logger: Rails.logger
+          )
+            @client = client
+            @logger = logger
+          end
+
+          def call(authenticators:)
+            authenticators.map do |authenticator|
+              {
+                service_id: authenticator.service_id,
+                type: 'authn-oidc',
+                name: authenticator.name,
+                redirect_uri: generate_redirect_url(
+                  client: @client.new(authenticator: authenticator),
+                  authenticator: authenticator
+                )
+              }
+            end
+          end
+
+          def generate_redirect_url(client:, authenticator:)
+            params = {
+              client_id: authenticator.client_id,
+              response_type: authenticator.response_type,
+              scope: ERB::Util.url_encode(authenticator.scope),
+              state: authenticator.state,
+              nonce: authenticator.nonce,
+              redirect_uri: ERB::Util.url_encode(authenticator.redirect_uri)
+            }.map { |key, value| "#{key}=#{value}" }.join("&")
+
+            "#{client.discovery_information.authorization_endpoint}?#{params}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module Authentication
+  module Handler
+    class AuthenticationHandler
+      def initialize(
+        authenticator_type:,
+        role: ::Role,
+        resource: ::Resource,
+        authn_repo: DB::Repository::AuthenticatorRepository,
+        namespace_selector: Authentication::Util::NamespaceSelector,
+        logger: Rails.logger,
+        authentication_error: LogMessages::Authentication::AuthenticationError
+      )
+        @role = role
+        @resource = resource
+        @authenticator_type = authenticator_type
+        @logger = logger
+        @authentication_error = authentication_error
+
+        # Dynamically load authenticator specific classes
+        namespace = namespace_selector.select(
+          authenticator_type: authenticator_type
+        )
+
+        @identity_resolver = "#{namespace}::ResolveIdentity".constantize
+        @strategy = "#{namespace}::Strategy".constantize
+        @authn_repo = authn_repo.new(
+          data_object: "#{namespace}::DataObjects::Authenticator".constantize
+        )
+      end
+
+      def call(parameters:, request_ip:)
+        raise Errors::Authentication::RequestBody::MissingRequestParam, parameters[:code] unless parameters[:code]
+        raise Errors::Authentication::RequestBody::MissingRequestParam, parameters[:state] unless parameters[:state]
+        # Load Authenticator policy and values (validates data stored as variables)
+        authenticator = @authn_repo.find(
+          type: @authenticator_type,
+          account: parameters[:account],
+          service_id: parameters[:service_id]
+        )
+
+        if authenticator.nil?
+          raise(
+            Errors::Conjur::RequestedResourceNotFound,
+            "Unable to find authenticator with account: #{parameters[:account]} and service-id: #{parameters[:service_id]}"
+          )
+        end
+
+        role = @identity_resolver.new.call(
+          identity: @strategy.new(
+            authenticator: authenticator
+          ).callback(parameters),
+          account: parameters[:account],
+          allowed_roles: @role.that_can(
+            :authenticate,
+            @resource[authenticator.resource_id]
+          ).all
+        )
+
+        # TODO: Add an error message
+        raise 'failed to authenticate' unless role
+
+        unless role.valid_origin?(request_ip)
+          raise Errors::Authentication::InvalidOrigin
+        end
+
+        log_audit_success(authenticator, role, request_ip, @authenticator_type)
+
+        TokenFactory.new.signed_token(
+          account: parameters[:account],
+          username: role.role_id.split(':').last
+        )
+      rescue => e
+        log_audit_failure(parameters[:account], parameters[:service_id], request_ip, @authenticator_type, e)
+        handle_error(e)
+      end
+
+      def handle_error(err)
+        @logger.warn(@authentication_error.new(err.inspect))
+
+        case err
+        when Errors::Authentication::Security::RoleNotAuthorizedOnResource
+          raise ApplicationController::Forbidden
+
+        when Errors::Authentication::RequestBody::MissingRequestParam,
+          Errors::Authentication::AuthnOidc::TokenVerificationFailed
+          raise ApplicationController::BadRequest
+
+        when Errors::Conjur::RequestedResourceNotFound
+          raise ApplicationController::RecordNotFound.new(err.message)
+
+        when Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty
+          raise ApplicationController::Unauthorized
+
+        when Errors::Authentication::Jwt::TokenExpired
+          raise ApplicationController::Unauthorized.new(err.message, true)
+
+        when Errors::Authentication::AuthnOidc::StateMismatch,
+          Errors::Authentication::Security::RoleNotFound
+          raise ApplicationController::BadRequest
+
+        when Errors::Authentication::Security::MultipleRoleMatchesFound
+          raise ApplicationController::Forbidden
+          # Code value mismatch
+        when Rack::OAuth2::Client::Error
+          raise ApplicationController::BadRequest
+
+        else
+          raise ApplicationController::Unauthorized
+        end
+      end
+
+      def log_audit_success(authenticator, conjur_role, client_ip, type)
+        ::Authentication::LogAuditEvent.new.call(
+          authentication_params:
+            Authentication::AuthenticatorInput.new(
+              authenticator_name: "#{type}",
+              service_id: authenticator.service_id,
+              account: authenticator.account,
+              username: conjur_role.role_id,
+              client_ip: client_ip,
+              credentials: nil,
+              request: nil
+            ),
+          audit_event_class: Audit::Event::Authn::Authenticate,
+          error: nil
+        )
+      end
+
+      def log_audit_failure(account, service_id, client_ip, type, error)
+        ::Authentication::LogAuditEvent.new.call(
+          authentication_params:
+            Authentication::AuthenticatorInput.new(
+              authenticator_name: "#{type}",
+              service_id: service_id,
+              account: account,
+              username: nil,
+              client_ip: client_ip,
+              credentials: nil,
+              request: nil
+            ),
+          audit_event_class: Audit::Event::Authn::Authenticate,
+          error: error
+        )
+      end
+    end
+  end
+end

--- a/app/domain/authentication/util/namespace_selector.rb
+++ b/app/domain/authentication/util/namespace_selector.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Authentication
+  module Util
+    class NamespaceSelector
+      def self.select(authenticator_type:)
+        case authenticator_type
+        when 'authn-oidc'
+          # 'V2' is a bit of a hack to handle the fact that
+          # the original OIDC authenticator is really a
+          # glorified JWT authenticator.
+          'Authentication::AuthnOidc::V2'
+        else
+          raise "'#{authenticator_type}' is not a supported authenticator type"
+          # TODO: make this dynamic based on authenticator type.
+        end
+      end
+    end
+  end
+end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -154,6 +154,11 @@ module Errors
         msg: "Account '{0-account-name}' is not defined in Conjur",
         code: "CONJ00008E"
       )
+
+      MultipleRoleMatchesFound = ::Util::TrackableErrorClass.new(
+        msg: "'{0-role}' matched multiple roles",
+        code: "CONJ00009E"
+      )
     end
 
     module RequestBody
@@ -224,6 +229,26 @@ module Errors
       ServiceIdMissing = ::Util::TrackableErrorClass.new(
         msg: "Service id is required when authenticating with authn-oidc",
         code: "CONJ00075E"
+      )
+
+      StateMismatch = ::Util::TrackableErrorClass.new(
+        msg: "Conjur internal state doesn't match given state",
+        code: "CONJ00127E"
+      )
+
+      TokenVerificationFailed = ::Util::TrackableErrorClass.new(
+        msg: "Conjur internal state doesn't match given state",
+        code: "CONJ00128E"
+      )
+
+      InvalidVariableValue = ::Util::TrackableErrorClass.new(
+        msg: "Parameter {0} with value {1} invalid",
+        code: "CONJ00129E"
+      )
+
+      InvalidProviderConfig = ::Util::TrackableErrorClass.new(
+        msg: "The OIDC provider variable values are misconfigured",
+        code: "CONJ00130E"
       )
 
     end

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       RAILS_ENV:
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw,authn-jwt/keycloak
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw,authn-jwt/keycloak,authn-oidc/keycloak2
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'
@@ -91,6 +91,7 @@ services:
       - ./ldap-certs:/ldap-certs:ro
       - log-volume:/src/conjur-server/log
       - jwks-volume:/var/jwks
+      - ./oauth/keycloak:/oauth/keycloak/scripts
     links:
       - conjur
       - pg
@@ -122,7 +123,7 @@ services:
       - KEYCLOAK_APP_USER=alice
       - KEYCLOAK_APP_USER_PASSWORD=alice
       - KEYCLOAK_APP_USER_EMAIL=alice@conjur.net
-      - KEYCLOAK_SECOND_APP_USER=bob
+      - KEYCLOAK_SECOND_APP_USER=bob.somebody
       - KEYCLOAK_SECOND_APP_USER_PASSWORD=bob
       - KEYCLOAK_SECOND_APP_USER_EMAIL=bob@conjur.net
       - KEYCLOAK_NON_CONJUR_APP_USER=not_in_conjur
@@ -130,7 +131,7 @@ services:
       - KEYCLOAK_NON_CONJUR_APP_USER_EMAIL=not_in_conjur
       - DB_VENDOR=H2
       - KEYCLOAK_CLIENT_ID=conjurClient
-      - KEYCLOAK_REDIRECT_URI=http://locallhost.com/
+      - KEYCLOAK_REDIRECT_URI=http://conjur:3000/authn-oidc/keycloak2/cucumber/authenticate
       - KEYCLOAK_CLIENT_SECRET=1234
       - KEYCLOAK_SCOPE=openid
     volumes:

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -86,6 +86,7 @@ _run_cucumber_tests() {
 
   docker-compose run "${run_flags[@]}" "${env_var_flags[@]}" \
     cucumber -ec "\
+      /oauth/keycloak/scripts/fetch_certificate &&
       bundle exec cucumber \
        --strict \
        ${cucumber_tags_arg} \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
       get     "/resources/:account"                   => "resources#index"
       get     "/resources"                            => "resources#index"
 
+      get     "/:authenticator/:account/providers"  => "providers#index"
+
       # NOTE: the order of these routes matters: we need the expire
       #       route to come first.
       post    "/secrets/:account/:kind/*identifier" => "secrets#expire",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
           post '/:authenticator(/:service_id)/:account/:id/authenticate' => 'authenticate#authenticate'
         end
 
+        # New OIDC endpoint
+        get '/:authenticator(/:service_id)/:account/authenticate' => 'authenticate#oidc_authenticate_code_redirect'
+
         post '/authn-gcp/:account/authenticate' => 'authenticate#authenticate_gcp'
         post '/authn-oidc(/:service_id)/:account/authenticate' => 'authenticate#authenticate_oidc'
         post '/authn-jwt/:service_id/:account(/:id)/authenticate' => 'authenticate#authenticate_jwt'

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -73,10 +73,12 @@ authenticators_oidc: >
   -r cucumber/api/features/step_definitions/user_steps.rb
   -r cucumber/api/features/support/logs_helpers.rb
   -r cucumber/api/features/step_definitions/logs_steps.rb
+  -r cucumber/policy/features/step_definitions/login_steps.rb
   -r cucumber/api/features/support/authz_helpers.rb
   -r cucumber/api/features/step_definitions/authz_steps.rb
   -r cucumber/policy/features/support/policy_helpers.rb
   -r cucumber/policy/features/step_definitions/policy_steps.rb
+  -r cucumber/policy/features/step_definitions/secrets_steps.rb
   -r cucumber/_authenticators_common
   -r cucumber/authenticators_ldap/features/support/authn_ldap_helper.rb
   -r cucumber/authenticators_ldap/features/step_definitions/authn_ldap_steps.rb

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -73,21 +73,21 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
   Scenario: Adding a group to keycloak/users group permits users to authenticate
     Given I extend the policy with:
     """
-    - !user bob
+    - !user bob.somebody
 
     - !group more-users
 
     - !grant
       role: !group more-users
-      member: !user bob
+      member: !user bob.somebody
 
     - !grant
       role: !group conjur/authn-oidc/keycloak/users
       member: !group more-users
     """
-    And I fetch an ID Token for username "bob" and password "bob"
+    And I fetch an ID Token for username "bob.somebody" and password "bob"
     When I authenticate via OIDC with id token
-    Then user "bob" has been authorized by Conjur
+    Then user "bob.somebody" has been authorized by Conjur
 
   @negative @acceptance
   Scenario: Non-existing username in ID token is denied
@@ -108,9 +108,9 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
   Scenario: User that is not permitted to webservice in ID token is denied
     Given I extend the policy with:
     """
-    - !user bob
+    - !user bob.somebody
     """
-    And I fetch an ID Token for username "bob" and password "bob"
+    And I fetch an ID Token for username "bob.somebody" and password "bob"
     And I save my place in the log file
     When I authenticate via OIDC with id token
     Then it is forbidden
@@ -225,15 +225,15 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
   Scenario: Authentication failure is written to the audit log
     Given I extend the policy with:
     """
-    - !user bob
+    - !user bob.somebody
     """
-    And I fetch an ID Token for username "bob" and password "bob"
+    And I fetch an ID Token for username "bob.somebody" and password "bob"
     And I save my place in the audit log file
     When I authenticate via OIDC with id token
     Then it is forbidden
     And The following appears in the audit log after my savepoint:
     """
-    cucumber:user:bob failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
+    cucumber:user:bob.somebody failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
     """
 
   @negative @acceptance

--- a/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
@@ -1,0 +1,342 @@
+@authenticators_oidc
+Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
+
+  In this feature we define an OIDC authenticator in policy and perform authentication
+  with Conjur. In successful scenarios we will also define a variable and permit the user to
+  execute it, to verify not only that the user can authenticate with the OIDC
+  Authenticator, but that it can retrieve a secret using the Conjur access token.
+
+  Background:
+    Given I load a policy:
+    """
+      - !policy
+        id: conjur/authn-oidc/keycloak2
+        body:
+          - !webservice
+            annotations:
+              description: Authentication service for Keycloak, based on Open ID Connect.
+          - !variable name
+          - !variable provider-uri
+          - !variable response-type
+          - !variable client-id
+          - !variable client-secret
+          - !variable claim-mapping
+          - !variable state
+          - !variable nonce
+          - !variable redirect-uri
+          - !variable provider-scope
+          - !group users
+          - !permit
+            role: !group users
+            privilege: [ read, authenticate ]
+            resource: !webservice
+      - !user
+        id: alice
+      - !grant
+        role: !group conjur/authn-oidc/keycloak2/users
+        member: !user alice
+    """
+    And I am the super-user
+    And I successfully set OIDC V2 variables for "keycloak2"
+
+  @smoke
+  Scenario: A valid code to get Conjur access token
+    # We want to verify the returned access token is valid for retrieving a secret
+    Given I have a "variable" resource called "test-variable"
+    And I permit user "alice" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I fetch a code for username "alice" and password "alice"
+    And I save my place in the audit log file
+    When I authenticate via OIDC V2 with code
+    Then user "alice" has been authorized by Conjur
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:alice successfully authenticated with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak2
+    """
+
+  @smoke
+  Scenario: A valid code with email as claim mapping
+    Given I extend the policy with:
+    """
+    - !user alice@conjur.net
+    - !grant
+      role: !group conjur/authn-oidc/keycloak2/users
+      member: !user alice@conjur.net
+    """
+    When I add the secret value "email" to the resource "cucumber:variable:conjur/authn-oidc/keycloak2/claim-mapping"
+    And I fetch a code for username "alice@conjur.net" and password "alice"
+    And I authenticate via OIDC V2 with code
+    Then user "alice@conjur.net" has been authorized by Conjur
+
+  @smoke
+  Scenario: Adding a group to keycloak2/users group permits users to authenticate
+    Given I extend the policy with:
+    """
+    - !user
+      id: bob.somebody
+    - !group more-users
+    - !grant
+      role: !group more-users
+      member: !user bob.somebody
+    - !grant
+      role: !group conjur/authn-oidc/keycloak2/users
+      member: !group more-users
+    """
+    And I fetch a code for username "bob@conjur.net" and password "bob"
+    When I authenticate via OIDC V2 with code
+    Then user "bob.somebody" has been authorized by Conjur
+
+  @negative @acceptance
+  Scenario: Non-existing username in claim mapping is denied
+    Given I fetch a code for username "not_in_conjur" and password "not_in_conjur"
+    And I save my place in the log file
+    When I authenticate via OIDC V2 with code
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotFound
+    """
+#    And The following appears in the audit log after my savepoint:
+#    """
+#     failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak2
+#    """
+
+  @negative @acceptance
+  Scenario: User that is not permitted to webservice in claim mapping is denied
+    Given I extend the policy with:
+    """
+    - !user
+      id: bob@conjur.net
+    """
+    And I fetch a code for username "bob@conjur.net" and password "bob"
+    And I save my place in the log file
+    When I authenticate via OIDC V2 with code
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::Security::RoleNotFound
+    """
+
+  @negative @acceptance
+  Scenario: Code without value of variable claim mapping is denied
+    When I add the secret value "non_existing_field" to the resource "cucumber:variable:conjur/authn-oidc/keycloak2/claim-mapping"
+    And I fetch a code for username "alice@conjur.net" and password "alice"
+    And I save my place in the log file
+    When I authenticate via OIDC V2 with code
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty
+    """
+
+  @negative @acceptance
+  Scenario: Adding a group to keycloak2/users group permits users to authenticate
+    Given I extend the policy with:
+    """
+    - !user
+      id: bob
+      annotations:
+        authn-oidc/identity: bob.somebody
+    - !group more-users
+    - !grant
+      role: !group more-users
+      member: !user bob
+    - !grant
+      role: !group conjur/authn-oidc/keycloak2/users
+      member: !group more-users
+    """
+
+#  @negative @acceptance
+#  Scenario: Adding a group to keycloak2/users group permits users to authenticate
+#    Given I extend the policy with:
+#    """
+#    - !user
+#      id: bob.somebody
+#      annotations:
+#        authn-oidc/identity: bob.somebody
+#    - !group more-users
+#    - !grant
+#      role: !group more-users
+#      member: !user bob.somebody
+#    - !grant
+#      role: !group conjur/authn-oidc/keycloak2/users
+#      member: !group more-users
+#    """
+#
+#    Given I extend the policy with:
+#    """
+#    - !user
+#      id: chad
+#      annotations:
+#        authn-oidc/identity: bob.somebody
+#    - !group more-users
+#    - !grant
+#      role: !group more-users
+#      member: !user chad
+#    - !grant
+#      role: !group conjur/authn-oidc/keycloak2/users
+#      member: !group more-users
+#    """
+#    Given I save my place in the log file
+#    And I fetch a code for username "bob.somebody" and password "bob"
+#    When I authenticate via OIDC V2 with code
+#    Then it is forbidden
+#    And The following appears in the log after my savepoint:
+#    """
+#    CONJ00009E 'bob.somebody' matched multiple roles
+#    """
+
+  @negative @acceptance
+  Scenario: Missing code is a bad request
+    Given I save my place in the log file
+    And I fetch a code for username "alice@conjur.net" and password "alice"
+    When I authenticate via OIDC V2 with no code in the request
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+#    And The following appears in the audit log after my savepoint:
+#    """
+#    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+#    """
+
+  @negative @acceptance
+  Scenario: Empty code is a bad request
+    Given I save my place in the log file
+    And I fetch a code for username "alice@conjur.net" and password "alice"
+    When I authenticate via OIDC V2 with code ""
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+#    And The following appears in the audit log after my savepoint:
+#    """
+#    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+#    """
+
+  @negative @acceptance
+  Scenario: Invalid code is a bad request
+    Given I save my place in the log file
+    And I fetch a code for username "alice@conjur.net" and password "alice"
+    When I authenticate via OIDC V2 with code "bad-code"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Rack::OAuth2::Client::Error
+    """
+
+  @negative @acceptance
+  Scenario: Invalid state is a bad request
+    Given I save my place in the log file
+    And I fetch a code for username "alice" and password "alice"
+    When I authenticate via OIDC V2 with state "bad-state"
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::AuthnOidc::StateMismatch
+    """
+
+  @negative @acceptance
+  Scenario: Bad OIDC provider credentials
+    Given I save my place in the log file
+    And I fetch a code for username "alice" and password "notalice"
+    When I authenticate via OIDC V2 with code
+    Then it is a bad request
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::RequestBody::MissingRequestParam
+    """
+
+  @negative @acceptance
+  Scenario: Non-Existent authenticator is not found
+    Given I save my place in the log file
+    And I fetch a code for username "alice" and password "alice"
+    When I authenticate via OIDC V2 with code and service-id "non-exist"
+    Then it is not found
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Conjur::RequestedResourceNotFound: CONJ00123E Resource
+    """
+
+#  @negative @acceptance
+#  Scenario: non-existing account in request is denied
+#    Given I save my place in the log file
+#    When I authenticate via OIDC V2 with code and account "non-existing"
+#    Then it is unauthorized
+#    And The following appears in the log after my savepoint:
+#    """
+#    Errors::Authentication::Security::AccountNotDefined
+#    """
+#    And The following appears in the audit log after my savepoint:
+#    """
+#    non-existing:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+#    """
+
+#  @negative @acceptance
+#  Scenario: admin user is denied
+#    And I fetch a code for username "admin" and password "admin"
+#    And I save my place in the log file
+#    When I authenticate via OIDC V2 with code
+#    Then it is unauthorized
+#    And The following appears in the log after my savepoint:
+#    """
+#    Errors::Authentication::AdminAuthenticationDenied
+#    """
+#    And The following appears in the audit log after my savepoint:
+#    """
+#    cucumber:user:USERNAME_MISSING failed to authenticate with authenticator authn-oidc service
+#    """
+
+  @smoke
+  Scenario: provider-uri dynamic change
+    And I fetch a code for username "alice" and password "alice"
+    And I authenticate via OIDC V2 with code
+    And user "alice" has been authorized by Conjur
+    # Update provider uri to a different hostname and verify `provider-uri` has changed
+    When I add the secret value "https://different-provider:8443" to the resource "cucumber:variable:conjur/authn-oidc/keycloak2/provider-uri"
+    And I authenticate via OIDC V2 with code
+    Then it is unauthorized
+    # Check recovery to a valid provider uri
+    When I successfully set OIDC V2 variables for "keycloak2"
+    And I fetch a code for username "alice" and password "alice"
+    And I authenticate via OIDC V2 with code
+    Then user "alice" has been authorized by Conjur
+
+  @negative @acceptance
+  Scenario: Unauthenticated is raised in case of an invalid OIDC Provider hostname
+    Given I fetch a code for username "alice" and password "alice"
+    And I authenticate via OIDC V2 with code
+    And user "alice" has been authorized by Conjur
+    # Update provider uri to reachable but invalid hostname
+    When I add the secret value "http://127.0.0.1.com/" to the resource "cucumber:variable:conjur/authn-oidc/keycloak2/provider-uri"
+    And I save my place in the log file
+    And I authenticate via OIDC V2 with code
+    Then it is unauthorized
+    And The following appears in the log after my savepoint:
+    """
+    Errors::Authentication::OAuth::ProviderDiscoveryFailed
+    """
+
+  # This test runs a failing authentication request that is already
+  # tested in another scenario (User that is not permitted to webservice in ID token is denied).
+  # We run it again here to verify that we write a message to the audit log
+#  @acceptance
+#  Scenario: Authentication failure is written to the audit log
+#    Given I extend the policy with:
+#    """
+#    - !user
+#      id: bob
+#      annotations:
+#        authn-oidc/identity: bob.somebody@cyberark.com
+#    """
+#    And I fetch a code for username "bob.somebody@cyberark.com" and password "bob"
+#    And I save my place in the audit log file
+#    When I authenticate via OIDC V2 with code
+#    Then it is forbidden
+#    And The following appears in the audit log after my savepoint:
+#    """
+#    cucumber:user:bob failed to authenticate with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
+#    """

--- a/cucumber/authenticators_oidc/features/list_authenticators.feature
+++ b/cucumber/authenticators_oidc/features/list_authenticators.feature
@@ -1,0 +1,99 @@
+@authenticators_oidc
+Feature: A user can view the various authenticators they can use.
+
+  @smoke
+  Scenario: List readable authenticators
+
+    Given I load a policy:
+    """
+    - !policy
+      id: conjur/authn-oidc/oidceast
+      body:
+      - !webservice
+      - !webservice status
+      - !variable provider-uri
+      - !variable client-id
+      - !variable client-secret
+      - !variable name
+      - !variable claim-mapping
+      - !variable nonce
+      - !variable state
+      - !group
+        id: authenticatable
+        annotations:
+          description: Users who can authenticate using this authenticator
+      - !permit
+        role: !group authenticatable
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+
+    And I extend the policy with:
+   """
+    - !policy
+      id: conjur/authn-oidc/okta
+      body:
+      - !webservice
+      - !webservice status
+      - !variable provider-uri
+      - !variable name
+      - !variable client-id
+      - !variable client-secret
+      - !variable claim-mapping
+      - !variable nonce
+      - !variable state
+      - !group
+        id: authenticatable
+        annotations:
+          description: Users who can authenticate using this authenticator
+      - !permit
+        role: !group authenticatable
+        privilege: [ read, authenticate ]
+        resource: !webservice
+    """
+
+    And I extend the policy with:
+    """
+    - !group secrets-fetchers
+    - !group cant-authenticate
+    - !user
+      id: alice
+      annotations:
+       authn-oidc/oidceast: alice.somebody@cyberark.com
+    - !user
+      id: bob
+      annotations:
+       authn-oidc/okta: bob.somebody@cyberark.com
+    - !grant
+      role: !group cant-authenticate
+      member: !user bob
+    - !grant
+      role: !group secrets-fetchers
+      member: !user alice
+    - !grant
+      role: !group conjur/authn-oidc/oidceast/authenticatable
+      member: !group secrets-fetchers
+    """
+    Then I can add a provider-url to variable resource "conjur/authn-oidc/oidceast/provider-uri"
+    Then I can add a secret to variable resource "conjur/authn-oidc/oidceast/client-id"
+    Then I can add a secret to variable resource "conjur/authn-oidc/oidceast/client-secret"
+    Then I can add the secret "oidceast" resource "conjur/authn-oidc/oidceast/name"
+    Then I can add a secret to variable resource "conjur/authn-oidc/oidceast/claim-mapping"
+    Then I can add a secret to variable resource "conjur/authn-oidc/oidceast/nonce"
+    Then I can add a secret to variable resource "conjur/authn-oidc/oidceast/state"
+    Then I can add a provider-url to variable resource "conjur/authn-oidc/okta/provider-uri"
+    Then I can add a secret to variable resource "conjur/authn-oidc/okta/client-id"
+    Then I can add the secret "okta" resource "conjur/authn-oidc/okta/name"
+    Then I can add a secret to variable resource "conjur/authn-oidc/okta/client-secret"
+    Then I can add a secret to variable resource "conjur/authn-oidc/okta/claim-mapping"
+    Then I can add a secret to variable resource "conjur/authn-oidc/okta/nonce"
+    Then I can add a secret to variable resource "conjur/authn-oidc/okta/state"
+    When I log in as user "admin"
+    Then the list of authenticators contains the service-id "oidceast"
+    Then the list of authenticators contains the service-id "okta"
+    When I log in as user "alice"
+    Then the list of authenticators contains the service-id "oidceast"
+    Then the list of authenticators does not contain the service-id "okta"
+    When I log in as user "bob"
+    Then the list of authenticators does not contain the service-id "oidceast"
+    Then the list of authenticators does not contain the service-id "okta"

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_list_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_list_steps.rb
@@ -1,0 +1,20 @@
+
+require 'cucumber/policy/features/support/client'
+require 'json'
+
+Then('the list of authenticators contains the service-id {string}') do |service_id|
+  @result = @client.fetch_authenticators
+  expect(@result.code).to eq(200)
+  expect(
+    @result.body.map { |x| x["service_id"] }
+  ).to include(service_id)
+end
+
+
+Then('the list of authenticators does not contain the service-id {string}') do |service_id|
+  @result = @client.fetch_authenticators
+  expect(@result.code).to eq(200)
+  expect(
+    @result.body.map { |x| x["service_id"] }
+  ).not_to include(service_id)
+end

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -7,10 +7,49 @@ Given(/I fetch an ID Token for username "([^"]*)" and password "([^"]*)"/) do |u
   parse_oidc_id_token
 end
 
+Given(/I fetch a code for username "([^"]*)" and password "([^"]*)"/) do |username, password|
+  Rails.application.config.conjur_config.authenticators = ['authn-oidc/keycloak2']
+
+  @client = Client.for('user', 'admin')
+  providers = @client.fetch_authenticators
+  url = providers.body.map { |x| x["redirect_uri"] }
+  res = Net::HTTP.get_response(URI(url[0]))
+  raise res if res.is_a?(Net::HTTPError) || res.is_a?(Net::HTTPClientError)
+
+  all_cookies = res.get_fields('set-cookie')
+  cookies_arrays = Array.new
+  all_cookies.each do |cookie|
+    cookies_arrays.push(cookie.split('; ')[0])
+  end
+
+  html = Nokogiri::HTML(res.body)
+  post_uri = URI(html.xpath('//form').first.attributes['action'].value)
+
+  http = Net::HTTP.new(post_uri.host, post_uri.port)
+  http.use_ssl = true
+  request = Net::HTTP::Post.new(post_uri.request_uri)
+  request['Cookie'] = cookies_arrays.join('; ')
+  request.set_form_data({'username' => username, 'password' => password})
+
+  response = http.request(request)
+
+  if response.is_a?(Net::HTTPRedirection)
+    parse_oidc_code(response['location'])
+  end
+end
+
 Given(/^I successfully set OIDC variables$/) do
   create_oidc_secret("provider-uri", oidc_provider_uri)
   create_oidc_secret("id-token-user-property", oidc_id_token_user_property)
 end
+
+When(/^I authenticate via OIDC V2 with code$/) do
+  authenticate_code_with_oidc(
+    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
+    account: AuthnOidcHelper::ACCOUNT
+  )
+end
+
 
 Given(/^I successfully set OIDC variables without a service-id$/) do
   create_oidc_secret("provider-uri", oidc_provider_uri, "")
@@ -19,6 +58,30 @@ end
 
 Given(/^I successfully set provider-uri variable$/) do
   create_oidc_secret("provider-uri", oidc_provider_uri)
+end
+
+When(/^I authenticate via OIDC V2 with code "([^"]*)"$/) do |code|
+  authenticate_code_with_oidc(
+    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
+    account: AuthnOidcHelper::ACCOUNT,
+    code: code,
+    )
+end
+
+When(/^I authenticate via OIDC V2 with no code in the request$/) do
+  authenticate_code_with_oidc(
+    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
+    account: AuthnOidcHelper::ACCOUNT,
+    code: nil,
+    )
+end
+
+When(/^I authenticate via OIDC V2 with state "([^"]*)"$/) do |state|
+  authenticate_code_with_oidc(
+    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
+    account: AuthnOidcHelper::ACCOUNT,
+    state: state,
+    )
 end
 
 Given(/^I successfully set provider-uri variable to value "([^"]*)"$/) do |provider_uri|
@@ -32,6 +95,25 @@ end
 When(/^I authenticate via OIDC with id token$/) do
   authenticate_id_token_with_oidc(
     service_id: AuthnOidcHelper::SERVICE_ID,
+    account: AuthnOidcHelper::ACCOUNT
+  )
+end
+
+Given(/^I successfully set OIDC V2 variables for "([^"]*)"$/) do |service_id|
+  create_oidc_secret("provider-uri", oidc_provider_uri, service_id)
+  create_oidc_secret("response-type", oidc_response_type, service_id)
+  create_oidc_secret("client-id", oidc_client_id, service_id)
+  create_oidc_secret("client-secret", oidc_client_secret, service_id)
+  create_oidc_secret("claim-mapping", oidc_claim_mapping, service_id)
+  create_oidc_secret("state", oidc_state, service_id)
+  create_oidc_secret("nonce", oidc_nonce, service_id)
+  create_oidc_secret("redirect-uri", oidc_redirect_uri, service_id)
+  create_oidc_secret("provider-scope", oidc_scope, service_id)
+end
+
+When(/^I authenticate via OIDC V2 with code and service-id "([^"]*)"$/) do |service_id|
+  authenticate_code_with_oidc(
+    service_id: service_id,
     account: AuthnOidcHelper::ACCOUNT
   )
 end

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
+require 'securerandom'
 
 # Utility methods for OIDC authenticator
 module AuthnOidcHelper
 
+  V2_SERVICE_ID = 'keycloak2'
   SERVICE_ID = 'keycloak'
   ACCOUNT = 'cucumber'
 
@@ -22,13 +24,34 @@ module AuthnOidcHelper
     post(path, payload)
   end
 
-  def create_oidc_secret(variable_name, value, service_id_suffix = "/keycloak")
-    path = "cucumber:variable:conjur/authn-oidc#{service_id_suffix}"
+  def authenticate_code_with_oidc(service_id:, account:, code: url_oidc_code, state: url_oidc_state)
+    path = "#{create_auth_url(service_id: service_id, account: account, user_id: nil)}"
+    get(url_with_params(path: path,code: code, state: state ))
+  end
+
+  def create_auth_url(service_id:, account:, user_id:)
+    service_id_part = service_id ? "/#{service_id}" : ""
+    user_id_part = "/#{user_id}" unless user_id.nil? || user_id.empty?
+    "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}#{user_id_part}/authenticate"
+  end
+
+  def url_with_params(path:, code: nil, state: nil)
+    return path unless code || state
+
+    "#{path}?code=#{code}&state=#{state}"
+  end
+
+  def create_oidc_secret(variable_name, value, service_id_suffix = "keycloak")
+    path = "cucumber:variable:conjur/authn-oidc/#{service_id_suffix}".chomp("/")
     Secret.create(resource_id: "#{path}/#{variable_name}", value: value)
   end
 
   def parsed_id_token
     @oidc_id_token.to_s
+  end
+
+  def oidc_code(oidc_code:)
+    @oidc_code = oidc_code
   end
 
   def invalid_id_token
@@ -61,10 +84,52 @@ module AuthnOidcHelper
     @oidc_scope ||= validated_env_var('KEYCLOAK_SCOPE')
   end
 
+  def oidc_required_request_parameters
+    @oidc_required_request_parameters ||= 'code state'
+  end
+
   def parse_oidc_id_token
     @oidc_id_token = (JSON.parse(@response_body))["id_token"]
   rescue => e
     raise "Failed to fetch id_token from HTTP response: #{@response_body} with Reason: #{e}"
+  end
+
+  def oidc_response_type
+    @oidc_response_type ||= 'code'
+  end
+
+  def oidc_claim_mapping
+    @oidc_claim_mapping ||= 'preferred_username'
+  end
+
+  def oidc_state
+    @oidc_state ||= SecureRandom.uuid
+  end
+
+  def oidc_nonce
+    @oidc_nonce ||= SecureRandom.uuid
+  end
+
+  def oidc_redirect_uri
+    @oidc_redirect_uri ||= 'http://conjur:3000/authn-oidc/keycloak2/cucumber/authenticate'
+  end
+
+  def parse_oidc_code(url)
+    params = CGI::parse(URI(url).query)
+    @url_oidc_code = params["code"][0] if params.has_key?("code")
+    @url_oidc_state = params["state"][0] if params.has_key?("state")
+  end
+
+  def url_oidc_code
+    @url_oidc_code
+  end
+
+  def url_oidc_code
+    @url_oidc_code
+  end
+
+  def url_oidc_state
+    @url_oidc_state
   end
 end
 

--- a/cucumber/policy/features/step_definitions/secrets_steps.rb
+++ b/cucumber/policy/features/step_definitions/secrets_steps.rb
@@ -9,6 +9,20 @@ Then(/^I can( not)? add a secret to ([\w_]+) resource "([^"]*)"$/) do |fail, _ki
 end
 
 # TODO: kind is now superfluous.  It is never used, since it's always "variable"
+Then(/^I can( not)? add a provider-url to ([\w_]+) resource "([^"]*)"$/) do |fail, _kind, id|
+  expected_status = fail ? 403 : 201
+  @oidc_provider_uri ||= validated_env_var('PROVIDER_URI')
+  resp = @client.add_secret(id: id, value: @oidc_provider_uri)
+  expect(resp.code).to eq(expected_status)
+end
+
+# TODO: kind is now superfluous.  It is never used, since it's always "variable"
+Then('I can add the secret {string} resource {string}') do |value, id|
+  resp = @client.add_secret(id: id, value: value)
+  expect(resp.code).to eq(201)
+end
+
+# TODO: kind is now superfluous.  It is never used, since it's always "variable"
 Then(/^I can( not)? fetch a secret from ([\w_]+) resource "([^"]*)"$/) do |fail, _kind, id|
   expected_status = fail ? 403 : 200
   resp = @client.fetch_secret(id: id)

--- a/cucumber/policy/features/support/client.rb
+++ b/cucumber/policy/features/support/client.rb
@@ -127,6 +127,10 @@ class Client
     resource(uri('roles', kind, id)).get(auth_header)
   end
 
+  def fetch_authenticators
+    resource(uri('authn-oidc', 'providers')).get(auth_header)
+  end
+
   def fetch_public_keys(username:)
     resource(uri('public_keys', 'user', username)).get(auth_header)
   end

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       #   connections without a password. This is *not* recommended. See
       #   PostgreSQL documentation about "trust"
       POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    expose:
+      - "5432"
+
 
   audit:
     image: postgres:10.16
@@ -124,7 +129,7 @@ services:
       - KEYCLOAK_APP_USER=alice
       - KEYCLOAK_APP_USER_PASSWORD=alice
       - KEYCLOAK_APP_USER_EMAIL=alice@conjur.net
-      - KEYCLOAK_SECOND_APP_USER=bob
+      - KEYCLOAK_SECOND_APP_USER=bob.somebody
       - KEYCLOAK_SECOND_APP_USER_PASSWORD=bob
       - KEYCLOAK_SECOND_APP_USER_EMAIL=bob@conjur.net
       - KEYCLOAK_NON_CONJUR_APP_USER=not_in_conjur
@@ -132,7 +137,7 @@ services:
       - KEYCLOAK_NON_CONJUR_APP_USER_EMAIL=not_in_conjur
       - DB_VENDOR=H2
       - KEYCLOAK_CLIENT_ID=conjurClient
-      - KEYCLOAK_REDIRECT_URI=http://locallhost.com/
+      - KEYCLOAK_REDIRECT_URI=http://conjur:3000/authn-oidc/keycloak2/cucumber/authenticate
       - KEYCLOAK_CLIENT_SECRET=1234
       - KEYCLOAK_SCOPE=openid
     ports:

--- a/dev/policies/authenticators/authn-oidc/keycloak2-users.yml
+++ b/dev/policies/authenticators/authn-oidc/keycloak2-users.yml
@@ -1,0 +1,15 @@
+- !user alice@conjur.net
+
+- !policy
+  id: keycloak
+  body:
+    - !user
+      id: alice
+      annotations:
+        authn-oidc/identity: 'alice@conjur.net'
+
+- !grant
+  members:
+    - !user alice@conjur.net
+    - !user alice@keycloak
+  role: !group conjur/authn-oidc/keycloak2/authenticatable

--- a/dev/policies/authenticators/authn-oidc/keycloak2.yml
+++ b/dev/policies/authenticators/authn-oidc/keycloak2.yml
@@ -1,0 +1,37 @@
+- !policy
+  id: conjur
+  body:
+    - !policy
+      id: authn-oidc
+      body:
+        - !policy
+          id: keycloak2
+          body:
+          - !webservice
+
+          - !variable provider-uri
+          - !variable client-id
+          - !variable client-secret
+
+          # URI of Conjur instance
+          - !variable redirect_uri
+
+          # Defines the JWT claim to use as the Conjur identifier
+          - !variable claim-mapping
+
+          # Nonce and State are random strings generated to supply an
+          # additional layer of security. These values should be generated when the
+          # authenticator is created.
+          - !variable nonce
+          - !variable state
+
+          # Group with permission to authenticate
+          - !group
+            id: authenticatable
+            annotations:
+              description: Users who can authenticate using this authenticator
+
+          - !permit
+            role: !group authenticatable
+            privilege: [ read, authenticate ]
+            resource: !webservice

--- a/dev/policies/authenticators/authn-oidc/okta-2.yml
+++ b/dev/policies/authenticators/authn-oidc/okta-2.yml
@@ -1,0 +1,37 @@
+- !policy
+  id: conjur
+  body:
+    - !policy
+      id: authn-oidc
+      body:
+        - !policy
+          id: okta-2
+          body:
+          - !webservice
+
+          - !variable provider-uri
+          - !variable client-id
+          - !variable client-secret
+
+          # URI of Conjur instance
+          - !variable redirect_uri
+
+          # Defines the JWT claim to use as the Conjur identifier
+          - !variable claim-mapping
+
+          # Nonce and State are random strings generated to supply an
+          # additional layer of security. These values should be generated when the
+          # authenticator is created.
+          - !variable nonce
+          - !variable state
+
+          # Group with permission to authenticate
+          - !group
+            id: authenticatable
+            annotations:
+              description: Users who can authenticate using this authenticator
+
+          - !permit
+            role: !group authenticatable
+            privilege: [ read, authenticate ]
+            resource: !webservice

--- a/dev/policies/authenticators/authn-oidc/okta-users.yml
+++ b/dev/policies/authenticators/authn-oidc/okta-users.yml
@@ -1,0 +1,15 @@
+- !user test.user3@mycompany.com
+
+- !policy
+  id: okta
+  body:
+    - !user
+      id: test.user3
+      annotations:
+        authn-oidc/identity: 'test.user@mycompany.com'
+
+- !grant
+  members:
+    - !user test.user3@mycompany.com
+    - !user test.user3@okta
+  role: !group conjur/authn-oidc/okta-2/authenticatable

--- a/dev/start
+++ b/dev/start
@@ -195,15 +195,32 @@ configure_oidc_authenticators() {
   client_add_secret \
     "conjur/authn-oidc/keycloak/id-token-user-property" "preferred_username"
 
+  # Specific for Keycloak Authenticator (for full flow)
+    client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/keycloak2.yml'
+    client_add_secret 'conjur/authn-oidc/keycloak2/provider-uri' 'https://keycloak:8443/auth/realms/master'
+    client_add_secret 'conjur/authn-oidc/keycloak2/client-id' 'conjurClient'
+    client_add_secret 'conjur/authn-oidc/keycloak2/client-secret' '1234'
+    client_add_secret 'conjur/authn-oidc/keycloak2/claim-mapping' 'email'
+    client_add_secret 'conjur/authn-oidc/keycloak2/nonce' 'af88d8f8ff6631fb4cf0'
+    client_add_secret 'conjur/authn-oidc/keycloak2/state' 'd38e57e0fd47ccffa9c2'
+    client_add_secret 'conjur/authn-oidc/keycloak2/redirect_uri' 'http://localhost:3000/authn-oidc/keycloak2/cucumber/authenticate'
+
+    client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/keycloak2-users.yml'
+
+
+
   if [[ $ENABLE_OIDC_OKTA = true ]]; then
-    # add variables' values for okta
-    client_load_policy "/src/conjur-server/ci/authn-oidc/policy_okta.yml"
+    # Specific for new OIDC Authenticator
+    client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/okta-2.yml'
+    client_add_secret 'conjur/authn-oidc/okta-2/provider-uri' 'https://dev-92899796.okta.com/oauth2/default'
+    client_add_secret 'conjur/authn-oidc/okta-2/client-id' '0oa3w3xig6rHiu9yT5d7'
+    client_add_secret 'conjur/authn-oidc/okta-2/client-secret' 'e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj'
+    client_add_secret 'conjur/authn-oidc/okta-2/claim-mapping' 'preferred_username'
+    client_add_secret 'conjur/authn-oidc/okta-2/nonce' '1656b4264b60af659fce'
+    client_add_secret 'conjur/authn-oidc/okta-2/state' '4f413476ef7e2395f0af'
+    client_add_secret 'conjur/authn-oidc/okta-2/redirect_uri' 'http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate'
 
-    client_add_secret \
-      "conjur/authn-oidc/okta/provider-uri" "https://dev-842018.oktapreview.com"
-
-    client_add_secret \
-      "conjur/authn-oidc/okta/id-token-user-property" "preferred_username"
+    client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/okta-users.yml'
   fi
 
   if [[ $ENABLE_OIDC_ADFS = true ]]; then
@@ -233,11 +250,11 @@ enable_oidc_authenticators() {
   echo "Configuring Keycloak as OpenID provider for automatic testing"
   # We enable an OIDC authenticator without a service-id to test that it's
   # invalid.
-  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak,authn-oidc"
+  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak,authn-oidc,authn-oidc/keycloak2"
 
   if [[ $ENABLE_OIDC_OKTA = true ]]; then
     echo "Configuring OKTA as OpenID provider for manual testing"
-    enabled_authenticators="$enabled_authenticators,authn-oidc/okta"
+    enabled_authenticators="$enabled_authenticators,authn-oidc/okta,authn-oidc/okta-2"
   fi
 
   if [[ $ENABLE_OIDC_ADFS = true ]]; then
@@ -354,7 +371,7 @@ init_jwt() {
 
 init_oidc() {
   # ADFS and OKTA make no sense without OIDC.
-  if [[ $ENABLE_AUTHN_OIDC = false && 
+  if [[ $ENABLE_AUTHN_OIDC = false &&
     ($ENABLE_OIDC_ADFS = true || $ENABLE_OIDC_OKTA = true) ]]
   then
     echo "Error: --oidc-adfs and --oidc-okta both require --authn-oidc"

--- a/spec/app/db/repository/authenticator_repository_spec.rb
+++ b/spec/app/db/repository/authenticator_repository_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('DB::Repository::AuthenticatorRepository') do
+  let(:resource_repository) { ::Resource }
+
+  let(:repo) do
+    DB::Repository::AuthenticatorRepository.new(
+      resource_repository: resource_repository,
+      data_object: Authentication::AuthnOidc::V2::DataObjects::Authenticator
+    )
+  end
+
+  let(:arguments) { %i[provider_uri client_id client_secret claim_mapping nonce state] }
+
+  describe('#find_all') do
+    context 'when webservice is not present' do
+      it { expect(repo.find_all(type: 'authn-oidc', account: 'rspec')).to eq([]) }
+    end
+
+    context 'when webservices are presents' do
+      let(:services) { %i[foo bar] }
+      before(:each) do
+        services.each do |service|
+          ::Role.create(
+            role_id: "rspec:policy:conjur/authn-oidc/#{service}-abc123"
+          )
+          ::Resource.create(
+            resource_id: "rspec:webservice:conjur/authn-oidc/#{service}-abc123",
+            owner_id: "rspec:policy:conjur/authn-oidc/#{service}-abc123"
+          )
+        end
+      end
+
+      context 'variables are not loaded' do
+        it { expect(repo.find_all(type: 'authn-oidc', account: 'rspec')).to eq([]) }
+      end
+
+      context 'variables are loaded' do
+        before(:each) do
+          services.each do |service|
+            arguments.each do |variable|
+              ::Resource.create(
+                resource_id: "rspec:variable:conjur/authn-oidc/#{service}-abc123/#{variable}",
+                owner_id: "rspec:policy:conjur/authn-oidc/#{service}-abc123"
+              )
+            end
+          end
+        end
+
+        context 'secrets are not set' do
+          it { expect(repo.find_all(type: 'authn-oidc', account: 'rspec')).to eq([]) }
+        end
+
+        context 'secrets are set' do
+          before(:each) do
+            services.each do |service|
+              arguments.each do |variable|
+                ::Secret.create(
+                  resource_id: "rspec:variable:conjur/authn-oidc/#{service}-abc123/#{variable}",
+                  value: "#{variable}-abc123"
+                )
+              end
+            end
+          end
+
+          let(:authenticators) { repo.find_all(type: 'authn-oidc', account: 'rspec') }
+
+          it { expect(authenticators.length).to eq(2) }
+          it { expect(authenticators.first).to be_kind_of(Authentication::AuthnOidc::V2::DataObjects::Authenticator) }
+          it { expect(authenticators.last).to be_kind_of(Authentication::AuthnOidc::V2::DataObjects::Authenticator) }
+
+          context 'filters invalid authenticators' do
+            before(:each) do
+              ::Role.create(
+                role_id: "rspec:policy:conjur/authn-oidc/baz-abc123"
+              )
+              ::Resource.create(
+                resource_id: "rspec:webservice:conjur/authn-oidc/baz-abc123",
+                owner_id: "rspec:policy:conjur/authn-oidc/baz-abc123"
+              )
+            end
+
+            it { expect(repo.find_all(type: 'authn-oidc', account: 'rspec').length).to eq(2) }
+
+            after(:each) do
+              ::Resource['rspec:webservice:conjur/authn-oidc/baz-abc123'].destroy
+              ::Role['rspec:policy:conjur/authn-oidc/baz-abc123'].destroy
+            end
+          end
+        end
+
+        after(:each) do
+          services.each do |service|
+            arguments.each do |variable|
+              ::Resource["rspec:variable:conjur/authn-oidc/#{service}-abc123/#{variable}"].destroy
+            end
+          end
+        end
+      end
+
+      after(:each) do
+        services.each do |service|
+          ::Resource["rspec:webservice:conjur/authn-oidc/#{service}-abc123"].destroy
+          ::Role["rspec:policy:conjur/authn-oidc/#{service}-abc123"].destroy
+        end
+      end
+
+    end
+  end
+
+  describe('#find') do
+    context 'when webservice is not present' do
+      it { expect(repo.find(type: 'authn-oidc', account: 'rspec', service_id: 'abc123')).to be(nil) }
+    end
+
+    context 'when webservice is present' do
+      before(:each) do
+        ::Role.create(
+          role_id: "rspec:policy:conjur/authn-oidc/abc123"
+        )
+        ::Resource.create(
+          resource_id: "rspec:webservice:conjur/authn-oidc/abc123",
+          owner_id: "rspec:policy:conjur/authn-oidc/abc123"
+        )
+      end
+
+      context 'when no variables are set' do
+        it { expect(repo.find(type: 'authn-oidc', account: 'rspec', service_id: 'abc123')).to be(nil) }
+      end
+
+      context 'when all variables are present' do
+        before(:each) do
+          arguments.each do |variable|
+            ::Resource.create(
+              resource_id: "rspec:variable:conjur/authn-oidc/abc123/#{variable}",
+              owner_id: "rspec:policy:conjur/authn-oidc/abc123"
+            )
+          end
+        end
+
+        context 'are empty' do
+          it { expect(repo.find(type: 'authn-oidc', account: 'rspec', service_id: 'abc123')).to be(nil) }
+        end
+
+        context 'are set' do
+          before(:each) do
+            arguments.each do |variable|
+              ::Secret.create(
+                resource_id: "rspec:variable:conjur/authn-oidc/abc123/#{variable}",
+                value: "#{variable}-abc123"
+              )
+            end
+          end
+
+          let(:authenticator) { repo.find(type: 'authn-oidc', account: 'rspec', service_id: 'abc123') }
+
+          it { expect(authenticator).to be_truthy }
+          it { expect(authenticator).to be_kind_of(Authentication::AuthnOidc::V2::DataObjects::Authenticator) }
+          it { expect(authenticator.account).to eq('rspec') }
+          it { expect(authenticator.service_id).to eq('abc123') }
+        end
+
+        after(:each) do
+          arguments.each do |variable|
+            ::Resource["rspec:variable:conjur/authn-oidc/abc123/#{variable}"].destroy
+          end
+        end
+      end
+
+      after(:each) do
+        ::Resource['rspec:webservice:conjur/authn-oidc/abc123'].destroy
+        ::Role['rspec:policy:conjur/authn-oidc/abc123'].destroy
+      end
+    end
+  end
+
+  describe('#exists?') do
+    context 'when webservice is present' do
+      before(:context) do
+        ::Role.create(
+          role_id: "rspec:policy:conjur/authn-oidc/abc123"
+        )
+        ::Resource.create(
+          resource_id: "rspec:webservice:conjur/authn-oidc/abc123",
+          owner_id: "rspec:policy:conjur/authn-oidc/abc123"
+        )
+      end
+
+      it { expect(repo.exists?(type: 'authn-oidc', account: 'rspec', service_id: 'abc123')).to be_truthy }
+      it { expect(repo.exists?(type: nil, account: 'rspec', service_id: 'abc123')).to be_falsey }
+      it { expect(repo.exists?(type: 'authn-oidc', account: nil, service_id: 'abc123')).to be_falsey }
+      it { expect(repo.exists?(type: 'authn-oidc', account: 'rspec', service_id: nil)).to be_falsey }
+
+      after(:context) do
+        ::Resource['rspec:webservice:conjur/authn-oidc/abc123'].destroy
+        ::Role['rspec:policy:conjur/authn-oidc/abc123'].destroy
+      end
+    end
+
+    context 'when webservice is not present' do
+      it { expect(repo.exists?(type: 'authn-oidc', account: 'rspec', service_id: 'abc123')).to be_falsey }
+      it { expect(repo.exists?(type: nil, account: 'rspec', service_id: 'abc123')).to be_falsey }
+      it { expect(repo.exists?(type: 'authn-oidc', account: nil, service_id: 'abc123')).to be_falsey }
+      it { expect(repo.exists?(type: 'authn-oidc', account: 'rspec', service_id: nil)).to be_falsey }
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::AuthnOidc::V2::Client) do
+  let(:authenticator) do
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
+      provider_uri: 'https://dev-92899796.okta.com/oauth2/default',
+      redirect_uri: 'http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate',
+      client_id: '0oa3w3xig6rHiu9yT5d7',
+      client_secret: 'e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj',
+      claim_mapping: 'foo',
+      nonce: '1656b4264b60af659fce',
+      state: 'state',
+      account: 'bar',
+      service_id: 'baz'
+    )
+  end
+
+  let(:client) do
+    Authentication::AuthnOidc::V2::Client.new(
+      authenticator: authenticator
+    )
+  end
+
+  describe '.callback' do
+    context 'when credentials are valid' do
+      it 'returns a valid JWT token', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
+        # Because JWT tokens have an expiration timeframe, we need to hold
+        # time constant after caching the request.
+        travel_to(Time.parse("2022-06-30 16:42:17 +0000")) do
+          token = client.callback(
+            code: 'qdDm7On1dEEzNmMlk2bF7IcOF8gCgfvgMCMXXXDlYEE'
+          )
+          expect(token).to be_a_kind_of(OpenIDConnect::ResponseObject::IdToken)
+          expect(token.raw_attributes['nonce']).to eq('1656b4264b60af659fce')
+          expect(token.raw_attributes['preferred_username']).to eq('test.user3@mycompany.com')
+          expect(token.aud).to eq('0oa3w3xig6rHiu9yT5d7')
+        end
+      end
+    end
+
+    context 'when JWT has expired' do
+      it 'raises an error', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
+        travel_to(Time.parse("2022-06-30 20:42:17 +0000")) do
+          expect do
+            client.callback(
+              code: 'qdDm7On1dEEzNmMlk2bF7IcOF8gCgfvgMCMXXXDlYEE'
+            )
+          end.to raise_error(
+            OpenIDConnect::ResponseObject::IdToken::ExpiredToken,
+            'Invalid ID token: Expired token'
+          )
+        end
+      end
+    end
+
+    context 'when code has previously been used' do
+      it 'raise an exception', vcr: 'authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials' do
+        expect do
+          client.callback(
+            code: '7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo'
+          )
+        end.to raise_error(
+          Rack::OAuth2::Client::Error,
+          'invalid_grant :: The authorization code is invalid or has expired.'
+        )
+      end
+    end
+
+    context 'when code has expired', vcr: 'authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials' do
+      it 'raise an exception' do
+        expect do
+          client.callback(
+            code: 'SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU'
+          )
+        end.to raise_error(
+          Rack::OAuth2::Client::Error,
+          'invalid_grant :: The authorization code is invalid or has expired.'
+        )
+      end
+    end
+
+    context 'when code is invalid' do
+      context 'raise an error when' do
+        it 'code is nil' do
+          expect { client.callback(code: nil) }.to raise_error(
+            Errors::Authentication::RequestBody::MissingRequestParam,
+            "CONJ00009E Field 'code' is missing or empty in request body"
+          )
+        end
+        it 'code is an empty string' do
+          expect { client.callback(code: '') }.to raise_error(
+            Errors::Authentication::RequestBody::MissingRequestParam,
+            "CONJ00009E Field 'code' is missing or empty in request body"
+          )
+        end
+      end
+    end
+  end
+
+  describe '.oidc_client' do
+    context 'when credentials are valid' do
+      it 'returns a valid oidc client', vcr: 'authenticators/authn-oidc/v2/client_initialization' do
+        oidc_client = client.oidc_client
+
+        expect(oidc_client).to be_a_kind_of(OpenIDConnect::Client)
+        expect(oidc_client.identifier).to eq('0oa3w3xig6rHiu9yT5d7')
+        expect(oidc_client.secret).to eq('e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj')
+        expect(oidc_client.redirect_uri).to eq('http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate')
+        expect(oidc_client.scheme).to eq('https')
+        expect(oidc_client.host).to eq('dev-92899796.okta.com')
+        expect(oidc_client.port).to eq(443)
+        expect(oidc_client.authorization_endpoint).to eq('/oauth2/default/v1/authorize')
+        expect(oidc_client.token_endpoint).to eq('/oauth2/default/v1/token')
+        expect(oidc_client.userinfo_endpoint).to eq('/oauth2/default/v1/userinfo')
+      end
+    end
+  end
+
+  describe '.discovery_information', vcr: 'authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials' do
+    context 'when credentials are valid' do
+      it 'endpoint returns valid data' do
+        discovery_information = client.discovery_information(invalidate: true)
+
+        expect(discovery_information.authorization_endpoint).to eq(
+          'https://dev-92899796.okta.com/oauth2/default/v1/authorize'
+        )
+        expect(discovery_information.token_endpoint).to eq(
+          'https://dev-92899796.okta.com/oauth2/default/v1/token'
+        )
+        expect(discovery_information.userinfo_endpoint).to eq(
+          'https://dev-92899796.okta.com/oauth2/default/v1/userinfo'
+        )
+        expect(discovery_information.jwks_uri).to eq(
+          'https://dev-92899796.okta.com/oauth2/default/v1/keys'
+        )
+        expect(discovery_information.end_session_endpoint).to eq(
+          'https://dev-92899796.okta.com/oauth2/default/v1/logout'
+        )
+      end
+    end
+
+    context 'when provider URI is invalid', vcr: 'authenticators/authn-oidc/v2/discovery_endpoint-invalid_oidc_provider' do
+      it 'returns an timeout error' do
+        client = Authentication::AuthnOidc::V2::Client.new(
+          authenticator: Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
+            provider_uri: 'https://foo.bar1234321.com',
+            redirect_uri: 'http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate',
+            client_id: '0oa3w3xig6rHiu9yT5d7',
+            client_secret: 'e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj',
+            claim_mapping: 'foo',
+            nonce: '1656b4264b60af659fce',
+            state: 'state',
+            account: 'bar',
+            service_id: 'baz'
+          )
+        )
+
+        expect{client.discovery_information(invalidate: true)}.to raise_error(
+          Errors::Authentication::OAuth::ProviderDiscoveryFailed
+        )
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
+  let(:default_args) do
+    {
+      provider_uri: 'https://foo.bar.com/baz',
+      client_id: 'client-id-123',
+      client_secret: 'client-secret-123',
+      claim_mapping: 'email',
+      nonce: 'nonce456',
+      state: 'state123',
+      account: 'default',
+      service_id: 'my-authenticator'
+    }
+  end
+  let(:args) { default_args }
+
+  # subject { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**default_args)}
+  let(:authenticator) { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**args) }
+
+  describe '.scope' do
+    context 'with default initializer' do
+      it { expect(authenticator.scope).to eq('openid email profile') }
+    end
+
+    context 'when initialized with a string argument' do
+      let(:args) { default_args.merge({ provider_scope: 'foo' }) }
+      it { expect(authenticator.scope).to eq('openid email profile foo') }
+    end
+
+    context 'when initialized with a non-string argument' do
+      let(:args) { default_args.merge({ provider_scope: 1 }) }
+      it { expect(authenticator.scope).to eq('openid email profile 1') }
+    end
+
+    context 'when initialized with an array argument' do
+      context 'single value array' do
+        let(:args) { default_args.merge({ provider_scope: ['foo'] }) }
+        it { expect(authenticator.scope).to eq('openid email profile foo') }
+      end
+
+      context 'multi-value array' do
+        let(:args) { default_args.merge({ provider_scope: ['foo', 'bar'] }) }
+        it { expect(authenticator.scope).to eq('openid email profile foo bar') }
+      end
+    end
+  end
+
+  describe '.name' do
+    context 'when name is missing' do
+      it { expect(authenticator.name).to eq('My Authenticator') }
+    end
+    context 'when name is present' do
+      let(:args) { default_args.merge(name: 'foo') }
+      it { expect(authenticator.name).to eq('foo') }
+    end
+  end
+
+  describe '.resource_id' do
+    context 'correctly renders' do
+      it { expect(authenticator.resource_id).to eq('default:webservice:conjur/authn-oidc/my-authenticator') }
+    end
+  end
+
+  describe '.response_type' do
+    context 'with default initializer' do
+      it { expect(authenticator.response_type).to eq('code') }
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/v2/resolve_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/resolve_identity_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(' Authentication::AuthnOidc::V2::ResolveIdentity') do
+  let(:resolve_identity) do
+    Authentication::AuthnOidc::V2::ResolveIdentity.new
+  end
+
+  describe('#call') do
+    let(:valid_role) do
+      instance_double(::Role).tap do |double|
+        allow(double).to receive(:id).and_return('rspec:user:alice')
+        allow(double).to receive(:resource?).and_return(true)
+      end
+    end
+
+    context 'when identity matches a role ID' do
+      it 'returns the matching role' do
+        expect(
+          resolve_identity.call(
+            account: 'rspec',
+            identity: 'alice',
+            allowed_roles: [ valid_role ]
+          ).id
+        ).to eq('rspec:user:alice')
+      end
+
+      context 'when it includes roles without resources' do
+        it 'returns the matching role' do
+          expect(
+            resolve_identity.call(
+              account: 'rspec',
+              identity: 'alice',
+              allowed_roles: [
+                instance_double(::Role).tap do |double|
+                  allow(double).to receive(:id).and_return('rspec:user:alice')
+                  allow(double).to receive(:resource?).and_return(false)
+                end,
+                valid_role
+              ]
+            ).id
+          ).to eq('rspec:user:alice')
+        end
+      end
+
+      context 'when the accounts are different' do
+        it 'returns the matching role' do
+          expect(
+            resolve_identity.call(
+              account: 'rspec',
+              identity: 'alice',
+              allowed_roles: [
+                instance_double(::Role).tap do |double|
+                  allow(double).to receive(:id).and_return('foo:user:alice')
+                  allow(double).to receive(:resource?).and_return(true)
+                end,
+                valid_role
+              ]
+            ).id
+          ).to eq('rspec:user:alice')
+        end
+      end
+    end
+
+    context 'when the provided identity does not match a role or annotation' do
+      it 'raises the error RoleNotFound' do
+        expect {
+          resolve_identity.call(
+            account: 'rspec',
+            identity: 'alice',
+            allowed_roles: [
+              instance_double(::Role).tap do |double|
+                allow(double).to receive(:id).and_return('rspec:user:bob')
+                allow(double).to receive(:resource?).and_return(true)
+              end,
+              instance_double(::Role).tap do |double|
+                allow(double).to receive(:id).and_return('rspec:user:chad')
+                allow(double).to receive(:resource?).and_return(true)
+                allow(double).to receive(:resource).and_return(
+                  instance_double(::Resource).tap do |resource|
+                    allow(resource).to receive(:annotation).with('authn-oidc/identity').and_return('chad.example')
+                  end
+                )
+              end
+            ]
+          )
+        }.to raise_error(
+          Errors::Authentication::Security::RoleNotFound,
+          /CONJ00007E 'alice' not found/
+        )
+      end
+    end
+
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
+
+  let(:jwt) { double(raw_attributes: { claim_mapping: "alice" }) }
+
+  let(:authenticator) do
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
+      account: "cucumber",
+      service_id: "foo",
+      redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+      provider_uri: "http://test",
+      name: "foo",
+      state: 'foostate',
+      client_id: "ConjurClient",
+      client_secret: 'client_secret',
+      claim_mapping: mapping,
+      nonce: 'secret'
+    )
+  end
+
+  let(:client) do
+    class_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
+      allow(double).to receive(:new).and_return(
+        current_client)
+    end
+  end
+
+  let(:current_client) do
+    instance_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
+      allow(double).to receive(:callback).and_return(jwt)
+    end
+  end
+
+  let(:strategy) do
+    Authentication::AuthnOidc::V2::Strategy.new(
+      authenticator: authenticator,
+      client: client
+    )
+  end
+
+  describe('#callback') do
+    context 'when a role_id matches the identity exist' do
+      let(:mapping) { "claim_mapping" }
+      it 'returns the role' do
+        expect(strategy.callback({ state: "foostate", code: "code" }))
+          .to eq("alice")
+      end
+    end
+
+    context 'When the authn state doesnt match the arguments' do
+      let(:mapping) { "claim_mapping" }
+      it 'raises an error' do
+        expect { strategy.callback({ state: "barstate", code: "code" }) }
+          .to raise_error(Errors::Authentication::AuthnOidc::StateMismatch)
+      end
+    end
+
+    context 'When the claiming matching in the token doesnt match the jwt' do
+      let(:mapping) { "wrong_mapping" }
+      it 'raises an error' do
+        expect { strategy.callback({ state: "foostate", code: "code" }) }
+          .to raise_error(Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty)
+      end
+    end
+  end
+end

--- a/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
+  let(:client) do
+    class_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
+      allow(double).to receive(:new).and_return(
+        current_client)
+    end
+  end
+
+  let(:current_client) do
+    instance_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
+      allow(double).to receive(:discovery_information).and_return(endpoint)
+    end
+  end
+
+  let(:endpoint) { double(authorization_endpoint: '"http://test"') }
+
+  let(:foo) do
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator
+      .new(account: "cucumber",
+           service_id: "foo",
+           redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+           provider_uri: "http://test",
+           name: "foo",
+           state: 'foostate',
+           client_id: "ConjurClient",
+           client_secret: 'client_secret',
+           claim_mapping: 'claim_mapping',
+           nonce: 'secret',
+           )
+  end
+
+  let(:bar) do
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator
+      .new(account: "cucumber",
+           service_id: "bar",
+           provider_uri: "http://test",
+           redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+           name: "bar",
+           state: 'barstate',
+           client_id: "ConjurClient",
+           client_secret: 'client_secret',
+           claim_mapping: 'claim_mapping',
+           nonce: 'secret')
+  end
+
+  let(:authenticators) {[foo, bar]}
+
+  let(:res) do
+    [{ name: "foo",
+       redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&state=foostate&nonce=secret&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+       service_id: "foo",
+       type: "authn-oidc" },
+     { name: "bar",
+       redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&state=barstate&nonce=secret&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+       service_id: "bar",
+       type: "authn-oidc" }]
+  end
+
+  let(:provider_context) do
+    ::Authentication::AuthnOidc::V2::Views::ProviderContext.new(
+      client: client
+    )
+  end
+
+  describe('#call') do
+    context 'when provider context is given multiple authenticators' do
+      it 'returns the providers object with the redirect urls' do
+        expect(provider_context.call(authenticators: authenticators))
+          .to eq(res)
+      end
+    end
+
+    context 'when provider context is  given no authenticators ' do
+      it 'returns an empty array' do
+        expect(provider_context.call(authenticators: []))
+          .to eq([])
+      end
+    end
+  end
+end
+

--- a/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn_iam/authenticator_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe(Authentication::AuthnIam::Authenticator) do
     "38a232969747b77e82f6c845f63941ebde89eb2cc20ed1c6f2dbabc92b6\"}"
   end
 
-  def valid_response 
-    double('HTTPResponse', 
-           code: 200, 
+  def valid_response
+    double('HTTPResponse',
+           code: 200,
            body: %(
                 <GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
                     <GetCallerIdentityResult>
@@ -31,13 +31,13 @@ RSpec.describe(Authentication::AuthnIam::Authenticator) do
                     <ResponseMetadata>
                         <RequestId>f555066a-7417-11e8-8ded-8daed431985e</RequestId>
                     </ResponseMetadata>
-                </GetCallerIdentityResponse> 
+                </GetCallerIdentityResponse>
             )
     )
   end
 
-  def invalid_response 
-    double('HTTPResponse', 
+  def invalid_response
+    double('HTTPResponse',
            code: 404,
            body: "Error"
     )
@@ -55,7 +55,7 @@ RSpec.describe(Authentication::AuthnIam::Authenticator) do
     Authentication::AuthnIam::Authenticator.new(env:[])
   end
 
-  it "valid? with expired AWS headers" do
+  it "valid? with expired AWS headers", vcr: 'authenticators/authn-iam/verify-expired-headers' do
     subject = authenticator_instance
     parameters = double('AuthenticationParameters', credentials: expired_aws_headers)
     expect{subject.valid?(parameters)}.to(
@@ -87,7 +87,7 @@ RSpec.describe(Authentication::AuthnIam::Authenticator) do
     subject = authenticator_instance
     expect(subject.identity_hash(invalid_response)).to eq(false)
   end
-  
+
   it "matches valid login to AWS IAM role (based on AWS response)" do
     subject = authenticator_instance
     identity_hash = subject.identity_hash(valid_response)

--- a/spec/app/domain/authentication/jwt/verify_and_decode_token_spec.rb
+++ b/spec/app/domain/authentication/jwt/verify_and_decode_token_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 RSpec.describe(Authentication::Jwt::VerifyAndDecodeToken) do
   let(:token_jwt) { "decoded_token" }
   let(:mock_decoded_token) { [token_jwt] }

--- a/spec/app/domain/authentication/util/namespace_selector_spec.rb
+++ b/spec/app/domain/authentication/util/namespace_selector_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::Util::NamespaceSelector) do
+  describe '#select' do
+    context 'when type is a supported authenticator type' do
+      context 'when type is `authn-oidc`' do
+        it 'returns the valid namespace' do
+          expect(
+            Authentication::Util::NamespaceSelector.select(
+              authenticator_type: 'authn-oidc'
+            )
+          ).to eq('Authentication::AuthnOidc::V2')
+        end
+      end
+    end
+    context 'when type is not supported' do
+      context 'when type is `authn-k8s`' do
+        it 'raises an error' do
+          expect {
+            Authentication::Util::NamespaceSelector.select(
+              authenticator_type: 'authn-k8s'
+            )
+          }.to raise_error(RuntimeError, "'authn-k8s' is not a supported authenticator type")
+        end
+      end
+      context 'when type is missing' do
+        it 'raises an error' do
+          expect {
+            Authentication::Util::NamespaceSelector.select(
+              authenticator_type: nil
+            )
+          }.to raise_error(RuntimeError, "'' is not a supported authenticator type")
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-iam/verify-expired-headers.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-iam/verify-expired-headers.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.0.4p208
+      X-Amz-Date:
+      - 20180620T025910Z
+      X-Amz-Security-Token:
+      - FQoDYXdzEPv//////////wEaDHwvkDqh5pHmZNe5hSK3AzevmnHjzweG6m1in/CQ8NB7PCY0nTtWsCXLU5FsHmOoXs6KgVOu8ucghebak4b/iaDCpSprH3GPjLcNatywkUEQqX8rQKy2DoKMy7ZMHNT1ivhEn
+        vE3HR0GPkkGGWYhLTTrQDdI5fBcb3yJ /TyrcmUuBTKXwQJmvcnDe505SPpuSZm7tdrDX5SpItMngqGcrRhCjuprpk5nPVwSQq6usp7hJYPmu/6u9eVP3rQ
+        TFPldhRvRxu5rcssURdrIwbjMugZQff/8XERxyxPrTkJQekcqMvvV6gexDZcBOS1JtIsKfJEXUmK3kwV4liQsUevxyanWMc4jT0tiBkDj2
+        nvXUFt6dejppdTTRdEtBXg5xZUrGDCQDUU9eBgydoTLGav9rWiM7bWtpP4A1m0E9LoX47FScSDkqk0Hy6Dr9jzhb4HOodlgaldTs8BNlgN9xXgACdacdPqnhaYLCgAWsaUZPKuZmdyH96F59rcrVscf456ivXTrXpt6pL1ZQyRCc04hkovErvv1L2CwEaGAc
+        k0bvbq0pbzTftTh7 9xY3pFxbL AALoR0t2/CfhyomvoG72Cl/nvAo7  m2QU
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=ASIAJJTVXJS5KDKXKNPQ/20180620/us-east-1/sts/aws4_request,
+        SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=230fa38a232969747b77e82f6c845f63941ebde89eb2cc20ed1c6f2dbabc92b6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      X-Amzn-Requestid:
+      - 8c409194-abfc-4e7a-914d-e6c63c4b6ebf
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '354'
+      Date:
+      - Tue, 05 Jul 2022 14:09:51 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+          <Error>
+            <Type>Sender</Type>
+            <Code>SignatureDoesNotMatch</Code>
+            <Message>Signature expired: 20180620T025910Z is now earlier than 20220705T135452Z (20220705T140952Z - 15 min.)</Message>
+          </Error>
+          <RequestId>8c409194-abfc-4e7a-914d-e6c63c4b6ebf</RequestId>
+        </ErrorResponse>
+  recorded_at: Tue, 05 Jul 2022 14:09:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-jwt/fetch-jwks.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-jwt/fetch-jwks.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.googleapis.com/oauth2/v3/certs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Server:
+      - scaffolding on HTTPServer2
+      Content-Length:
+      - '747'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 05 Jul 2022 13:37:01 GMT
+      Expires:
+      - Tue, 05 Jul 2022 20:04:28 GMT
+      Cache-Control:
+      - public, max-age=23247, must-revalidate, no-transform
+      Content-Type:
+      - application/json; charset=UTF-8
+      Age:
+      - '57'
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "keys": [
+            {
+              "use": "sig",
+              "e": "AQAB",
+              "kty": "RSA",
+              "alg": "RS256",
+              "kid": "2650a2ce47b1ab3ba4099797f8c06ebc3de928ac",
+              "n": "yxRIhtcR01o3nb6hXnPj1U2FbNg6NoL2KGkJGB5QLWMV7qMdxvH_oOsP_sq71EnNXznmUc7FvK9RfoQxy1JGFM6gKzkI-wqXwFVhpCzWqW1pcczoJ8OTXtm1ltWO63KFyh2NpJ6KFOVInHqNoP8_QWwCE1_qfEQryeshv5hBPGgu3e6DuD9SzJ0hTGHrinbER8dxmrGcBrqeyvqMdDxAisYaPxNEOAThSIoGk5JuQ9dHWQtYZKfoy9vd0kVFnyHpss3pgEw4rn0efr_GmvF5V_JGrMkOaJsp8N_qpunWtH_A7XoPrjIw2A2NU_ZOevt07fzKZjws1d0HHmnHA7PWsw"
+            },
+            {
+              "kid": "1bd685f5e8fc62d758705c1eb0e8a7524c475975",
+              "alg": "RS256",
+              "e": "AQAB",
+              "n": "nN6M3RHeDNE57lTiYTtXNnpADuEu1EmbBLPWzkTVAMLlxL5q-kbhUfMSW4rUDwQNaTmJtBfgqhTy-yUvT_DEs2v3ebW_Pw6csNTlaY6zvjPP4qvgRhC7xsPfU9pRWi8br_GBs7OYnWjjXa-Pfx9oRDOdRnSxqI9t44rbqB1E5n-VoeICQY2hHqmtWL2rOb-qdyYuWazTsDr7aXc_inBSf6SCA6ASWjQRy6Ijk1TWvUk1-yBz4gmp72AvhHRNMsY1VHxF5FsQrf2PhlrLZpOUR5Oy__24GAQhvB6Q1GJqnRCGwa0S12WuNJDjHBElYE6tluto5Q65bl525-a8ejDcpQ",
+              "use": "sig",
+              "kty": "RSA"
+            }
+          ]
+        }
+  recorded_at: Tue, 05 Jul 2022 13:37:58 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-jwt/valid-jwks.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-jwt/valid-jwks.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.googleapis.com/oauth2/v3/certs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Server:
+      - scaffolding on HTTPServer2
+      Content-Length:
+      - '742'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 05 Jul 2022 14:05:24 GMT
+      Expires:
+      - Tue, 05 Jul 2022 20:42:16 GMT
+      Cache-Control:
+      - public, max-age=23812, must-revalidate, no-transform
+      Content-Type:
+      - application/json; charset=UTF-8
+      Age:
+      - '14'
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "keys": [
+            {
+              "kty": "RSA",
+              "e": "AQAB",
+              "kid": "2650a2ce47b1ab3ba4099797f8c06ebc3de928ac",
+              "n": "yxRIhtcR01o3nb6hXnPj1U2FbNg6NoL2KGkJGB5QLWMV7qMdxvH_oOsP_sq71EnNXznmUc7FvK9RfoQxy1JGFM6gKzkI-wqXwFVhpCzWqW1pcczoJ8OTXtm1ltWO63KFyh2NpJ6KFOVInHqNoP8_QWwCE1_qfEQryeshv5hBPGgu3e6DuD9SzJ0hTGHrinbER8dxmrGcBrqeyvqMdDxAisYaPxNEOAThSIoGk5JuQ9dHWQtYZKfoy9vd0kVFnyHpss3pgEw4rn0efr_GmvF5V_JGrMkOaJsp8N_qpunWtH_A7XoPrjIw2A2NU_ZOevt07fzKZjws1d0HHmnHA7PWsw",
+              "use": "sig",
+              "alg": "RS256"
+            },
+            {
+              "alg": "RS256",
+              "use": "sig",
+              "n": "nN6M3RHeDNE57lTiYTtXNnpADuEu1EmbBLPWzkTVAMLlxL5q-kbhUfMSW4rUDwQNaTmJtBfgqhTy-yUvT_DEs2v3ebW_Pw6csNTlaY6zvjPP4qvgRhC7xsPfU9pRWi8br_GBs7OYnWjjXa-Pfx9oRDOdRnSxqI9t44rbqB1E5n-VoeICQY2hHqmtWL2rOb-qdyYuWazTsDr7aXc_inBSf6SCA6ASWjQRy6Ijk1TWvUk1-yBz4gmp72AvhHRNMsY1VHxF5FsQrf2PhlrLZpOUR5Oy__24GAQhvB6Q1GJqnRCGwa0S12WuNJDjHBElYE6tluto5Q65bl525-a8ejDcpQ",
+              "kty": "RSA",
+              "e": "AQAB",
+              "kid": "1bd685f5e8fc62d758705c1eb0e8a7524c475975"
+            }
+          ]
+        }
+  recorded_at: Tue, 05 Jul 2022 14:05:38 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 17:19:05 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 17:19:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Tue, 12 Jul 2022 16:31:08 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 17:19:05 GMT
+- request:
+    method: post
+    uri: https://dev-92899796.okta.com/oauth2/default/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+    headers:
+      User-Agent:
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 17:19:05 GMT
+      Authorization:
+      - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 17:19:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Okta-Request-Id:
+      - Yr3bCsdZJUAaGw2mXm8FNgAADRM
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      X-Rate-Limit-Limit:
+      - '300'
+      X-Rate-Limit-Remaining:
+      - '299'
+      X-Rate-Limit-Reset:
+      - '1656609606'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Set-Cookie:
+      - JSESSIONID=20DB7FF8635C66C478EE266D41EC5A6D; Path=/; Secure; HttpOnly
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_grant","error_description":"The authorization code
+        is invalid or has expired."}'
+  recorded_at: Thu, 30 Jun 2022 17:19:06 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 17:07:38 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 17:07:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Tue, 12 Jul 2022 16:31:08 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
+- request:
+    method: post
+    uri: https://dev-92899796.okta.com/oauth2/default/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+    headers:
+      User-Agent:
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 17:07:38 GMT
+      Authorization:
+      - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 17:07:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Okta-Request-Id:
+      - Yr3YWxFu57C3xLMlxeiK2QAABbM
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      X-Rate-Limit-Limit:
+      - '300'
+      X-Rate-Limit-Remaining:
+      - '299'
+      X-Rate-Limit-Reset:
+      - '1656608919'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Set-Cookie:
+      - JSESSIONID=43FD607685A5D5094F4326B6CD522697; Path=/; Secure; HttpOnly
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_grant","error_description":"The authorization code
+        is invalid or has expired."}'
+  recorded_at: Thu, 30 Jun 2022 17:07:39 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
@@ -1,0 +1,219 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Tue, 12 Jul 2022 16:31:08 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
+- request:
+    method: post
+    uri: https://dev-92899796.okta.com/oauth2/default/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+    headers:
+      User-Agent:
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+      Authorization:
+      - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 16:43:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Okta-Request-Id:
+      - Yr3Slh4a2cZq__AflSs8wQAADtA
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      X-Rate-Limit-Limit:
+      - '300'
+      X-Rate-Limit-Remaining:
+      - '299'
+      X-Rate-Limit-Reset:
+      - '1656607442'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Robots-Tag:
+      - noindex,nofollow
+      Set-Cookie:
+      - JSESSIONID=7D061355C0A559E9DE2767B0389890C8; Path=/; Secure; HttpOnly
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":3600,"access_token":"eyJraWQiOiJZR1NUUUxBVDdLb1JPd2RhTWtWa1RyNXhIUXM3Zm1jNG5CTUJsT1NuZHVzIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnl1SkFCZmtqT2FJNHVsOVczMzFabFp0Rk5UQ0ZhSTA3aVJHZFNxcmtJTEEiLCJpc3MiOiJodHRwczovL2Rldi05Mjg5OTc5Ni5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2NTY2MDczODIsImV4cCI6MTY1NjYxMDk4MiwiY2lkIjoiMG9hM3czeGlnNnJIaXU5eVQ1ZDciLCJ1aWQiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsInNjcCI6WyJwcm9maWxlIiwib3BlbmlkIl0sImF1dGhfdGltZSI6MTY1NjYwNjcxNywic3ViIjoidGVzdC51c2VyM0BteWNvbXBhbnkuY29tIn0.w3mFIqKKJII8zWwr5pNFaLIF4R2JslczkUNBHetQfbqrJbw8QDTJi8wkrzVuYF6kmjEapUwyhfip49P7NLvmA88HO7yzqJ9Nu5ZeSftkeR29ldEUgDXN_wdmzer_AvqzNwZbb8W_BqrfUpXXDIGroIKhCjgDMAKW1JlQf85yM-oRuy1qSUIX983US2mixkQzvs0W2sd3Fc0ehTh8ZONjjQMvlbbzNgjOpixz-2gSi61KpQEbw4_jRzYZKavv6El_2lhv5i4AlwP0kXMs6b6W7n3y3bDEFagNj2H5GxLjvt0CUp-NvVX_aWCsJiVoFtu9ahgRbPe3J1PRipnKuQ3rIg","scope":"profile
+        openid","id_token":"eyJraWQiOiJZR1NUUUxBVDdLb1JPd2RhTWtWa1RyNXhIUXM3Zm1jNG5CTUJsT1NuZHVzIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsIm5hbWUiOiJUZXN0IFVzZXIzIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2Rldi05Mjg5OTc5Ni5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6IjBvYTN3M3hpZzZySGl1OXlUNWQ3IiwiaWF0IjoxNjU2NjA3MzgyLCJleHAiOjE2NTY2MTA5ODIsImp0aSI6IklELjdubmF3YUdkc1daT2VKazl6YWxNUFpnVGhuX3Z2QkNDcndBazVHcHRjS00iLCJhbXIiOlsicHdkIl0sImlkcCI6IjAwbzN3MXk4dHV1YVljQ1Q3NWQ3Iiwibm9uY2UiOiIxNjU2YjQyNjRiNjBhZjY1OWZjZSIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QudXNlcjNAbXljb21wYW55LmNvbSIsImF1dGhfdGltZSI6MTY1NjYwNjcxNywiYXRfaGFzaCI6IkU3TDJUUEZrM0dGMXlRQzdEaUJ1UkEifQ.YDeYm3bP5hFmP4u6uuKV2fU8ICZ72LIa_tlG0qfYCVcHS1lZeHqbyJPEWfgmnSGAxenieavntCbsW-g6UdtCeGsoXGPw3tDW-oiNyZsdBPw-xTCg01JSd4d26Oponia0amkhvglXRkAuGVRJciO89oTVabxvYlcP-PvOeaiFjn4q9hFvTQTI6sItPhxp6rMa3Ri9VJkOR1fdkI-w9bwGW8WN-u4GscQoCU054HPVaHPT8fQ86Bl3Aty8Bf2e5Gw6WIpLSFgWd6Nmhiv1ANUcW8vSLxsefWI6N37j-0fCa1fgZefv-M-Kg_dfE-8a33YxzAwN5NB3HCbv7FNsYD1rIg"}'
+  recorded_at: Thu, 30 Jun 2022 16:43:02 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/v1/keys
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - OpenIDConnect (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 16:43:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=128312, must-revalidate
+      Expires:
+      - Sat, 02 Jul 2022 04:21:35 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yr3SlwZrGYc1D5ItYgm_cgAABxk
+    body:
+      encoding: UTF-8
+      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"YGSTQLAT7KoROwdaMkVkTr5xHQs7fmc4nBMBlOSndus","use":"sig","e":"AQAB","n":"y4r4NkyseHCyJ44QE4n4_n4Xxi63nkZlcTuJkr8I-yOgXKWk9h9giq6FJcMYwHXTtM2sQQ-yVJu_GSCgWWq2QmgaQt-1H8ldrJhlw1_W33POdCPQHjOdvUGJ8xgKbasIuFJrR_SPXJ5WQz8yIQsTQXaIgSP2NHTLRRg_KFsMe9nkYY7Mz_T9ZsQyzxal9fnefJa5mExEuWi7STIEJfgQqbzezdN-t1ZFpoVCAUFhNwKNYcsTvMDR43e3zdY_ii09rWakRzEicoFGeeQPZcgxcHWnYAmirufmu_gj9lGE-sOFatcXkIK07gziDa8CzTqh6OKitQdT__CNKSiOgYT1Pw"}]}'
+  recorded_at: Thu, 30 Jun 2022 16:43:03 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 16:43:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Tue, 12 Jul 2022 16:31:08 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 20:53:10 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 20:53:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Tue, 12 Jul 2022 16:31:08 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 20:53:10 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 30 Jun 2022 20:53:10 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 Jun 2022 20:53:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
+        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
+        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
+        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
+        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Fri, 01 Jul 2022 20:53:11 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yr4NN7wdOzHatG786KpGLQAACUY
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 30 Jun 2022 20:53:11 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Desired Outcome

This PR adds support for OIDC's code-based authorization flow. This functionality allows Conjur to use an external
OIDC Provider (Okta, Keycloak), to authenticate users and redirect them to Conjur on success. Conjur will resolve the identified user to a Conjur User ID and return and Authorization Token.

### Implemented Changes

The architecture of this feature is different from that of the other authenticators. The intention of this architecture is to simplify testing and reduce developer cognitive load.

- Authenticator Specific Constructs:
    - Authenticator Data Object - contains the configuration data specific to an authenticator type.
    - Strategy - implements the lower level details (the "how") an authenticator verifies an external identity.
    - Resolve Identity - functionality to an externally identified identity with an internal identity.
    - Client - handles the low level network specifics of verifying an identity with an external identity provider.
- Generic Authenticator Constructs:
    - Authentication Handler - a generic handler which calls the authenticator specific objects to orchestrate the authentication flow.

### Planned Future Work

- Add tests for Authentication Handler: [ONYX-22990](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22990)
- Document Authenticator Architecture: [ONYX-22991](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22991)

### Connected Issue/Story

[Jira Epic](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17888)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
