### PR TITLE
Remove dev dependencies after building gems

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -17,23 +17,6 @@ LABEL name="conjur-ubi" \
       summary="Conjur UBI-based image" \
       description="Conjur provides secrets management and machine identity for modern infrastructure."
 
-RUN INSTALL_PKGS="gcc \
-                  gcc-c++ \
-                  git \
-                  glibc-devel \
-                  libxml2-devel \
-                  libxslt-devel \
-                  make \
-                  openldap-clients \
-                  tzdata" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    # Aug 4, 2022: Temporarily install the updated kernel headers package from
-    # centos until the UBI repository is updated with a version that resolves
-    # CVE-2022-1012 and CVE-2022-32250.
-    yum install -y http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-headers-4.18.0-408.el8.x86_64.rpm && \
-    yum -y clean all --enablerepo='*'
-
 # Create conjur user with one that has known gid / uid.
 RUN groupadd -r conjur \
              -g 777 && \
@@ -69,8 +52,28 @@ COPY Gemfile \
      Gemfile.lock ./
 COPY gems/ gems/
 
+# Install package dependencies for Conjur
+RUN INSTALL_PKGS="openldap-clients \
+                  tzdata" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
 
-RUN bundle --without test development
+# Install Gems (and build native gems) for Conjur
+RUN INSTALL_PKGS="gcc \
+                  gcc-c++ \
+                  git \
+                  glibc-devel \
+                  libxml2-devel \
+                  libxslt-devel \
+                  make" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # Install the gems dependencies
+    bundle --without test development && \
+    # Remove the build packages
+    yum remove -y $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
 
 COPY . .
 


### PR DESCRIPTION

### Implemented Changes

This PR provides a permanent solution to the first build fix PR here: https://github.com/cyberark/conjur/pull/2622

It does so by removing the build tools from the image after building all of the native gems for Conjur.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-24161](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-24161)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
