### PR TITLE
Ensure Materialized Views are refreshed in unit tests after creating resources manually (outside of policy load)

### DIFF
--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -113,6 +113,8 @@ describe Resource, :type => :model do
       end
       it "the corresponding role is listed exactly once in the owner's list of roles" do
         the_membership_again
+        # update materialized view
+        Sequel::Model.db << "REFRESH MATERIALIZED VIEW all_roles_view;"
         expect(the_user.all_roles.reverse_order(:role_id).all.map(&:role_id)).to eq([ the_user, the_role ].map(&:role_id))
       end
     end
@@ -120,6 +122,8 @@ describe Resource, :type => :model do
       RoleMembership.create(role: the_role, member: the_user, admin_option: true)
     end
     it "the corresponding role is in the owner's list of roles" do
+      # update materialized view
+      Sequel::Model.db << "REFRESH MATERIALIZED VIEW all_roles_view;"
       expect(the_user.all_roles.all).to include(the_role)
     end
     context "changing the owner" do


### PR DESCRIPTION
### Desired Outcome

It appears that we will need a way to signal tests in rspec when to refresh materialized views after calling a CRUD method any conjur resource models.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
