### PR TITLE
Follow GCP function redirects in tests

### DIFF
--- a/ci/test_suites/authenticators_gcp/validate_gcf_url_accessible.sh
+++ b/ci/test_suites/authenticators_gcp/validate_gcf_url_accessible.sh
@@ -6,9 +6,16 @@ gcp_func_url=$1
 audience=$2
 optional_identity_token=$3
 
-status_code=$(curl -o /dev/null -s -w "%{http_code}\n" \
-  -H "Authorization: bearer $optional_identity_token" \
-  -H 'Metadata-Flavor: Google' "$gcp_func_url?audience=${audience}")
+status_code=$(
+  curl \
+    --output /dev/null \
+    --silent \
+    --location \
+    --write-out "%{http_code}\n" \
+    --header "Authorization: bearer $optional_identity_token" \
+    --header 'Metadata-Flavor: Google' \
+    "$gcp_func_url?audience=${audience}"
+  )
 
 if [ ! "$status_code" = "200" ]; then
   echo "-- Function returned error, HTTP Status: '${status_code}', \


### PR DESCRIPTION
The `ci/test_suites/authenticators_gcp/validate_gcf_url_accessible.sh` script has started failing with a 302 response in the GCP test suite. We now follow the redirect when we receive this response, allowing the test suite to successfully complete.

