### PR TITLE
Include the supplied version in gen_versions

### DIFF
--- a/build_utils.sh
+++ b/build_utils.sh
@@ -6,11 +6,12 @@ function version_tag() {
   git rev-parse --short=8 HEAD
 }
 
-# generate less specific versions, eg. given 1.2.3 will print 1.2 and 1
-# (note: the argument itself is not printed, append it explicitly if needed)
+# generate set of less specific versions, eg. given 1.2.3 will print 1.2.3,
+# 1.2 and 1
 function gen_versions()
 {
   local version=$1
+  echo "$version"
   while [[ $version = *.* ]]; do
     version=${version%.*}
     echo "$version"


### PR DESCRIPTION
The output of gen_versions is used for determining the list of target
versions to publish.  This will include the supplied version number
as well.

### Desired Outcome

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- Update gen_versions to include the supplied version

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
