### PR TITLE
Collect authenticator metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -6,13 +6,17 @@ if Rails.application.config.conjur_config.telemetry_enabled
   # Require all defined metrics
   Dir.glob(Rails.root + 'lib/monitoring/metrics/*.rb', &method(:require))
 
+  # Load the authentication module early so that telemetry can see which authenticators are installed on startup
+  Dir.glob(Rails.root + 'app/domain/authentication/**/*.rb', &method(:require))
+
   # Register new metrics and setup the Prometheus client store
   metrics = [
     Monitoring::Metrics::ApiRequestCounter.new,
     Monitoring::Metrics::ApiRequestHistogram.new,
     Monitoring::Metrics::ApiExceptionCounter.new,
     Monitoring::Metrics::PolicyResourceGauge.new,
-    Monitoring::Metrics::PolicyRoleGauge.new
+    Monitoring::Metrics::PolicyRoleGauge.new,
+    Monitoring::Metrics::AuthenticatorGauge.new,
   ]
   Monitoring::Prometheus.setup(metrics: metrics)
 

--- a/lib/monitoring/metrics.rb
+++ b/lib/monitoring/metrics.rb
@@ -58,7 +58,9 @@ module Monitoring
     end
 
     def throttle_policy_event(metric)
-      # TODO: revisit throttling for metrics which execute DB queries
+      # TODO: Revisit throttling for metrics which execute DB queries. 
+      # Currently this method is only used to group events that should run
+      # when a policy is loaded. It does not throttle the amount of updates.
       metric.pubsub.subscribe('conjur.policy_loaded') do
         metric.pubsub.publish(metric.sub_event_name)
       end

--- a/lib/monitoring/metrics/authenticator_gauge.rb
+++ b/lib/monitoring/metrics/authenticator_gauge.rb
@@ -1,0 +1,62 @@
+module Monitoring
+  module Metrics
+    class AuthenticatorGauge
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+
+      def setup(registry, pubsub)
+        @registry = registry
+        @pubsub = pubsub
+        @metric_name = :conjur_server_authenticator
+        @docstring = 'Number of authenticators enabled'
+        @labels = [:type, :status]
+        @sub_event_name = 'conjur.authenticator_count_update'
+        @throttle = true
+        
+        # Create/register the metric
+        Metrics.create_metric(self, :gauge)
+
+        # Run update to set the initial counts on startup
+        update
+      end
+
+      def update(*payload)
+        metric = @registry.get(@metric_name)
+        update_enabled_authenticators(metric)
+        update_installed_authenticators(metric)
+        update_configured_authenticators(metric)
+      end
+
+      def update_enabled_authenticators(metric)
+        enabled_authenticators = Authentication::InstalledAuthenticators.enabled_authenticators
+        enabled_authenticator_counts = get_authenticator_counts(enabled_authenticators)
+        enabled_authenticator_counts.each do |type, count|
+          metric.set(count, labels: { type: type, status: 'enabled'})
+        end
+      end
+
+      def update_installed_authenticators(metric)
+        installed_authenticators = Authentication::InstalledAuthenticators.authenticators(ENV).keys
+        installed_authenticators.each do |type|
+          metric.set(1, labels: { type: type, status: 'installed'})
+        end
+      end
+
+      def update_configured_authenticators(metric)
+        configured_authenticators =  Authentication::InstalledAuthenticators.configured_authenticators
+        configured_authenticator_counts = get_authenticator_counts(configured_authenticators)
+        configured_authenticator_counts.each do |type, count|
+          metric.set(count, labels: { type: type, status: 'configured'})
+        end
+      end
+
+      def get_authenticator_counts(authenticators)
+        authenticator_counts = {}
+        authenticators.each do |authenticator|
+          type = authenticator.split('/')[0]
+          authenticator_counts[type] ? authenticator_counts[type] += 1 : authenticator_counts[type] = 1
+        end
+        return authenticator_counts
+      end
+    end
+  end
+end

--- a/spec/lib/monitoring/metrics/authenticator_metrics_spec.rb
+++ b/spec/lib/monitoring/metrics/authenticator_metrics_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'monitoring/query_helper'
+require 'monitoring/metrics/authenticator_gauge'
+Dir.glob(Rails.root + 'lib/monitoring/metrics/authenticator_.rb', &method(:require))
+
+describe 'authenticator metrics', type: :request  do
+
+  before do
+    pubsub.unsubscribe('conjur.policy_loaded')
+    pubsub.unsubscribe('conjur.authenticator_count_update')
+
+    @authenticator_metric = Monitoring::Metrics::AuthenticatorGauge.new
+
+    # Clear and setup the Prometheus client store
+    Monitoring::Prometheus.setup(
+      registry: Prometheus::Client::Registry.new, 
+      metrics: metrics
+    )
+
+    Slosilo["authn:rspec"] ||= Slosilo::Key.new
+  end
+  
+  def headers_with_auth(payload)
+    token_auth_header.merge({ 'RAW_POST_DATA' => payload })
+  end
+
+  let(:registry) { Monitoring::Prometheus.registry }
+
+  let(:metrics) { [ @authenticator_metric ] }
+
+  let(:pubsub) { Monitoring::PubSub.instance }
+
+  let(:policy_load_event_name) { 'conjur.policy_loaded' }
+
+  let(:policies_url) { '/policies/rspec/policy/root' }
+
+  let(:current_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+
+  let(:token_auth_header) do
+    bearer_token = Slosilo["authn:rspec"].signed_token(current_user.login)
+    token_auth_str =
+      "Token token=\"#{Base64.strict_encode64(bearer_token.to_json)}\""
+    { 'HTTP_AUTHORIZATION' => token_auth_str }
+  end
+
+  context 'when a policy is loaded' do
+
+    it 'publishes a policy load event (POST)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@authenticator_metric.sub_event_name)
+
+      post(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'publishes a policy load event (PUT)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@authenticator_metric.sub_event_name)
+
+      put(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'publishes a policy load event (PATCH)' do
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(policy_load_event_name).and_call_original
+      expect(Monitoring::PubSub.instance).to receive(:publish).with(@authenticator_metric.sub_event_name)
+
+      patch(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'calls update on the correct metrics' do
+      expect(@authenticator_metric).to receive(:update)
+
+      post(policies_url, env: headers_with_auth('[!variable test]'))
+    end
+
+    it 'updates the registry' do
+      authenticators_before = registry.get(@authenticator_metric.metric_name).get(labels: { type: 'authn-jwt', status: 'configured' })
+      post(policies_url, env: headers_with_auth(
+        <<~POLICY
+        - !policy
+           id: conjur/authn-jwt/sysadmins
+           body:
+            - !webservice 
+
+            - !group
+              id: clients
+
+            - !permit
+              resource: !webservice
+              privilege: [ read, authenticate ]
+              role: !group clients
+      POLICY
+        ))
+
+      authenticators_after = registry.get(@authenticator_metric.metric_name).get(labels: { type: 'authn-jwt', status: 'configured' })
+
+      expect(authenticators_after - authenticators_before).to eql(1.0)
+    end
+
+    it 'trims the authenticator service id' do
+      authenticators = ['authn', 'authn-iam/some-service/id', 'authn-oidc/some/nested/service-id', 'authn-oidc/some/other/service-id']
+      authenticator_counts = @authenticator_metric.get_authenticator_counts(authenticators)
+
+      expect(authenticator_counts['authn']).to eql(1)
+      expect(authenticator_counts['authn-iam']).to eql(1)
+      expect(authenticator_counts['authn-oidc']).to eql(2)
+    end
+
+  end
+end

--- a/spec/lib/monitoring/metrics/policy_metrics_spec.rb
+++ b/spec/lib/monitoring/metrics/policy_metrics_spec.rb
@@ -81,13 +81,13 @@ describe 'policy metrics', type: :request  do
     end
 
     it 'updates the registry' do
-      resources_before = registry.get(:conjur_resource_count).get(labels: { kind: 'group' })
-      roles_before = registry.get(:conjur_role_count).get(labels: { kind: 'group' })
+      resources_before = registry.get(@resource_metric.metric_name).get(labels: { kind: 'group' })
+      roles_before = registry.get(@role_metric.metric_name).get(labels: { kind: 'group' })
 
       post(policies_url, env: headers_with_auth('[!group test]'))
 
-      resources_after = registry.get(:conjur_resource_count).get(labels: { kind: 'group' })
-      roles_after = registry.get(:conjur_role_count).get(labels: { kind: 'group' })
+      resources_after = registry.get(@resource_metric.metric_name).get(labels: { kind: 'group' })
+      roles_after = registry.get(@role_metric.metric_name).get(labels: { kind: 'group' })
 
       expect(resources_after - resources_before).to eql(1.0)
       expect(roles_after - roles_before).to eql(1.0)

--- a/spec/lib/monitoring/query_helper_spec.rb
+++ b/spec/lib/monitoring/query_helper_spec.rb
@@ -1,16 +1,37 @@
 require 'monitoring/query_helper'
+require 'spec_helper'
 
-describe Monitoring::QueryHelper do
+describe Monitoring::QueryHelper, type: :request do
   let(:queryhelper) { Monitoring::QueryHelper.instance }
+
+  let(:policies_url) { '/policies/rspec/policy/root' }
+
+  let(:current_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+
+  let(:token_auth_header) do
+    bearer_token = Slosilo["authn:rspec"].signed_token(current_user.login)
+    token_auth_str =
+      "Token token=\"#{Base64.strict_encode64(bearer_token.to_json)}\""
+    { 'HTTP_AUTHORIZATION' => token_auth_str }
+  end
+
+  def headers_with_auth(payload)
+    token_auth_header.merge({ 'RAW_POST_DATA' => payload })
+  end
+
+  before do
+    Slosilo["authn:rspec"] ||= Slosilo::Key.new
+    post(policies_url, env: headers_with_auth('[!group test]'))
+  end
 
   it 'returns policy resource counts' do
     resource_counts = queryhelper.policy_resource_counts
-    expect(resource_counts).not_to be_empty
+    expect(resource_counts['group']).to equal(1)
   end
 
   it 'returns policy role counts' do
     role_counts = queryhelper.policy_role_counts
-    expect(role_counts).not_to be_empty
+    expect(role_counts['group']).to equal(1)
   end
 
 end


### PR DESCRIPTION
### Desired Outcome

For this we need to register authenticators counts metrics onto the Prometheus client store. Consult the solution design for the authenticators counts metric definitions. The general idea is to

1) Publish an event (e.g. authenticator_update) the subscriber can use to make the metrics updates. This event is published on authenticator configuration update, which we believe takes place exclusively at update_config in the AuthenticateController.

2) The Prometheus subscriber for these metrics will interpret that event and make appropriate metric updates to the store. In this case the subscriber is responsible for determining the latest authenticators counts by querying the database.

The act of adding the metrics onto the store, combined with the prior work to setup the Prometheus exporter should result in the metric being present in the scrape target endpoint GET /metrics.

For the end-to-end tests:

lightweight test: configure authenticators by invoking the authenticate endpoints, and ensure that any changes are reflected in the response of the scrape target endpoint
pub/sub plumbing is unit tested so that when policy is loaded (1) an event is dispatched, (2) an event dispatched results in the correct subscriber logic running, (3) the subsciber logic grabs the latest authenticators counts and writes them onto the Prometheus store

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16832](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16832)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
