### PR TITLE
Add RedHat preflight image scan to publish script

### DIFF
--- a/publish-images.sh
+++ b/publish-images.sh
@@ -70,6 +70,7 @@ done
 LOCAL_IMAGE="conjur:${LOCAL_TAG}"
 RH_LOCAL_IMAGE="conjur-ubi:${LOCAL_TAG}"
 IMAGE_NAME="cyberark/conjur"
+REDHAT_CERT_PID="5f905d433a93dc782c77a0f9"
 REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6/conjur"
 
 # Normalize version number in the case of '+' included
@@ -134,7 +135,11 @@ if [[ "${REDHAT}" = true ]]; then
   echo "Publishing ${VERSION} to RedHat registry..."
   # Publish only the tag version to the Redhat container registry
   if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+    # push image to red hat
     tag_and_push "${VERSION}" "${RH_LOCAL_IMAGE}" "${REDHAT_IMAGE}"
+
+    # scan image with preflight tool
+    scan_redhat_image "${REDHAT_IMAGE}:${VERSION}" "${REDHAT_CERT_PID}"
   else
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1


### PR DESCRIPTION
### Desired Outcome

Even though 1.18.0 and 1.18.1 have been released, the latest available image in RedHat's image registry is [1.17.3](https://catalog.redhat.com/software/containers/cyberark/conjur/5fd81ee429373868204299fe). This PR uses the RedHat's pre-flight tool to certify and begin scanning promoted images, so they can be made publicly available manually.

### Implemented Changes

These changes implements a new release tool for red hat preflight mentioned here: https://github.com/conjurinc/release-tools/pull/38.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
