### PR TITLE
AuthnOIDC V2: Customizable Token TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This is disabled by default, but is available under the
   `CONJUR_FEATURE_PKCE_SUPPORT_ENABLED` feature flag.
   [cyberark/conjur#2678](https://github.com/cyberark/conjur/pull/2678)
+- OIDC Authenticator can now be configured to distribute access tokens with a
+  custom time-to-live.
+  [cyberark/conjur#2683](https://github.com/cyberark/conjur/pull/2683)
 
 ## [1.19.0] - 2022-11-29
 

--- a/app/db/repository/authenticator_repository.rb
+++ b/app/db/repository/authenticator_repository.rb
@@ -77,7 +77,7 @@ module DB
             allowed_args = %i[account service_id] +
                           @data_object.const_get(:REQUIRED_VARIABLES) +
                           @data_object.const_get(:OPTIONAL_VARIABLES)
-            args_list = args_list.select{ |key, _| allowed_args.include?(key) }
+            args_list = args_list.select{ |key, value| allowed_args.include?(key) && value.present? }
           end
           @data_object.new(**args_list)
         rescue ArgumentError => e

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -20,7 +20,8 @@ module Authentication
             redirect_uri: nil,
             name: nil,
             response_type: 'code',
-            provider_scope: nil
+            provider_scope: nil,
+            token_ttl: 'PT8M'
           )
             @account = account
             @provider_uri = provider_uri
@@ -34,6 +35,7 @@ module Authentication
             @name = name
             @provider_scope = provider_scope
             @redirect_uri = redirect_uri
+            @token_ttl = token_ttl
           end
 
           def scope
@@ -46,6 +48,13 @@ module Authentication
 
           def resource_id
             "#{account}:webservice:conjur/authn-oidc/#{service_id}"
+          end
+
+          # Returns the validity duration, in seconds, of an instance's access tokens.
+          def token_ttl
+            ActiveSupport::Duration.parse(@token_ttl)
+          rescue ActiveSupport::Duration::ISO8601Parser::ParsingError
+            raise Errors::Authentication::DataObjects::InvalidTokenTTL.new(resource_id, @token_ttl)
           end
         end
       end

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -78,7 +78,8 @@ module Authentication
 
         TokenFactory.new.signed_token(
           account: parameters[:account],
-          username: role.role_id.split(':').last
+          username: role.role_id.split(':').last,
+          user_ttl: authenticator.token_ttl
         )
       rescue => e
         log_audit_failure(parameters[:account], parameters[:service_id], request_ip, @authenticator_type, e)

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -106,6 +106,15 @@ module Errors
       code: "CONJ00126E"
     )
 
+    module DataObjects
+
+      InvalidTokenTTL = ::Util::TrackableErrorClass.new(
+        msg: "Webservice '{0-webservice}' configured with invalid custom token TTL '{1-ttl}': must be a valid duration as described by ISO 8601",
+        code: "CONJ00134E"
+      )
+
+    end
+
     module AuthenticatorClass
 
       DoesntStartWithAuthn = ::Util::TrackableErrorClass.new(

--- a/cucumber/_authenticators_common/features/support/conjur_token.rb
+++ b/cucumber/_authenticators_common/features/support/conjur_token.rb
@@ -11,6 +11,10 @@ class ConjurToken
     payload['sub']
   end
 
+  def duration
+    payload['exp'] - payload['iat']
+  end
+
   private
 
   def payload

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -180,6 +180,10 @@ Given(/^I successfully set OIDC V2 variables for "([^"]*)"$/) do |service_id|
   create_oidc_secret("provider-scope", oidc_scope, service_id)
 end
 
+Given(/^I set a custom token TTL of "([^"]*)" for "([^"]*)"$/) do |duration_iso8601, service_id|
+  create_oidc_secret("token-ttl", duration_iso8601, service_id)
+end
+
 When(/^I authenticate via OIDC V2 with code and service-id "([^"]*)"$/) do |service_id|
   authenticate_code_with_oidc(
     service_id: service_id,
@@ -190,6 +194,21 @@ end
 Then(/^The okta user has been authorized by conjur/) do
   username = ENV['OKTA_USERNAME']
   expect(retrieved_access_token.username).to eq(username)
+end
+
+Then(/^user "(\S+)" has been authorized by Conjur for (\d+) (\S+)$/) do |username, duration, duration_unit|
+  token = retrieved_access_token
+  expect(token.username).to eq(username)
+
+  case duration_unit
+  when /hours?/
+    expected_duration = duration * 3600
+  when /minutes?/
+    expected_duration = duration * 60
+  when /seconds?/
+    expected_duration = duration
+  end
+  expect(token.duration).to eq(expected_duration)
 end
 
 When(/^I authenticate via OIDC with id token and without a service-id$/) do

--- a/spec/app/db/repository/authenticator_repository_spec.rb
+++ b/spec/app/db/repository/authenticator_repository_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe('DB::Repository::AuthenticatorRepository') do
   # Verify tests pass with flag enabled/disabled
-  %w[true false].each do |pkce_flag_enabled|
+  [true, false].each do |pkce_flag_enabled|
     context "with flag #{pkce_flag_enabled}" do
       let(:data_object) do
         if pkce_flag_enabled
@@ -177,6 +177,21 @@ RSpec.describe('DB::Repository::AuthenticatorRepository') do
               it { expect(authenticator).to be_kind_of(data_object) }
               it { expect(authenticator.account).to eq('rspec') }
               it { expect(authenticator.service_id).to eq('abc123') }
+
+              context 'custom token TTL' do
+                before(:each) do
+                  ::Resource.create(
+                    resource_id: "rspec:variable:conjur/authn-oidc/abc123/token_ttl",
+                    owner_id: "rspec:policy:conjur/authn-oidc/abc123"
+                  )
+                  ::Secret.create(
+                    resource_id: "rspec:variable:conjur/authn-oidc/abc123/token_ttl",
+                    value: "PT2H"
+                  )
+                end
+
+                it { expect(authenticator.token_ttl).to eq(2.hours) }
+              end
             end
 
             after(:each) do

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/data_objects/authenticator.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/data_objects/authenticator.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator') do
+RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator) do
   let(:default_args) do
     {
       provider_uri: 'https://foo.bar.com/baz',
@@ -15,7 +15,7 @@ RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Auth
   end
   let(:args) { default_args }
 
-  let(:authenticator) { Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator.new(**args) }
+  let(:authenticator) { described_class.new(**args) }
 
   describe '.scope' do
     context 'with default initializer' do
@@ -69,6 +69,24 @@ RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Auth
   describe '.response_type' do
     context 'with default initializer' do
       it { expect(authenticator.response_type).to eq('code') }
+    end
+  end
+
+  describe '.token_ttl' do
+    context 'with default initializer' do
+      it { expect(authenticator.token_ttl).to eq(8.minutes) }
+    end
+
+    context 'when initialized with a valid duration' do
+      let (:args) { default_args.merge({ token_ttl: 'PT1H'}) }
+      it { expect(authenticator.token_ttl).to eq(1.hour)}
+    end
+
+    context 'when initialized with an invalid duration' do
+      let (:args) { default_args.merge({ token_ttl: 'PTinvalidH' }) }
+      it { expect {
+        authenticator.token_ttl
+      }.to raise_error(Errors::Authentication::DataObjects::InvalidTokenTTL) }
     end
   end
 end

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
+RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
   let(:default_args) do
     {
       provider_uri: 'https://foo.bar.com/baz',
@@ -17,8 +17,7 @@ RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
   end
   let(:args) { default_args }
 
-  # subject { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**default_args)}
-  let(:authenticator) { Authentication::AuthnOidc::V2::DataObjects::Authenticator.new(**args) }
+  let(:authenticator) { described_class.new(**args) }
 
   describe '.scope' do
     context 'with default initializer' do
@@ -67,6 +66,24 @@ RSpec.describe('Authentication::AuthnOidc::V2::DataObjects::Authenticator') do
   describe '.response_type' do
     context 'with default initializer' do
       it { expect(authenticator.response_type).to eq('code') }
+    end
+  end
+
+  describe '.token_ttl' do
+    context 'with default initializer' do
+      it { expect(authenticator.token_ttl).to eq(8.minutes) }
+    end
+
+    context 'when initialized with a valid duration' do
+      let (:args) { default_args.merge({ token_ttl: 'PT1H'}) }
+      it { expect(authenticator.token_ttl).to eq(1.hour)}
+    end
+
+    context 'when initialized with an invalid duration' do
+      let (:args) { default_args.merge({ token_ttl: 'PTinvalidH' }) }
+      it { expect {
+        authenticator.token_ttl
+      }.to raise_error(Errors::Authentication::DataObjects::InvalidTokenTTL) }
     end
   end
 end


### PR DESCRIPTION
### Desired Outcome

Allow users to extend the TTL of tokens distributed by a certain AuthnOIDC V2 instance.

### Implemented Changes

When creating an AuthnOIDC V2 instance in policy, add a `token-ttl` variable in the parent policy to configure a custom token TTL. The value assigned to this variable must be a string representing an ISO 8601 Duration. By default, AuthnOIDC still distributes 8 minute tokens. This can be increased up to a 5 hour global maximum.

```yaml
- !policy
  id conjur/authn-oidc/${service_id}
  body:
    - !webservice

    - !variable token-ttl
    ...
```

Includes `token-ttl` as an `OPTIONAL_VARIABLE` on the `DataObjects::Authenticator` class.

Includes `MINIMUM_AUTHENTICATION_TOKEN_EXPIRATION` constant on the `TokenFactory` class, in order to eliminate any negative duraitons.

Includes RSpec and Cucumber test cases.

### Connected Issue/Story

CyberArk internal issue ID: ONYX-29302 & ONYX-29303

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
