### PR TITLE
Bugfix: Authn-K8s API URL with trailing slash breaks KubeClient factory

### DIFF
--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -155,12 +155,16 @@ module Authentication
         k8s_clients.find do |client|
           begin
             client.respond_to?(method_name)
-          rescue KubeException => e
-            raise e unless e.error_code == 404
+          rescue => e
+            if e.kind_of?(KubeException)
+              raise e unless e.error_code == 404
+            end
 
             false
           end
-        end
+        end.tap { |client|
+          raise Errors::Authentication::AuthnK8s::NoMatchingClient, method_name if client.blank?
+        }
       end
 
       # If more API versions appear, add them here.

--- a/app/domain/authentication/authn_k8s/kube_client_factory.rb
+++ b/app/domain/authentication/authn_k8s/kube_client_factory.rb
@@ -14,7 +14,7 @@ module Authentication
     module KubeClientFactory
 
       def self.client(api: 'api', version: 'v1', host_url: nil, options: nil)
-        full_url = "#{host_url}/#{api}"
+        full_url = "#{normalize(host_url)}/#{api}"
         validate_host_url!(full_url)
 
         Kubeclient::Client.new(full_url, version, **options)
@@ -22,6 +22,11 @@ module Authentication
 
       class << self
         private
+
+        def normalize(url)
+          return url unless url.ends_with?("/")
+          return url[0..-2]
+        end
 
         def validate_host_url! host_url
           raise if URI.parse(host_url).host.empty?

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -401,6 +401,11 @@ module Errors
         msg: "Invalid Kubernetes host id: {0}. Must end with <namespace>/<resource_type>/<resource_id>",
         code: "CONJ00048E"
       )
+
+      NoMatchingClient = ::Util::TrackableErrorClass.new(
+        msg: "Unable to establish Kubernetes client to execute method: \#{0}",
+        code: "CONJ00132E"
+      )
     end
 
     module AuthnAzure


### PR DESCRIPTION
### Desired Outcome

When Authn-K8s is configured with an API URL that contains a trailing slash, like `https://example.com:8080/`, the Kubeclient gem breaks with a nondescript error message and stack trace.

Trailing slashes on API URLs should be accepted, and result in a properly configured K8s client.

### Implemented Changes

- Prune trailing slash when constructing K8s API URL
- Wrap nondescript error with `CONJ00132E`
- Test cases:
  - Authn-K8s succeeds with API URL with trailing slash
  - Authn-K8s fails if API URL does not point to valid K8s server

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
