### PR TITLE
Remove code and state from the info logs of the url request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.18.2] - 2022-09-01
 
+### Security
+- Remove code and state from the debug logs
+  [conjurinc/conjur-ui#2644](https://github.com/cyberark/conjur/pull/2644)
+
 ### Changed
 - Reduces debug log verbosity.
   [cyberark/conjur#2639](https://github.com/cyberark/conjur/pull/2639)

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :value]
+Rails.application.config.filter_parameters += [:password, :value, :code, :state]


### PR DESCRIPTION
#### What does this PR do?
adds code and state to the list of paramters that are filtered in the log

#### How should this be manually tested?
Run the okta cucumber tests and then make sure code and state are filtered in the development.log 
