### PR TITLE
[FIX] Lazy setup of metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,13 +1,11 @@
-require 'monitoring/pub_sub'
+Rails.application.configure do
+  # The PubSub module needs to be loaded regardless of whether telemetry is
+  # enabled to prevent errors if/when the injected code executes
+  require 'monitoring/pub_sub'
+  return unless config.conjur_config.telemetry_enabled
 
-if Rails.application.config.conjur_config.telemetry_enabled 
-  require 'monitoring/prometheus'
-  require 'monitoring/metrics'
-  # Require all defined metrics
-  Dir.glob(Rails.root + 'lib/monitoring/metrics/*.rb', &method(:require))
-
-  # Load the authentication module early so that telemetry can see which authenticators are installed on startup
-  Dir.glob(Rails.root + 'app/domain/authentication/**/*.rb', &method(:require))
+  # Require all defined metrics/modules
+  Dir.glob(Rails.root + 'lib/monitoring/**/*.rb', &method(:require))
 
   # Register new metrics and setup the Prometheus client store
   metrics = [
@@ -18,11 +16,17 @@ if Rails.application.config.conjur_config.telemetry_enabled
     Monitoring::Metrics::PolicyRoleGauge.new,
     Monitoring::Metrics::AuthenticatorGauge.new,
   ]
-  Monitoring::Prometheus.setup(metrics: metrics)
+  registry = ::Prometheus::Client::Registry.new
+
+  # Use a callback to perform lazy setup on first incoming request
+  # - avoids race condition with DB initialization
+  lazy_init = lambda do
+    Monitoring::Prometheus.setup(metrics: metrics, registry: registry)
+  end
 
   # Initialize Prometheus middleware. We want to ensure that the middleware
   # which collects and exports metrics is loaded at the start of the 
   # middleware chain to prevent any modifications to incoming HTTP requests
-  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: Monitoring::Prometheus.registry, path: '/metrics')
-  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusCollector, pubsub: Monitoring::PubSub.instance)
+  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusExporter, registry: registry, path: '/metrics')
+  Rails.application.config.middleware.insert_before(0, Monitoring::Middleware::PrometheusCollector, pubsub: Monitoring::PubSub.instance, lazy_init: lazy_init)
 end

--- a/lib/monitoring/metrics.rb
+++ b/lib/monitoring/metrics.rb
@@ -54,16 +54,7 @@ module Monitoring
       metric.pubsub.subscribe(metric.sub_event_name) do |payload|
         metric.update(payload)
       end
-      throttle_policy_event(metric) unless !metric.throttle
     end
 
-    def throttle_policy_event(metric)
-      # TODO: Revisit throttling for metrics which execute DB queries. 
-      # Currently this method is only used to group events that should run
-      # when a policy is loaded. It does not throttle the amount of updates.
-      metric.pubsub.subscribe('conjur.policy_loaded') do
-        metric.pubsub.publish(metric.sub_event_name)
-      end
-    end
   end
 end

--- a/lib/monitoring/metrics/api_exception_counter.rb
+++ b/lib/monitoring/metrics/api_exception_counter.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiExceptionCounter
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/api_request_counter.rb
+++ b/lib/monitoring/metrics/api_request_counter.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiRequestCounter
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/api_request_histogram.rb
+++ b/lib/monitoring/metrics/api_request_histogram.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class ApiRequestHistogram
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry

--- a/lib/monitoring/metrics/authenticator_gauge.rb
+++ b/lib/monitoring/metrics/authenticator_gauge.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class AuthenticatorGauge
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry
@@ -9,8 +9,7 @@ module Monitoring
         @metric_name = :conjur_server_authenticator
         @docstring = 'Number of authenticators enabled'
         @labels = [:type, :status]
-        @sub_event_name = 'conjur.authenticator_count_update'
-        @throttle = true
+        @sub_event_name = 'conjur.policy_loaded'
         
         # Create/register the metric
         Metrics.create_metric(self, :gauge)

--- a/lib/monitoring/metrics/policy_resouce_gauge.rb
+++ b/lib/monitoring/metrics/policy_resouce_gauge.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class PolicyResourceGauge
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry
@@ -9,8 +9,7 @@ module Monitoring
         @metric_name = :conjur_resource_count
         @docstring = 'Number of resources in Conjur database'
         @labels = %i[kind]
-        @sub_event_name = 'conjur.resource_count_update'
-        @throttle = true
+        @sub_event_name = 'conjur.policy_loaded'
         
         # Create/register the metric
         Metrics.create_metric(self, :gauge)

--- a/lib/monitoring/metrics/policy_role_gauge.rb
+++ b/lib/monitoring/metrics/policy_role_gauge.rb
@@ -1,7 +1,7 @@
 module Monitoring
   module Metrics
     class PolicyRoleGauge
-      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name, :throttle
+      attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
       def setup(registry, pubsub)
         @registry = registry
@@ -9,8 +9,7 @@ module Monitoring
         @metric_name = :conjur_role_count
         @docstring = 'Number of roles in Conjur database'
         @labels = %i[kind]
-        @sub_event_name = 'conjur.role_count_update'
-        @throttle = true
+        @sub_event_name = 'conjur.policy_loaded'
         
         # Create/register the metric
         Metrics.create_metric(self, :gauge)
@@ -22,7 +21,7 @@ module Monitoring
       def update(*payload)
         metric = @registry.get(@metric_name)
         Monitoring::QueryHelper.instance.policy_role_counts.each do |kind, value|
-          metric.set(value, labels: { kind: kind })
+          metric.set(value, labels: { kind: kind }) unless kind == '!'
         end
       end
     end

--- a/spec/lib/monitoring/middleware/prometheus_collector_spec.rb
+++ b/spec/lib/monitoring/middleware/prometheus_collector_spec.rb
@@ -28,13 +28,19 @@ describe Monitoring::Middleware::PrometheusCollector do
 
   let(:env) { Rack::MockRequest.env_for }
 
+  let(:lazy_init) {
+    lambda do
+      # nothing
+    end 
+  }
+
   let(:app) do
     app = ->(env) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
   end
 
   let(:pubsub) { Monitoring::PubSub.instance }
 
-  let(:options) { { pubsub: pubsub } }
+  let(:options) { { pubsub: pubsub, lazy_init: lazy_init} }
 
   subject { described_class.new(app, **options) }
 


### PR DESCRIPTION
### Desired Outcome

Fix the Conjur image built from this feature branch. Currently the initializer runs before DB migration when deployed via Conjur Quickstart, resulting in errors when the initializer attempts to read resource counts from the DB on startup.

### Implemented Changes

Implement lazy setup by waiting until the first HTTP request is handled by Conjur to set up the metrics.
Cleanup some old code pertaining to throttling metric updates which was never implemented.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
