### PR TITLE
Tag oidc unit tests

### DIFF
--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/client_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::Client) do
     end
   end
 
-  describe '.callback' do
+  describe '.callback', :type => 'unit' do
     context 'when credentials are valid' do
       it 'returns a valid JWT token', vcr: 'authenticators/authn-oidc/pkce_support_feature/client_callback-valid_oidc_credentials' do
         # Because JWT tokens have an expiration timeframe, we need to hold
@@ -149,7 +149,7 @@ RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::Client) do
     end
   end
 
-  describe '.discovery_information', vcr: 'authenticators/authn-oidc/pkce_support_feature/discovery_endpoint-valid_oidc_credentials' do
+  describe '.discovery_information', :type => 'unit', vcr: 'authenticators/authn-oidc/pkce_support_feature/discovery_endpoint-valid_oidc_credentials' do
     context 'when credentials are valid' do
       it 'endpoint returns valid data' do
         discovery_information = client.discovery_information(invalidate: true)

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/data_objects/authenticator.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/data_objects/authenticator.rb
@@ -17,7 +17,7 @@ RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authe
 
   let(:authenticator) { described_class.new(**args) }
 
-  describe '.scope' do
+  describe '.scope', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.scope).to eq('openid email profile') }
     end
@@ -50,7 +50,7 @@ RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authe
     end
   end
 
-  describe '.name' do
+  describe '.name', :type => 'unit' do
     context 'when name is missing' do
       it { expect(authenticator.name).to eq('My Authenticator') }
     end
@@ -60,19 +60,19 @@ RSpec.describe(Authentication::AuthnOidc::PkceSupportFeature::DataObjects::Authe
     end
   end
 
-  describe '.resource_id' do
+  describe '.resource_id', :type => 'unit' do
     context 'correctly renders' do
       it { expect(authenticator.resource_id).to eq('default:webservice:conjur/authn-oidc/my-authenticator') }
     end
   end
 
-  describe '.response_type' do
+  describe '.response_type', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.response_type).to eq('code') }
     end
   end
 
-  describe '.token_ttl' do
+  describe '.token_ttl', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.token_ttl).to eq(8.minutes) }
     end

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/resolve_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/resolve_identity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(' Authentication::AuthnOidc::PkceSupportFeature::ResolveIdentity'
     Authentication::AuthnOidc::PkceSupportFeature::ResolveIdentity.new
   end
 
-  describe('#call') do
+  describe('#call', :type => 'unit') do
     let(:valid_role) do
       instance_double(::Role).tap do |double|
         allow(double).to receive(:id).and_return('rspec:user:alice')

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/strategy_rspec.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/strategy_rspec.rb
@@ -38,7 +38,7 @@ RSpec.describe(' Authentication::AuthnOidc::PkceSupportFeature::Strategy') do
     )
   end
 
-  describe('#callback') do
+  describe('#callback', :type => 'unit') do
     context 'when a role_id matches the identity exist' do
       let(:mapping) { "claim_mapping" }
       it 'returns the role' do

--- a/spec/app/domain/authentication/authn-oidc/pkce_support_feature/views/providor_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/pkce_support_feature/views/providor_context_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe('Authentication::AuthnOidc::PkceSupportFeature::Views::ProviderCo
     end
   end
 
-  describe('#call') do
+  describe('#call', :type => 'unit') do
     context 'when provider context is given multiple authenticators' do
       it 'returns the providers object with the redirect urls' do
         expect(provider_context.call(authenticators: authenticators))

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
     )
   end
 
-  describe '.callback' do
+  describe '.callback', :type => 'unit' do
     context 'when credentials are valid' do
       it 'returns a valid JWT token', vcr: 'authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials' do
         # Because JWT tokens have an expiration timeframe, we need to hold
@@ -99,7 +99,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
     end
   end
 
-  describe '.oidc_client' do
+  describe '.oidc_client', :type => 'unit' do
     context 'when credentials are valid' do
       it 'returns a valid oidc client', vcr: 'authenticators/authn-oidc/v2/client_initialization' do
         oidc_client = client.oidc_client
@@ -118,7 +118,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
     end
   end
 
-  describe '.discovery_information', vcr: 'authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials' do
+  describe '.discovery_information', :type => 'unit', vcr: 'authenticators/authn-oidc/v2/discovery_endpoint-valid_oidc_credentials' do
     context 'when credentials are valid' do
       it 'endpoint returns valid data' do
         discovery_information = client.discovery_information(invalidate: true)

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator.rb
@@ -19,7 +19,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
 
   let(:authenticator) { described_class.new(**args) }
 
-  describe '.scope' do
+  describe '.scope', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.scope).to eq('openid email profile') }
     end
@@ -47,7 +47,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
     end
   end
 
-  describe '.name' do
+  describe '.name', :type => 'unit' do
     context 'when name is missing' do
       it { expect(authenticator.name).to eq('My Authenticator') }
     end
@@ -57,19 +57,19 @@ RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
     end
   end
 
-  describe '.resource_id' do
+  describe '.resource_id', :type => 'unit' do
     context 'correctly renders' do
       it { expect(authenticator.resource_id).to eq('default:webservice:conjur/authn-oidc/my-authenticator') }
     end
   end
 
-  describe '.response_type' do
+  describe '.response_type', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.response_type).to eq('code') }
     end
   end
 
-  describe '.token_ttl' do
+  describe '.token_ttl', :type => 'unit' do
     context 'with default initializer' do
       it { expect(authenticator.token_ttl).to eq(8.minutes) }
     end

--- a/spec/app/domain/authentication/authn-oidc/v2/resolve_identity_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/resolve_identity_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe(' Authentication::AuthnOidc::V2::ResolveIdentity') do
+RSpec.describe('Authentication::AuthnOidc::V2::ResolveIdentity', :type => 'unit') do
   let(:resolve_identity) do
     Authentication::AuthnOidc::V2::ResolveIdentity.new
   end
@@ -91,6 +91,5 @@ RSpec.describe(' Authentication::AuthnOidc::V2::ResolveIdentity') do
         )
       end
     end
-
   end
 end

--- a/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/strategy_rspec.rb
@@ -41,7 +41,7 @@ RSpec.describe(' Authentication::AuthnOidc::V2::Strategy') do
     )
   end
 
-  describe('#callback') do
+  describe('#callback', :type => 'unit') do
     context 'when a role_id matches the identity exist' do
       let(:mapping) { "claim_mapping" }
       it 'returns the role' do

--- a/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/views/providor_context_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
     )
   end
 
-  describe('#call') do
+  describe('#call', :type => 'unit') do
     context 'when provider context is given multiple authenticators' do
       it 'returns the providers object with the redirect urls' do
         expect(provider_context.call(authenticators: authenticators))
@@ -84,4 +84,3 @@ RSpec.describe('Authentication::AuthnOidc::V2::Views::ProviderContext') do
     end
   end
 end
-

--- a/spec/app/domain/authentication/util/namespace_selector_spec.rb
+++ b/spec/app/domain/authentication/util/namespace_selector_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe(Authentication::Util::NamespaceSelector) do
-  describe '#select' do
+  describe '#select', :type => 'unit' do
     context 'when type is a supported authenticator type' do
       context 'when type is `authn-oidc`' do
         context 'when pkce support feature flag is enabled' do


### PR DESCRIPTION
To run the tests, start conjur dev environment:

```bash
cd git/conjur/dev
./start
```

Exec into the conjur container and run the tests:

```
docker-compose exec conjur bash

rspec -f d --color --dry-run --tag @type:unit
```

### Desired Outcome

First round of unittags to rspec tests for oidc pkce and v2.

See the above commands for visualizing which tests have been tagged.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_

    - Tests for the authn-oidc strategies were previously not being run due to a typo in the file name `_rspec.rb` vs `_spec.rb`
    - authn-oidc tests have been tagged as described above

- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

CyberArk internal issue ID: [CNJR-178]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
