### PR TITLE
Enable PKCE by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Provides support for PKCE in the OIDC Authenticator code redirect workflow.
-  This is disabled by default, but is available under the
+  This is enabled by default. If needed, it can be disabled using the
   `CONJUR_FEATURE_PKCE_SUPPORT_ENABLED` feature flag.
   [cyberark/conjur#2678](https://github.com/cyberark/conjur/pull/2678)
 - OIDC Authenticator can now be configured to distribute access tokens with a

--- a/app/domain/authentication/authn_oidc/pkce_support_feature/client.rb
+++ b/app/domain/authentication/authn_oidc/pkce_support_feature/client.rb
@@ -37,14 +37,12 @@ module Authentication
           end
         end
 
-        def callback(code:, nonce:, code_verifier:)
+        def callback(code:, nonce:, code_verifier: nil)
           oidc_client.authorization_code = code
+          access_token_args = { scope: true, client_auth_method: :basic }
+          access_token_args[:code_verifier] = code_verifier if code_verifier.present?
           begin
-            bearer_token = oidc_client.access_token!(
-              scope: true,
-              client_auth_method: :basic,
-              code_verifier: code_verifier
-            )
+            bearer_token = oidc_client.access_token!(**access_token_args)
           rescue Rack::OAuth2::Client::Error => e
             # Only handle the expected errors related to access token retrieval.
             case e.message

--- a/app/domain/authentication/authn_oidc/pkce_support_feature/strategy.rb
+++ b/app/domain/authentication/authn_oidc/pkce_support_feature/strategy.rb
@@ -13,7 +13,7 @@ module Authentication
         end
 
         def callback(args)
-          %i[code nonce code_verifier].each do |param|
+          %i[code nonce].each do |param|
             unless args[param].present?
               raise Errors::Authentication::RequestBody::MissingRequestParam, param.to_s
             end

--- a/app/domain/authentication/handler/authentication_handler.rb
+++ b/app/domain/authentication/handler/authentication_handler.rb
@@ -94,7 +94,8 @@ module Authentication
           raise ApplicationController::Forbidden
 
         when Errors::Authentication::RequestBody::MissingRequestParam,
-          Errors::Authentication::AuthnOidc::TokenVerificationFailed
+          Errors::Authentication::AuthnOidc::TokenVerificationFailed,
+          Errors::Authentication::AuthnOidc::TokenRetrievalFailed
           raise ApplicationController::BadRequest
 
         when Errors::Conjur::RequestedResourceNotFound

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
     #
     # Once the change is made on the UI (which is the intended target), the behavior
     # enabled by the flag should be made the default behavior.
-    pkce_support: false
+    pkce_support: true
   }.freeze
 
   config.feature_flags = Conjur::FeatureFlags::Features.new(

--- a/cucumber/authenticators_oidc/features/authn_oidc_okta.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_okta.feature
@@ -18,6 +18,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with Okta using OIDC
           - !variable state
           - !variable nonce
           - !variable redirect-uri
+
           - !group users
 
           - !permit
@@ -30,6 +31,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with Okta using OIDC
 
   @smoke
   Scenario: Authenticating with Conjur using Okta
-    Given I fetch a code from okta
+    Given I retrieve OIDC configuration from the provider endpoint for "okta-2"
+    And I authenticate and fetch a code from Okta
     When I authenticate via OIDC with code and service_id "okta-2"
-    Then The okta user has been authorized by conjur
+    Then the okta user has been authorized by conjur

--- a/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
+++ b/cucumber/authenticators_oidc/features/step_definitions/authn_oidc_steps.rb
@@ -7,13 +7,28 @@ Given(/I fetch an ID Token for username "([^"]*)" and password "([^"]*)"/) do |u
   parse_oidc_id_token
 end
 
-Given(/I fetch a code for username "([^"]*)" and password "([^"]*)"/) do |username, password|
-  Rails.application.config.conjur_config.authenticators = ['authn-oidc/keycloak2']
+Given(/I fetch a code for username "([^"]*)" and password "([^"]*)" from "([^"]*)"/) do |username, password, service_id|
+  Rails.application.config.conjur_config.authenticators = ["authn-oidc/#{service_id}"]
 
-  @client = Client.for('user', 'admin')
-  providers = @client.fetch_authenticators
-  url = providers.body.map { |x| x["redirect_uri"] }
-  res = Net::HTTP.get_response(URI(url[0]))
+  # Retrieve the specified authenticator provider
+  provider = JSON.parse(
+    Net::HTTP.get(
+      URI("#{conjur_hostname}/authn-oidc/cucumber/providers")
+    )
+  ).first { |p| p['service_id'] == service_id }
+
+  @scenario_context.add(:nonce, provider['nonce'])
+
+  # The version of Keycloak we're using does not accept PKCE. We need
+  # to strip code challenge and code challenge args from the redirect
+  # URI
+  redirect_uri = URI.parse(provider['redirect_uri'])
+  params = URI.decode_www_form(redirect_uri.query).to_h
+  params.delete('code_challenge')
+  params.delete('code_challenge_method')
+  redirect_uri.query = URI.encode_www_form(params)
+
+  res = Net::HTTP.get_response(redirect_uri)
   raise res if res.is_a?(Net::HTTPError) || res.is_a?(Net::HTTPClientError)
 
   all_cookies = res.get_fields('set-cookie')
@@ -29,7 +44,7 @@ Given(/I fetch a code for username "([^"]*)" and password "([^"]*)"/) do |userna
   http.use_ssl = true
   request = Net::HTTP::Post.new(post_uri.request_uri)
   request['Cookie'] = cookies_arrays.join('; ')
-  request.set_form_data({'username' => username, 'password' => password})
+  request.set_form_data({ 'username' => username, 'password' => password })
 
   response = http.request(request)
 
@@ -45,13 +60,23 @@ Given(/^I load a policy with okta user:/) do |policy|
   - !grant
     role: !group conjur/authn-oidc/okta-2/users
     member: !user #{ENV['OKTA_USERNAME']}"""
- 
+
   load_root_policy(policy + user_policy)
 end
 
-Given(/^I fetch a code from okta/) do
+Given(/^I retrieve OIDC configuration from the provider endpoint for "([^"]*)"/) do |service_id|
+  provider = JSON.parse(
+    Net::HTTP.get(
+      URI("#{conjur_hostname}/authn-oidc/cucumber/providers")
+    )
+  ).first { |p| p['service_id'] == service_id }
+  @scenario_context.add(:nonce, provider['nonce'])
+  @scenario_context.add(:code_verifier, provider['code_verifier'])
+  @scenario_context.add(:redirect_uri, provider['redirect_uri'])
+end
+
+Given(/^I authenticate and fetch a code from Okta/) do
   uri = URI("https://#{URI(okta_provider_uri).host}/api/v1/authn")
-  puts uri
   body = JSON.generate({ username: ENV['OKTA_USERNAME'], password: ENV['OKTA_PASSWORD'] })
 
   http = Net::HTTP.new(uri.host, uri.port)
@@ -63,32 +88,16 @@ Given(/^I fetch a code from okta/) do
 
   response = http.request(request)
   session_token = JSON.parse(response.body)["sessionToken"]
-  puts session_token
 
-  oidc_parameters = {
-    client_id: okta_client_id,
-    redirect_uri: okta_redirect_uri,
-    response_type: oidc_response_type,
-    scope: okta_scope,
-    state: oidc_state,
-    nonce: oidc_nonce,
-    sessionToken: session_token
-  }
-
-  query_string = ""
-  oidc_parameters.each {|key, value| query_string += "#{key}=#{value}&"}
-  uri = URI("#{okta_provider_uri}/v1/authorize?#{query_string}")
-  puts uri
+  uri = URI("#{@scenario_context.get(:redirect_uri)}&state=test-state&sessionToken=#{session_token}")
   request = Net::HTTP::Get.new(uri.request_uri)
   response = http.request(request)
 
   if response.is_a?(Net::HTTPRedirection)
     parse_oidc_code(response['location'])
   else
-    puts "test"
     raise "Failed to retrieve OIDC code status: #{response.code}"
   end
-  puts response.body
 end
 
 Given(/^I successfully set OIDC variables$/) do
@@ -123,27 +132,19 @@ Given(/^I successfully set provider-uri variable$/) do
 end
 
 When(/^I authenticate via OIDC V2 with code "([^"]*)"$/) do |code|
+  @scenario_context.add(:code, code)
   authenticate_code_with_oidc(
     service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    code: code,
-    )
+    account: AuthnOidcHelper::ACCOUNT
+  )
 end
 
 When(/^I authenticate via OIDC V2 with no code in the request$/) do
+  @scenario_context.add(:code, nil)
   authenticate_code_with_oidc(
     service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    code: nil,
-    )
-end
-
-When(/^I authenticate via OIDC V2 with state "([^"]*)"$/) do |state|
-  authenticate_code_with_oidc(
-    service_id: "#{AuthnOidcHelper::SERVICE_ID}2",
-    account: AuthnOidcHelper::ACCOUNT,
-    state: state,
-    )
+    account: AuthnOidcHelper::ACCOUNT
+  )
 end
 
 Given(/^I successfully set provider-uri variable to value "([^"]*)"$/) do |provider_uri|
@@ -191,7 +192,7 @@ When(/^I authenticate via OIDC V2 with code and service-id "([^"]*)"$/) do |serv
   )
 end
 
-Then(/^The okta user has been authorized by conjur/) do
+Then(/^the okta user has been authorized by conjur/) do
   username = ENV['OKTA_USERNAME']
   expect(retrieved_access_token.username).to eq(username)
 end

--- a/cucumber/authenticators_oidc/features/support/authn_oidc_okta_helper.rb
+++ b/cucumber/authenticators_oidc/features/support/authn_oidc_okta_helper.rb
@@ -23,7 +23,7 @@ module AuthnOidcHelper
   end
 
   def okta_redirect_uri
-    @okta_redirect_uri ||= 'http://localhost:3000/authn-oidc/okta/cucumber/authenticate'
+    @okta_redirect_uri ||= ENV.fetch('OKTA_REDIRECT', 'http://localhost:3000/authn-oidc/okta/cucumber/authenticate')
   end
 end
 

--- a/cucumber/authenticators_oidc/features/support/hooks.rb
+++ b/cucumber/authenticators_oidc/features/support/hooks.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Before do
+  # Create a new Scenario Context to use for sharing
+  # data between scenario steps.
+  @scenario_context = Utilities::ScenarioContext.new
+end
+
+After do
+  # Reset scenario context
+  @scenario_context.reset!
+end

--- a/cucumber/authenticators_oidc/features/support/scenario_context.rb
+++ b/cucumber/authenticators_oidc/features/support/scenario_context.rb
@@ -1,0 +1,25 @@
+module Utilities
+  class ScenarioContext
+    def initialize
+      @context = {}
+    end
+
+    def set(key, value)
+      @context[key] = value
+    end
+
+    alias add set
+
+    def key?(key)
+      @context.key?(key)
+    end
+
+    def get(key)
+      @context[key]
+    end
+
+    def reset!
+      @context = {}
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

Make the PKCE feature on by default. In the unforeseen case this feature needs to be disabled, it can be done by toggling the feature flag to `false`.

**Note**: The non-PKCE workflow will be removed in a future release.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- PKCE flag was set to `true`

***Note***: The version of Keycloak used to test OIDC functionality does not support PKCE. This PR make PKCE optional instead of mandatory. By default, the redirect URIs generated by the provider endpoint will generate a PKCE protected code. 

Upgrading Keycloak will occur in a future effort.

### Connected Issue/Story

CyberArk internal issue ID: ONYX-30385

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
