### PR TITLE
Add refresh_token logic and tests to OIDC API

### DIFF
--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -15,8 +15,11 @@ module Authentication
 
         # Don't love this name...
         def callback(args)
-            jwt, refresh_token = nil, nil
+          jwt, refresh_token = nil, nil
           if args[:refresh_token]
+            unless args[:nonce].present?
+              raise Errors::Authentication::RequestBody::MissingRequestParam, 'nonce'
+            end
             jwt, refresh_token = @client.get_token_with_refresh_token(
               refresh_token: args[:refresh_token],
               nonce: args[:nonce]

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -21,9 +21,6 @@ module Authentication
               refresh_token: args[:refresh_token],
               nonce: args[:nonce]
             )
-
-            # Re-use the same refresh token if rotation not enabled
-            refresh_token = args[:refresh_token] if refresh_token.nil?
           else
             %i[code nonce code_verifier].each do |param|
               unless args[param].present?

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -30,7 +30,7 @@ module Authentication
         )
       end
 
-      def call(parameters:, body:, request_ip:)
+      def call(parameters:, request_ip:)
 
         # Load Authenticator policy and values (validates data stored as variables)
         authenticator = @authn_repo.find(
@@ -45,8 +45,6 @@ module Authentication
             "Unable to find authenticator with account: #{parameters[:account]} and service-id: #{parameters[:service_id]}"
           )
         end
-
-        populate_oidc_params(parameters, body)
 
         identity, headers_h = @strategy.new(
           authenticator: authenticator
@@ -79,12 +77,6 @@ module Authentication
       rescue => e
         log_audit_failure(parameters[:account], parameters[:service_id], request_ip, @authenticator_type, e)
         handle_error(e)
-      end
-
-      def populate_oidc_params(parameters, body)
-        %i[code nonce code_verifier state refresh_token].each do |param|
-          parameters[param] = body[param] if body[param]
-        end
       end
 
       def handle_error(err)

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -30,7 +30,8 @@ module Authentication
         )
       end
 
-      def call(parameters:, request_ip:)
+      def call(parameters:, body:, request_ip:)
+
         # Load Authenticator policy and values (validates data stored as variables)
         authenticator = @authn_repo.find(
           type: @authenticator_type,
@@ -44,6 +45,8 @@ module Authentication
             "Unable to find authenticator with account: #{parameters[:account]} and service-id: #{parameters[:service_id]}"
           )
         end
+
+        populate_oidc_params(parameters, body)
 
         identity, headers_h = @strategy.new(
           authenticator: authenticator
@@ -76,6 +79,12 @@ module Authentication
       rescue => e
         log_audit_failure(parameters[:account], parameters[:service_id], request_ip, @authenticator_type, e)
         handle_error(e)
+      end
+
+      def populate_oidc_params(parameters, body)
+        %i[code nonce code_verifier state refresh_token].each do |param|
+          parameters[param] = body[param] if body[param]
+        end
       end
 
       def handle_error(err)

--- a/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+++ b/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
@@ -84,6 +84,7 @@ module AuthenticatorHelpers
   def post(path, payload, options = {})
     result             = RestClient.post(path, payload, options)
     @response_body     = result.body
+    @response_headers  = result.headers
     @http_status       = result.code
   rescue RestClient::Exception => e
     @rest_client_error = e

--- a/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
@@ -71,6 +71,17 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
     And The authentication response includes header "X-OIDC-Refresh-Token"
 
   @smoke
+  Scenario: A valid refresh token to get Conjur access token and OIDC refresh token
+    Given I enable OIDC V2 refresh token flows for "keycloak2"
+    And I fetch a code for username "alice" and password "alice"
+    And I authenticate via OIDC V2 with code
+    And The authentication response includes header "X-OIDC-Refresh-Token"
+    When I store the current access token
+    And I authenticate via OIDC V2 with refresh token
+    Then user "alice" has been authorized by Conjur
+    And a new access token was issued
+
+  @smoke
   Scenario: A valid code with email as claim mapping
     Given I extend the policy with:
     """

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -164,6 +164,24 @@ When(/^I authenticate via OIDC V2 with code "([^"]*)"$/) do |code|
   )
 end
 
+When(/^I authenticate via OIDC V2 with refresh token$/) do 
+  authenticate_with_oidc_refresh_token(
+    service_id: @context.get(:service_id),
+    account: @context.get(:account),
+    refresh_token: @context.get(:x_oidc_refresh_token),
+    nonce: @context.get(:nonce)
+  )
+end
+
+When(/^I store the current access token$/) do
+  @context.set(:access_token => retrieved_access_token)
+end
+
+When(/^a new access token was issued$/) do
+  previous_token = @context.get(:access_token)
+  expect(retrieved_access_token.token).not_to eq(@context.get(:access_token).token)
+end
+
 When(/^I authenticate via OIDC V2 with no code in the request$/) do
   authenticate_with_oidc_code(
     service_id: @context.get(:service_id),
@@ -216,7 +234,10 @@ end
 
 Then(/^The authentication response includes header "([^"]*)"$/) do |header|
   header_sym = header.parameterize.underscore.to_sym
-  expect(@response_headers[header_sym]).not_to be_nil
+  # Store header for future steps
+  header_val = @response_headers[header_sym]
+  @context.set(header_sym => header_val)
+  expect(header_val).not_to be_nil
 end
 
 Then(/^The Okta user has been authorized by Conjur/) do

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -33,6 +33,12 @@ module AuthnOidcHelper
     get(url)
   end
 
+  def authenticate_with_oidc_refresh_token(service_id:, account:, refresh_token:, nonce:)
+    path = authn_url(type: 'oidc', account: account, service_id: service_id)
+    payload = {:refresh_token => refresh_token, :nonce => nonce}
+    post(path, payload)
+  end
+
   # Generic Authenticator URL builder
   def authn_url(type:, account:, service_id: nil, user_id: nil, params: {})
     path = [

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_helper.rb
@@ -29,8 +29,8 @@ module AuthnOidcHelper
   end
 
   def authenticate_with_oidc_code(service_id:, account:, params: {})
-    url = authn_url(type: 'oidc', account: account, service_id: service_id, params: params)
-    get(url)
+    path = authn_url(type: 'oidc', account: account, service_id: service_id)
+    post(path, params)
   end
 
   def authenticate_with_oidc_refresh_token(service_id:, account:, refresh_token:, nonce:)

--- a/spec/app/domain/authentication/authn-oidc/v2/strategy_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/strategy_spec.rb
@@ -100,15 +100,6 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
           expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)
         end
 
-        it 'returns the role and refresh token when passed a refresh token' do
-          expect(current_client).to receive(:get_token_with_refresh_token)
-            .with(:refresh_token => 'token', :nonce => nil)
-          role, headers_h = strategy.callback(refresh_token: 'token')
-
-          expect(role).to eq("alice")
-          expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)
-        end
-
         it 'returns the role and refresh token when passed a refresh token and nonce' do
           expect(current_client).to receive(:get_token_with_refresh_token)
             .with(:refresh_token => 'token', :nonce => 'nonce')
@@ -116,6 +107,13 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
 
           expect(role).to eq("alice")
           expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)
+        end
+        
+        context 'when nonce is missing' do
+          it 'raises a `MissingRequestParam` error' do
+            expect { strategy.callback(refresh_token: 'token') }
+              .to raise_error(Errors::Authentication::RequestBody::MissingRequestParam)
+          end
         end
       end
     end

--- a/spec/app/domain/authentication/authn-oidc/v2/strategy_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/strategy_spec.rb
@@ -84,13 +84,35 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
       let(:current_client) do
         instance_double(::Authentication::AuthnOidc::V2::Client).tap do |double|
           allow(double).to receive(:get_token_with_code).and_return([jwt, refresh_token])
+          allow(double).to receive(:get_token_with_refresh_token).and_return([jwt, refresh_token])
         end
       end
 
+      let(:mapping) { "claim_mapping" }
+
       context 'when a role_id matches the identity exist' do
-        let(:mapping) { "claim_mapping" }
-        it 'returns the role and its refresh token' do
+        it 'returns the role and refresh token when passed an authz code' do
+          expect(current_client).to receive(:get_token_with_code)
+            .with(:nonce => 'nonce', :code => 'code', :code_verifier => 'foo')
           role, headers_h = strategy.callback(nonce: 'nonce', code: 'code', code_verifier: 'foo')
+
+          expect(role).to eq("alice")
+          expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)
+        end
+
+        it 'returns the role and refresh token when passed a refresh token' do
+          expect(current_client).to receive(:get_token_with_refresh_token)
+            .with(:refresh_token => 'token', :nonce => nil)
+          role, headers_h = strategy.callback(refresh_token: 'token')
+
+          expect(role).to eq("alice")
+          expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)
+        end
+
+        it 'returns the role and refresh token when passed a refresh token and nonce' do
+          expect(current_client).to receive(:get_token_with_refresh_token)
+            .with(:refresh_token => 'token', :nonce => 'nonce')
+          role, headers_h = strategy.callback(refresh_token: 'token', nonce: 'nonce')
 
           expect(role).to eq("alice")
           expect(headers_h).to include('X-OIDC-Refresh-Token' => refresh_token)


### PR DESCRIPTION
### Desired Outcome

Generalize Conjur's existing OIDC API to accept refresh tokens in the request body on POST requests to `/authn-oidc(/:service_id)/:account/authenticate`. This endpoint should accept form-encoded data representing an OIDC credential in the request body, and respond with a Conjur access token.

### Implemented Changes
- Update the authenticate_controller to parse the request body to support the following types of OIDC request
  - Authorization code (authenticate against OIDC provider)
  - Refresh token (re-authenticate against OIDC provider)
  - ID token (authenticates to Conjur)
- Update authenticate_handler and strategy to route requests accordingly
- Add relevant rspec tests/cucumber scenarios

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
