### PR TITLE
Update vcr cassettes to specify Ruby 3.0.5

### DIFF
--- a/spec/fixtures/vcr_cassettes/authenticators/authn-iam/verify-expired-headers.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-iam/verify-expired-headers.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux x86_64) ruby/3.0.4p208
+      - rest-client/2.1.0 (linux x86_64) ruby/3.0.5p211
       X-Amz-Date:
       - 20180620T025910Z
       X-Amz-Security-Token:

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:
@@ -75,7 +75,7 @@ http_interactions:
       string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
     headers:
       User-Agent:
-      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:
@@ -75,7 +75,7 @@ http_interactions:
       string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
     headers:
       User-Agent:
-      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:
@@ -75,7 +75,7 @@ http_interactions:
       string: grant_type=authorization_code&code=7wKEGhsN9UEL5MG9EfDJ8KWMToKINzvV29uyPsQZYpo&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=1656b4264b60af659fce
     headers:
       User-Agent:
-      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:
@@ -158,7 +158,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - OpenIDConnect (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - OpenIDConnect (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_initialization.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:
@@ -75,7 +75,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.4 (2022-04-12))
+      - SWD (1.3.0) (2.8.3, ruby 3.0.5 (2022-11-24 revision ba5cf0f7c5))
       Accept:
       - "*/*"
       Date:


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Get Conjur build passing after updating base images to using Ruby 3.0.5

### Implemented Changes

Updated VCR cassette files to specify a Ruby 3.0.5 user agent. 