### PR TITLE
Adds status support for V2 OIDC Authenticators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the OIDC provider endpoint would include duplicate OIDC authenticators. This
   change resolves ONYX-25530.
   [cyberark/conjur#2678](https://github.com/cyberark/conjur/pull/2678)
+- Allows V2 OIDC authenticators to be checked through the authenticator status
+  endpoint.  This change resolves ONYX-25531.
+  [cyberark/conjur#2692](https://github.com/cyberark/conjur/pull/2692)
 
 ### Added
 - Provides support for PKCE in the OIDC Authenticator code redirect workflow.

--- a/app/domain/authentication/authn_oidc/validate_status.rb
+++ b/app/domain/authentication/authn_oidc/validate_status.rb
@@ -4,7 +4,8 @@ module Authentication
     ValidateStatus = CommandClass.new(
       dependencies: {
         fetch_authenticator_secrets: Authentication::Util::FetchAuthenticatorSecrets.new,
-        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new
+        discover_identity_provider: Authentication::OAuth::DiscoverIdentityProvider.new,
+        required_variable_names: %w[provider-uri id-token-user-property]
       },
       inputs: %i[account service_id]
     ) do
@@ -29,12 +30,8 @@ module Authentication
           service_id: @service_id,
           conjur_account: @account,
           authenticator_name: "authn-oidc",
-          required_variable_names: required_variable_names
+          required_variable_names: @required_variable_names
         )
-      end
-
-      def required_variable_names
-        @required_variable_names ||= %w[provider-uri id-token-user-property]
       end
 
       def validate_provider_is_responsive


### PR DESCRIPTION
### Desired Outcome

This commit adds support for checking a V2 authenticator configuration using the authenticator status endpoint. Previously, status was invalid because the required variables differ between version 1 and 2.

### Implemented Changes

The change is intentionally hacky to minimize the size of the change. Most of the issue will be resolved when we add support for validating an OIDC JWT in V2.  This will allow us to depreciate the V1 functionality. 

### Connected Issue/Story

CyberArk internal issue ID: ONYX-25531

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
