### PR TITLE
Remove old access key for AWS rotator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - List resources request (`GET /resources`) now produce audit events.
   ([cyberark/conjur#2652](https://github.com/cyberark/conjur/pull/2652)
 
+### Changed
+- AWS Access Key Rotation now preserves only one key
+
 ## [1.18.4] - 2022-09-11
 
 ### Added

--- a/app/domain/rotation/rotators/aws/secret_key.rb
+++ b/app/domain/rotation/rotators/aws/secret_key.rb
@@ -34,11 +34,18 @@ module Rotation
           # New key on AWS
           new_key = client.create_access_key.access_key
 
+          # Old key on AWS
+          old_key = creds.conjur_ids[:access_key_id]
+
           # Update in conjur
           facade.update_variables(Hash[
             creds.conjur_ids[:access_key_id]    , new_key.access_key_id,
             creds.conjur_ids[:secret_access_key], new_key.secret_access_key
           ])
+
+          # Delete key just used for rotation
+          # This prevents leaving two active access keys
+          client.delete_access_key(access_key_id: old_key)
         end
 
         private 


### PR DESCRIPTION
### Desired Outcome

Only one active AWS key should be preserved to honor the rotation schedule (otherwise the max age will be 2x what is intended, to have a max age of 60 days the rotation schedule would need to be set to 30 days).  This adds a change to remove the key that was just rotated.

### Implemented Changes
- Delete key that was to be rotated out

### Connected Issue/Story

CyberArk internal issue link: [ONYX-21462](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-21462)

### Definition of Done

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests
- [x] The changes in this PR cannot be automatically tested

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation
