### PR TITLE
Nonce and PKCE Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.19.0] - 2022-10-11
+
+### Changed
+- OIDC authenticator now uses PKCE and dynamic nonce. ([cyberark/conjur#2661](https://github.com/cyberark/conjur/pull/2661)
+
 ## [1.18.5] - 2022-09-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.19.0] - 2022-10-11
 
 ### Changed
-- OIDC authenticator now uses PKCE and dynamic nonce. ([cyberark/conjur#2661](https://github.com/cyberark/conjur/pull/2661)
+- OIDC authenticator now uses PKCE and dynamic nonce. ([cyberark/conjur#2662](https://github.com/cyberark/conjur/pull/2662)
 
 ## [1.18.5] - 2022-09-14
 

--- a/app/db/repository/authenticator_repository.rb
+++ b/app/db/repository/authenticator_repository.rb
@@ -54,8 +54,11 @@ module DB
             args[variable.resource_id.split('/')[-1].underscore.to_sym] = variable.secret.value
           end
         end
+
+        allowed_args = %i[account service_id] + @data_object.const_get(:REQUIRED_VARIABLES) + @data_object.const_get(:OPTIONAL_VARIABLES)
         begin
-          @data_object.new(**args_list)
+          allowed_arg_list =  args_list.select{ |key, _| allowed_args.include?(key) }
+          @data_object.new(**allowed_arg_list)
         rescue ArgumentError => e
           @logger.debug("DB::Repository::AuthenticatorRepository.load_authenticator - exception: #{e}")
           nil

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -4,7 +4,9 @@ module Authentication
       module DataObjects
         class Authenticator
 
-          # required
+          REQUIRED_VARIABLES = %i[provider_uri client_id client_secret claim_mapping].freeze
+          OPTIONAL_VARIABLES = %i[redirect_uri response_type provider_scope name].freeze
+
           attr_reader :provider_uri, :client_id, :client_secret, :claim_mapping, :nonce, :state, :account
           attr_reader :service_id, :redirect_uri, :response_type
 
@@ -13,8 +15,6 @@ module Authentication
             client_id:,
             client_secret:,
             claim_mapping:,
-            nonce:,
-            state:,
             account:,
             service_id:,
             redirect_uri: nil,
@@ -27,9 +27,7 @@ module Authentication
             @client_id = client_id
             @client_secret = client_secret
             @claim_mapping = claim_mapping
-            @nonce = nonce
             @response_type = response_type
-            @state = state
             @service_id = service_id
             @name = name
             @provider_scope = provider_scope
@@ -37,7 +35,7 @@ module Authentication
           end
 
           def scope
-            (%w[openid email profile] + [*@provider_scope]).uniq.join(' ')
+            (%w[openid email profile] + [*@provider_scope.to_s.split(' ')]).uniq.join(' ')
           end
 
           def name

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -7,7 +7,7 @@ module Authentication
           REQUIRED_VARIABLES = %i[provider_uri client_id client_secret claim_mapping].freeze
           OPTIONAL_VARIABLES = %i[redirect_uri response_type provider_scope name].freeze
 
-          attr_reader :provider_uri, :client_id, :client_secret, :claim_mapping, :nonce, :state, :account
+          attr_reader :provider_uri, :client_id, :client_secret, :claim_mapping, :account
           attr_reader :service_id, :redirect_uri, :response_type
 
           def initialize(

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -15,12 +15,17 @@ module Authentication
 
         # Don't love this name...
         def callback(args)
-          # TODO: Check that `code` and `state` attributes are present
-          raise Errors::Authentication::AuthnOidc::StateMismatch unless args[:state] == @authenticator.state
+          %i[code nonce code_verifier].each do |param|
+            unless args[param].present?
+              raise Errors::Authentication::RequestBody::MissingRequestParam, param.to_s
+            end
+          end
 
           identity = resolve_identity(
             jwt: @client.callback(
-              code: args[:code]
+              code: args[:code],
+              nonce: args[:nonce],
+              code_verifier: args[:code_verifier]
             )
           )
           unless identity.present?

--- a/app/domain/authentication/authn_oidc/v2/views/provider_context.rb
+++ b/app/domain/authentication/authn_oidc/v2/views/provider_context.rb
@@ -1,3 +1,6 @@
+require 'securerandom'
+require 'digest'
+
 module Authentication
   module AuthnOidc
     module V2
@@ -5,37 +8,50 @@ module Authentication
         class ProviderContext
           def initialize(
             client: Authentication::AuthnOidc::V2::Client,
+            digest: Digest::SHA256,
+            random: SecureRandom,
             logger: Rails.logger
           )
             @client = client
             @logger = logger
+            @digest = digest
+            @random = random
           end
 
           def call(authenticators:)
             authenticators.map do |authenticator|
+              nonce = @random.hex(25)
+              code_verifier = @random.hex(25)
+              code_challenge = @digest.base64digest(code_verifier).tr("+/", "-_").tr("=", "")
               {
                 service_id: authenticator.service_id,
                 type: 'authn-oidc',
                 name: authenticator.name,
+                nonce: nonce,
+                code_verifier: code_verifier,
                 redirect_uri: generate_redirect_url(
                   client: @client.new(authenticator: authenticator),
-                  authenticator: authenticator
+                  authenticator: authenticator,
+                  nonce: nonce,
+                  code_challenge: code_challenge
                 )
               }
             end
           end
 
-          def generate_redirect_url(client:, authenticator:)
+          def generate_redirect_url(client:, authenticator:, nonce:, code_challenge:)
             params = {
               client_id: authenticator.client_id,
               response_type: authenticator.response_type,
               scope: ERB::Util.url_encode(authenticator.scope),
-              state: authenticator.state,
-              nonce: authenticator.nonce,
+              nonce: nonce,
+              code_challenge: code_challenge,
+              code_challenge_method: 'S256',
               redirect_uri: ERB::Util.url_encode(authenticator.redirect_uri)
-            }.map { |key, value| "#{key}=#{value}" }.join("&")
+            }
+            formatted_params = params.map { |key, value| "#{key}=#{value}" }.join("&")
 
-            "#{client.discovery_information.authorization_endpoint}?#{params}"
+            "#{client.discovery_information.authorization_endpoint}?#{formatted_params}"
           end
         end
       end

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -31,13 +31,6 @@ module Authentication
       end
 
       def call(parameters:, request_ip:)
-        required_parameters = %i[state code]
-        required_parameters.each do |parameter|
-          if !parameters.key?(parameter) || parameters[parameter].strip.empty?
-            raise Errors::Authentication::RequestBody::MissingRequestParam, parameter
-          end
-        end
-
         # Load Authenticator policy and values (validates data stored as variables)
         authenticator = @authn_repo.find(
           type: @authenticator_type,

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -82,7 +82,8 @@ module Authentication
           raise ApplicationController::Forbidden
 
         when Errors::Authentication::RequestBody::MissingRequestParam,
-          Errors::Authentication::AuthnOidc::TokenVerificationFailed
+          Errors::Authentication::AuthnOidc::TokenVerificationFailed,
+          Errors::Authentication::AuthnOidc::TokenRetrievalFailed
           raise ApplicationController::BadRequest
 
         when Errors::Conjur::RequestedResourceNotFound
@@ -94,16 +95,11 @@ module Authentication
         when Errors::Authentication::Jwt::TokenExpired
           raise ApplicationController::Unauthorized.new(err.message, true)
 
-        when Errors::Authentication::AuthnOidc::StateMismatch,
-          Errors::Authentication::Security::RoleNotFound
+        when Errors::Authentication::Security::RoleNotFound
           raise ApplicationController::BadRequest
 
         when Errors::Authentication::Security::MultipleRoleMatchesFound
           raise ApplicationController::Forbidden
-          # Code value mismatch
-        when Rack::OAuth2::Client::Error
-          raise ApplicationController::BadRequest
-
         else
           raise ApplicationController::Unauthorized
         end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -231,16 +231,6 @@ module Errors
         code: "CONJ00075E"
       )
 
-      StateMismatch = ::Util::TrackableErrorClass.new(
-        msg: "Conjur internal state doesn't match given state",
-        code: "CONJ00127E"
-      )
-
-      TokenVerificationFailed = ::Util::TrackableErrorClass.new(
-        msg: "Conjur internal state doesn't match given state",
-        code: "CONJ00128E"
-      )
-
       InvalidVariableValue = ::Util::TrackableErrorClass.new(
         msg: "Parameter {0} with value {1} invalid",
         code: "CONJ00129E"
@@ -249,6 +239,16 @@ module Errors
       InvalidProviderConfig = ::Util::TrackableErrorClass.new(
         msg: "The OIDC provider variable values are misconfigured",
         code: "CONJ00130E"
+      )
+
+      TokenVerificationFailed = ::Util::TrackableErrorClass.new(
+        msg: "JWT Token validation failed: '{0-error}'",
+        code: "CONJ00128E"
+      )
+
+      TokenRetrievalFailed = ::Util::TrackableErrorClass.new(
+        msg: "Access Token retrieval failure: '{0-error}'",
+        code: "CONJ00133E"
       )
 
     end

--- a/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+++ b/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
@@ -65,10 +65,6 @@ module AuthenticatorHelpers
     http_status == 504 || client_timeout?
   end
 
-  def load_root_policy(policy)
-    conjur_api.load_policy('root', policy, method: Conjur::API::POLICY_METHOD_PUT)
-  end
-
   def get(path, options = {})
     options = options.merge(
       method: :get,
@@ -77,6 +73,7 @@ module AuthenticatorHelpers
     result             = RestClient::Request.execute(options)
     @response_body     = result.body
     @http_status       = result.code
+    result
   rescue RestClient::Exception => e
     @rest_client_error = e
     @http_status       = e.http_code

--- a/cucumber/_authenticators_common/features/support/hooks.rb
+++ b/cucumber/_authenticators_common/features/support/hooks.rb
@@ -4,6 +4,41 @@ Before('@skip') do
   skip_this_scenario
 end
 
+# The following is a context object. It allows data to be shared between
+# Scenario steps. The use of this context should help reduce the current
+# practice of setting and retrieving instance variables in different Scenario
+# Steps.
+
+# An example of when a Context might be used is when retriving a user's Conjur
+# Authorization Token on one step, and validating the  token on another step.
+module Scenario
+  class Context
+    def initialize(logger: Rails.logger, **kwargs)
+      @store = {}
+      @logger = logger
+      set(**kwargs) if kwargs
+    end
+
+    def get(key)
+      @store[key]
+    end
+
+    def set(**kwargs)
+      kwargs.each do |key, value|
+        @store[key] = value
+      end
+    end
+
+    def keys
+      @store.keys
+    end
+
+    def unset
+      @store = {}
+    end
+  end
+end
+
 # Reset the DB between each test
 #
 # Prior to this hook, our tests had hidden coupling.  This ensures each test is
@@ -11,6 +46,7 @@ end
 Before do
   @user_index = 0
   @host_index = 0
+  @context = Scenario::Context.new(account: 'cucumber')
 
   Role.truncate(cascade: true)
   Secret.truncate
@@ -21,7 +57,7 @@ Before do
       Slosilo.send(:keystore).adapter.model[k].delete
     end
   end
-  
+
   Account.find_or_create_accounts_resource
   admin_role = Role.create(role_id: "cucumber:user:admin")
   creds = Credentials.new(role: admin_role)
@@ -42,4 +78,5 @@ After do
   @env.each do |key, value|
     ENV[key] = value
   end
+  @context.unset
 end

--- a/cucumber/authenticators_oidc/features/authn_oidc_okta.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_okta.feature
@@ -1,9 +1,13 @@
+# NOTE: This feature only tests the code exchange with Okta, it does not complete
+# a full browser redirect request. This is adequate as this is the portion of the
+# authentication process specific to Conjur.
+
 @authenticators_oidc
 Feature: OIDC Authenticator V2 - Users can authenticate with Okta using OIDC
 
   Background:
-    Given I load a policy with okta user:
-    """
+    Given I load a policy:
+      """
       - !policy
         id: conjur/authn-oidc/okta-2
         body:
@@ -15,9 +19,8 @@ Feature: OIDC Authenticator V2 - Users can authenticate with Okta using OIDC
           - !variable client-id
           - !variable client-secret
           - !variable claim-mapping
-          - !variable state
-          - !variable nonce
           - !variable redirect-uri
+
           - !group users
 
           - !permit
@@ -25,11 +28,17 @@ Feature: OIDC Authenticator V2 - Users can authenticate with Okta using OIDC
             privilege: [ read, authenticate ]
             resource: !webservice
     """
-    And I am the super-user
-    And I successfully set Okta OIDC V2 variables
+    And I add an Okta user
+    And I set conjur variables
+      | variable_id                               | value                                                         | environment_variable  |
+      | conjur/authn-oidc/okta-2/provider-uri     |                                                               | OKTA_PROVIDER_URI     |
+      | conjur/authn-oidc/okta-2/client-id        |                                                               | OKTA_CLIENT_ID        |
+      | conjur/authn-oidc/okta-2/client-secret    |                                                               | OKTA_CLIENT_SECRET    |
+      | conjur/authn-oidc/okta-2/claim-mapping    | preferred_username                                            |                       |
+      | conjur/authn-oidc/okta-2/redirect-uri     | http://localhost:3000/authn-oidc/okta/cucumber/authenticate |                       |
 
   @smoke
   Scenario: Authenticating with Conjur using Okta
-    Given I fetch a code from okta
-    When I authenticate via OIDC with code and service_id "okta-2"
-    Then The okta user has been authorized by conjur
+    Given I fetch a code from Okta
+    When I authenticate via OIDC V2 with code and service-id "okta-2"
+    Then The Okta user has been authorized by Conjur

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -1,3 +1,25 @@
+Given('I set conjur variables') do |table|
+  client = Client.for("user", "admin")
+  table.hashes.each do |variable_hash|
+    # Use environment variable if set
+    if variable_hash['environment_variable'].present?
+      variable_name = variable_hash['environment_variable']
+      value = ENV[variable_name]
+      if value.blank?
+        raise "Environment variable: '#{variable_name}' must be set"
+      end
+    # Otherwise, use provided value
+    else
+      value = variable_hash['value']
+    end
+
+    client.add_secret(
+      id: variable_hash['variable_id'],
+      value: value
+    )
+  end
+end
+
 Given(/I fetch an ID Token for username "([^"]*)" and password "([^"]*)"/) do |username, password|
   path = "#{oidc_provider_internal_uri}/token"
   payload = { grant_type: 'password', username: username, password: password, scope: oidc_scope }
@@ -10,85 +32,98 @@ end
 Given(/I fetch a code for username "([^"]*)" and password "([^"]*)"/) do |username, password|
   Rails.application.config.conjur_config.authenticators = ['authn-oidc/keycloak2']
 
-  @client = Client.for('user', 'admin')
-  providers = @client.fetch_authenticators
-  url = providers.body.map { |x| x["redirect_uri"] }
-  res = Net::HTTP.get_response(URI(url[0]))
-  raise res if res.is_a?(Net::HTTPError) || res.is_a?(Net::HTTPClientError)
+  client = Client.for('user', 'admin')
+  provider = JSON.parse(client.fetch_authenticators).first
 
-  all_cookies = res.get_fields('set-cookie')
-  cookies_arrays = Array.new
+  #  Save Nonce & Code Verifier for future use
+  @context.set(
+    nonce: provider['nonce'],
+    code_verifier: provider['code_verifier'],
+    service_id: provider['service_id']
+  )
+
+  response = Net::HTTP.get_response(URI(provider['redirect_uri']))
+  raise response if response.is_a?(Net::HTTPError) || response.is_a?(Net::HTTPClientError)
+
+  all_cookies = response.get_fields('set-cookie')
+  cookies_arrays = []
   all_cookies.each do |cookie|
     cookies_arrays.push(cookie.split('; ')[0])
   end
 
-  html = Nokogiri::HTML(res.body)
+  html = Nokogiri::HTML(response.body)
   post_uri = URI(html.xpath('//form').first.attributes['action'].value)
 
   http = Net::HTTP.new(post_uri.host, post_uri.port)
   http.use_ssl = true
   request = Net::HTTP::Post.new(post_uri.request_uri)
   request['Cookie'] = cookies_arrays.join('; ')
-  request.set_form_data({'username' => username, 'password' => password})
+  request.set_form_data({ 'username' => username, 'password' => password })
 
   response = http.request(request)
 
   if response.is_a?(Net::HTTPRedirection)
-    parse_oidc_code(response['location'])
+    redirect = URI(response['location'])
+    code = redirect.query.split('&').find{|i| i.split('=')[0] == 'code' }.split('=').last
+    # Save Code for future steps
+    @context.set(code: code)
   end
 end
 
-Given(/^I load a policy with okta user:/) do |policy|
+Given(/^I add an Okta user/) do
+  # Ensure required environment variables are present
+  environment_variables_present?('OKTA_USERNAME')
+
   user_policy = """
-  - !user #{ENV['OKTA_USERNAME']}
+  - !user #{ENV.fetch('OKTA_USERNAME')}
 
   - !grant
     role: !group conjur/authn-oidc/okta-2/users
-    member: !user #{ENV['OKTA_USERNAME']}"""
- 
-  load_root_policy(policy + user_policy)
+    member: !user #{ENV.fetch('OKTA_USERNAME')}
+  """
+  @client ||= Client.for("user", "admin")
+  @result = @client.update_policy(id: 'root', policy: user_policy)
 end
 
-Given(/^I fetch a code from okta/) do
-  uri = URI("https://#{URI(okta_provider_uri).host}/api/v1/authn")
-  puts uri
-  body = JSON.generate({ username: ENV['OKTA_USERNAME'], password: ENV['OKTA_PASSWORD'] })
+Given(/^I fetch a code from Okta/) do
+  # Ensure required environment variables are present
+  environment_variables_present?(%w[OKTA_USERNAME OKTA_PASSWORD])
 
-  http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
-  request = Net::HTTP::Post.new(uri.request_uri)
-  request['Accept'] = 'application/json'
-  request['Content-Type'] = 'application/json'
-  request.body = body
+  client = Client.for('user', 'admin')
+  provider = JSON.parse(client.fetch_authenticators).first
 
-  response = http.request(request)
-  session_token = JSON.parse(response.body)["sessionToken"]
-  puts session_token
+  #  Save Nonce & Code Verifier for future use
+  @context.set(
+    nonce: provider['nonce'],
+    code_verifier: provider['code_verifier'],
+    service_id: provider['service_id']
+  )
 
-  oidc_parameters = {
-    client_id: okta_client_id,
-    redirect_uri: okta_redirect_uri,
-    response_type: oidc_response_type,
-    scope: okta_scope,
-    state: oidc_state,
-    nonce: oidc_nonce,
-    sessionToken: session_token
-  }
+  # Get a user session ID via the Okta `authn` endpoint
+  provider_uri = URI(provider['redirect_uri'])
+  uri = URI("https://#{provider_uri.host}/api/v1/authn")
+  result = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+    request.body = { username: ENV['OKTA_USERNAME'], password: ENV['OKTA_PASSWORD'] }.to_json
+    http.request(request)
+  end
 
-  query_string = ""
-  oidc_parameters.each {|key, value| query_string += "#{key}=#{value}&"}
-  uri = URI("#{okta_provider_uri}/v1/authorize?#{query_string}")
-  puts uri
-  request = Net::HTTP::Get.new(uri.request_uri)
-  response = http.request(request)
+  # Authenticate using the previously retrieved Session Token
+  session_token = JSON.parse(result.body)["sessionToken"]
+  uri = URI("#{provider['redirect_uri']}&state=foo&sessionToken=#{session_token}")
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+    request = Net::HTTP::Get.new(uri)
+    http.request(request)
+  end
 
   if response.is_a?(Net::HTTPRedirection)
-    parse_oidc_code(response['location'])
+    redirect = URI(response['location'])
+    code = redirect.query.split('&').find{|i| i.split('=')[0] == 'code' }.split('=').last
+    # Save Code for future steps
+    @context.set(code: code)
   else
-    puts "test"
-    raise "Failed to retrieve OIDC code status: #{response.code}"
+    raise "Failed to retrieve OIDC code. Status: '#{response.code}', Response: '#{response.body}'"
   end
-  puts response.body
 end
 
 Given(/^I successfully set OIDC variables$/) do
@@ -97,20 +132,15 @@ Given(/^I successfully set OIDC variables$/) do
 end
 
 When(/^I authenticate via OIDC V2 with code$/) do
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT
+  authenticate_with_oidc_code(
+    service_id: @context.get(:service_id),
+    account: @context.get(:account),
+    params: {
+      code: @context.get(:code),
+      nonce: @context.get(:nonce),
+      code_verifier: @context.get(:code_verifier)
+    }
   )
-end
-
-Given(/^I successfully set Okta OIDC V2 variables$/) do
-  create_oidc_secret("provider-uri", okta_provider_uri, "okta-2")
-  create_oidc_secret("client-id", okta_client_id, "okta-2")
-  create_oidc_secret("client-secret", okta_client_secret, "okta-2")
-  create_oidc_secret("claim-mapping", oidc_claim_mapping, "okta-2")
-  create_oidc_secret("state", oidc_state, "okta-2")
-  create_oidc_secret("nonce", oidc_nonce, "okta-2")
-  create_oidc_secret("redirect-uri", okta_redirect_uri, "okta-2")
 end
 
 Given(/^I successfully set OIDC variables without a service-id$/) do
@@ -123,27 +153,27 @@ Given(/^I successfully set provider-uri variable$/) do
 end
 
 When(/^I authenticate via OIDC V2 with code "([^"]*)"$/) do |code|
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    code: code,
-    )
+  authenticate_with_oidc_code(
+    service_id: @context.get(:service_id),
+    account: @context.get(:account),
+    params: {
+      code: code,
+      nonce: @context.get(:nonce),
+      code_verifier: @context.get(:code_verifier)
+    }
+  )
 end
 
 When(/^I authenticate via OIDC V2 with no code in the request$/) do
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    code: nil,
-    )
-end
-
-When(/^I authenticate via OIDC V2 with state "([^"]*)"$/) do |state|
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    state: state,
-    )
+  authenticate_with_oidc_code(
+    service_id: @context.get(:service_id),
+    account: @context.get(:account),
+    params: {
+      code: nil,
+      nonce: @context.get(:nonce),
+      code_verifier: @context.get(:code_verifier)
+    }
+  )
 end
 
 Given(/^I successfully set provider-uri variable to value "([^"]*)"$/) do |provider_uri|
@@ -168,26 +198,19 @@ When(/^I authenticate via OIDC with id token in header$/) do
   )
 end
 
-Given(/^I successfully set OIDC V2 variables for "([^"]*)"$/) do |service_id|
-  create_oidc_secret("provider-uri", oidc_provider_uri, service_id)
-  create_oidc_secret("response-type", oidc_response_type, service_id)
-  create_oidc_secret("client-id", oidc_client_id, service_id)
-  create_oidc_secret("client-secret", oidc_client_secret, service_id)
-  create_oidc_secret("claim-mapping", oidc_claim_mapping, service_id)
-  create_oidc_secret("state", oidc_state, service_id)
-  create_oidc_secret("nonce", oidc_nonce, service_id)
-  create_oidc_secret("redirect-uri", oidc_redirect_uri, service_id)
-  create_oidc_secret("provider-scope", oidc_scope, service_id)
-end
-
 When(/^I authenticate via OIDC V2 with code and service-id "([^"]*)"$/) do |service_id|
-  authenticate_code_with_oidc(
+  authenticate_with_oidc_code(
     service_id: service_id,
-    account: AuthnOidcHelper::ACCOUNT
+    account: @context.get(:account),
+    params: {
+      code: @context.get(:code),
+      nonce: @context.get(:nonce),
+      code_verifier: @context.get(:code_verifier)
+    }
   )
 end
 
-Then(/^The okta user has been authorized by conjur/) do
+Then(/^The Okta user has been authorized by Conjur/) do
   username = ENV['OKTA_USERNAME']
   expect(retrieved_access_token.username).to eq(username)
 end
@@ -207,16 +230,14 @@ When(/^I authenticate via OIDC with id token and account "([^"]*)"$/) do |accoun
 end
 
 When(/^I authenticate via OIDC V2 with code and account "([^"]*)"$/) do |account|
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: account
-  )
-end
-
-When(/^I authenticate via OIDC with code and service_id "([^"]*)"$/) do |service_id|
-  authenticate_code_with_oidc(
-    service_id: service_id,
-    account: AuthnOidcHelper::ACCOUNT
+  authenticate_with_oidc_code(
+    service_id: @context.get(:service_id),
+    account: account,
+    params: {
+      code: @context.get(:code),
+      nonce: @context.get(:nonce),
+      code_verifier: @context.get(:code_verifier)
+    }
   )
 end
 

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -1,21 +1,18 @@
 # frozen_string_literal: true
+
 require 'securerandom'
 
 # Utility methods for OIDC authenticator
 module AuthnOidcHelper
 
-  V2_SERVICE_ID = 'keycloak2'
   SERVICE_ID = 'keycloak'
   ACCOUNT = 'cucumber'
 
   # The OIDC authentication request should not have the host id in its URL.
   # We add this option here as users can make such a mistake and we want to verify
   # that we raise a proper error in such a case
-  def authenticate_id_token_with_oidc(service_id:, account:, id_token: parsed_id_token, user_id: "")
-    service_id_part = service_id ? "/#{service_id}" : ""
-    user_id_part = "/#{user_id}" unless user_id.nil? || user_id.empty?
-    path = "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}#{user_id_part}/authenticate"
-
+  def authenticate_id_token_with_oidc(service_id:, account:, id_token: parsed_id_token, user_id: nil)
+    path = authn_url(type: 'oidc', account: account, service_id: service_id, user_id: user_id)
     payload = {}
     unless id_token.nil?
       payload["id_token"] = id_token
@@ -25,28 +22,33 @@ module AuthnOidcHelper
   end
 
   def authenticate_id_token_with_oidc_in_header(service_id:, account:, id_token: parsed_id_token)
-    service_id_part = service_id ? "/#{service_id}" : ""
-    path = "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}/authenticate"
+    path = authn_url(type: 'oidc', account: account, service_id: service_id)
     headers = {}
     headers["Authorization"] = "Bearer #{id_token}"
     post(path, {}, headers)
   end
 
-  def authenticate_code_with_oidc(service_id:, account:, code: url_oidc_code, state: url_oidc_state)
-    path = "#{create_auth_url(service_id: service_id, account: account, user_id: nil)}"
-    get(url_with_params(path: path,code: code, state: state ))
+  def authenticate_with_oidc_code(service_id:, account:, params: {})
+    url = authn_url(type: 'oidc', account: account, service_id: service_id, params: params)
+    get(url)
   end
 
-  def create_auth_url(service_id:, account:, user_id:)
-    service_id_part = service_id ? "/#{service_id}" : ""
-    user_id_part = "/#{user_id}" unless user_id.nil? || user_id.empty?
-    "#{conjur_hostname}/authn-oidc#{service_id_part}/#{account}#{user_id_part}/authenticate"
-  end
+  # Generic Authenticator URL builder
+  def authn_url(type:, account:, service_id: nil, user_id: nil, params: {})
+    path = [
+      "authn-#{type}",
+      service_id,
+      account,
+      user_id,
+      'authenticate'
+    ].compact.join('/')
+    result = "#{conjur_hostname}/#{path}"
 
-  def url_with_params(path:, code: nil, state: nil)
-    return path unless code || state
-
-    "#{path}?code=#{code}&state=#{state}"
+    unless params.empty?
+      param_args = params.map{|k, v| "#{k}=#{v}"}.join('&')
+      result += "?#{param_args}"
+    end
+    result
   end
 
   def create_oidc_secret(variable_name, value, service_id_suffix = "keycloak")
@@ -92,52 +94,21 @@ module AuthnOidcHelper
     @oidc_scope ||= validated_env_var('KEYCLOAK_SCOPE')
   end
 
-  def oidc_required_request_parameters
-    @oidc_required_request_parameters ||= 'code state'
-  end
-
   def parse_oidc_id_token
     @oidc_id_token = (JSON.parse(@response_body))["id_token"]
   rescue => e
     raise "Failed to fetch id_token from HTTP response: #{@response_body} with Reason: #{e}"
   end
 
-  def oidc_response_type
-    @oidc_response_type ||= 'code'
-  end
-
-  def oidc_claim_mapping
-    @oidc_claim_mapping ||= 'preferred_username'
-  end
-
-  def oidc_state
-    @oidc_state ||= SecureRandom.uuid
-  end
-
-  def oidc_nonce
-    @oidc_nonce ||= SecureRandom.uuid
-  end
-
-  def oidc_redirect_uri
-    @oidc_redirect_uri ||= 'http://conjur:3000/authn-oidc/keycloak2/cucumber/authenticate'
-  end
-
-  def parse_oidc_code(url)
-    params = CGI::parse(URI(url).query)
-    @url_oidc_code = params["code"][0] if params.has_key?("code")
-    @url_oidc_state = params["state"][0] if params.has_key?("state")
-  end
-
-  def url_oidc_code
-    @url_oidc_code
-  end
-
-  def url_oidc_code
-    @url_oidc_code
-  end
-
-  def url_oidc_state
-    @url_oidc_state
+  # Verify a required set of environment variables is present.
+  #
+  # Note: arguments can be passed either as a string or an array of strings.
+  def environment_variables_present?(*args)
+    [*args].flatten.each do |variable|
+      unless ENV.key?(variable) && ENV[variable].present?
+        raise "Environment variable '#{variable}' must be set"
+      end
+    end
   end
 end
 

--- a/dev/policies/authenticators/authn-oidc/keycloak2.yml
+++ b/dev/policies/authenticators/authn-oidc/keycloak2.yml
@@ -14,7 +14,7 @@
           - !variable client-secret
 
           # URI of Conjur instance
-          - !variable redirect_uri
+          - !variable redirect-uri
 
           # Defines the JWT claim to use as the Conjur identifier
           - !variable claim-mapping

--- a/dev/policies/authenticators/authn-oidc/okta-2.yml
+++ b/dev/policies/authenticators/authn-oidc/okta-2.yml
@@ -14,7 +14,7 @@
           - !variable client-secret
 
           # URI of Conjur instance
-          - !variable redirect_uri
+          - !variable redirect-uri
 
           # Defines the JWT claim to use as the Conjur identifier
           - !variable claim-mapping

--- a/dev/start
+++ b/dev/start
@@ -16,9 +16,9 @@ if [ ! -f "../VERSION" ]; then
 fi
 
 # Minimal set of services.  We add to this list based on cmd line flags.
-services=(pg conjur client)
+services=(pg conjur client cucumber)
 
-# Authenticators to enable. 
+# Authenticators to enable.
 default_authenticators="authn,authn-k8s/test"
 enabled_authenticators="$default_authenticators"
 
@@ -83,7 +83,7 @@ the Conjur container.  To start the application server, run:
     # conjurctl server
 
 Usage: start [options]
-    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable 
+    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable
                     authentication via:
                     'curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate'
     --rotators      Starts a cucumber and test postgres container.
@@ -203,7 +203,7 @@ configure_oidc_authenticators() {
     client_add_secret 'conjur/authn-oidc/keycloak2/claim-mapping' 'email'
     client_add_secret 'conjur/authn-oidc/keycloak2/nonce' 'af88d8f8ff6631fb4cf0'
     client_add_secret 'conjur/authn-oidc/keycloak2/state' 'd38e57e0fd47ccffa9c2'
-    client_add_secret 'conjur/authn-oidc/keycloak2/redirect_uri' 'http://localhost:3000/authn-oidc/keycloak2/cucumber/authenticate'
+    client_add_secret 'conjur/authn-oidc/keycloak2/redirect-uri' 'http://localhost:3000/authn-oidc/keycloak2/cucumber/authenticate'
 
     client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/keycloak2-users.yml'
 
@@ -218,7 +218,7 @@ configure_oidc_authenticators() {
     client_add_secret 'conjur/authn-oidc/okta-2/claim-mapping' 'preferred_username'
     client_add_secret 'conjur/authn-oidc/okta-2/nonce' '1656b4264b60af659fce'
     client_add_secret 'conjur/authn-oidc/okta-2/state' '4f413476ef7e2395f0af'
-    client_add_secret 'conjur/authn-oidc/okta-2/redirect_uri' 'http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate'
+    client_add_secret 'conjur/authn-oidc/okta-2/redirect-uri' 'http://localhost:3000/authn-oidc/okta-2/cucumber/authenticate'
 
     client_load_policy '/src/conjur-server/dev/policies/authenticators/authn-oidc/okta-users.yml'
   fi

--- a/spec/app/db/repository/authenticator_repository_spec.rb
+++ b/spec/app/db/repository/authenticator_repository_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe('DB::Repository::AuthenticatorRepository') do
     )
   end
 
-  let(:arguments) { %i[provider_uri client_id client_secret claim_mapping nonce state] }
+  let(:arguments) { %i[provider_uri client_id client_secret claim_mapping extra] }
 
   describe('#find_all') do
     context 'when webservice is not present' do

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -10,17 +10,23 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       client_id: '0oa3w3xig6rHiu9yT5d7',
       client_secret: 'e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj',
       claim_mapping: 'foo',
-      nonce: '1656b4264b60af659fce',
-      state: 'state',
       account: 'bar',
       service_id: 'baz'
     )
   end
 
   let(:client) do
-    Authentication::AuthnOidc::V2::Client.new(
-      authenticator: authenticator
-    )
+    VCR.use_cassette("authenticators/authn-oidc/v2/client_load") do
+      client = Authentication::AuthnOidc::V2::Client.new(
+        authenticator: authenticator
+      )
+      # The call `oidc_client` queries the OIDC endpoint. As such,
+      # we need to wrap this in a VCR call. Calling this before
+      # returning the client to allow this call to be more effectively
+      # mocked.
+      client.oidc_client
+      client
+    end
   end
 
   describe '.callback' do
@@ -28,12 +34,14 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       it 'returns a valid JWT token', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
         # Because JWT tokens have an expiration timeframe, we need to hold
         # time constant after caching the request.
-        travel_to(Time.parse("2022-06-30 16:42:17 +0000")) do
+        travel_to(Time.parse("2022-09-30 17:02:17 +0000")) do
           token = client.callback(
-            code: 'qdDm7On1dEEzNmMlk2bF7IcOF8gCgfvgMCMXXXDlYEE'
+            code: '-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw',
+            code_verifier: 'c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d',
+            nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
           )
           expect(token).to be_a_kind_of(OpenIDConnect::ResponseObject::IdToken)
-          expect(token.raw_attributes['nonce']).to eq('1656b4264b60af659fce')
+          expect(token.raw_attributes['nonce']).to eq('7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d')
           expect(token.raw_attributes['preferred_username']).to eq('test.user3@mycompany.com')
           expect(token.aud).to eq('0oa3w3xig6rHiu9yT5d7')
         end
@@ -42,10 +50,12 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
 
     context 'when JWT has expired' do
       it 'raises an error', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
-        travel_to(Time.parse("2022-06-30 20:42:17 +0000")) do
+        travel_to(Time.parse("2022-10-01 17:02:17 +0000")) do
           expect do
             client.callback(
-              code: 'qdDm7On1dEEzNmMlk2bF7IcOF8gCgfvgMCMXXXDlYEE'
+              code: '-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw',
+              code_verifier: 'c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d',
+              nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
             )
           end.to raise_error(
             OpenIDConnect::ResponseObject::IdToken::ExpiredToken,
@@ -59,7 +69,9 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       it 'raise an exception', vcr: 'authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials' do
         expect do
           client.callback(
-            code: '7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo'
+            code: '-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw',
+            code_verifier: 'c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d',
+            nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
           )
         end.to raise_error(
           Rack::OAuth2::Client::Error,
@@ -72,29 +84,14 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       it 'raise an exception' do
         expect do
           client.callback(
-            code: 'SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU'
+            code: 'SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU',
+            code_verifier: 'c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d',
+            nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
           )
         end.to raise_error(
           Rack::OAuth2::Client::Error,
           'invalid_grant :: The authorization code is invalid or has expired.'
         )
-      end
-    end
-
-    context 'when code is invalid' do
-      context 'raise an error when' do
-        it 'code is nil' do
-          expect { client.callback(code: nil) }.to raise_error(
-            Errors::Authentication::RequestBody::MissingRequestParam,
-            "CONJ00009E Field 'code' is missing or empty in request body"
-          )
-        end
-        it 'code is an empty string' do
-          expect { client.callback(code: '') }.to raise_error(
-            Errors::Authentication::RequestBody::MissingRequestParam,
-            "CONJ00009E Field 'code' is missing or empty in request body"
-          )
-        end
       end
     end
   end
@@ -150,8 +147,6 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
             client_id: '0oa3w3xig6rHiu9yT5d7',
             client_secret: 'e349BMTTIpLO-rPuPqLLkLyH_pO-loUzhIVJCrHj',
             claim_mapping: 'foo',
-            nonce: '1656b4264b60af659fce',
-            state: 'state',
             account: 'bar',
             service_id: 'baz'
           )

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -48,6 +48,40 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       end
     end
 
+    context 'when code verifier does not match' do
+      it 'raises an error', vcr: 'authenticators/authn-oidc/v2/client_callback-invalid_code_verifier' do
+        travel_to(Time.parse("2022-10-17 17:23:30 +0000")) do
+          expect do
+            client.callback(
+              code: 'GV48_SF4a19ghvBhVbbSG3Lr8BuFl8PhWVPZSbokV2o',
+              code_verifier: 'bad-code-verifier',
+              nonce: '3e6bd5235e4692b37ca1f04cb01b6e0cb177aa20dcef19e89f'
+            )
+          end.to raise_error(
+            Errors::Authentication::AuthnOidc::TokenRetrievalFailed,
+            "CONJ00133E Access Token retrieval failure: 'PKCE verification failed'"
+          )
+        end
+      end
+    end
+
+    context 'when nonce does not match' do
+      it 'raises an error', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
+        travel_to(Time.parse("2022-09-30 17:02:17 +0000")) do
+          expect do
+            client.callback(
+              code: '-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw',
+              code_verifier: 'c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d',
+              nonce: 'bad-nonce'
+            )
+          end.to raise_error(
+            Errors::Authentication::AuthnOidc::TokenVerificationFailed,
+            "CONJ00128E JWT Token validation failed: 'Provided nonce does not match the nonce in the JWT'"
+          )
+        end
+      end
+    end
+
     context 'when JWT has expired' do
       it 'raises an error', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
         travel_to(Time.parse("2022-10-01 17:02:17 +0000")) do
@@ -58,8 +92,8 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
               nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
             )
           end.to raise_error(
-            OpenIDConnect::ResponseObject::IdToken::ExpiredToken,
-            'Invalid ID token: Expired token'
+            Errors::Authentication::AuthnOidc::TokenVerificationFailed,
+            "CONJ00128E JWT Token validation failed: 'JWT has expired'"
           )
         end
       end
@@ -74,8 +108,8 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
             nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
           )
         end.to raise_error(
-          Rack::OAuth2::Client::Error,
-          'invalid_grant :: The authorization code is invalid or has expired.'
+          Errors::Authentication::AuthnOidc::TokenRetrievalFailed,
+          "CONJ00133E Access Token retrieval failure: 'Authorization code is invalid or has expired'"
         )
       end
     end
@@ -89,8 +123,8 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
             nonce: '7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d'
           )
         end.to raise_error(
-          Rack::OAuth2::Client::Error,
-          'invalid_grant :: The authorization code is invalid or has expired.'
+          Errors::Authentication::AuthnOidc::TokenRetrievalFailed,
+          "CONJ00133E Access Token retrieval failure: 'Authorization code is invalid or has expired'"
         )
       end
     end

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
@@ -9,15 +9,12 @@ RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
       client_id: 'client-id-123',
       client_secret: 'client-secret-123',
       claim_mapping: 'email',
-      nonce: 'nonce456',
-      state: 'state123',
       account: 'default',
       service_id: 'my-authenticator'
     }
   end
   let(:args) { default_args }
 
-  # subject { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**default_args)}
   let(:authenticator) { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**args) }
 
   describe '.scope' do
@@ -37,12 +34,12 @@ RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
 
     context 'when initialized with an array argument' do
       context 'single value array' do
-        let(:args) { default_args.merge({ provider_scope: ['foo'] }) }
+        let(:args) { default_args.merge({ provider_scope: 'foo' }) }
         it { expect(authenticator.scope).to eq('openid email profile foo') }
       end
 
       context 'multi-value array' do
-        let(:args) { default_args.merge({ provider_scope: ['foo', 'bar'] }) }
+        let(:args) { default_args.merge({ provider_scope: 'foo bar' }) }
         it { expect(authenticator.scope).to eq('openid email profile foo bar') }
       end
     end

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
       it { expect(authenticator.scope).to eq('openid email profile 1') }
     end
 
+    context 'when initialized with a duplicated argument' do
+      let(:args) { default_args.merge({ provider_scope: 'profile' }) }
+      it { expect(authenticator.scope).to eq('openid email profile') }
+    end
+
     context 'when initialized with an array argument' do
       context 'single value array' do
         let(:args) { default_args.merge({ provider_scope: 'foo' }) }

--- a/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
@@ -13,18 +13,15 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
       redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
       provider_uri: "http://test",
       name: "foo",
-      state: 'foostate',
       client_id: "ConjurClient",
       client_secret: 'client_secret',
-      claim_mapping: mapping,
-      nonce: 'secret'
+      claim_mapping: mapping
     )
   end
 
   let(:client) do
     class_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
-      allow(double).to receive(:new).and_return(
-        current_client)
+      allow(double).to receive(:new).and_return(current_client)
     end
   end
 
@@ -45,24 +42,38 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
     context 'when a role_id matches the identity exist' do
       let(:mapping) { "claim_mapping" }
       it 'returns the role' do
-        expect(strategy.callback({ state: "foostate", code: "code" }))
-          .to eq("alice")
+        expect(strategy.callback(nonce: 'nonce', code: 'code', code_verifier: 'foo'))
+          .to eq('alice')
       end
     end
 
-    context 'When the authn state doesnt match the arguments' do
-      let(:mapping) { "claim_mapping" }
-      it 'raises an error' do
-        expect { strategy.callback({ state: "barstate", code: "code" }) }
-          .to raise_error(Errors::Authentication::AuthnOidc::StateMismatch)
-      end
-    end
-
-    context 'When the claiming matching in the token doesnt match the jwt' do
-      let(:mapping) { "wrong_mapping" }
-      it 'raises an error' do
-        expect { strategy.callback({ state: "foostate", code: "code" }) }
+    context "when the claiming matching in the token doesn't match the jwt" do
+      let(:mapping) { 'wrong_mapping' }
+      it 'raises a `IdTokenClaimNotFoundOrEmpty` error' do
+        expect { strategy.callback(code: 'code', nonce: 'nonce', code_verifier: 'foo') }
           .to raise_error(Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty)
+      end
+    end
+
+    context 'when required parameters are missing' do
+      let(:mapping) { '' }
+      context 'when code is missing' do
+        it 'raises a `MissingRequestParam` error' do
+          expect { strategy.callback(nonce: 'nonce', code_verifier: 'foo') }
+            .to raise_error(Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+      context 'when nonce is missing' do
+        it 'raises a `MissingRequestParam` error' do
+          expect { strategy.callback(code: 'code', code_verifier: 'foo') }
+            .to raise_error(Errors::Authentication::RequestBody::MissingRequestParam)
+        end
+      end
+      context 'when code_verifier is missing' do
+        it 'raises a `MissingRequestParam` error' do
+          expect { strategy.callback(nonce: 'nonce', code: 'code') }
+            .to raise_error(Errors::Authentication::RequestBody::MissingRequestParam)
+        end
       end
     end
   end

--- a/spec/app/domain/authentication/authn-oidc/v2/views/provider_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/views/provider_context_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
   let(:foo) do
     Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
       account: "cucumber",
-      service_id: "foo",
+      service_id: "foo_service",
       redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
       provider_uri: "http://test",
-      name: "foo",
+      name: "foo_name",
       client_id: "ConjurClient",
       client_secret: 'client_secret',
       claim_mapping: 'claim_mapping'
@@ -33,10 +33,10 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
   let(:bar) do
     Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
       account: "cucumber",
-      service_id: "bar",
+      service_id: "bar_service",
       provider_uri: "http://test",
       redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
-      name: "bar",
+      name: "bar_name",
       client_id: "ConjurClient",
       client_secret: 'client_secret',
       claim_mapping: 'claim_mapping'
@@ -48,20 +48,20 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
   let(:res) do
     [
       {
-        name: "foo",
+        name: "foo_name",
         redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
          "&nonce=random&code_challenge=digested&code_challenge_method=S256" \
          "&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
-        service_id: "foo",
+        service_id: "foo_service",
         code_verifier: 'random',
         nonce: 'random',
         type: "authn-oidc"
       }, {
-        name: "bar",
+        name: "bar_name",
         redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
          "&nonce=random&code_challenge=digested&code_challenge_method=S256" \
          "&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
-        service_id: "bar",
+        service_id: "bar_service",
         type: "authn-oidc",
         code_verifier: 'random',
         nonce: 'random'

--- a/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
   let(:client) do
     class_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
-      allow(double).to receive(:new).and_return(
-        current_client)
+      allow(double).to receive(:new).and_return(current_client)
     end
   end
 
@@ -19,52 +18,66 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
   let(:endpoint) { double(authorization_endpoint: '"http://test"') }
 
   let(:foo) do
-    Authentication::AuthnOidc::V2::DataObjects::Authenticator
-      .new(account: "cucumber",
-           service_id: "foo",
-           redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
-           provider_uri: "http://test",
-           name: "foo",
-           state: 'foostate',
-           client_id: "ConjurClient",
-           client_secret: 'client_secret',
-           claim_mapping: 'claim_mapping',
-           nonce: 'secret',
-           )
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
+      account: "cucumber",
+      service_id: "foo",
+      redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+      provider_uri: "http://test",
+      name: "foo",
+      client_id: "ConjurClient",
+      client_secret: 'client_secret',
+      claim_mapping: 'claim_mapping'
+    )
   end
 
   let(:bar) do
-    Authentication::AuthnOidc::V2::DataObjects::Authenticator
-      .new(account: "cucumber",
-           service_id: "bar",
-           provider_uri: "http://test",
-           redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
-           name: "bar",
-           state: 'barstate',
-           client_id: "ConjurClient",
-           client_secret: 'client_secret',
-           claim_mapping: 'claim_mapping',
-           nonce: 'secret')
+    Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(
+      account: "cucumber",
+      service_id: "bar",
+      provider_uri: "http://test",
+      redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+      name: "bar",
+      client_id: "ConjurClient",
+      client_secret: 'client_secret',
+      claim_mapping: 'claim_mapping'
+    )
   end
 
   let(:authenticators) {[foo, bar]}
 
   let(:res) do
-    [{ name: "foo",
-       redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
-         "&state=foostate&nonce=secret&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
-       service_id: "foo",
-       type: "authn-oidc" },
-     { name: "bar",
-       redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
-         "&state=barstate&nonce=secret&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
-       service_id: "bar",
-       type: "authn-oidc" }]
+    [
+      {
+        name: "foo",
+        redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&nonce=random&code_challenge=digested&code_challenge_method=S256" \
+         "&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+        service_id: "foo",
+        code_verifier: 'random',
+        nonce: 'random',
+        type: "authn-oidc"
+      }, {
+        name: "bar",
+        redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&nonce=random&code_challenge=digested&code_challenge_method=S256" \
+         "&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+        service_id: "bar",
+        type: "authn-oidc",
+        code_verifier: 'random',
+        nonce: 'random'
+      }
+    ]
   end
 
+  let(:secure_random) { class_double(SecureRandom, hex: 'random') }
+
   let(:provider_context) do
+    digest = double
+    allow(digest).to receive(:base64digest).and_return('digested')
     ::Authentication::AuthnOidc::V2::Views::ProviderContext.new(
-      client: client
+      client: client,
+      random: secure_random,
+      digest: digest
     )
   end
 
@@ -84,4 +97,3 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
     end
   end
 end
-

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
@@ -1,85 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
-      Accept:
-      - "*/*"
-      Date:
-      - Thu, 30 Jun 2022 17:19:05 GMT
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 Jun 2022 17:19:05 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Server:
-      - nginx
-      Public-Key-Pins-Report-Only:
-      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
-        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
-        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
-      X-Xss-Protection:
-      - '0'
-      P3p:
-      - CP="HONK"
-      Content-Security-Policy:
-      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
-        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
-        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
-        frame-ancestors ''self'''
-      Expect-Ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
-      Cache-Control:
-      - max-age=86400, must-revalidate
-      Expires:
-      - Tue, 12 Jul 2022 16:31:08 GMT
-      Vary:
-      - Origin
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      X-Okta-Request-Id:
-      - YsxQTEzo3y4Lo9fSGY_LawAABPE
-    body:
-      encoding: UTF-8
-      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
-        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
-  recorded_at: Thu, 30 Jun 2022 17:19:05 GMT
-- request:
     method: post
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+      string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
       Accept:
       - "*/*"
       Date:
-      - Thu, 30 Jun 2022 17:19:05 GMT
+      - Fri, 30 Sep 2022 17:19:21 GMT
       Authorization:
       - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
       Content-Type:
@@ -90,7 +23,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Thu, 30 Jun 2022 17:19:06 GMT
+      - Fri, 30 Sep 2022 17:19:22 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -104,21 +37,37 @@ http_interactions:
         pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
         max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
       X-Okta-Request-Id:
-      - Yr3bCsdZJUAaGw2mXm8FNgAADRM
+      - YzclGT9F51eImbj6lTlN0AAACl4
       X-Xss-Protection:
       - '0'
       P3p:
       - CP="HONK"
+      Content-Security-Policy-Report-Only:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''nonce-8XxNsgGJ7tleqCeom6XuCfv4ASDp8xU7hm86MEgqU-0''
+        ''unsafe-eval'' ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
       Content-Security-Policy:
       - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
         dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
         *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
         data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
       X-Rate-Limit-Limit:
@@ -126,7 +75,7 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '299'
       X-Rate-Limit-Reset:
-      - '1656609606'
+      - '1664558421'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -140,12 +89,12 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=315360000; includeSubDomains
       Set-Cookie:
-      - JSESSIONID=20DB7FF8635C66C478EE266D41EC5A6D; Path=/; Secure; HttpOnly
+      - JSESSIONID=8B02BEDFF41B92741E6EEBB6CA0B2D80; Path=/; Secure; HttpOnly
       - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
     body:
       encoding: UTF-8
       string: '{"error":"invalid_grant","error_description":"The authorization code
         is invalid or has expired."}'
-  recorded_at: Thu, 30 Jun 2022 17:19:06 GMT
+  recorded_at: Fri, 30 Sep 2022 17:19:22 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-invalid_code_verifier.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-invalid_code_verifier.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://dev-92899796.okta.com/oauth2/default/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=authorization_code&code=GV48_SF4a19ghvBhVbbSG3Lr8BuFl8PhWVPZSbokV2o&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=3e6bd5235e4692b37ca1f04cb01b6e0cb177aa20dcef19e89f&code_verifier=bad-code-verifier
+    headers:
+      User-Agent:
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 17 Oct 2022 17:23:30 GMT
+      Authorization:
+      - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Mon, 17 Oct 2022 17:24:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Okta-Request-Id:
+      - Y02Pw8hcjYzIfnEoK4T9AAAACQU
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self''; report-uri https://okta.report-uri.com/r/d/csp/enforce;
+        report-to csp'
+      X-Rate-Limit-Limit:
+      - '300'
+      X-Rate-Limit-Remaining:
+      - '299'
+      X-Rate-Limit-Reset:
+      - '1666027519'
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      Set-Cookie:
+      - JSESSIONID=9ABDA66E3EA85BE59AB6233C8DC28B7F; Path=/; Secure; HttpOnly
+      - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_grant","error_description":"PKCE verification failed."}'
+  recorded_at: Mon, 17 Oct 2022 17:23:30 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
@@ -1,85 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
-      Accept:
-      - "*/*"
-      Date:
-      - Thu, 30 Jun 2022 17:07:38 GMT
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 Jun 2022 17:07:38 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Server:
-      - nginx
-      Public-Key-Pins-Report-Only:
-      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
-        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
-        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
-      X-Xss-Protection:
-      - '0'
-      P3p:
-      - CP="HONK"
-      Content-Security-Policy:
-      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
-        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
-        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
-        frame-ancestors ''self'''
-      Expect-Ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
-      Cache-Control:
-      - max-age=86400, must-revalidate
-      Expires:
-      - Tue, 12 Jul 2022 16:31:08 GMT
-      Vary:
-      - Origin
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      X-Okta-Request-Id:
-      - YsxQTEzo3y4Lo9fSGY_LawAABPE
-    body:
-      encoding: UTF-8
-      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
-        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
-  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
-- request:
     method: post
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
       Accept:
       - "*/*"
       Date:
-      - Thu, 30 Jun 2022 17:07:38 GMT
+      - Fri, 30 Sep 2022 17:18:17 GMT
       Authorization:
       - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
       Content-Type:
@@ -90,7 +23,7 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Thu, 30 Jun 2022 17:07:39 GMT
+      - Fri, 30 Sep 2022 17:18:18 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -104,21 +37,37 @@ http_interactions:
         pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
         max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
       X-Okta-Request-Id:
-      - Yr3YWxFu57C3xLMlxeiK2QAABbM
+      - Yzck2nN7s2AQGePZY8c2gQAAB94
       X-Xss-Protection:
       - '0'
       P3p:
       - CP="HONK"
+      Content-Security-Policy-Report-Only:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''nonce-ZUSAcrGWJJO_LGxCGbys2QL4CSrTAzGBje02qK26sdc''
+        ''unsafe-eval'' ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
       Content-Security-Policy:
       - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
         dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
         *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
         data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
       X-Rate-Limit-Limit:
@@ -126,7 +75,7 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '299'
       X-Rate-Limit-Reset:
-      - '1656608919'
+      - '1664558358'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -140,12 +89,12 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=315360000; includeSubDomains
       Set-Cookie:
-      - JSESSIONID=43FD607685A5D5094F4326B6CD522697; Path=/; Secure; HttpOnly
+      - JSESSIONID=69068D777A11001AB7E7539E934C9A20; Path=/; Secure; HttpOnly
       - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
     body:
       encoding: UTF-8
       string: '{"error":"invalid_grant","error_description":"The authorization code
         is invalid or has expired."}'
-  recorded_at: Thu, 30 Jun 2022 17:07:39 GMT
+  recorded_at: Fri, 30 Sep 2022 17:18:18 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
@@ -1,85 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
-      Accept:
-      - "*/*"
-      Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Server:
-      - nginx
-      Public-Key-Pins-Report-Only:
-      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
-        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
-        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
-      X-Xss-Protection:
-      - '0'
-      P3p:
-      - CP="HONK"
-      Content-Security-Policy:
-      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
-        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
-        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
-        frame-ancestors ''self'''
-      Expect-Ct:
-      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
-      Cache-Control:
-      - max-age=86400, must-revalidate
-      Expires:
-      - Tue, 12 Jul 2022 16:31:08 GMT
-      Vary:
-      - Origin
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=315360000; includeSubDomains
-      X-Okta-Request-Id:
-      - YsxQTEzo3y4Lo9fSGY_LawAABPE
-    body:
-      encoding: UTF-8
-      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
-        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
-  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
-- request:
     method: post
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
+      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
       Accept:
       - "*/*"
       Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
+      - Fri, 30 Sep 2022 17:02:17 GMT
       Authorization:
       - Basic MG9hM3czeGlnNnJIaXU5eVQ1ZDc6ZTM0OUJNVFRJcExPLXJQdVBxTExrTHlIX3BPLWxvVXpoSVZKQ3JIag==
       Content-Type:
@@ -90,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 Jun 2022 16:43:03 GMT
+      - Fri, 30 Sep 2022 17:14:38 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -104,21 +37,37 @@ http_interactions:
         pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
         max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
       X-Okta-Request-Id:
-      - Yr3Slh4a2cZq__AflSs8wQAADtA
+      - Yzcj_ieURr1wLPVErCrikAAAC84
       X-Xss-Protection:
       - '0'
       P3p:
       - CP="HONK"
+      Content-Security-Policy-Report-Only:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''nonce-ZFIOD_nd7I1XFja243oXrDS25KhzLla9BnlkbWhH1OU''
+        ''unsafe-eval'' ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
+        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
       Content-Security-Policy:
       - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
         dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
         *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
         data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
       X-Rate-Limit-Limit:
@@ -126,7 +75,7 @@ http_interactions:
       X-Rate-Limit-Remaining:
       - '299'
       X-Rate-Limit-Reset:
-      - '1656607442'
+      - '1664558138'
       Cache-Control:
       - no-cache, no-store
       Pragma:
@@ -142,14 +91,14 @@ http_interactions:
       X-Robots-Tag:
       - noindex,nofollow
       Set-Cookie:
-      - JSESSIONID=7D061355C0A559E9DE2767B0389890C8; Path=/; Secure; HttpOnly
+      - JSESSIONID=392B5556071EB935B2684D3AF2D492E5; Path=/; Secure; HttpOnly
       - autolaunch_triggered=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":3600,"access_token":"eyJraWQiOiJZR1NUUUxBVDdLb1JPd2RhTWtWa1RyNXhIUXM3Zm1jNG5CTUJsT1NuZHVzIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnl1SkFCZmtqT2FJNHVsOVczMzFabFp0Rk5UQ0ZhSTA3aVJHZFNxcmtJTEEiLCJpc3MiOiJodHRwczovL2Rldi05Mjg5OTc5Ni5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2NTY2MDczODIsImV4cCI6MTY1NjYxMDk4MiwiY2lkIjoiMG9hM3czeGlnNnJIaXU5eVQ1ZDciLCJ1aWQiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsInNjcCI6WyJwcm9maWxlIiwib3BlbmlkIl0sImF1dGhfdGltZSI6MTY1NjYwNjcxNywic3ViIjoidGVzdC51c2VyM0BteWNvbXBhbnkuY29tIn0.w3mFIqKKJII8zWwr5pNFaLIF4R2JslczkUNBHetQfbqrJbw8QDTJi8wkrzVuYF6kmjEapUwyhfip49P7NLvmA88HO7yzqJ9Nu5ZeSftkeR29ldEUgDXN_wdmzer_AvqzNwZbb8W_BqrfUpXXDIGroIKhCjgDMAKW1JlQf85yM-oRuy1qSUIX983US2mixkQzvs0W2sd3Fc0ehTh8ZONjjQMvlbbzNgjOpixz-2gSi61KpQEbw4_jRzYZKavv6El_2lhv5i4AlwP0kXMs6b6W7n3y3bDEFagNj2H5GxLjvt0CUp-NvVX_aWCsJiVoFtu9ahgRbPe3J1PRipnKuQ3rIg","scope":"profile
-        openid","id_token":"eyJraWQiOiJZR1NUUUxBVDdLb1JPd2RhTWtWa1RyNXhIUXM3Zm1jNG5CTUJsT1NuZHVzIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsIm5hbWUiOiJUZXN0IFVzZXIzIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2Rldi05Mjg5OTc5Ni5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6IjBvYTN3M3hpZzZySGl1OXlUNWQ3IiwiaWF0IjoxNjU2NjA3MzgyLCJleHAiOjE2NTY2MTA5ODIsImp0aSI6IklELjdubmF3YUdkc1daT2VKazl6YWxNUFpnVGhuX3Z2QkNDcndBazVHcHRjS00iLCJhbXIiOlsicHdkIl0sImlkcCI6IjAwbzN3MXk4dHV1YVljQ1Q3NWQ3Iiwibm9uY2UiOiIxNjU2YjQyNjRiNjBhZjY1OWZjZSIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QudXNlcjNAbXljb21wYW55LmNvbSIsImF1dGhfdGltZSI6MTY1NjYwNjcxNywiYXRfaGFzaCI6IkU3TDJUUEZrM0dGMXlRQzdEaUJ1UkEifQ.YDeYm3bP5hFmP4u6uuKV2fU8ICZ72LIa_tlG0qfYCVcHS1lZeHqbyJPEWfgmnSGAxenieavntCbsW-g6UdtCeGsoXGPw3tDW-oiNyZsdBPw-xTCg01JSd4d26Oponia0amkhvglXRkAuGVRJciO89oTVabxvYlcP-PvOeaiFjn4q9hFvTQTI6sItPhxp6rMa3Ri9VJkOR1fdkI-w9bwGW8WN-u4GscQoCU054HPVaHPT8fQ86Bl3Aty8Bf2e5Gw6WIpLSFgWd6Nmhiv1ANUcW8vSLxsefWI6N37j-0fCa1fgZefv-M-Kg_dfE-8a33YxzAwN5NB3HCbv7FNsYD1rIg"}'
-  recorded_at: Thu, 30 Jun 2022 16:43:02 GMT
+      string: '{"token_type":"Bearer","expires_in":3600,"access_token":"eyJraWQiOiI3NE5OR2R0RC1rQ2p1b2tZRFRVaG05VVQ3SXRjaUY5S1dEMVNEVktyZW80IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULkNoVzZRVU1iYllmalZZdGhZT0MxT2FqR3gzNk52NUIteWFTcnNtdTBBM3ciLCJpc3MiOiJodHRwczovL2Rldi05Mjg5OTc5Ni5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2NjQ1NTgwNzgsImV4cCI6MTY2NDU2MTY3OCwiY2lkIjoiMG9hM3czeGlnNnJIaXU5eVQ1ZDciLCJ1aWQiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsInNjcCI6WyJlbWFpbCIsInByb2ZpbGUiLCJvcGVuaWQiXSwiYXV0aF90aW1lIjoxNjY0NTU3ODUzLCJzdWIiOiJ0ZXN0LnVzZXIzQG15Y29tcGFueS5jb20ifQ.hxsTC4_AO9M-KzYDmOac9KK2cqdvZVEXtB0jagLMEkfdkZ4XTm2h8UBcbdTlwKa1UWbM5y9JuwTeQ5_J3FJP-YMkzsfcrYvvYkAd0V7Dw39CjRh5SFU7y-_ReCWGUp5Ni__yLcfmRl0EUAufs-JauyPX3GiknYD4QPZsfjCl0qGfZ7QrPOFOO4IJu7DuKCNVb-fR9aTS4VGEdff62idOoTKexXAuIaWw9yicSTULGFpIxeyPiVMjRQtpuZAl15rdmdZi2fJqlMEY7fbMY5OzgRcT-KCITk6vzY8DsoJosOZbNBYSvwHBilbcxJYMz3o9xn39ADZIvGX69M-3llbKRQ","scope":"email
+        profile openid","id_token":"eyJraWQiOiI3NE5OR2R0RC1rQ2p1b2tZRFRVaG05VVQ3SXRjaUY5S1dEMVNEVktyZW80IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHU1Z2tvNmRmNDRqMmZHcDVkNyIsIm5hbWUiOiJSb2JlcnQgV2lsbGlhbXMgSUlJIiwiZW1haWwiOiJ0ZXN0LnVzZXIzQG15Y29tcGFueS5jb20iLCJ2ZXIiOjEsImlzcyI6Imh0dHBzOi8vZGV2LTkyODk5Nzk2Lm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiMG9hM3czeGlnNnJIaXU5eVQ1ZDciLCJpYXQiOjE2NjQ1NTgwNzgsImV4cCI6MTY2NDU2MTY3OCwianRpIjoiSUQuMFE0Uy1xTEpCaW5fbi1PUHQySVBzYVhOaE8yMjRrLVpqVlFpLVNodUxNNCIsImFtciI6WyJwd2QiXSwiaWRwIjoiMDBvM3cxeTh0dXVhWWNDVDc1ZDciLCJub25jZSI6IjdlZmNiYmEzNmE5Yjk2ZmRiNTI4NWExNTk2NjVjM2QzODJhYmQ4YjZiMzI4OGZjYzhkIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdC51c2VyM0BteWNvbXBhbnkuY29tIiwiYXV0aF90aW1lIjoxNjY0NTU3ODUzLCJhdF9oYXNoIjoiY3d4OTNFaTJXdVYzRzZ3MFRiYmJBZyJ9.SrRuxy27rvHveLtC_2lWFpTWXTSc1I4UCDs4jd1pUKD4iBldSLXk7fWEY7VNQFqtHGidOSBD4rOUiSCpphLKHGfLgFLyRlqjU2k4nG8BGqslaEuiN2YhsVDECAjjjctDUazSaDHKsYiPCt4f9w7DeCWShDkG7QLH-CHlUkYzzeBz3bXmxYm2h1LzhMstZldvFTbcB-pKtKauavzhYK2NIb8k86EpXr7tHQ4wbgOUzX6_m8lw-9gMhGZc32vxROiaqu776DmZ7doQwLx3UN3NqRIdhlCThCy4seF_3_YanE73PAhCRNRTiEBZ5svct7XGBw8Vl5VElV7b6lAC21Ni5w"}'
+  recorded_at: Fri, 30 Sep 2022 17:02:17 GMT
 - request:
     method: get
     uri: https://dev-92899796.okta.com/oauth2/default/v1/keys
@@ -162,14 +111,14 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
+      - Fri, 30 Sep 2022 17:02:17 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 30 Jun 2022 16:43:03 GMT
+      - Fri, 30 Sep 2022 17:14:39 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -190,20 +139,22 @@ http_interactions:
       - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
         dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
         *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
         data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
       Expect-Ct:
       - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
       Cache-Control:
-      - max-age=128312, must-revalidate
+      - max-age=7730945, must-revalidate
       Expires:
-      - Sat, 02 Jul 2022 04:21:35 GMT
+      - Thu, 29 Dec 2022 04:43:44 GMT
       Vary:
       - Origin
       X-Content-Type-Options:
@@ -211,9 +162,9 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=315360000; includeSubDomains
       X-Okta-Request-Id:
-      - Yr3SlwZrGYc1D5ItYgm_cgAABxk
+      - Yzcj_2SzA_OGwA_yMGySgwAAAek
     body:
       encoding: UTF-8
-      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"YGSTQLAT7KoROwdaMkVkTr5xHQs7fmc4nBMBlOSndus","use":"sig","e":"AQAB","n":"y4r4NkyseHCyJ44QE4n4_n4Xxi63nkZlcTuJkr8I-yOgXKWk9h9giq6FJcMYwHXTtM2sQQ-yVJu_GSCgWWq2QmgaQt-1H8ldrJhlw1_W33POdCPQHjOdvUGJ8xgKbasIuFJrR_SPXJ5WQz8yIQsTQXaIgSP2NHTLRRg_KFsMe9nkYY7Mz_T9ZsQyzxal9fnefJa5mExEuWi7STIEJfgQqbzezdN-t1ZFpoVCAUFhNwKNYcsTvMDR43e3zdY_ii09rWakRzEicoFGeeQPZcgxcHWnYAmirufmu_gj9lGE-sOFatcXkIK07gziDa8CzTqh6OKitQdT__CNKSiOgYT1Pw"}]}'
-  recorded_at: Thu, 30 Jun 2022 16:43:03 GMT
+      string: '{"keys":[{"kty":"RSA","alg":"RS256","kid":"74NNGdtD-kCjuokYDTUhm9UT7ItciF9KWD1SDVKreo4","use":"sig","e":"AQAB","n":"zhlW4oIEvu5wcGQ4ROfpumaqQWluAGi6FIV1Hi-gFuA9Z_Gxw4x3fQnZbpsXsuWlu2Ivfl-9RCiu2AGcpUiH7cX84BWTRtwdOuPXMvOx_g1EUVna1IdVbXSsvWzgi0gOHsv9ZGyoq9BPRccn4m69824SvoAsIi3m-Jr0W3RFe3dCojkGDmrDiH7h8mhR_CjG2IRaQVxc0OqhwOYGAIsivhKQB7YjxqR3fMyUYEpJg3285r5r0-05slJDcUfJ3kILUgAvBBx0fZdLdopHij7hWFaPPKWHW7gKvFlX8h2_IMFMkaGlCF0XQ9S35hiQa12Nqf9frEDa48qcBmUweW67Rw"},{"kty":"RSA","alg":"RS256","kid":"_I6KGcucpmmj1en6JMfUuFB7SDKergpmgfP5nOBucxI","use":"sig","e":"AQAB","n":"40IMCS23bTWYL04XSZ-lwwnKuxVpkULRZYFxUrsYSXt5O-Tob52kIfw_QV_I3qNTZqjbfzSmokifNGF8_O1sQVuENE0vDpxenh05eV8h497sunnhsuOLkl4Y0CqgLWcfH-4qgF8musOPsVBdQIZ7SQ4BNMupgAkgyxENynDDlM4GeAwhu7TYtmtA2eOsj4ut6GrLNk-6KjhHvllmVdH09RJox5cz5atwTNI_LkwK9AHRLCaaM27KNLX498kFDTLPfB27zGwwODLuOy0i6XHskf4fnzrL-ttXliVtt0zgfMKPBCPxkm8Ynk7FRZbKisZRwl82aSyDWfZo-gHU2-U8Bw"}]}'
+  recorded_at: Fri, 30 Sep 2022 17:02:17 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
@@ -12,14 +12,14 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
+      - Thu, 06 Oct 2022 22:13:54 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 30 Jun 2022 16:43:02 GMT
+      - Thu, 06 Oct 2022 22:13:55 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -40,12 +40,14 @@ http_interactions:
       - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
         dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
         *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
-        https://oinmanager.okta.com data:; script-src ''unsafe-inline'' ''unsafe-eval''
-        ''self'' dev-92899796.okta.com *.oktacdn.com; style-src ''unsafe-inline''
-        ''self'' dev-92899796.okta.com *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com;
-        frame-src ''self'' dev-92899796.okta.com dev-92899796-admin.okta.com login.okta.com;
-        img-src ''self'' dev-92899796.okta.com *.oktacdn.com *.tiles.mapbox.com *.mapbox.com
-        app.pendo.io data.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
         data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
         frame-ancestors ''self'''
       Expect-Ct:
@@ -53,7 +55,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400, must-revalidate
       Expires:
-      - Tue, 12 Jul 2022 16:31:08 GMT
+      - Fri, 07 Oct 2022 22:13:55 GMT
       Vary:
       - Origin
       X-Content-Type-Options:
@@ -61,10 +63,286 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=315360000; includeSubDomains
       X-Okta-Request-Id:
-      - YsxQTEzo3y4Lo9fSGY_LawAABPE
+      - Yz9TI_MTaB3_WDnGc1HzWAAADII
     body:
       encoding: UTF-8
       string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
         id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
-  recorded_at: Thu, 30 Jun 2022 17:07:38 GMT
+  recorded_at: Thu, 06 Oct 2022 22:13:55 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 06 Oct 2022 22:13:55 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Oct 2022 22:13:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Fri, 07 Oct 2022 22:13:56 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yz9TJACEb_A1PbEeXb-UlAAACpI
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 06 Oct 2022 22:13:56 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 06 Oct 2022 22:13:56 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Oct 2022 22:13:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Fri, 07 Oct 2022 22:13:56 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yz9TJJEklkO44lgEvnjWdwAABHI
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 06 Oct 2022 22:13:56 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 06 Oct 2022 22:13:56 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Oct 2022 22:13:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Fri, 07 Oct 2022 22:13:55 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yz9TJdnAqVMcaT4YlT5ioQAAADM
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 06 Oct 2022 22:13:57 GMT
+- request:
+    method: get
+    uri: https://dev-92899796.okta.com/oauth2/default/.well-known/openid-configuration
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      Accept:
+      - "*/*"
+      Date:
+      - Thu, 06 Oct 2022 22:13:57 GMT
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 06 Oct 2022 22:13:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="r5EfzZxQVvQpKo3AgYRaT7X2bDO/kj3ACwmxfdT2zt8="; pin-sha256="MaqlcUgk2mvY/RFSGeSwBRkI+rZ6/dxe/DuQfBT/vnQ=";
+        pin-sha256="72G5IEvDEWn+EThf3qjR7/bQSWaS2ZSLqolhnO6iyJI="; pin-sha256="rrV6CLCCvqnk89gWibYT0JO6fNQ8cCit7GGoiVTjCOg=";
+        max-age=60; report-uri="https://okta.report-uri.com/r/default/hpkp/reportOnly"
+      X-Xss-Protection:
+      - '0'
+      P3p:
+      - CP="HONK"
+      Content-Security-Policy:
+      - 'default-src ''self'' dev-92899796.okta.com *.oktacdn.com; connect-src ''self''
+        dev-92899796.okta.com dev-92899796-admin.okta.com *.oktacdn.com *.mixpanel.com
+        *.mapbox.com app.pendo.io data.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com https://oinmanager.okta.com
+        data:; script-src ''unsafe-inline'' ''unsafe-eval'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com; style-src ''unsafe-inline'' ''self'' dev-92899796.okta.com
+        *.oktacdn.com app.pendo.io cdn.pendo.io pendo-static-5634101834153984.storage.googleapis.com
+        pendo-static-5391521872216064.storage.googleapis.com; frame-src ''self'' dev-92899796.okta.com
+        dev-92899796-admin.okta.com login.okta.com; img-src ''self'' dev-92899796.okta.com
+        *.oktacdn.com *.tiles.mapbox.com *.mapbox.com app.pendo.io data.pendo.io cdn.pendo.io
+        pendo-static-5634101834153984.storage.googleapis.com pendo-static-5391521872216064.storage.googleapis.com
+        data: blob:; font-src ''self'' dev-92899796.okta.com data: *.oktacdn.com fonts.gstatic.com;
+        frame-ancestors ''self'''
+      Expect-Ct:
+      - report-uri="https://oktaexpectct.report-uri.com/r/t/ct/reportOnly", max-age=0
+      Cache-Control:
+      - max-age=86400, must-revalidate
+      Expires:
+      - Fri, 07 Oct 2022 22:13:56 GMT
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains
+      X-Okta-Request-Id:
+      - Yz9TJf0JGaDLjG0YjGuzMQAADco
+    body:
+      encoding: UTF-8
+      string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
+        id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
+  recorded_at: Thu, 06 Oct 2022 22:13:57 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_load.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_load.yml
@@ -12,14 +12,14 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 30 Sep 2022 17:20:21 GMT
+      - Sat, 01 Oct 2022 17:02:17 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 30 Sep 2022 17:20:22 GMT
+      - Fri, 07 Oct 2022 21:10:51 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -55,7 +55,7 @@ http_interactions:
       Cache-Control:
       - max-age=86400, must-revalidate
       Expires:
-      - Sat, 01 Oct 2022 17:20:22 GMT
+      - Sat, 08 Oct 2022 21:10:51 GMT
       Vary:
       - Origin
       X-Content-Type-Options:
@@ -63,10 +63,10 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=315360000; includeSubDomains
       X-Okta-Request-Id:
-      - YzclVurfnxPX_ppopbqLhAAABZY
+      - Y0CV2zAVa-KLmseiKVuYoQAABrc
     body:
       encoding: UTF-8
       string: '{"issuer":"https://dev-92899796.okta.com/oauth2/default","authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-92899796.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-92899796.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code
         id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access","device_sso"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://dev-92899796.okta.com/oauth2/default/v1/device/authorize"}'
-  recorded_at: Fri, 30 Sep 2022 17:20:22 GMT
+  recorded_at: Sat, 01 Oct 2022 17:02:17 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Desired Outcome

This PR attempts to address two objectives:

1. Improve the security of the OIDC Code authenticator by adding dynamic Nonce and PKCE support.
2. Refactor related Cucumber tests to: 
    - Provide a single mechanism for sharing data between Cucumber Scenario Steps (`Scenario::Context`)
    - Allow Conjur variables to be set in table form
    - Allow required environment variables defined per-step
    
### Implemented Changes

The above objectives are captured in two separate commits to simplify review.  

#### Commit 1 (`Security improvements for OIDC code authenticator`)
This PR adds support for dynamically generated Nonce and PKCE values (generated as part of the provider -  `app/domain/authentication/authn_oidc/v2/views/provider_context.rb`). This PR also adds support for defining required values on the OIDC Authenticator object.

All unit tests have been updated to reflect the current functionality.

##### Provider Endpoint Changes

`GET /authn-oidc/cucumber/providers` response changes from:

```json
[{
	"service_id": "okta-2",
	"type": "authn-oidc",
	"name": "Okta 2",
	"redirect_uri": "https://dev-92899796.okta.com/oauth2/default/v1/authorize?client_id=0oa3w3xig6rHiu9yT5d7\u0026response_type=code\u0026scope=openid%20email%20profile\u0026state=4f413476ef7e2395f0af\u0026nonce=1656b4264b60af659fce\u0026redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate"
}]
```

to:

```json
[{
	"service_id": "okta-2",
	"type": "authn-oidc",
	"name": "Okta 2",
	"nonce": "e6257c2eb20f26b6316e3512255e57048b7d507f7bd56e1598",
	"code_verifier": "c4e3727424188ca3a8e55aaa2f227ac4d2b2cb0ea514a2be93",
	"redirect_uri": "https://dev-92899796.okta.com/oauth2/default/v1/authorize?client_id=0oa3w3xig6rHiu9yT5d7\u0026response_type=code\u0026scope=openid%20email%20profile\u0026nonce=e6257c2eb20f26b6316e3512255e57048b7d507f7bd56e1598\u0026code_challenge=1jJLa1ITqhSRlH-fwTO9HT8f5A8IbcCfI1pJMHKnGp0\u0026code_challenge_method=S256\u0026redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate"
}]
```

- Nonce is dynamically generated on each Provider List request.
- Redirect URI no longer includes a state value.
- Redirect URI includes a dynamically generated PKCE SHA256 hashed code challenge (corresponding verifier is included as `code_verifier`). Code challenge and code verify are generated on each Provider List request.

#### Authenticate Request Changes

Authenticate request changes from: 

```
GET /authn-oidc/<service-id>/<account>/authenticate?code=<okta-code>&state=<state>
```

to:

```
GET /authn-oidc/<service-id>/<account>/authenticate?code=<okta-code>&nonce=<nonce>&code_verifier=<code-verifier>
```

- Previously set authenticator policy values for `state` and `nonce` are ignored.
- `code`, `nonce`, and `code_verifier` are required parameter fields.

### Commit 2 (`Update and cleanup Cucumber tests for OIDC `)
Key bits to look at are:

- `hooks.rb` (`cucumber/_authenticators_common/features/support/hooks.rb`) - Adds a Scenario Context object to share data between steps
- `cucumber/authenticators_oidc/features/authn_oidc_okta.feature` - Adds table-based loading of variables, values, and optionally, values from environment variables
- Removed a scenario on the `authn_oidc_v2.feature` ("Scenario: provider-uri dynamic change").  It feels like a test much better suited to move upstream.  We are testing this at the unit level by verifying the OIDC client handles both happy and sad provider URI values.  @adamouamani, is it OK to move this test out of the integration level?

### Connected Issue/Story

CyberArk internal issue link: [ONYX-26870](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26870)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [ONYX-26871](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26871)
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
