### PR TITLE
Add: audit event to GET /roles/:account/:kind/*identifier?memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2691](https://github.com/cyberark/conjur/pull/2691)
 - Show resource request (`GET /resources/:account/:kind/*identifier`) now produce audit events.
   [cyberark/conjur#2695](https://github.com/cyberark/conjur/pull/2695)
+- List memberships request (`GET /roles/:account/:kind/*identifier?memberships`) now produce audit events.
+  [cyberark/conjur#2693](https://github.com/cyberark/conjur/pull/2693)
 
 ## [1.19.0] - 2022-11-29
 

--- a/app/models/audit/event/memberships.rb
+++ b/app/models/audit/event/memberships.rb
@@ -1,0 +1,89 @@
+module Audit
+  module Event
+    class Memberships
+      def initialize(
+        user_id:,
+        client_ip:,
+        success:,
+        subject:,
+        error_message: nil
+      )
+        @user_id = user_id
+        @client_ip = client_ip
+        @subject = subject
+        @success = success
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # NOTE: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
+      end
+
+      def message
+        attempted_action.message(
+          success_msg: "#{@user_id} successfully listed memberships with parameters: #{@subject}",
+          failure_msg: "#{@user_id} failed to list memberships with parameters: #{@subject}",
+          error_msg: @error_message
+        )
+      end
+
+      def message_id
+        'membership'
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => @subject,
+          SDID::CLIENT => { ip: @client_ip }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'list'
+        )
+      end
+    end
+
+  end
+
+end

--- a/cucumber/api/features/memberships.feature
+++ b/cucumber/api/features/memberships.feature
@@ -61,6 +61,7 @@ Feature: Obtain the memberships of a role
     And I create a new user "carol"
     And I grant user "carol" to user "bob"
     And I grant user "bob" to user "alice"
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/user/alice?memberships"
     Then the JSON should be:
     """
@@ -73,6 +74,16 @@ Feature: Obtain the memberships of a role
       }
     ]
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * membership
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" kind="user" role="cucumber:user:alice"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed memberships with parameters: {:account=>"cucumber", :kind=>"user", :role=>"cucumber:user:alice"}
+    """
+
 
   @smoke
   Scenario: Direct memberships can be counted
@@ -80,12 +91,22 @@ Feature: Obtain the memberships of a role
     And I create a new user "carol"
     And I grant user "carol" to user "bob"
     And I grant user "bob" to user "alice"
-    When I successfully GET "/roles/cucumber/user/alice?memberships&count"
+    Given I save my place in the audit log file for remote
+    When I successfully GET "/roles/cucumber/user/alice?memberships&count=true"
     Then the JSON should be:
     """
     {
       "count": 1
     }
+    """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * membership
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" count="true" kind="user" role="cucumber:user:alice"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed memberships with parameters: {:account=>"cucumber", :count=>"true", :kind=>"user", :role=>"cucumber:user:alice"}
     """
 
   @smoke
@@ -94,6 +115,7 @@ Feature: Obtain the memberships of a role
     And I create a new user "carol"
     And I grant user "alice" to user "bob"
     And I grant user "carol" to user "bob"
+    Given I save my place in the audit log file for remote
     When I successfully GET "/roles/cucumber/user/bob?memberships&search=alice"
     Then the JSON should be:
     """
@@ -105,6 +127,15 @@ Feature: Obtain the memberships of a role
         "role": "cucumber:user:alice"
       }
     ]
+    """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * membership
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" search="alice" kind="user" role="cucumber:user:bob"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin successfully listed memberships with parameters: {:account=>"cucumber", :search=>"alice", :kind=>"user", :role=>"cucumber:user:bob"}
     """
 
   @smoke
@@ -134,3 +165,4 @@ Feature: Obtain the memberships of a role
       "cucumber:user:charles"
     ]
     """
+

--- a/spec/models/audit/event/memberships_spec.rb
+++ b/spec/models/audit/event/memberships_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Audit::Event::Memberships do
+  let(:user_id) { 'rspec:user:my_user' }
+  let(:client_ip) { 'my-client-ip' }
+  let(:list_param) { { "limit"=> "1000" } }
+  let(:success) { true }
+  let(:error_message) { nil }
+
+
+  subject do
+    Audit::Event::Memberships.new(
+      user_id: user_id,
+      client_ip: client_ip,
+      subject: list_param,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user successfully listed memberships with parameters: {"limit"=>"1000"}'
+                                 )
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq(
+                                'rspec:user:my_user successfully listed memberships with parameters: {"limit"=>"1000"}'
+                              )
+    end
+
+    it 'contains the user field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::AUTH => { user: user_id }
+                                                              }))
+    end
+
+    it 'contains the ip field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::CLIENT => { ip: client_ip }
+                                                              }))
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "success" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user failed to list memberships with parameters: {"limit"=>"1000"}'
+                                 )
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "list", result: "failure" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+
+
+end


### PR DESCRIPTION
### Desired Outcome

This PR adds an audit log message for list members using the API endpoint `GET /roles/{account}/{kind}/{identifier}?memberships`

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- Example audit message

**Audit Example:**
```
<86>1 2022-12-29T21:56:07.426Z - conjur 74681 memberships [auth@43868 user="cucumber:user:admin"][subject@43868 role="cucumber:user:alice"][client@43868 ip="127.0.0.1"][action@43868 result="success" operation="list"] cucumber:user:admin successfully listed memberships with parameters: {:account=>"cucumber", :kind=>"user"}
```

### Connected Issue/Story

Resolves [ONYX-26177](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-26177)



### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
