### PR TITLE
Add: audit event to GET /api/roles/conjur/{kind}/{identifier}?members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - OIDC Authenticator can now be configured to distribute access tokens with a
   custom time-to-live.
   [cyberark/conjur#2683](https://github.com/cyberark/conjur/pull/2683)
+- List members request (`GET /roles/conjur/{kind}/{identifier}?members`) now produce audit events.
+  [cyberark/conjur#2691](https://github.com/cyberark/conjur/pull/2691)
 
 ## [1.19.0] - 2022-11-29
 

--- a/app/models/audit/event/members.rb
+++ b/app/models/audit/event/members.rb
@@ -1,0 +1,87 @@
+module Audit
+  module Event
+    class Members
+      def initialize(
+        user_id:,
+        client_ip:,
+        success:,
+        subject:,
+        error_message: nil
+      )
+        @user_id = user_id
+        @client_ip = client_ip
+        @subject = subject
+        @success = success
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # NOTE: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
+      end
+
+      def message
+        attempted_action.message(
+          success_msg: "#{@user_id} successfully listed members with parameters: #{@subject}",
+          failure_msg: "#{@user_id} failed to list members with parameters: #{@subject}",
+          error_msg: @error_message
+        )
+      end
+
+      def message_id
+        'members'
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => @subject,
+          SDID::CLIENT => { ip: @client_ip }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'list'
+        )
+      end
+    end
+  end
+end

--- a/cucumber/api/features/member_list.feature
+++ b/cucumber/api/features/member_list.feature
@@ -31,6 +31,7 @@ The members of a role can be listed, searched, and paged.
 
   @smoke
   Scenario: List role members
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members"
     Then the JSON should be:
         """
@@ -72,9 +73,19 @@ The members of a role can be listed, searched, and paged.
         }
         ]
         """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :role=>"cucumber:group:dev"}
+    """
 
   @smoke
   Scenario: Search role members
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members&search=alice"
     Then the JSON should be:
         """
@@ -88,17 +99,39 @@ The members of a role can be listed, searched, and paged.
         }
         ]
         """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" search="alice" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :search=>"alice", :role=>"cucumber:group:dev"}
+    """
+
 
   @acceptance
   Scenario: Search for non-existant member
+    Given I save my place in the audit log file for remote
      When I successfully GET "/roles/cucumber/group/dev?members&search=non_existent_user"
      Then the JSON should be:
          """
          []
          """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" search="non_existent_user" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :search=>"non_existent_user", :role=>"cucumber:group:dev"}
+    """
+
 
   @smoke
   Scenario: Page role members
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members&limit=3"
     Then the JSON should be:
         """
@@ -126,7 +159,17 @@ The members of a role can be listed, searched, and paged.
         }
         ]
         """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" limit="3" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :limit=>"3", :role=>"cucumber:group:dev"}
+    """
 
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members&limit=3&offset=3"
     Then the JSON should be:
         """
@@ -147,9 +190,19 @@ The members of a role can be listed, searched, and paged.
         }
         ]
         """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" limit="3" offset="3" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :limit=>"3", :offset=>"3", :role=>"cucumber:group:dev"}
+    """
 
   @smoke
   Scenario: Counting role members
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members&count=true"
     Then the JSON should be:
     """
@@ -157,7 +210,17 @@ The members of a role can be listed, searched, and paged.
         "count": 5
     }
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" count="true" kind="group" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :count=>"true", :kind=>"group", :role=>"cucumber:group:dev"}
+    """
 
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/dev?members&count=true&limit=3"
     Then the JSON should be:
     """
@@ -165,9 +228,19 @@ The members of a role can be listed, searched, and paged.
         "count": 5
     }
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" count="true" kind="group" limit="3" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :count=>"true", :kind=>"group", :limit=>"3", :role=>"cucumber:group:dev"}
+    """
 
   @smoke
   Scenario: Filter role members by kind
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group&kind[]=user"
     Then the JSON should be:
     """
@@ -195,7 +268,17 @@ The members of a role can be listed, searched, and paged.
         }
     ]
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" role="cucumber:group:employees"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :role=>"cucumber:group:employees"}
+    """
 
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/employees?members&kind[]=group"
     Then the JSON should be:
     """
@@ -209,7 +292,17 @@ The members of a role can be listed, searched, and paged.
         }
     ]
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" role="cucumber:group:employees"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :role=>"cucumber:group:employees"}
+    """
 
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/group/employees?members&kind=group"
     Then the JSON should be:
     """
@@ -223,3 +316,30 @@ The members of a role can be listed, searched, and paged.
         }
     ]
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" role="cucumber:group:employees"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group", :role=>"cucumber:group:employees"}
+    """
+
+
+  @negative @acceptance
+  Scenario: The members list cannot be limited with non numeric value
+    Given I save my place in the audit log file for remote
+    When I GET "/roles/cucumber/group/dev?members&limit=abc"
+    Then the HTTP response status code is 500
+    And there is an audit record matching:
+    """
+      <84>1 * * conjur * members
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="group" limit="abc" role="cucumber:group:dev"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="list"]
+      cucumber:user:admin failed to list members with parameters: {:account=>"cucumber", :kind=>"group", :limit=>"abc", :role=>"cucumber:group:dev"}:
+      Limits must be greater than or equal to 1
+    """
+

--- a/spec/models/audit/event/members_spec.rb
+++ b/spec/models/audit/event/members_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Audit::Event::Members do
+  let(:user_id) { 'rspec:user:my_user' }
+  let(:role_id) { 'rspec:role:my_role'}
+  let(:client_ip) { 'my-client-ip' }
+  let(:list_param) { { "limit"=> "1000" } }
+  let(:success) { true }
+  let(:error_message) { nil }
+
+
+  subject do
+    Audit::Event::Members.new(
+      user_id: user_id,
+      client_ip: client_ip,
+      subject: list_param,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user successfully listed members with parameters: {"limit"=>"1000"}'
+                                 )
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq(
+                                'rspec:user:my_user successfully listed members with parameters: {"limit"=>"1000"}'
+                              )
+    end
+
+    it 'contains the role field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::SUBJECT => { "limit"=> "1000" }
+                                                              }))
+    end
+
+    it 'contains the user field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::AUTH => { user: user_id }
+                                                              }))
+    end
+
+    it 'contains the ip field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::CLIENT => { ip: client_ip }
+                                                              }))
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "success" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user failed to list members with parameters: {"limit"=>"1000"}'
+                                 )
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "failure" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+
+
+end


### PR DESCRIPTION
### Desired Outcome

This PR adds an audit log message for list members using the API endpoint `GET /api/roles/conjur/{kind}/{identifier}?members`

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- Example audit message

**Successful Audit:**
```
<86>1 * * conjur * members [auth@43868 user="cucumber:user:admin"] [subject@43868 role="cucumber:group:employees"] [client@43868 ip="\d+\.\d+\.\d+\.\d+"] [action@43868 result="success" operation="list"] cucumber:user:admin successfully listed members with parameters: {:account=>"cucumber", :kind=>"group"}
```

**Failed Audit:**
```
<84>1 * * conjur * members [auth@43868 user="cucumber:user:admin"] [subject@43868 role="cucumber:group:dev"] [client@43868 ip="\d+\.\d+\.\d+\.\d+"] [action@43868 result="failure" operation="list"] cucumber:user:admin failed to list members with parameters: {:account=>"cucumber", :kind=>"group", :limit=>"abc"}: Limits must be greater than or equal to 1
```

### Connected Issue/Story

Resolves [ONYX-26905](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26095)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
