### PR TITLE
Fix Redhat image push

### DIFF
--- a/publish-images.sh
+++ b/publish-images.sh
@@ -71,7 +71,9 @@ LOCAL_IMAGE="conjur:${LOCAL_TAG}"
 RH_LOCAL_IMAGE="conjur-ubi:${LOCAL_TAG}"
 IMAGE_NAME="cyberark/conjur"
 REDHAT_CERT_PID="5f905d433a93dc782c77a0f9"
-REDHAT_IMAGE="scan.connect.redhat.com/ospid-9fb7aea1-0c01-4527-8def-242f3cde7dc6/conjur"
+REDHAT_REGISTRY="quay.io"
+REDHAT_REMOTE_IMAGE="${REDHAT_REGISTRY}/redhat-isv-containers/${REDHAT_CERT_PID}"
+REDHAT_USER="redhat-isv-containers+${REDHAT_CERT_PID}-robot"
 
 # Normalize version number in the case of '+' included
 VERSION="$(echo -n "${VERSION}" | tr "+" "_")"
@@ -134,14 +136,14 @@ fi
 if [[ "${REDHAT}" = true ]]; then
   echo "Publishing ${VERSION} to RedHat registry..."
   # Publish only the tag version to the Redhat container registry
-  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+  if docker login "${REDHAT_REGISTRY}" -u "${REDHAT_USER}" -p "${REDHAT_API_KEY}"; then
     # push image to red hat
-    tag_and_push "${VERSION}" "${RH_LOCAL_IMAGE}" "${REDHAT_IMAGE}"
+    tag_and_push "${VERSION}" "${RH_LOCAL_IMAGE}" "${REDHAT_REMOTE_IMAGE}"
 
     # scan image with preflight tool
-    scan_redhat_image "${REDHAT_IMAGE}:${VERSION}" "${REDHAT_CERT_PID}"
+    scan_redhat_image "${REDHAT_REMOTE_IMAGE}:${VERSION}" "${REDHAT_CERT_PID}"
   else
-    echo 'Failed to log in to scan.connect.redhat.com'
+    echo 'Failed to log in to quay.io'
     exit 1
   fi
 fi


### PR DESCRIPTION
### Desired Outcome

Fix Redhat image pushing by updating the scanning registry on PROMOTE to quay.io (formerly scan.connect.redhat.com)

### Implemented Changes

Updates to publish-images.sh script


### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
