### PR TITLE
Add OpenSSL trivyignores and bump rails-html-sanitizer to 1.4.3

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,12 +1,24 @@
-# CVE-2022-0778
+# OpenSSL CVEs
 #
-# In order to support FIPS with OpenSSL we are required to use OpenSSL version
-# 1.0.2 until OpenSSL supports the FIPS module in newer versions. The latest
-# available version to us is 1.0.2zd, which includes this fix. Trivy does not
-# recognize 1.0.2zd as a valid fixed version, hence the need for this ignore.
-#
-# Performed by @samirshetty, approved by @andytinkham
+# Because of the way OpenSSL 1.0.2 has moved to premium support and our Ubuntu
+# base image, trivy flags a number of OpenSSL issues in Conjur because the fix
+# for most Ubuntu users is to move to 1.1.1 instead of having the continued support
+# in the 1.0.2 line. Additionally, trivy flages 1.0.2zf as vulnerable to issues that
+# only affect 1.1.x. As of the time of this writing, we use 1.0.2zf which either 
+# has the fix or is unaffected by these issues.
+CVE-2022-2097
+CVE-2022-2068
+CVE-2022-1292
 CVE-2022-0778
+CVE-2021-23841
+CVE-2021-23840
+CVE-2021-3712
+CVE-2019-1563
+CVE-2019-1551
+CVE-2019-1549
+CVE-2019-1547
+CVE-2018-0735
+CVE-2018-0734
 
 # NULL pointer deref. OpenSSL 1.0.2 is not impacted
 CVE-2021-3449

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.16.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -274,7 +274,9 @@ GEM
     net-ssh (6.1.0)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.7-x86_64-linux)
       racc (~> 1.4)
     openid_connect (1.3.0)
       activemodel
@@ -335,7 +337,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails_12factor (0.0.3)
       rails_serve_static_assets


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Clean out trivy results in master build

### Implemented Changes

- Adds .trivyignore entries for all the OpenSSL CVEs where we already have the fixed version or are unaffected
- Bumps rails-html-sanitizer to 1.4.3 

### Connected Issue/Story

CyberArk internal issue: CONJSE-1435

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
