### PR TITLE
Allow OIDC Providers to be available via local socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [1.18.1] - 2022-08-01
+## [1.18.1] - 2022-07-29
+### Changed
+- Adds support for local processes to retrieve a list of configured OIDC providers
+  [cyberark/conjur#2616](https://github.com/cyberark/conjur/pull/2616)
 
-## [1.18.0] - 2022-08-01
-
-### Added
-- Adds support for namespace label based identity scope for the Kubernetes Authenticator
-  [cyberark/conjur#2613](https://github.com/cyberark/conjur/pull/2613)
-
+## [1.18.0] - 2022-07-12
 ### Changed
 - Adds support for authentication using OIDC's code authorization flow
   [cyberark/conjur#2595](https://github.com/cyberark/conjur/pull/2595)

--- a/app/db/repository/authenticator_repository.rb
+++ b/app/db/repository/authenticator_repository.rb
@@ -8,12 +8,16 @@ module DB
       end
 
       def find_all(type:, account:)
-        @resource_repository.where(
+        authenticators = @resource_repository.where(
           Sequel.like(
             :resource_id,
             "#{account}:webservice:conjur/#{type}/%"
           )
-        ).all.map do |webservice|
+        )
+        @logger.debug("#{self.class}##{__method__} - #{authenticators.count} found")
+        return [] if authenticators.count.zero?
+
+        authenticators.all.map do |webservice|
           load_authenticator(account: account, id: webservice.id.split(':').last, type: type)
         end.compact
       end

--- a/app/domain/authentication/authn_oidc/v2/commands/list_providers.rb
+++ b/app/domain/authentication/authn_oidc/v2/commands/list_providers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'command_class'
+require './app/db/repository/authenticator_repository'
+
+module Authentication
+  module AuthnOidc
+    module V2
+      module Commands
+        ListProviders ||= CommandClass.new(
+          dependencies: {
+            json_lib: JSON
+          },
+          inputs: %i[message]
+        ) do
+          def call
+            params = @json_lib.parse(@message)
+            (account = params.delete("account")) || raise("'account' is required")
+            Authentication::AuthnOidc::V2::Views::ProviderContext.new.call(
+              authenticators: DB::Repository::AuthenticatorRepository.new(
+                data_object:  Authentication::AuthnOidc::V2::DataObjects::Authenticator
+              ).find_all(
+                account: account,
+                type: 'authn-oidc'
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/domain/commands/authentication/issue_token.rb
+++ b/app/domain/commands/authentication/issue_token.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'command_class'
+
+module Commands
+  module Authentication
+    IssueToken ||= CommandClass.new(
+      dependencies: {
+        json_lib: JSON,
+        slosilo_lib: Slosilo
+      },
+      inputs: %i[message]
+    ) do
+      def call
+        claims = @json_lib.parse(@message)
+        claims = claims.slice("account", "sub", "exp", "cidr")
+        (account = claims.delete("account")) || raise("'account' is required")
+        raise "'sub' is required" unless claims['sub']
+
+        key = @slosilo_lib["authn:#{account}"]
+        if key
+          key.issue_jwt(claims).to_json
+        else
+          raise "No signing key found for account #{account.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/app/domain/util/socket_server.rb
+++ b/app/domain/util/socket_server.rb
@@ -1,0 +1,63 @@
+require 'timeout'
+require 'fileutils'
+require 'socket'
+
+module Util
+  class SocketService
+    def initialize(socket:, queue_length: 5, timeout: 1, message_writer: $stderr)
+      @socket = socket
+      @queue_length = queue_length
+      @timeout = timeout
+      @message_writer = message_writer
+
+      socket_dir = File.dirname(socket)
+
+      return if File.directory?(socket_dir)
+
+      raise("Socket Service requires directory #{socket_dir.inspect} to exist and be a directory")
+    end
+
+    # Accepts a block for the desired response behavior.
+    # The message passed to the socket is available as a string
+    # inside the block as a block attribute. Ex:
+    #
+    #   Util::SocketService.new(socket: '/socket/path').run do |passed_arguments|
+    #     Authentication::AuthnOidc::V2::Commands::ListProviders.new.call(
+    #       message: passed_arguments
+    #     )
+    #   end
+    def run(&block)
+      raise "Socket: #{@socket} already exists" if File.exist?(@socket)
+
+      server = UNIXServer.new(@socket)
+
+      trap(0) do
+        # remove the socket on exit
+        @message_writer.puts("Removing socket #{@socket}")
+        File.unlink(@socket)
+      end
+
+      server.listen(@queue_length)
+
+      @message_writer.puts("service is listening at #{@socket}")
+
+      while connection = server.accept
+        begin
+          Timeout.timeout(@timeout) do
+            arguments = connection.gets.strip
+            begin
+              connection.puts(block.call(arguments))
+            rescue
+              @message_writer.puts("Error in service '#{@socket}': #{$!}")
+              connection.puts
+            ensure
+              connection.close
+            end
+          end
+        rescue Timeout::Error
+          @message_writer.puts("Timeout::Error in service '#{@socket}'")
+        end
+      end
+    end
+  end
+end

--- a/app/domain/util/socket_server.rb
+++ b/app/domain/util/socket_server.rb
@@ -4,17 +4,33 @@ require 'socket'
 
 module Util
   class SocketService
-    def initialize(socket:, queue_length: 5, timeout: 1, message_writer: $stderr)
+    def initialize(socket:, queue_length: 5, timeout: 1, logger: Logger.new($stderr, level: Logger::INFO))
       @socket = socket
       @queue_length = queue_length
       @timeout = timeout
-      @message_writer = message_writer
+      @logger = logger
 
-      socket_dir = File.dirname(socket)
+      validate_filesystem_assumptions(socket_file: socket)
+    end
+
+    def validate_filesystem_assumptions(socket_file:)
+      if File.exist?(socket_file)
+        raise "Socket: #{socket_file} already exists"
+      end
+
+      socket_dir = File.dirname(socket_file)
 
       return if File.directory?(socket_dir)
 
       raise("Socket Service requires directory #{socket_dir.inspect} to exist and be a directory")
+    end
+
+    def cleanup
+      # remove the socket on exit
+      # !! Note !!: A logger isn't allowed in a `trap` block, so we need
+      # to provide an IO.pipe to write the exit message to.
+      $stderr.puts("Removing socket #{@socket}")
+      File.unlink(@socket)
     end
 
     # Accepts a block for the desired response behavior.
@@ -26,36 +42,34 @@ module Util
     #       message: passed_arguments
     #     )
     #   end
+    #
+    # !! Note: the response is transformed into JSON to be sent through the socket.
     def run(&block)
-      raise "Socket: #{@socket} already exists" if File.exist?(@socket)
-
       server = UNIXServer.new(@socket)
-
-      trap(0) do
-        # remove the socket on exit
-        @message_writer.puts("Removing socket #{@socket}")
-        File.unlink(@socket)
-      end
+      trap(0) { cleanup }
 
       server.listen(@queue_length)
+      @logger.info("service is listening at #{@socket}")
 
-      @message_writer.puts("service is listening at #{@socket}")
-
-      while connection = server.accept
+      loop do
+        connection = server.accept
         begin
           Timeout.timeout(@timeout) do
             arguments = connection.gets.strip
             begin
-              connection.puts(block.call(arguments))
+              @logger.debug("arguments: #{arguments.inspect}")
+              response = connection.puts(block.call(arguments).to_json)
+              @logger.debug("response: #{response.inspect}")
+              response
             rescue
-              @message_writer.puts("Error in service '#{@socket}': #{$!}")
+              @logger.error("Error in service '#{@socket}': #{$ERROR_INFO}")
               connection.puts
             ensure
               connection.close
             end
           end
         rescue Timeout::Error
-          @message_writer.puts("Timeout::Error in service '#{@socket}'")
+          @logger.error("Timeout::Error in service '#{@socket}'")
         end
       end
     end

--- a/app/models/authn_local.rb
+++ b/app/models/authn_local.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'timeout'
-require 'fileutils'
-require 'socket'
-
 AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
   class << self
     def run socket:, queue_length:, timeout:
@@ -22,57 +18,15 @@ AuthnLocal = Struct.new(:socket, :queue_length, :timeout) do
       timeout ||= 1
       timeout = timeout.to_i
 
-      AuthnLocal.new(socket, queue_length, timeout).run
-    end
-  end
-
-  def run
-    FileUtils.rm_rf(socket)
-
-    server = UNIXServer.new(socket)
-
-    trap(0) do
-      # remove the socket on exit
-      # alternatively it can be removed on startup
-      # (or both)
-      $stderr.puts("Removing socket #{socket}")
-      File.unlink(socket)
-    end
-
-    server.listen(queue_length)
-
-    puts("authn-local is listening at #{socket}")
-
-    while conn = server.accept
-      begin
-        Timeout.timeout(timeout) do
-          claims = conn.gets.strip
-          begin
-            conn.puts(issue_token(claims))
-          rescue
-            $stderr.puts("Error in authn-local: #{$!.to_s}")
-            conn.puts
-          ensure
-            conn.close
-          end
-        end
-      rescue Timeout::Error
-        $stderr.puts("Timeout::Error in authn-local")
+      Util::SocketService.new(
+        socket: socket,
+        queue_length: queue_length,
+        timeout: timeout
+      ).run do |passed_arguments|
+        Commands::Authentication::IssueToken.new.call(
+          message: passed_arguments
+        )
       end
-    end
-  end
-
-  def issue_token claims
-    claims = JSON.parse(claims)
-    claims = claims.slice("account", "sub", "exp", "cidr")
-    (account = claims.delete("account")) || raise("'account' is required")
-    raise "'sub' is required" unless claims['sub']
-
-    key = Slosilo["authn:#{account}"]
-    if key 
-      key.issue_jwt(claims).to_json
-    else
-      raise "No signing key found for account #{account.inspect}"
     end
   end
 end

--- a/bin/conjur-cli/commands/server.rb
+++ b/bin/conjur-cli/commands/server.rb
@@ -40,6 +40,7 @@ module Commands
       # processes
       fork_server_process
       fork_authn_local_process
+      fork_provider_list_process
       fork_rotation_process
 
       # Block until all child processes end
@@ -98,12 +99,12 @@ module Commands
     def cleanup_pidfile
       # Get the path to conjurctl
       conjurctl_path = `readlink -f $(which conjurctl)`
-    
+
       # Navigate from its directory (/bin) to the root Conjur server directory
       conjur_server_dir = Pathname.new(File.join(File.dirname(conjurctl_path), '..')).cleanpath
       pid_file_path = File.join(conjur_server_dir, 'tmp/pids/server.pid')
       return unless File.exist?(pid_file_path)
-      
+
       puts("Removing existing PID file: #{pid_file_path}")
       File.delete(pid_file_path)
     end
@@ -130,6 +131,12 @@ module Commands
     def fork_authn_local_process
       Process.fork do
         exec("rake authn_local:run")
+      end
+    end
+
+    def fork_provider_list_process
+      Process.fork do
+        exec("rake ui:run")
       end
     end
 

--- a/lib/tasks/authn_local.rake
+++ b/lib/tasks/authn_local.rake
@@ -9,4 +9,18 @@ namespace :authn_local do
 
     AuthnLocal.run(socket: socket, queue_length: queue_length, timeout: timeout)
   end
+
+  task authenticate: :environment do
+    require 'json'
+    require 'socket'
+
+    response = UNIXSocket.open('/run/authn-local/.socket') do |socket|
+      socket.puts({
+        account: 'cucumber',
+        sub: 'admin'
+      }.to_json)
+      JSON.parse(socket.gets)
+    end
+    puts("received: #{response}")
+  end
 end

--- a/lib/tasks/ui.rake
+++ b/lib/tasks/ui.rake
@@ -5,8 +5,14 @@ require './app/domain/authentication/authn_oidc/v2/commands/list_providers'
 
 namespace :ui do
   task run: :environment do
-    Util::SocketService.new(socket: '/run/ui/.socket').run do |passed_arguments|
-      Authentication::AuthnOidc::V2::Commands::ListProviders.new.call(
+    logger = Logger.new($stderr, level: Logger::DEBUG)
+    Util::SocketService.new(
+      socket: '/run/ui/.socket',
+      logger: logger
+    ).run do |passed_arguments|
+      Authentication::AuthnOidc::V2::Commands::ListProviders.new(
+        logger: logger
+      ).call(
         message: passed_arguments
       )
     end

--- a/lib/tasks/ui.rake
+++ b/lib/tasks/ui.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require './app/domain/util/socket_server'
+require './app/domain/authentication/authn_oidc/v2/commands/list_providers'
+
+namespace :ui do
+  task run: :environment do
+    Util::SocketService.new(socket: '/run/ui/.socket').run do |passed_arguments|
+      Authentication::AuthnOidc::V2::Commands::ListProviders.new.call(
+        message: passed_arguments
+      )
+    end
+  end
+
+  task retrieve_providers: :environment do
+    require 'json'
+    require 'socket'
+
+    response = UNIXSocket.open('/run/ui/.socket') do |socket|
+      socket.puts({ account: 'cucumber' }.to_json)
+      JSON.parse(socket.gets)
+    end
+    puts("received: #{response}")
+  end
+end


### PR DESCRIPTION
### Desired Outcome

The outcome of this PR is to provide a mechanism for a local service to retrieve a list of configured OIDC authenticators.  

**Note**
This functionality is intended as a stop-gap for the UI in Conjur Enterprise. The `ui` socket service will be removed in the near future.

### Implemented Changes

This PR includes a couple of changes:
- Refactor the `authn-local` unix socket server to accept a custom response.
- Enable the `/:authenticator/:account/providers` route to be served over a local unix socket.
- Refactors `authn-local` to utilize the generic unix socket service

### Connected Issue/Story

CyberArk internal issue link: [ONYX-23542](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23542)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

**Note**
- `authn-local service is tested at the integration level
- The behavior of the `Authentication::AuthnOidc::V2::Views::ProviderContext` class is well tested with unit tests.
- Additional tests need to be added in the near future.

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
