### PR TITLE
Prevent status webservices from being returned on the providers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - List resources request (`GET /resources`) now produce audit events.
-  ([cyberark/conjur#2652](https://github.com/cyberark/conjur/pull/2652)
+  [cyberark/conjur#2652](https://github.com/cyberark/conjur/pull/2652)
 
 ### Changed
 - AWS Access Key Rotation now preserves only one key
+
+### Fixed
+- Removed Status webservices from the list providers endpoint
+  [cyberark/conjur#2640](https://github.com/cyberark/conjur/pull/2640)
 
 ## [1.18.4] - 2022-09-11
 

--- a/app/domain/authentication/installed_authenticators.rb
+++ b/app/domain/authentication/installed_authenticators.rb
@@ -4,6 +4,7 @@ module Authentication
   class InstalledAuthenticators
 
     AUTHN_RESOURCE_PREFIX = "conjur/authn-"
+    AUTHN_STATUS_FILTER = %r{conjur/(authn(?:-[^/]+)?(?:/[^/]+)?)$}
 
     class << self
       def authenticators(env, authentication_module: ::Authentication)
@@ -28,7 +29,7 @@ module Authentication
           .where(identifier.like("#{AUTHN_RESOURCE_PREFIX}%"))
           .where(kind => "webservice")
           .select_map(identifier)
-          .map { |id| id[%r{^conjur/(authn(?:-[^/]+)?(?:/[^/]+)?)$}, 1] } # filter out nested status webservice
+          .map { |id| id[AUTHN_STATUS_FILTER, 1] } # filter out nested status webservice
           .compact
           .push(::Authentication::Common.default_authenticator_name)
       end

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       RAILS_ENV:
       REQUIRE_SIMPLECOV: "true"
       CONJUR_LOG_LEVEL: debug
-      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw,authn-jwt/keycloak,authn-oidc/keycloak2,authn-oidc/okta-2
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-oidc/okta,authn-oidc/oidceast,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw,authn-jwt/keycloak,authn-oidc/keycloak2,authn-oidc/okta-2
       LDAP_URI: ldap://ldap-server:389
       LDAP_BASE: dc=conjur,dc=net
       LDAP_FILTER: '(uid=%s)'

--- a/dev/start
+++ b/dev/start
@@ -250,7 +250,7 @@ enable_oidc_authenticators() {
   echo "Configuring Keycloak as OpenID provider for automatic testing"
   # We enable an OIDC authenticator without a service-id to test that it's
   # invalid.
-  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak,authn-oidc,authn-oidc/keycloak2"
+  enabled_authenticators="$enabled_authenticators,authn-oidc/keycloak,authn-oidc/okta,authn-oidc/oidceast,authn-oidc/keycloak2"
 
   if [[ $ENABLE_OIDC_OKTA = true ]]; then
     echo "Configuring OKTA as OpenID provider for manual testing"


### PR DESCRIPTION
### Desired Outcome

Duplictae authenticators show up in the providers endpoint due to not removing the status webservices from the list of providers. This pr removes web services that end in /status from the list of authenticators

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
Added the regex used in InstalledAuthenticators to remove the status webservices  
- _How should the reviewer approach this PR, especially if manual tests are required?_
That the tests work effectively and the code is reasonably made  
- _Are there relevant screenshots you can add to the PR description?_
No 
### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-25530](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-25530)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
