### PR TITLE
Add callback extensions for Policy Load and Group Membership API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   by default, but is available under the
   `CONJUR_FEATURE_POLICY_LOAD_EXTENSIONS` feature flag.
   [cyberark/conjur#2671](https://github.com/cyberark/conjur/pull/2671)
+- Conjur roles API can now emit callbacks to extensions on member add and
+  remove events (e.g. before/after add member). This is disabled by default,
+  but is available under the `CONJUR_FEATURE_ROLES_API_EXTENSIONS` feature flag.
+  [cyberark/conjur#2671](https://github.com/cyberark/conjur/pull/2671)
 
 ### Changed
 - OIDC authenticator now uses PKCE and dynamic nonce. ([cyberark/conjur#2662](https://github.com/cyberark/conjur/pull/2662)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.19.0] - 2022-10-11
 
+### Added
+- Conjur policy loads can now emit callbacks to extensions on policy
+  load lifecycle events (e.g. before/after policy load). This is disabled
+  by default, but is available under the
+  `CONJUR_FEATURE_POLICY_LOAD_EXTENSIONS` feature flag.
+  [cyberark/conjur#2671](https://github.com/cyberark/conjur/pull/2671)
+
 ### Changed
 - OIDC authenticator now uses PKCE and dynamic nonce. ([cyberark/conjur#2662](https://github.com/cyberark/conjur/pull/2662)
 

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-# Loads a policy into the database, by operating on a PolicyVersion which has already been created with the policy id, 
+require 'conjur/extension/repository'
+
+# Loads a policy into the database, by operating on a PolicyVersion which has already been created with the policy id,
 # policy text, the authenticated user, and the policy owner. The PolicyVersion also parses the policy
 # and checks it for syntax errors, before this code is invoked.
 #
 # The algorithm works by loading the policy into a new, temporary schema (schemas are lightweight namespaces
-# in Postgres). Then this "new" policy (in the temporary schema) is merged into the "old" policy (in the 
+# in Postgres). Then this "new" policy (in the temporary schema) is merged into the "old" policy (in the
 # primary schema). The merge algorithm proceeds in distinct phases:
 #
 # 1) Records which exist in the "old" policy but not in the "new" policy are deleted from the "old" policy.
@@ -35,13 +37,22 @@
 # All steps occur within a transaction, so that if any errors occur (e.g. a role or permission grant which references
 # a non-existent role or resource), the entire operation is rolled back.
 #
-# Future: Note that it is also possible to skip step (1) (deletion of records from the "old" policy which are not defined in the 
+# Future: Note that it is also possible to skip step (1) (deletion of records from the "old" policy which are not defined in the
 # "new"). This "safe" mode can be operationally important, because the presence of cascading foreign key constraints in the schema
 # means that many records can potentially be deleted as a consequence of deleting an important "root"-ish record. For
 # example, deleting the "admin" role will most likely cascade to delete all records in the database.
 
 module Loader
+  # As a legacy class, we know Orchestrate is too long and should be refactored
+  # rubocop:disable Metrics/ClassLength
+  #
+  # We intentionally call @feature_flags.enabled? multiple times and don't
+  # factor it out to make these checks easy to discover.
+  # :reek:RepeatedConditional
   class Orchestrate
+    # Constant for policy load extensions
+    POLICY_LOAD_EXTENSION_KIND = :policy_load
+
     extend Forwardable
     include Schemata::Helper
     include Handlers::RestrictedTo
@@ -61,9 +72,20 @@ module Loader
       annotations: [ :resource_id, :name, :value ]
     }
 
-    def initialize policy_version
+    def initialize(
+      policy_version,
+      extension_repository: Conjur::Extension::Repository.new,
+      feature_flags: Rails.application.config.feature_flags
+    )
       @policy_version = policy_version
       @schemata = Schemata.new
+      @feature_flags = feature_flags
+
+      # Only attempt to load policy load extensions if the feature is enabled
+      @extensions =
+        if @feature_flags.enabled?(:policy_load_extensions)
+          extension_repository.extension(kind: POLICY_LOAD_EXTENSION_KIND)
+        end
 
       # Transform each statement into a Loader type
       @create_records = policy_version.create_records.map do |policy_object|
@@ -73,13 +95,18 @@ module Loader
         Loader::Types.wrap(policy_object, self)
       end
     end
-    
+
     # Gets the id of the policy being loaded.
     def policy_id
       policy_version.policy.id
     end
 
     def setup_db_for_new_policy
+      # We use the db setup to signal the start of a policy load
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(:before_load_policy, policy_version: @policy_version)
+      end
+
       perform_deletion
 
       create_schema
@@ -149,6 +176,14 @@ module Loader
     # Matching rows are selected by primary keys only, using a LEFT JOIN between the
     # existing policy and the new policy.
     def delete_removed
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :before_delete,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+
       TABLES.each do |table|
         columns = Array(model_for_table(table).primary_key) + [ :policy_id ]
 
@@ -171,6 +206,17 @@ module Loader
           WHERE #{comparisons(table, columns, "#{primary_schema}.", 'deleted_from_')}
         DELETE
       end
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :after_delete,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+      # rubocop:enable Style/GuardClause
     end
 
     # Delete rows from the new policy which are already present in another policy.
@@ -215,7 +261,18 @@ module Loader
       DELETE
     end
 
+    # We intentionally call @feature_flags.enabled? multiple times and don't
+    # factor it out to make these checks easy to discover.
+    # :reek:DuplicateMethodCall
     def update_changed
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :before_update,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+
       in_primary_schema do
         TABLES.each do |table|
           pk_columns = Array(Sequel::Model(table).primary_key)
@@ -238,10 +295,33 @@ module Loader
           UPDATE
         end
       end
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :after_update,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+      # rubocop:enable Style/GuardClause
     end
 
     # Copy all remaining records in the new schema into the master schema.
+    #
+    # We intentionally call @feature_flags.enabled? multiple times and don't
+    # factor it out to make these checks easy to discover.
+    # :reek:DuplicateMethodCall
     def insert_new
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :before_insert,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+
       @new_roles = ::Role.all
 
       in_primary_schema do
@@ -249,12 +329,23 @@ module Loader
         TABLES.each { |table| insert_table_records(table) }
         enable_policy_log_trigger
       end
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :after_insert,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+      # rubocop:enable Style/GuardClause
     end
 
     def insert_table_records(table)
-      columns = (TABLE_EQUIVALENCE_COLUMNS[table] + [ :policy_id ]).join(", ")          
+      columns = (TABLE_EQUIVALENCE_COLUMNS[table] + [ :policy_id ]).join(", ")
       db.run("INSERT INTO #{table} ( #{columns} ) SELECT #{columns} FROM #{schema_name}.#{table}")
-      
+
       # For large policies, the policy logging triggers occupy the majority
       # of the policy load time. To make this more efficient on the initial
       # load, we disable the triggers and update the policy log in bulk.
@@ -263,7 +354,7 @@ module Loader
 
     def disable_policy_log_trigger
       # To disable the triggers during the bulk load we use a local
-      # configuration setting that the trigger function is aware of. 
+      # configuration setting that the trigger function is aware of.
       # When we set this variable to `true`, then the trigger will
       # observe the setting value and skip its own policy log.
       db.run('SET LOCAL conjur.skip_insert_policy_log_trigger = true')
@@ -277,10 +368,10 @@ module Loader
       primary_key_columns = Array(Sequel::Model(table).primary_key).map(&:to_s).pg_array
       db.run(<<-POLICY_LOG)
           INSERT INTO policy_log(
-            policy_id, 
+            policy_id,
             version,
-            operation, 
-            kind, 
+            operation,
+            kind,
             subject)
           SELECT
           (policy_log_record(
@@ -304,13 +395,35 @@ module Loader
     end
 
     # Perform explicitly requested deletions
+    #
+    # We intentionally call @feature_flags.enabled? multiple times and don't
+    # factor it out to make these checks easy to discover.
+    # :reek:DuplicateMethodCall
     def perform_deletion
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :before_delete,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+
       delete_records.map(&:delete!)
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :after_delete,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+      # rubocop:enable Style/GuardClause
     end
 
-    # Loads the records into the temporary schema (since the schema search path contains only the temporary schema).
-    #
-    #  
+    # Loads the records into the temporary schema (since the schema search path
+    # contains only the temporary schema).
     def load_records
       raise "Policy version must be saved before loading" unless policy_version.resource_id
 
@@ -351,8 +464,8 @@ module Loader
       CREATE OR REPLACE FUNCTION account(id text) RETURNS text
       LANGUAGE sql IMMUTABLE
       AS $$
-      SELECT CASE 
-        WHEN split_part($1, ':', 1) = '' THEN NULL 
+      SELECT CASE
+        WHEN split_part($1, ':', 1) = '' THEN NULL
         ELSE split_part($1, ':', 1)
       END
       $$;
@@ -362,21 +475,40 @@ module Loader
       db.execute("ALTER TABLE roles ADD PRIMARY KEY ( role_id )")
 
       db.execute("ALTER TABLE role_memberships ALTER COLUMN admin_option SET DEFAULT 'f'")
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        @extensions.call(
+          :after_create_schema,
+          policy_version: @policy_version,
+          schema_name: schema_name
+        )
+      end
+      # rubocop:enable Style/GuardClause
     end
 
     # Drops the temporary schema and everything remaining in it. Also reset the schema search path.
     def drop_schema
       restore_search_path
       db.execute("DROP SCHEMA #{schema_name} CASCADE")
+
+      # We want to use the if statement here to wrap the feature flag check
+      # rubocop:disable Style/GuardClause
+      if @feature_flags.enabled?(:policy_load_extensions)
+        # We use dropping the temp schema to represent the end of a policy load
+        @extensions.call(:after_load_policy, policy_version: policy_version)
+      end
+      # rubocop:enable Style/GuardClause
     end
 
     def db
       Sequel::Model.db
     end
-    
-    # PostgreSQL has many types of caches, one of which is the "catalog cache". 
-    # When a connection is established to the database, this cache is initialized alongside it, and persists for the duration of the connection. 
-    # This cache contains references to Database Objects, such as indexes, etc. (not data records themselves). 
+
+    # PostgreSQL has many types of caches, one of which is the "catalog cache".
+    # When a connection is established to the database, this cache is initialized alongside it, and persists for the duration of the connection.
+    # This cache contains references to Database Objects, such as indexes, etc. (not data records themselves).
     # This cache is not cleaned up by the system automatically. However, if the connection is disconnected, the cache is dumped.
     # further reading: Postgres community email thread: https://www.postgresql.org/message-id/flat/20161219.201505.11562604.horiguchi.kyotaro@lab.ntt.co.jp.
     # The default connection pool does not support closing connections.We must be able to close connections on demand
@@ -385,6 +517,7 @@ module Loader
     # [docs](https://www.rubydoc.info/github/jeremyevans/sequel/Sequel/ShardedThreadedConnectionPool)
     def release_db_connection
       Sequel::Model.db.disconnect
-    end  
+    end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -22,7 +22,12 @@ Rails.application.configure do
     # When enabled, policy load extensions cause the policy orchestration
     # to emit lifecycle event callbacks (e.g. before_insert, after_load_policy)
     # during policy load.
-    policy_load_extensions: false
+    policy_load_extensions: false,
+
+    # If enabled, the Roles API will emit callbacks to extensions for
+    # before/after events when role memberships are added or removed
+    # through the REST API.
+    roles_api_extensions: false
   }.freeze
 
   config.feature_flags = Conjur::FeatureFlags::Features.new(

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,29 @@
+Rails.application.configure do
+  # Loads Feature Flag configuration.
+  #
+  # The `feature_flags` arguement is an array of valid feature flags (as Ruby
+  # Symbols) used in Conjur to limit or prevent access to a new feature.
+  #
+  # By default, all feature flags are toggled "Off".  A feature can be enabled
+  # by setting an environment variable of the following form:
+  #
+  # CONJUR_FEATURE_<feature_name>_ENABLED=true
+  #
+  # <feature_name> must match the flag provide in the `feature_flags` arguement.
+  #
+  # The feature flag is available for using the following form:
+  #
+  # Rails.configuration.feature_flags.enabled?(:feature_name)
+
+  # Hash of feature flags. The hash key is the feature flag name, the value is
+  # the status if no flag is given (its default state).
+  # ex. { telemetry: true }
+  feature_flags = {
+  }.freeze
+
+  config.feature_flags = Conjur::FeatureFlags::Features.new(
+    logger: Rails.logger,
+    environment_settings: ENV,
+    feature_flags: feature_flags
+  )
+end

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -19,6 +19,10 @@ Rails.application.configure do
   # the status if no flag is given (its default state).
   # ex. { telemetry: true }
   feature_flags = {
+    # When enabled, policy load extensions cause the policy orchestration
+    # to emit lifecycle event callbacks (e.g. before_insert, after_load_policy)
+    # during policy load.
+    policy_load_extensions: false
   }.freeze
 
   config.feature_flags = Conjur::FeatureFlags::Features.new(

--- a/design/extensions.md
+++ b/design/extensions.md
@@ -1,0 +1,95 @@
+# Extensions
+
+Extensions allow for low-level integration with Conjur application lifecycle
+events. This is useful for detailed automation and application extensions (e.g.
+Enterprise Conjur services).
+
+Extensions are an experimental feature and each group of available extension
+points is currently disabled by default and may be enabled with a
+[feature flag](./feature_flags.md).
+
+## Functional Overview
+
+Extensions are implemented as Ruby source code, co-located by the Conjur
+application server. Extensions are added as subdirectories under
+`{conjur-base-directory}/extensions`. The name of the extension is the name of the
+subdirectory. For example, an extension named `my-extension` must live in the
+subdirectory `{conjur-base-directory}/extension/my-extension`).
+
+The entrypoint for a Conjur extension is a Ruby source file (`*.rb`) that also
+uses the extension name as the filename. So the entrypoint for `my-extension`
+must be located at
+`{conjur-base-directory}/extension/my-extension/my-extension.rb`.
+
+The extension entry point may load other Ruby source files that implement the
+extension, and registers individual classes with Conjur that implement
+particular extension points.
+
+Finally, for Conjur to auto-load an extension, it must be enabled in the Conjur
+config with either the `CONJUR_EXTENSIONS` environment variable or the
+`extensions` value in the `conjur.yml` configuration file. The environment
+variable must be a comma-delimited list of extensions name. The value in the
+`conjur.yml` config may either be a comma-delimited string or a YAML array of
+extension names.
+
+### Define a new extension
+
+To create a new extension (e.g. `my-extension`), create both a subdirectory
+and Ruby source file using the extension name under
+`{conjur-base-directory}/extensions`. For example:
+
+```sh
+{conjur-base-directory}/extension/my-extension/my-extension.rb
+```
+
+This source file is the extension entry point. It is used to:
+
+- Load other required Ruby source files
+- Register extension classes with Conjur
+
+For example:
+
+```ruby
+# {conjur-base-directory}/extension/my-extension/my-extension.rb
+
+require_relative 'my-extension-implementation'
+
+Conjur::Extension::Repository.register(
+  kind: :a_conjur_extension_point,
+  implementation_class: MyExtensionImplementation
+)
+```
+
+### Enable an extension
+
+There are two ways to allow Conjur to load an extension when it runs:
+
+- **Use `CONJUR_EXTENSIONS` environment variable**
+
+  The variable value must be a comma delimited string of extension names. For
+  example, to set the variable on a Docker container:
+
+  ```sh
+  docker run ... -e 'CONJUR_EXTENSIONS=my-extension,some-other-extension' ...
+  ```
+
+- **Use the `conjur.yml` config file**
+
+  Alternatively, the extensions may be set in the Conjur config file, such as:
+
+  ```yaml
+  ...
+  extensions:
+    - my-extension
+    - some-other-extension
+  ...
+  ```
+
+  After updating the config file, the configuration must be applied in Conjur
+  with the following command in the Conjur container:
+
+  ```sh
+  conjurctl configuration apply
+  ```
+
+## Available Extension Points

--- a/design/extensions.md
+++ b/design/extensions.md
@@ -93,3 +93,60 @@ There are two ways to allow Conjur to load an extension when it runs:
   ```
 
 ## Available Extension Points
+
+### Policy Load Callbacks
+
+Policy load callback extension classes receive event method calls during Conjur
+policy load orchestration.
+
+#### **Feature flag**
+
+Policy load callbacks are enabled with the feature flag
+`CONJUR_FEATURE_POLICY_LOAD_EXTENSIONS`.
+
+#### **Extension registration**
+
+Policy load callback extension classes are registered registered with the kind
+`:policy_load`. For example:
+
+```rb
+Conjur::ExtensionRepository.register(
+  kind: :policy_load,
+  implementation_class: ...
+)
+```
+
+#### **Available events**
+
+- `before_load_policy`, `after_load_policy`
+
+  Events before and after the policy load context (temporary database schema)
+  is created and dropped.
+
+  Arguments: `policy_version`
+
+- `after_create_schema`
+
+  Emitted after the temporary database schema is initialized.
+
+  Arguments: `policy_version`, `schema_name`
+
+- `before_insert`, `after_insert`
+
+  Emitted before and after new records are inserted into the primary database
+  schema.
+
+  Arguments: `policy_version`, `schema_name`
+
+- `before_update`, `after_update`
+
+  Emitted before and after existing records are updated in the primary database
+  schema.
+
+  Arguments: `policy_version`, `schema_name`
+
+- `before_delete`, `after_delete`
+
+  Emitted before after records are deleted from the primary database schema.
+
+  Arguments: `policy_version`, `schema_name`

--- a/design/extensions.md
+++ b/design/extensions.md
@@ -150,3 +150,46 @@ Conjur::ExtensionRepository.register(
   Emitted before after records are deleted from the primary database schema.
 
   Arguments: `policy_version`, `schema_name`
+
+### Roles API Callbacks
+
+Roles API callback extension classes receive event method calls when role
+members are added or removed using the Conjur REST API.
+
+#### **Feature flag**
+
+Roles API callbacks are enabled with the feature flag
+`CONJUR_FEATURE_ROLES_API_EXTENSIONS`.
+
+#### **Extension registration**
+
+Roles API callback extension classes are registered registered with the kind
+`:roles_api`. For example:
+
+```rb
+Conjur::ExtensionRepository.register(
+  kind: :roles_api,
+  implementation_class: ...
+)
+```
+
+#### **Available events**
+
+- `before_add_member`
+
+  Emitted before a member is added to a role with the Conjur REST API.
+
+  Arguments: `role`, `member`
+
+- `after_add_member`
+
+  Emitted after a member is added to a role with the Conjur REST API.
+
+  Arguments: `role`, `member`, `membership`
+
+- `before_delete_member`, `after_delete_member`
+
+  Emitted before and after a member is removed from a role with the Conjur REST
+  API.
+
+  Arguments: `role`, `member`, `membership`

--- a/design/feature_flags.md
+++ b/design/feature_flags.md
@@ -1,0 +1,48 @@
+# Feature Flags
+
+Feature flags enable partially completed or experimental features to be
+available in the official Conjur releases.
+[Martin Fowler](https://martinfowler.com/articles/feature-toggles.html) has an
+excellent article outlining various approaches to leveraging feature flags.
+
+## Functional Overview
+
+For our initial Feature Flag implementation only supports setting flags via
+environment variables. In the future, we should support feature flags through
+file-based as well.
+
+### Define a new feature flag
+
+To create a new feature flag, add the feature name to the `feature_flags` hash
+in `config/initializers/feature_flags.rb`. Set the hash entry value to the
+default state for the feature flag. For example, to create a feature flag
+for a feature called `Telemetry Endpoint`, add the following:
+
+```ruby
+feature_flags = {
+  telemetry_endpoint: false
+}
+```
+and restart Conjur.
+
+### Gate a feature
+
+After a new flag has been added to the `feature_flags` hash, the Telemetry
+Endpoint is now a valid feature flag. Functionality can be gated with the
+following:
+
+```ruby
+if Rails.configuration.feature_flags.enabled?(:telemetry_endpoint)
+  ... # Gated code here
+end
+```
+
+### Enable a feature
+
+To enable the Telemetry Endpoint feature, set the feature environment variable flag:
+
+```sh
+CONJUR_FEATURE_TELEMETRY_ENDPOINT_ENABLED=true
+```
+
+and restart Conjur to pick up the new flag setting.

--- a/lib/conjur/conjur_config.rb
+++ b/lib/conjur/conjur_config.rb
@@ -29,7 +29,8 @@ module Conjur
       user_authorization_token_ttl: 480, # The default TTL of User is 8 minutes
       host_authorization_token_ttl: 480, # The default TTL of Host is 8 minutes
       authn_api_key_default: true,
-      authenticators: []
+      authenticators: [],
+      extensions: []
     )
 
     def initialize(*args)
@@ -91,6 +92,10 @@ module Conjur
     end
 
     def authenticators=(val)
+      super(str_to_list(val)&.uniq)
+    end
+
+    def extensions=(val)
       super(str_to_list(val)&.uniq)
     end
 

--- a/lib/conjur/extension/extension.rb
+++ b/lib/conjur/extension/extension.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Conjur
+  module Extension
+    # Extension::Extension represents the Conjur interface to call
+    # extension points. It contains a set of classes that implement a particular
+    # extension and proxies method calls to those classes. It does so with an
+    # added safety of preventing errors in an extension from raising to the
+    # calling process, or from preventing other extensions from being called.
+    class Extension
+      def initialize(
+        implementations:,
+        logger: Rails.logger
+      )
+        @logger = logger
+        @implementations = implementations.to_set
+
+        @logger.debug(
+          "Extension::Extension - Using extension classes: " \
+          "#{@implementations.map(&:name).join(', ')}"
+        )
+      end
+
+      def call(method, **kwargs)
+        @logger.debug(
+          "Extension::Extension - Calling #{method}"
+        )
+
+        @implementations.each do |implementation|
+          implementation.call(method, **kwargs)
+        end
+      end
+    end
+  end
+end

--- a/lib/conjur/extension/implementation.rb
+++ b/lib/conjur/extension/implementation.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative './implementation_method'
+
+module Conjur
+  module Extension
+    # Extension::Implementation is a proxy wrapper around a Conjur extension
+    # class. It handles instantiating an instance of the extension class and
+    # proxying method calls to it through `#call`.
+    class Implementation
+
+      def self.from_class(
+        implementation_class,
+        logger: Rails.logger,
+        **kwargs
+      )
+        # Instantiate the extension class
+        implementation = ImplementationMethod.new(
+          # For the constructor, we're looking for the method on the class
+          # itself, rather than an instance of it.
+          implementation_object: implementation_class,
+          method: :new,
+          # These are dependencies the extension may use in its
+          # implementation. At a minimum, extension initializers must include
+          # a **kwargs initializer argument to consume any arguments it
+          # doesn't declare specifically.
+          logger: logger,
+          **kwargs
+        ).call
+
+        # Wrap the extension object with an Implementation proxy interface
+        Implementation.new(
+          implementation_object: implementation,
+          logger: logger
+        )
+      end
+
+      def initialize(
+        implementation_object:,
+        logger: Rails.logger
+      )
+        @implementation_object = implementation_object
+        @logger = logger
+      end
+
+      def name
+        @implementation_object.class.name
+      end
+
+      # Extension implementations are comparable by their class names
+      def hash
+        name.hash
+      end
+
+      def eql?(other)
+        name == other.name
+      end
+
+      # We use :reek:ManualDispatch to proxy the given method to each of the
+      # extension classes.
+      def call(method, **kwargs)
+        unless @implementation_object.respond_to?(method)
+          @logger.debug(
+            "Extension::Implementation#call - " \
+            "'#{implementation_class_name}' doesn't respond to " \
+            "'#{method}'"
+          )
+          return
+        end
+
+        @logger.debug(
+          "Extension::Implementation#call - Calling '#{method}' on " \
+          "'#{implementation_class_name}'"
+        )
+        begin
+          ImplementationMethod.new(
+            implementation_object: @implementation_object,
+            method: method,
+            **kwargs
+          ).call
+        rescue => e
+          # Failed extension calls do not bubble up exceptions. They are
+          # logged, but otherwise ignored by Conjur. Exceptions in extensions
+          # should be fully handled in the extension implementation itself.
+          @logger.error(
+            "Extension::Implementation - Failed to call '#{method}' on " \
+            "'#{implementation_class_name}': #{e.message}"
+          )
+        end
+      end
+
+      protected
+
+      def implementation_class_name
+        @implementation_object.class.name
+      end
+    end
+  end
+end

--- a/lib/conjur/extension/implementation_method.rb
+++ b/lib/conjur/extension/implementation_method.rb
@@ -1,0 +1,81 @@
+module Conjur
+  module Extension
+    # ImplementationMethod encapsulates a call to a Conjur Extension that
+    # safely proxies arguments to extension based on how the extension
+    # method was implemented. For example, if the extension call includes
+    # an argument, but the extension implementation doesn't define a parameter
+    # to accept it, then the method call would fail if call naively. So we
+    # finess the method calls to allow extensions to "just work" as much as
+    # possible.
+    class ImplementationMethod
+      def initialize(
+        implementation_object:,
+        method:,
+        **kwargs
+      )
+        @implementation_object = implementation_object
+        @method = method
+        @kwargs = kwargs
+      end
+
+      def call
+        # If the target method doesn't accept any parameters, we won't try to
+        # send any
+        if target_parameters.length.zero?
+          return @implementation_object.send(@method)
+        end
+
+        # If the target method declares parameters we can't provide, raise
+        # an error message with enough detail to identify the issue and
+        # resolve it
+        unless invalid_parameters.length.zero?
+          message = "Invalid target method parameters: " \
+                    "#{invalid_parameter_names.join(', ')}. The method " \
+                    "parameters must be empty or keyword args."
+
+          unless @kwargs.empty?
+            message += " The only required keyword arguments allowed are: " \
+                       "#{@kwargs.keys.join(', ')}"
+          end
+
+          raise StandardError, message
+        end
+
+        # If the given keyword args match the expected arguments, call the
+        # method
+        @implementation_object.send(@method, **@kwargs)
+      end
+
+      protected
+
+      def target_parameters
+        if @method == :new
+          # If we're trying to call :new on a class, we actually need to check
+          # the parameters on the :initialize instance method.
+          @implementation_object.instance_method(:initialize).parameters
+        else
+          @implementation_object.method(@method).parameters
+        end
+      end
+
+      def invalid_parameter_names
+        invalid_parameters.map { |param| param[1] }
+      end
+
+      def invalid_parameters
+        # Determine which parameters are invalid, by filtering out those
+        # that are valid.
+        @invalid_parameters ||= target_parameters.reject do |param|
+          param_type, param_name = param
+          # A parameter is valid if it's one of our known named kwargs
+          if param_type == :keyreq && @kwargs.keys.include?(param_name)
+            next true
+          end
+
+          # A parameter is valid if it's optional, otherwise it's invalid
+          next %i[opt key rest keyrest block].include?(param_type)
+        end
+      end
+    end
+  end
+end

--- a/lib/conjur/extension/repository.rb
+++ b/lib/conjur/extension/repository.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require_relative './extension'
+require_relative './implementation'
+
+module Conjur
+  module Extension
+    # Extension::Repository loads Conjur extensions from the file systems
+    # and allows Conjur to retrieve an interface (Extension Set) for
+    # calling methods on extension classes safely.
+    #
+    # :reek:TooManyInstanceVariables, :reek:InstanceVariableAssumption
+    class Repository
+      attr_reader :extensions
+
+      # ExtensionClass is uses to store the registered extension classes
+      # in a more strongly typed manner
+      RegisteredExtensionClass = Struct.new(
+        :kind,
+        :implementation_class,
+        keyword_init: true
+      )
+
+      @loaded_extensions = []
+      @registered_extension_classes = []
+
+      class << self
+        # This are intentionally writable to support testing
+        # :reek:Attribute
+        attr_accessor :loaded_extensions, :registered_extension_classes
+
+        # :reek:LongParameterList is due to dependency injection
+        def register(
+          kind:,
+          implementation_class:,
+          logger: Rails.logger,
+          registered_extension_classes: @registered_extension_classes
+        )
+          logger.info(
+            "Registering #{kind} extension: " \
+            "#{implementation_class} " \
+            "(#{Object.const_source_location(implementation_class.name).join(':')})"
+          )
+          registered_extension_classes.push(
+            RegisteredExtensionClass.new(
+              kind: kind,
+              implementation_class: implementation_class
+            )
+          )
+        end
+      end
+
+      # auto_load is not a control parameter for the class as a whole, but
+      # only whether it tries to pre-load available Conjur extensions
+      # :reek:BooleanParameter :reek:ControlParameter
+      #
+      # :reek:LongParameterList due to dependency injection
+      def initialize(
+        extensions_dir: File.join(Dir.getwd, 'extensions'),
+        logger: Rails.logger,
+        extensions: Rails.application.config.conjur_config.extensions,
+        extension_cls: Extension,
+        implementation_cls: Implementation,
+        auto_load: true
+      )
+        @extensions_dir = extensions_dir
+        @logger = logger
+        @extensions = extensions
+        @extension_cls = extension_cls
+        @implementation_cls = implementation_cls
+
+        return unless auto_load
+
+        # Only attempt to load the extensions that are configured to load
+        @extensions.each do |name|
+          load_extension(name)
+        end
+      end
+
+      # Load an individual extension by name from the extensions directory
+      def load_extension(name)
+        # Check that we haven't already loaded this extension
+        return false if already_loaded?(name)
+
+        @logger.info("Loading extension: #{name}")
+        extension_path = File.join(
+          @extensions_dir,
+          name,
+          "#{name}.rb"
+        )
+
+        # Check that the requested extension exists where it is expected
+        return false unless exist?(extension_path)
+
+        # Load the extension source file
+        @logger.debug(
+          "Extension::Repository - Loading extension from '#{extension_path}'"
+        )
+        return false unless load(extension_path, wrap: true)
+
+        # Record that we've loaded this extension
+        self.class.loaded_extensions.push(name)
+
+        true
+      end
+
+      # returns an Extension::Extension object, used for calling extension
+      # methods from Conjur application code
+      def extension(kind:)
+        @extension_cls.new(
+          implementations: implementations_for_kind(kind),
+          logger: @logger
+        )
+      end
+
+      private
+
+      # :reek:DuplicateMethodCall due to ext.implementation_class, but factoring
+      # that to a variable doesn't improve performance or readability
+      def implementations_for_kind(kind)
+        self.class.registered_extension_classes
+          .select { |ext| ext.kind == kind }
+          .map do |ext|
+            @logger.debug(
+              "Extension::Repository - Initializing extension " \
+              "#{ext.implementation_class.name}"
+            )
+
+            @implementation_cls.from_class(
+              ext.implementation_class,
+              # Dependencies that are injected into the extension class
+              # initializers (when possible):
+              logger: @logger
+            )
+          rescue => e
+            @logger.warn(
+              "Extension::Repository - Cannot initialize extension " \
+              "'#{ext.implementation_class.name}': #{e.message}"
+            )
+            nil
+          end
+          .compact
+      end
+
+      def already_loaded?(name)
+        return false unless self.class.loaded_extensions.include?(name)
+
+        @logger.debug(
+          "Extension::Repository - Extension " \
+          "'#{name}' is already loaded"
+        )
+
+        true
+      end
+
+      def exist?(path)
+        dir = File.dirname(path)
+        unless File.directory?(dir)
+          @logger.debug(
+            "Extension::Repository - Expected extension " \
+            "directory at '#{dir}', but this path does not exist " \
+            "or is not a directory"
+          )
+
+          return false
+        end
+
+        unless File.file?(path)
+          @logger.debug(
+            "Extension::Repository - Expected extension " \
+            "file at '#{path}', but this path does not exist or is " \
+            "not a file"
+          )
+
+          return false
+        end
+
+        # The extension directory and file exist in the extensions directory
+        true
+      end
+    end
+  end
+end

--- a/lib/conjur/feature_flags.rb
+++ b/lib/conjur/feature_flags.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Conjur
+  module FeatureFlags
+    # Provides feature flagging support
+    class Features
+      # Instantiates a new Conjur::FeatureFlags::Features object
+      #
+      # @param logger [Logger] the logger used for output
+      # @param environment_settings [Hash] the environment variable has
+      #   (typically ENV)
+      # @param feature_flags [Array<Symbol>] the list of valid feature flags
+      #
+      # @return [Conjur::FeatureFlags::Features]
+      def initialize(
+        logger: Rails.logger,
+        environment_settings: ENV,
+        feature_flags: {}
+      )
+        @logger = logger
+        @enabled_features = merge_with_environment_variable_flags(
+          features: feature_flags,
+          env: environment_settings
+        )
+      end
+
+      # Check to see if a feature flag has been enabled
+      #
+      # @param feature_name [Symbol] the feature flag we want to check
+      #
+      # @return [Boolean]
+      def enabled?(feature_name)
+        @logger.debug(
+          "Conjur::FeatureFlags::Features#enabled? " \
+          "- feature flag name: '#{feature_name.inspect}'"
+        )
+
+        validate(feature_name)
+        result = @enabled_features[feature_name]
+
+        @logger.debug(
+          "Conjur::FeatureFlags::Features#enabled? result: '#{result}'"
+        )
+
+        result
+      end
+
+      private
+
+      # Verifies that the feature flag is valid
+      #
+      # @param feature_name [Symbol] the feature flag we want to check
+      #
+      # @return [nil]
+      def validate(feature_name)
+        unless feature_name.is_a?(Symbol)
+          raise ArgumentError, 'Feature name must be a symbol'
+        end
+
+        return if @enabled_features.key?(feature_name)
+
+        raise InvalidFeatureFlagError, feature_name
+      end
+
+      # Builds a hash of the feature flags whether they should be toggled on or
+      # off. Environment variable flags are set with the following format:
+      #   CONJUR_FEATURE_<feature_name>_ENABLED
+      #
+      # @param features [Array<Symbol>] list of feature flags
+      # @param environment [Hash] the environment variables and their values
+      #
+      # @return [Hash<Symbol>:<Boolean>] hash of feature names and their enabled
+      #   state (true/false)
+      def merge_with_environment_variable_flags(features:, env:)
+        features.to_h do |feature, default_value|
+          env_key = "CONJUR_FEATURE_#{feature.upcase}_ENABLED"
+
+          # Check environment variable for feature flag
+          # We only care about specific 'true' or 'false' values
+          case env[env_key].to_s.downcase
+          when 'true'
+            @logger.debug(
+              "Feature '#{feature}' enabled via " \
+              "environment variable '#{env_key}'"
+            )
+
+            next [feature, true]
+          when 'false'
+            @logger.debug(
+              "Feature '#{feature}' disabled via " \
+              "environment variable '#{env_key}'"
+            )
+
+            next [feature, false]
+          end
+
+          # Only log for default state if the flag is enabled by default
+          if default_value
+            @logger.debug("Feature '#{feature}' enabled by default")
+          end
+
+          [feature, default_value]
+        end
+      end
+
+      # Provides an error for when an invalid flag is passed to the
+      # `enabled?` method. The flag must be in the list of valid flags.
+      class InvalidFeatureFlagError < StandardError
+        def initialize(flag_name)
+          super("Feature flag not defined: #{flag_name}")
+        end
+      end
+    end
+  end
+end

--- a/lib/test/audit_sink.rb
+++ b/lib/test/audit_sink.rb
@@ -36,7 +36,10 @@ module Test
     end
 
     def socket_path
-      @socket_path ||= "audit_test_#{Process.pid}_#{Thread.current.object_id}.sock"
+      @socket_path ||= File.join(
+        Dir.tmpdir,
+        "audit_test_#{Process.pid}_#{Thread.current.object_id}.sock"
+      )
     end
 
     attr_reader :socket, :messages
@@ -45,7 +48,7 @@ module Test
       def instance
         @instance ||= new
       end
-      
+
       extend Forwardable
       def_delegators :instance, :messages
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+DatabaseCleaner.strategy = :truncation
+
+describe RolesController, type: :request do
+  before do
+    Slosilo["authn:rspec"] ||= Slosilo::Key.new
+  end
+
+  let(:current_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+
+  let(:role_url) do
+    '/roles/rspec/group/test'
+  end
+
+  describe '#add_member' do
+    before(:each) do
+      payload = <<~YAML
+        - !group test
+        - !group other
+      YAML
+
+      put(
+        '/policies/rspec/policy/root',
+        env: token_auth_header.merge({ 'RAW_POST_DATA' => payload })
+      )
+    end
+
+    context 'when the role API extensions are enabled' do
+      let(:extension_double) do
+        instance_double(Conjur::Extension::Extension)
+          .tap do |extension_double|
+            allow(extension_double)
+              .to receive(:call)
+          end
+      end
+
+      before do
+        allow_any_instance_of(Conjur::FeatureFlags::Features)
+          .to receive(:enabled?).with(:roles_api_extensions).and_return(true)
+
+        allow_any_instance_of(Conjur::Extension::Repository)
+          .to receive(:extension)
+          .with(kind: RolesController::ROLES_API_EXTENSION_KIND)
+          .and_return(extension_double)
+      end
+
+      it "loads the extension classes" do
+        expect_any_instance_of(Conjur::Extension::Repository)
+          .to receive(:extension)
+          .with(kind: RolesController::ROLES_API_EXTENSION_KIND)
+
+        post("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+
+      it "emits the expected callbacks" do
+        expect(extension_double)
+          .to receive(:call)
+          .with(:before_add_member, role: anything, member: anything)
+
+        expect(extension_double)
+          .to receive(:call)
+          .with(:after_add_member, role: anything, member: anything, membership: anything)
+
+        post("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+    end
+
+    context 'when the role API extensions are disabled' do
+      before do
+        allow_any_instance_of(Conjur::FeatureFlags::Features)
+          .to receive(:enabled?).with(:roles_api_extensions).and_return(false)
+      end
+
+      it "does not load the extension classes" do
+        expect_any_instance_of(Conjur::Extension::Repository)
+          .not_to receive(:extension_set)
+          .with(RolesController::ROLES_API_EXTENSION_KIND)
+
+        post("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+    end
+  end
+
+  describe '#delete_member' do
+    before(:each) do
+      payload = <<~YAML
+        - !group test
+        - !group other
+
+        - !grant
+          role: !group test
+          member: !group other
+      YAML
+
+      put(
+        '/policies/rspec/policy/root',
+        env: token_auth_header.merge({ 'RAW_POST_DATA' => payload })
+      )
+    end
+
+    context 'when the role API extensions are enabled' do
+      let(:extension_double) do
+        instance_double(Conjur::Extension::Extension)
+          .tap do |extension_double|
+            allow(extension_double)
+              .to receive(:call)
+          end
+      end
+
+      before do
+        allow_any_instance_of(Conjur::FeatureFlags::Features)
+          .to receive(:enabled?).with(:roles_api_extensions).and_return(true)
+
+        allow_any_instance_of(Conjur::Extension::Repository)
+          .to receive(:extension)
+          .with(kind: RolesController::ROLES_API_EXTENSION_KIND)
+          .and_return(extension_double)
+      end
+
+      it "loads the extension classes" do
+        expect_any_instance_of(Conjur::Extension::Repository)
+          .to receive(:extension)
+          .with(kind: RolesController::ROLES_API_EXTENSION_KIND)
+
+        delete("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+
+      it "runs the expected callbacks" do
+        expect(extension_double)
+          .to receive(:call)
+          .with(:before_delete_member, role: anything, member: anything, membership: anything)
+
+        expect(extension_double)
+          .to receive(:call)
+          .with(:after_delete_member, role: anything, member: anything, membership: anything)
+
+        delete("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+    end
+
+    context 'when the role API extensions are disable' do
+      it "does not load the extension classes" do
+        expect_any_instance_of(Conjur::Extension::Repository)
+          .not_to receive(:extension)
+          .with(RolesController::ROLES_API_EXTENSION_KIND)
+
+        delete("#{role_url}?members&member=rspec:group:other", env: token_auth_header)
+      end
+    end
+  end
+
+  let(:token_auth_header) do
+    bearer_token = Slosilo["authn:rspec"].signed_token(current_user.login)
+    token_auth_str =
+      "Token token=\"#{Base64.strict_encode64(bearer_token.to_json)}\""
+    { 'HTTP_AUTHORIZATION' => token_auth_str }
+  end
+end

--- a/spec/fixtures/extensions/test_extension/test_extension.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative './test_extension_a'
+require_relative './test_extension_b'
+require_relative './test_extension_c'
+require_relative './test_extension_d'
+require_relative './test_extension_e'
+require_relative './test_extension_f'
+
+# To ensure we're not calling any outside code we don't expect, all extension
+# code must be explicitly declared up front.
+#
+# Because we're referencing the classname before it is actually loaded
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionA
+)
+
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionB
+)
+
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionC
+)
+
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionD
+)
+
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionE
+)
+
+Conjur::Extension::Repository.register(
+  kind: :rspec,
+  implementation_class: TestExtensionF
+)

--- a/spec/fixtures/extensions/test_extension/test_extension_a.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_a.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TestExtensionA
+  def initialize(logger:)
+    @logger = logger
+  end
+
+  def on_callback(**_kwarg); end
+end

--- a/spec/fixtures/extensions/test_extension/test_extension_b.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_b.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class TestExtensionB
+  def initialize(**_kwargs); end
+
+  def on_callback
+  end
+end

--- a/spec/fixtures/extensions/test_extension/test_extension_c.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_c.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TestExtensionC
+end

--- a/spec/fixtures/extensions/test_extension/test_extension_d.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_d.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TestExtensionD
+  def initialize(_required_arg); end
+end

--- a/spec/fixtures/extensions/test_extension/test_extension_e.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_e.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TestExtensionE
+  def on_callback(required_param:); end
+end

--- a/spec/fixtures/extensions/test_extension/test_extension_f.rb
+++ b/spec/fixtures/extensions/test_extension/test_extension_f.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TestExtensionF
+  def on_callback
+    raise 'failure in the extension'
+  end
+end

--- a/spec/lib/conjur/extension/extension_spec.rb
+++ b/spec/lib/conjur/extension/extension_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'logger'
+require 'conjur/extension/extension'
+
+describe Conjur::Extension::Extension do
+  # Test dependencies
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+  let(:extensions_dir) { File.expand_path('../../../../fixtures/extensions', __FILE__) }
+  let(:extensions) { [ 'test_extension' ] }
+  let(:auto_load) { false }
+
+  subject(:extension_repository) do
+    Conjur::Extension::Repository.new(
+      extensions_dir: extensions_dir,
+      logger: logger,
+      extensions: extensions,
+      auto_load: auto_load
+    )
+  end
+
+  before do
+    extension_repository.load_extension('test_extension')
+  end
+
+  subject(:extension_set) do
+    Conjur::Extension::Extension.new(
+      implementations: [
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionA,
+          logger: logger
+        ),
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionB,
+          logger: logger
+        ),
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionC,
+          logger: logger
+        ),
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionE,
+          logger: logger
+        ),
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionF,
+          logger: logger
+        )
+      ],
+      logger: logger
+    )
+  end
+
+  describe '#call' do
+    it 'calls the method on classes that implement the method' do
+      expect_any_instance_of(TestExtensionA).to receive(:on_callback)
+      expect_any_instance_of(TestExtensionB).to receive(:on_callback)
+
+      extension_set.call(:on_callback)
+    end
+
+    it "logs classes that don't respond to the message" do
+      extension_set.call(:on_callback)
+      expect(log_output.string).to include(
+        "'TestExtensionC' doesn't respond to 'on_callback'"
+      )
+    end
+
+    it "logs classes that don't have a usable method signatures" do
+      extension_set.call(:on_callback)
+      expect(log_output.string).to include(
+        "Failed to call 'on_callback' on 'TestExtensionE': " \
+        "Invalid target method parameters: required_param. " \
+        "The method parameters must be empty or keyword args"
+      )
+    end
+
+    it "logs classes that raise an exception when called" do
+      extension_set.call(:on_callback)
+      expect(log_output.string).to include(
+        "Failed to call 'on_callback' on 'TestExtensionF': failure in the extension"
+      )
+    end
+  end
+end

--- a/spec/lib/conjur/extension/implementation_spec.rb
+++ b/spec/lib/conjur/extension/implementation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'logger'
+require 'conjur/extension/implementation'
+
+describe Conjur::Extension::Implementation do
+  # Test dependencies
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+  let(:extensions_dir) { File.expand_path('../../../../fixtures/extensions', __FILE__) }
+  let(:extensions) { [ 'test_extension' ] }
+  let(:auto_load) { false }
+
+  subject(:extension_repository) do
+    Conjur::Extension::Repository.new(
+      extensions_dir: extensions_dir,
+      logger: logger,
+      extensions: extensions,
+      auto_load: auto_load
+    )
+  end
+
+  before do
+    extension_repository.load_extension('test_extension')
+  end
+
+  context "when the extension class cannot be initialized" do
+    it "raise an error" do
+      expect do
+        Conjur::Extension::Implementation.from_class(
+          TestExtensionD
+        )
+      end
+        .to raise_error(/Invalid target method parameters: _required_arg/)
+    end
+  end
+end

--- a/spec/lib/conjur/extension/repository_spec.rb
+++ b/spec/lib/conjur/extension/repository_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'logger'
+require 'conjur/extension/repository'
+
+class TestExtensionClass; end
+
+describe Conjur::Extension::Repository do
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+  let(:extensions_dir) do
+    File.expand_path('../../../../fixtures/extensions', __FILE__)
+  end
+  let(:extensions) { [ 'test_extension' ] }
+  let(:auto_load) { true }
+  let(:extension_cls_double) do
+    double(Conjur::Extension::Extension)
+  end
+
+  before(:each) do
+    # Reset the extension classes before each test
+    Conjur::Extension::Repository.loaded_extensions = []
+    Conjur::Extension::Repository.registered_extension_classes = []
+  end
+
+  subject(:repository) do
+    Conjur::Extension::Repository.new(
+      extensions_dir: extensions_dir,
+      logger: logger,
+      extensions: extensions,
+      extension_cls: extension_cls_double,
+      auto_load: auto_load
+    )
+  end
+
+  describe 'self#register' do
+    it 'adds the extension to the registered extensions collection' do
+      Conjur::Extension::Repository.register(
+        kind: :rspec,
+        implementation_class: TestExtensionClass,
+        logger: logger
+      )
+
+      expect(Conjur::Extension::Repository.registered_extension_classes)
+        .to include(
+          have_attributes(
+            kind: :rspec,
+            implementation_class: TestExtensionClass
+          )
+        )
+    end
+
+    it 'logs the registration' do
+      Conjur::Extension::Repository.register(
+        kind: :rspec,
+        implementation_class: TestExtensionClass,
+        logger: logger
+      )
+
+      expect(log_output.string)
+        .to match(%r{Registering rspec extension: TestExtensionClass \(\/src\/conjur-server\/spec\/lib\/conjur\/extension/repository_spec.rb:\d+\)})
+    end
+  end
+
+  describe '#loaded_extensions' do
+    it 'returns the configured and available extensions' do
+      expect(repository.class.loaded_extensions).to include('test_extension')
+    end
+
+    it 'logs that the extensions are loaded' do
+      repository.class.loaded_extensions
+
+      expect(log_output.string).to include('Loading extension: test_extension')
+    end
+  end
+
+  describe '#load' do
+    let(:auto_load) { false }
+
+    it 'loads the given extension' do
+      expect(repository.load_extension('test_extension')).to be(true)
+      expect(repository.class.loaded_extensions).to include('test_extension')
+    end
+
+    it 'registers the classes in the extension' do
+      repository.load_extension('test_extension')
+
+      expect(repository.class.registered_extension_classes)
+        .to include(
+          have_attributes(
+            kind: :rspec,
+            implementation_class: TestExtensionA
+          )
+        )
+
+      expect(repository.class.registered_extension_classes)
+        .to include(
+          have_attributes(
+            kind: :rspec,
+            implementation_class: TestExtensionB
+          )
+        )
+
+      expect(repository.class.registered_extension_classes)
+        .to include(
+          have_attributes(
+            kind: :rspec,
+            implementation_class: TestExtensionC
+          )
+        )
+    end
+
+    it 'logs the loaded extension' do
+      repository.load_extension('test_extension')
+      expect(log_output.string).to include('Loading extension: test_extension')
+    end
+
+    context 'When the extension is already loaded' do
+      before do
+        repository.load_extension('test_extension')
+      end
+
+      it 'does not load an extension' do
+        expect(repository.load_extension('test_extension')).to be(false)
+      end
+
+      it 'logs the failure' do
+        repository.load_extension('test_extension')
+        expect(log_output.string)
+          .to include(
+            "Extension 'test_extension' is already loaded"
+          )
+      end
+    end
+
+    context "When the extension's directory doesn't exist" do
+      it 'does not load an extension' do
+        expect(repository.load_extension('nonexistent_extension')).to be(false)
+      end
+
+      it 'logs the failure' do
+        subject.load_extension('nonexistent_extension')
+        expect(log_output.string)
+          .to include(
+            "Expected extension directory at " \
+            "'/src/conjur-server/spec/fixtures/extensions/nonexistent_extension', " \
+            "but this path does not exist or is not a directory"
+          )
+      end
+    end
+
+    context "When the extension's file doesn't exist" do
+      it 'does not load an extension' do
+        expect(repository.load_extension('no_file_extension')).to be(false)
+      end
+
+      it 'logs the failure' do
+        repository.load_extension('no_file_extension')
+        expect(log_output.string)
+          .to include(
+            "Expected extension file at " \
+            "'/src/conjur-server/spec/fixtures/extensions/no_file_extension/no_file_extension.rb', " \
+            "but this path does not exist or is not a file"
+          )
+      end
+    end
+  end
+
+  describe '#extension' do
+    before do
+      # We need to ensure the repository is created first
+      # so that the TestExtension classes are loaded.
+      repository
+    end
+
+    it 'creates an extension object' do
+      expect(extension_cls_double)
+        .to receive(:new)
+        .with(
+          hash_including(
+            implementations: [
+              have_attributes(name: 'TestExtensionA'),
+              have_attributes(name: 'TestExtensionB'),
+              have_attributes(name: 'TestExtensionC'),
+              # TestExtensionD is excluded because it can't be initialized
+              have_attributes(name: 'TestExtensionE'),
+              have_attributes(name: 'TestExtensionF')
+            ]
+          )
+        )
+
+      repository.extension(kind: :rspec)
+    end
+  end
+end

--- a/spec/lib/conjur/feature_flags_spec.rb
+++ b/spec/lib/conjur/feature_flags_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'conjur/feature_flags'
+
+describe Conjur::FeatureFlags::Features do
+  describe '#enabled?' do
+    let(:log_output) { StringIO.new }
+    let(:logger) { Logger.new(log_output) }
+    let(:feature_flags) do
+      {
+        foo: false,
+        bar: false,
+        baz: false
+      }
+    end
+
+    let(:environment_settings) do
+      {
+        'FOO' => 'true',
+        'CONJUR_FEATURE_BAR_ENABLED' => 'true',
+        'CONJUR_FEATURE_BLANK_ENABLED' => 'true'
+      }
+    end
+
+    subject do
+      Conjur::FeatureFlags::Features.new(
+        logger: logger,
+        environment_settings: environment_settings,
+        feature_flags: feature_flags
+      )
+    end
+
+    context 'a feature is enabled by default' do
+      let(:feature_flags) do
+        {
+          default_feature: true
+        }
+      end
+
+      context 'with value `false`' do
+        let(:environment_settings) do
+          { 'CONJUR_FEATURE_DEFAULT_FEATURE_ENABLED' => 'false' }
+        end
+
+        it 'returns false' do
+          expect(subject.enabled?(:default_feature)).to be(false)
+        end
+      end
+
+      context 'with no value' do
+        let(:environment_settings) { {} }
+
+        it 'returns true' do
+          expect(subject.enabled?(:default_feature)).to be(true)
+        end
+      end
+
+      context 'with blank value' do
+        let(:environment_settings) do
+          { 'CONJUR_FEATURE_DEFAULT_FEATURE_ENABLED' => '' }
+        end
+
+        it 'returns true' do
+          expect(subject.enabled?(:default_feature)).to be(true)
+        end
+      end
+
+      context 'with value `Falsey`' do
+        let(:environment_settings) do
+          { 'CONJUR_FEATURE_BLANK_ENABLED' => 'Falsey' }
+        end
+
+        it 'returns true' do
+          expect(subject.enabled?(:default_feature)).to be(true)
+        end
+      end
+    end
+
+    context 'a feature is enabled' do
+      context 'and declared' do
+        context 'with value `true`' do
+          it 'returns true' do
+            expect(subject.enabled?(:bar)).to be(true)
+          end
+
+          it 'logs the environment variable' do
+            subject
+            expect(log_output.string).to include('DEBUG')
+            expect(log_output.string).to include('CONJUR_FEATURE_BAR_ENABLED')
+          end
+        end
+
+        context 'with value `false`' do
+          let(:environment_settings) do
+            { 'CONJUR_FEATURE_BLANK_ENABLED' => 'false' }
+          end
+          let(:feature_flags) { { blank: false } }
+
+          it 'returns false' do
+            expect(subject.enabled?(:blank)).to be(false)
+          end
+        end
+
+        context 'with value `Truthy`' do
+          let(:environment_settings) do
+            { 'CONJUR_FEATURE_BLANK_ENABLED' => 'Truthy' }
+          end
+          let(:feature_flags) { { blank: false } }
+
+          it 'returns false' do
+            expect(subject.enabled?(:blank)).to be(false)
+          end
+        end
+      end
+
+      context 'and not declared' do
+        it 'returns false' do
+          expect(subject.enabled?(:baz)).to be(false)
+        end
+      end
+    end
+
+    context 'argument is not a symbol' do
+      it 'returns an error' do
+        expect { subject.enabled?('bar') }.to raise_error(
+          ArgumentError,
+          'Feature name must be a symbol'
+        )
+      end
+    end
+
+    context 'argument is not a valid flag' do
+      it 'returns an error' do
+        expect { subject.enabled?(:blank) }.to raise_error(
+          Conjur::FeatureFlags::Features::InvalidFeatureFlagError,
+          'Feature flag not defined: blank'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

The outcome of this PR is to expose Conjur application events through callback extensions that may be used in Conjur enterprise to trigger further logic based on these events (e.g. when a policy is loaded, when role membership is modified).

Further, as these are experimental capabilities, they are added behind feature flags to avoid them impacting general
use of Conjur.

### Implemented Changes

This PR:

- Adds the ability to configure Feature flags for gating application changes unless specifically enabled.
- Adds the ability to load allow-listed extensions for Conjur
- Adds an extension point for receiving callbacks from Conjur policy load lifecycle events
- Adds an extension point for receiving role member callbacks for changes through the Roles REST API.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-26940](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26940)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
