### PR TITLE
Ofira jwt OIDC header1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.18.4] - 2022-09-11
+
+### Added
+- Adds support for authorization token in header in OIDC authenticator.
+  [cyberark/conjur#2637](https://github.com/cyberark/conjur/pull/2637)
+
 ## [1.18.3] - 2022-09-07
 
 ### Security

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -39,7 +39,23 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     And I successfully set OIDC variables
 
   @smoke
-  Scenario: A valid id token to get Conjur access token
+  Scenario: A valid id token in header to get Conjur access token
+    # We want to verify the returned access token is valid for retrieving a secret
+    Given I have a "variable" resource called "test-variable"
+    And I permit user "alice" to "execute" it
+    And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
+    And I fetch an ID Token for username "alice" and password "alice"
+    And I save my place in the audit log file
+    When I authenticate via OIDC with id token in header
+    Then user "alice" has been authorized by Conjur
+    And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
+    And The following appears in the audit log after my savepoint:
+    """
+    cucumber:user:alice successfully authenticated with authenticator authn-oidc service cucumber:webservice:conjur/authn-oidc/keycloak
+    """
+
+  @smoke
+  Scenario: A valid id token in body to get Conjur access token
     # We want to verify the returned access token is valid for retrieving a secret
     Given I have a "variable" resource called "test-variable"
     And I permit user "alice" to "execute" it

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -161,6 +161,13 @@ When(/^I authenticate via OIDC with id token$/) do
   )
 end
 
+When(/^I authenticate via OIDC with id token in header$/) do
+  authenticate_id_token_with_oidc_in_header(
+    service_id: AuthnOidcHelper::SERVICE_ID,
+    account: AuthnOidcHelper::ACCOUNT
+  )
+end
+
 Given(/^I successfully set OIDC V2 variables for "([^"]*)"$/) do |service_id|
   create_oidc_secret("provider-uri", oidc_provider_uri, service_id)
   create_oidc_secret("response-type", oidc_response_type, service_id)

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -24,6 +24,14 @@ module AuthnOidcHelper
     post(path, payload)
   end
 
+  def authenticate_id_token_with_oidc_in_header(service_id:, account:, id_token: parsed_id_token)
+    service_id_part = service_id ? "/#{service_id}" : ""
+    path = "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}/authenticate"
+    headers = {}
+    headers["Authorization"] = "Bearer #{id_token}"
+    post(path, {}, headers)
+  end
+
   def authenticate_code_with_oidc(service_id:, account:, code: url_oidc_code, state: url_oidc_state)
     path = "#{create_auth_url(service_id: service_id, account: account, user_id: nil)}"
     get(url_with_params(path: path,code: code, state: state ))


### PR DESCRIPTION
### Desired Outcome

Adding capability to do OIDC authentication when the ID Token is passed in header

### Implemented Changes

The changes are done in controller and its helping classes relevant to OIDC
The changes are to handle requests that get ID Token in header instead of body of request
The request that comes without IDToken in body is trying to read Authorization token from header and 
checks if it has a "Bearer " prefix. After it the prefix is cut-out and the token after it is passed as an ID Toke
to the existing validation mechanism

### Connected Issue/Story

Resolves [ONYX-23732](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23732)

### Definition of Done
OIDC authentication for UI is implemented and passed first testing

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
