### PR TITLE
Add testing for new XOR constraint

### DIFF
--- a/app/domain/authentication/constraints/required_exclusive_constraint.rb
+++ b/app/domain/authentication/constraints/required_exclusive_constraint.rb
@@ -1,6 +1,8 @@
 module Authentication
   module Constraints
 
+    # This constraint is initialized with an array of strings.
+    # They represent resource restrictions where exactly one is required.
     class RequiredExclusiveConstraint
 
       def initialize(required_exclusive:)
@@ -9,7 +11,7 @@ module Authentication
 
       def validate(resource_restrictions:)
         restrictions_found = resource_restrictions & @required_exclusive
-        raise Errors::Authentication::Constraints::IllegalExclusiveRequiredCombination, @required_exclusive unless restrictions_found.length == 1
+        raise Errors::Authentication::Constraints::IllegalRequiredExclusiveCombination.new(@required_exclusive, restrictions_found) unless restrictions_found.length == 1
       end
 
     end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -670,8 +670,9 @@ module Errors
         code: "CONJ00069E"
       )
 
-      IllegalExclusiveRequiredCombination = ::Util::TrackableErrorClass.new(
-        msg: "Role must have only one of the following required constraints: {0-constraints}",
+      IllegalRequiredExclusiveCombination = ::Util::TrackableErrorClass.new(
+        msg: "Role must have exactly one of the following required constraints: " \
+             "{0-constraints}. Role configured with {1-provided}",
         code: "CONJ00069E"
       )
 

--- a/spec/app/domain/authentication/constraints/required_exclusive_constraint_spec.rb
+++ b/spec/app/domain/authentication/constraints/required_exclusive_constraint_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Authentication::Constraints::RequiredExclusiveConstraint) do
+  context "Given RequiredExclusiveConstraint initialized with 3 restrictions" do
+    let(:reqx_restrictions) { %w[reqx_one reqx_two reqx_three] }
+    let(:additional_restriction) { "additional" }
+    let(:raised_error) { ::Errors::Authentication::Constraints::IllegalRequiredExclusiveCombination }
+
+    subject(:constraint) do
+      Authentication::Constraints::RequiredExclusiveConstraint.new(required_exclusive: reqx_restrictions)
+    end
+
+    context "when validating with no ReqX restrictions" do
+      let(:expected_error_message) { /#{Regexp.escape(reqx_restrictions.to_s)}/ }
+
+      subject do
+        constraint.validate(resource_restrictions: [additional_restriction])
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(raised_error, expected_error_message)
+      end
+    end
+
+    context "when validating with one ReqX restriction" do
+      subject do
+        constraint.validate(resource_restrictions: [reqx_restrictions.first, additional_restriction])
+      end
+
+      it "does not raise an error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context "when validating with many ReqX restrictions" do
+      let(:resource_restrictions) { reqx_restrictions[1, 2] }
+      let(:expected_error_message) { /#{Regexp.escape(resource_restrictions.to_s)}/ }
+
+      subject do
+        constraint.validate(resource_restrictions: resource_restrictions + [additional_restriction])
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(raised_error, expected_error_message)
+      end
+    end
+
+    context "when validating with all ReqX restrictions" do
+      let(:expected_error_message) { /#{Regexp.escape(reqx_restrictions.to_s)}/ }
+
+      subject do
+        constraint.validate(resource_restrictions: reqx_restrictions + [additional_restriction])
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(raised_error, expected_error_message)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
### Desired Outcome

This PR adds RSpec tests for the new constraint used in Authn-K8s namespace-label based identity scope. The new constraint needs to enforce XOR on a set of resource restrictions. Given a set of restrictions, and authenticating host must be configured with _exactly one_ from the set.

Given that resource restrictions **A** and **B** are subject to the new constraint, the outcomes should be as follows:
| **A** configured | **B** configured | **Constraint Validation Result** |
|------------------|------------------|----------------------------------|
| 0                | 0                | `Error`                          |
| 0                | 1                | Success                          |
| 1                | 0                | Success                          |
| 1                | 1                | `Error`                          |

### Implemented Changes

- RSpec tests for the new Constraint class 

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23180](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23180)

### Definition of Done

- [x] Test the new `Constraint` with RSpec

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
