### PR TITLE
Add audit message for List request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.18.5] - 2022-09-14
 
+### Added
+- List resources request (`GET /resources`) now produce audit events.
+  ([cyberark/conjur#2652](https://github.com/cyberark/conjur/pull/2652)
+
 ## [1.18.4] - 2022-09-11
 
 ### Added

--- a/app/models/audit/event/list.rb
+++ b/app/models/audit/event/list.rb
@@ -1,0 +1,90 @@
+module Audit
+  module Event
+    # NOTE: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
+    class List
+
+      def initialize(
+        user_id:,
+        client_ip:,
+        success:,
+        subject:,
+        error_message: nil
+      )
+        @user_id = user_id
+        @client_ip = client_ip
+        @subject = subject
+        @success = success
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # NOTE: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      def message
+        attempted_action.message(
+          success_msg: "#{@user_id} successfully listed resources with parameters: #{@subject}",
+          failure_msg: "#{@user_id} failed to list resources with parameters: #{@subject}",
+          error_msg: @error_message
+        )
+      end
+
+      def message_id
+        'list'
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => @subject,
+          SDID::CLIENT => { ip: @client_ip }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'list'
+        )
+      end
+    end
+  end
+end

--- a/cucumber/api/features/resource_list_by_role.feature
+++ b/cucumber/api/features/resource_list_by_role.feature
@@ -21,9 +21,19 @@ Feature: List resources for another role
 
   @smoke
   Scenario: The resource list can be retrieved for a different role, specified the query parameter role
+    Given I save my place in the audit log file for remote
     When I successfully GET "/resources?role=cucumber:user:alice"
     Then the resource list should contain "variable" "dev/dev-var"
     And the resource list should not contain "variable" "prod/prod-var"
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * list
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 role="cucumber:user:alice"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed resources with parameters: {:role=>"cucumber:user:alice"}
+    """
 
   @smoke
   Scenario: The resource list can be retrieved for a different role, specified the query parameter acting_as
@@ -33,5 +43,16 @@ Feature: List resources for another role
 
   @negative @acceptance
   Scenario: Attempting to retrieve the resource list for a different role but without giving the account in the ID results in a 403
+    Given I save my place in the audit log file for remote
     When I GET "/resources?acting_as=user:alice"
     Then the HTTP response status code is 403
+    And there is an audit record matching:
+    """
+      <84>1 * * conjur * list
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 acting_as="user:alice"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="list"]
+      cucumber:user:admin failed to list resources with parameters: {:acting_as=>"user:alice"}:
+      The authenticated user lacks the necessary privilege
+    """

--- a/spec/models/audit/event/list_spec.rb
+++ b/spec/models/audit/event/list_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Audit::Event::List do
+  let(:user_id) { 'rspec:user:my_user' }
+  let(:client_ip) { 'my-client-ip' }
+  let(:list_param) { { "limit"=> "1000" } }
+  let(:success) { true }
+  let(:error_message) { nil }
+
+
+  subject do
+    Audit::Event::List.new(
+      user_id: user_id,
+      client_ip: client_ip,
+      subject: list_param,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+        'rspec:user:my_user successfully listed resources with parameters: {"limit"=>"1000"}'
+      )
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq(
+        'rspec:user:my_user successfully listed resources with parameters: {"limit"=>"1000"}'
+      )
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "success" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+        'rspec:user:my_user failed to list resources with parameters: {"limit"=>"1000"}'
+      )
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "failure" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when the resource does not exist and a failure occurs' do
+    let(:success) { false }
+    let(:error_message) { 'The authenticated user lacks the necessary privilege'}
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+        'rspec:user:my_user failed to list resources with parameters: {"limit"=>"1000"}: ' \
+        'The authenticated user lacks the necessary privilege'
+      )
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+end


### PR DESCRIPTION
### Desired Outcome

This PR adds an audit log message for List request  using the API endpoint `GET /resources` 


### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _Example audit message_

**Successful Audit:**
```
<86>1 2022-09-15T07:25:34.064+00:00 cc00d96ebc41 conjur test-id list [auth@43868 user="CyberArk:user:admin"][subject@43868 limit="3"][client@43868 ip="172.17.0.1"][action@43868 result="success" operation="list"][meta sequenceId="2"] CyberArk:user:admin successfully listed resources with parameter: {:limit=>"3"}
```

**Failed Audit:**
```
<84>1 2022-09-15T11:12:48.797+00:00 cc00d96ebc41 conjur test-id list [auth@43868 user="CyberArk:user:admin"][subject@43868 role="conjurr:user:alice"][client@43868 ip="172.17.0.1"][action@43868 result="failure" operation="list"][meta sequenceId="2"] CyberArk:user:admin failed to listed resources with parameter: {:role=>"conjurr:user:alice"}: The authenticated user lacks the necessary privilege
```

### Connected Issue/Story

Resolves #[ONYX-23737)](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-23737)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
