### PR TITLE
Write failure audit event for JWT authentication

### DIFF
--- a/app/controllers/authenticate_controller.rb
+++ b/app/controllers/authenticate_controller.rb
@@ -127,6 +127,12 @@ class AuthenticateController < ApplicationController
     )
     render_authn_token(authn_token)
   rescue => e
+    # At this point authenticator_input.username is always empty (e.g. cucumber:user:USERNAME_MISSING)
+    log_audit_failure(
+      authn_params: authenticator_input,
+      audit_event_class: Audit::Event::Authn::Authenticate,
+      error: e
+    )
     handle_authentication_error(e)
   end
 

--- a/cucumber/authenticators_jwt/features/authn_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt.feature
@@ -59,6 +59,10 @@ Feature: JWT Authenticator - JWKs Basic sanity
     """
     CONJ00004E 'authn-jwt/non-existing' is not enabled
     """
+    And The following appears in the audit log after my savepoint:
+    """
+    webservice:conjur/authn-jwt/non-existing: CONJ00004E 'authn-jwt/non-existing' is not enabled
+    """
 
   @negative @acceptance
   Scenario: ONYX-8821: Host that doesn't exist is denied


### PR DESCRIPTION
### Desired Outcome
Write failure audit event for JWT authentication


### Connected Issue/Story

CyberArk internal issue link: [ONYX-22023](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-22023)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
