### PR TITLE
Add: audit event to GET /resources/:account/:kind/*identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2683](https://github.com/cyberark/conjur/pull/2683)
 - List members request (`GET /roles/conjur/{kind}/{identifier}?members`) now produce audit events.
   [cyberark/conjur#2691](https://github.com/cyberark/conjur/pull/2691)
+- Show resource request (`GET /resources/:account/:kind/*identifier`) now produce audit events.
+  [cyberark/conjur#2695](https://github.com/cyberark/conjur/pull/2695)
 
 ## [1.19.0] - 2022-11-29
 

--- a/app/models/audit/event/show.rb
+++ b/app/models/audit/event/show.rb
@@ -1,0 +1,90 @@
+module Audit
+  module Event
+    # NOTE: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
+    class Show
+
+      attr_reader :message_id
+
+      def initialize(
+        user_id:,
+        client_ip:,
+        subject:,
+        message_id:,
+        success:,
+        error_message: nil
+      )
+        @user_id = user_id
+        @subject = subject
+        @client_ip = client_ip
+        @success = success
+        @message_id=message_id
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # NOTE: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      def message
+        attempted_action.message(
+          success_msg: "#{@user_id} successfully fetched #{message_id} details.",
+          failure_msg: "#{@user_id} failed to fetch #{message_id} details",
+          error_msg: @error_message
+        )
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => @subject,
+          SDID::CLIENT => { ip: @client_ip }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: 'get'
+        )
+      end
+    end
+  end
+end

--- a/cucumber/api/features/resource_show.feature
+++ b/cucumber/api/features/resource_show.feature
@@ -15,7 +15,7 @@ Feature: Fetch resource details.
     And I create a new user "bob"
     And I permit user "bob" to "execute" it
     And I set annotation "description" to "Front end server"
-
+    Given I save my place in the audit log file for remote
     When I successfully GET "/resources/cucumber/:resource_kind/:resource_id"
     Then the JSON should be:
     """
@@ -42,8 +42,27 @@ Feature: Fetch resource details.
       ]
     }
     """
+    And there is an audit record matching:
+    """
+      <86>1 * * conjur * resource
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 resource="cucumber:variable:@namespace@/app-01.mycorp.com"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="get"]
+      cucumber:user:alice successfully fetched resource details.
+    """
 
   @negative @acceptance
   Scenario: Trying to show a resource that does not exist
+    Given I save my place in the audit log file for remote
     When I GET "/resources/cucumber/santa/claus"
     Then the HTTP response status code is 404
+    And there is an audit record matching:
+    """
+      <84>1 * * conjur * resource
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 resource="cucumber:santa:claus"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="get"]
+      cucumber:user:alice failed to fetch resource details: Santa 'claus' not found in account 'cucumber'
+    """

--- a/spec/models/audit/event/show_spec.rb
+++ b/spec/models/audit/event/show_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Audit::Event::Show do
+  let(:user_id) { 'rspec:user:my_user' }
+  let(:message_id) { 'message-id'}
+  let(:client_ip) { 'my-client-ip' }
+  let(:list_param) {
+    { role_id: "rspec:role:my_role",resource_id:"data/resource/secret" }
+  }
+  let(:success) { true }
+  let(:error_message) { nil }
+
+
+  subject do
+    Audit::Event::Show.new(
+      user_id: user_id,
+      client_ip: client_ip,
+      subject: list_param,
+      message_id: message_id,
+      success: success,
+      error_message: error_message
+    )
+  end
+
+  context 'when successful' do
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user successfully fetched message-id details.'
+                                 )
+    end
+
+    it 'uses the INFO log level' do
+      expect(subject.severity).to eq(Syslog::LOG_INFO)
+    end
+
+    it 'renders to string correctly' do
+      expect(subject.to_s).to eq(
+                                'rspec:user:my_user successfully fetched message-id details.'
+                              )
+    end
+
+    it 'contains the subject list field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::SUBJECT => {
+                                                                  role_id: "rspec:role:my_role",
+                                                                  resource_id: "data/resource/secret" }
+                                                              }))
+    end
+
+    it 'contains the user field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::AUTH => { user: user_id }
+                                                              }))
+    end
+
+    it 'contains the ip field' do
+      expect(subject.structured_data).to match(hash_including({
+                                                                Audit::SDID::CLIENT => { ip: client_ip }
+                                                              }))
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "get", result: "success" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+  context 'when a failure occurs' do
+    let(:success) { false }
+
+    it 'produces the expected message' do
+      expect(subject.message).to eq(
+                                   'rspec:user:my_user failed to fetch message-id details'
+                                 )
+    end
+
+    it 'uses the WARNING log level' do
+      expect(subject.severity).to eq(Syslog::LOG_WARNING)
+    end
+
+    it 'produces the expected action_sd' do
+      expect(subject.action_sd).to eq({ "action@43868": { operation: "get", result: "failure" } })
+    end
+
+    it_behaves_like 'structured data includes client IP address'
+  end
+
+
+
+end


### PR DESCRIPTION
### Desired Outcome
This PR adds an audit log message for get resource using the API endpoint `GET /resources/:account/:kind/*identifier`

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- Example audit message

**Successful audit:**
```
<86>1 2023-01-01T10:19:59.551Z - conjur 5979 resource [auth@43868 user="cucumber:user:alice"][subject@43868 resource="cucumber:variable:@namespace@/app-01.mycorp.com"][client@43868 ip="127.0.0.1"][action@43868 result="success" operation="get"] cucumber:user:alice successfully fetched resource details.
```

**Failed audit:**
```
<84>1 2023-01-01T09:45:03.798Z - conjur 92353 resource [auth@43868 user="cucumber:user:alice"][subject@43868 resource="cucumber:santa:claus"][client@43868 ip="127.0.0.1"][action@43868 result="failure" operation="get"] cucumber:user:alice failed to fetch resource details.: Santa 'claus' not found in account 'cucumber'
```

### Connected Issue/Story

Resolves [ONYX-27697](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-27697)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
