### PR TITLE
Updates provider to prevent a bad OIDC provider from breaking the log…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Previously, if an OIDC authenticator was configured with a `Status` webservice,
-  the OIDC provider endpoint would include duplicate OIDC authenticators. This
-  change resolves ONYX-25530.
+  the OIDC provider endpoint would include duplicate OIDC authenticators. This change resolves ONYX-25530.
   [cyberark/conjur#2678](https://github.com/cyberark/conjur/pull/2678)
 - Allows V2 OIDC authenticators to be checked through the authenticator status
   endpoint.  This change resolves ONYX-25531.
   [cyberark/conjur#2692](https://github.com/cyberark/conjur/pull/2692)
+- Previously, if an OIDC provider endpoint was incorrect, the provider list endpoint
+  would raise an exception. This change resolves ONYX-30387
+  [cyberark/conjur#2688](https://github.com/cyberark/conjur/pull/2688)
 
 ### Added
 - Provides support for PKCE in the OIDC Authenticator code redirect workflow.

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/views/providor_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/views/providor_context_spec.rb
@@ -2,73 +2,125 @@
 
 require 'spec_helper'
 
-RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator') do
-  let(:default_args) do
-    {
-      provider_uri: 'https://foo.bar.com/baz',
-      client_id: 'client-id-123',
-      client_secret: 'client-secret-123',
-      claim_mapping: 'email',
-      account: 'default',
-      service_id: 'my-authenticator'
-    }
+RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::Views::ProviderContext') do
+  let(:client) do
+    class_double(::Authentication::AuthnOidc::PkceSupportFeature::Client).tap do |double|
+      allow(double).to receive(:new).and_return(current_client)
+    end
   end
-  let(:args) { default_args }
 
-  let(:authenticator) { Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator.new(**args) }
-
-  describe '.scope' do
-    context 'with default initializer' do
-      it { expect(authenticator.scope).to eq('openid email profile') }
+  let(:current_client) do
+    instance_double(::Authentication::AuthnOidc::PkceSupportFeature::Client).tap do |double|
+      allow(double).to receive(:discovery_information).and_return(endpoint)
     end
+  end
 
-    context 'when initialized with a string argument' do
-      let(:args) { default_args.merge({ provider_scope: 'foo' }) }
-      it { expect(authenticator.scope).to eq('openid email profile foo') }
+  let(:endpoint) { double(authorization_endpoint: '"http://test"') }
+
+  let(:foo) do
+    Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator.new(
+      account: "cucumber",
+      service_id: "foo",
+      redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+      provider_uri: "http://foo",
+      name: "foo",
+      client_id: "ConjurClient",
+      client_secret: 'client_secret',
+      claim_mapping: 'claim_mapping'
+    )
+  end
+
+  let(:bar) do
+    Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authenticator.new(
+      account: "cucumber",
+      service_id: "bar",
+      provider_uri: "http://bar",
+      redirect_uri: "http://conjur/authn-oidc/cucumber/authenticate",
+      name: "bar",
+      client_id: "ConjurClient",
+      client_secret: 'client_secret',
+      claim_mapping: 'claim_mapping'
+    )
+  end
+
+  let(:authenticators) {[foo, bar]}
+
+  let(:response) do
+    [
+      {
+        name: "foo",
+        redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&nonce=random-string&code_challenge=random-sha&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+        service_id: "foo",
+        type: "authn-oidc",
+        nonce: 'random-string',
+        code_verifier: 'random-string'
+      }, {
+        name: "bar",
+        redirect_uri: "\"http://test\"?client_id=ConjurClient&response_type=code&scope=openid%20email%20profile" \
+         "&nonce=random-string&code_challenge=random-sha&code_challenge_method=S256&redirect_uri=http%3A%2F%2Fconjur%2Fauthn-oidc%2Fcucumber%2Fauthenticate",
+        service_id: "bar",
+        type: "authn-oidc",
+        nonce: 'random-string',
+        code_verifier: 'random-string'
+      }
+    ]
+  end
+
+  let(:provider_context) do
+    ::Authentication::AuthnOidc::PkceSupportFeature::Views::ProviderContext.new(
+      client: client,
+      random: random,
+      digest: digest,
+      logger: logger
+    )
+  end
+
+  let(:log_output) { StringIO.new }
+  let(:logger) { Logger.new(log_output) }
+
+  let(:digest) do
+    class_double(Digest::SHA256).tap do |double|
+      allow(double).to receive(:base64digest).and_return('random-sha')
     end
+  end
 
-    context 'when initialized with a non-string argument' do
-      let(:args) { default_args.merge({ provider_scope: 1 }) }
-      it { expect(authenticator.scope).to eq('openid email profile 1') }
+  let(:random) do
+    class_double(SecureRandom).tap do |double|
+      allow(double).to receive(:hex).and_return('random-string')
     end
+  end
 
-    context 'when initialized with a duplicated argument' do
-      let(:args) { default_args.merge({ provider_scope: 'profile' }) }
-      it { expect(authenticator.scope).to eq('openid email profile') }
-    end
-
-    context 'when initialized with an array argument' do
-      context 'single value array' do
-        let(:args) { default_args.merge({ provider_scope: 'foo' }) }
-        it { expect(authenticator.scope).to eq('openid email profile foo') }
+  describe('#call') do
+    context 'when provider context is given multiple authenticators' do
+      it 'returns the providers object with the redirect urls' do
+        expect(provider_context.call(authenticators: authenticators))
+          .to eq(response)
       end
+    end
 
-      context 'multi-value array' do
-        let(:args) { default_args.merge({ provider_scope: 'foo bar' }) }
-        it { expect(authenticator.scope).to eq('openid email profile foo bar') }
+    context 'when provider context is  given no authenticators ' do
+      it 'returns an empty array' do
+        expect(provider_context.call(authenticators: []))
+          .to eq([])
       end
     end
-  end
 
-  describe '.name' do
-    context 'when name is missing' do
-      it { expect(authenticator.name).to eq('My Authenticator') }
-    end
-    context 'when name is present' do
-      let(:args) { default_args.merge(name: 'foo') }
-      it { expect(authenticator.name).to eq('foo') }
-    end
-  end
-
-  describe '.resource_id' do
-    context 'correctly renders' do
-      it { expect(authenticator.resource_id).to eq('default:webservice:conjur/authn-oidc/my-authenticator') }
-    end
-  end
-
-  describe '.response_type' do
-    context 'with default initializer' do
-      it { expect(authenticator.response_type).to eq('code') }
+    context 'when authenticator discovery endpoint is unreachable' do
+      let(:current_client) do
+        instance_double(::Authentication::AuthnOidc::PkceSupportFeature::Client).tap do |double|
+          allow(double).to receive(:discovery_information).and_raise(
+            Errors::Authentication::OAuth::ProviderDiscoveryFailed
+          )
+        end
+      end
+      it 'does not cause an exception' do
+        expect(provider_context.call(authenticators: authenticators)).to eq([])
+        expect(log_output.string).to include('WARN')
+        %w[foo bar].each do |authenticator|
+          expect(log_output.string).to include("Authn-OIDC '#{authenticator}' provider-uri: 'http://#{authenticator}' is unreachable")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Desired Outcome

If a V2 OIDC authenticator is configured with a bad OIDC endpoint URI, the providers API endpoint will fail. This PR handles the exception and returns the valid providers.

### Implemented Changes
- Handles exceptions from the OIDC client

### Connected Issue/Story

CyberArk internal issue ID: 30387

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
