### PR TITLE
POC: Batch retrieval with POST and JSON body

### DIFF
--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -149,14 +149,16 @@ class SecretsController < RestController
   def variable_ids
     return @variable_ids if @variable_ids
 
+    # If the variable IDs are passed as a field on a JSON request body, the value
+    # stored in the params hash will be an array of ID strings.
     @variable_ids = params[:variable_ids] || []
+    # If the variable IDs are passed as a query parameter, the value stored in the
+    # params hash will be a string of comma-delimited IDs.
     @variable_ids = @variable_ids.split(',').compact if @variable_ids.is_a?(String)
 
     # Checks that variable_ids is not empty and doesn't contain empty variable ids
     raise ArgumentError, 'variable_ids' if @variable_ids.empty? ||
-      @variable_ids.count != @variable_ids.reject { |id|
-        !id.is_a?(String) || id.empty?
-      }.count
+      @variable_ids.count != @variable_ids.reject { |id| !id.is_a?(String) || id.empty? }.count
 
     @variable_ids
   end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -148,7 +148,15 @@ class SecretsController < RestController
   def variable_ids
     return @variable_ids if @variable_ids
 
+    # Parse variable IDs delivered as a querystring, formatted as
+    # ?variable_ids=<account>:<kind>:<id-1>,...,<account>:<kind>:<id-n>
     @variable_ids = (params[:variable_ids] || '').split(',').compact
+    # Parse variable IDs delivered as JSON payload, formatted as
+    # {"variable_ids":["<account>:<kind>:<id-1>",...,"<account>:<kind>:<id-n>"]}
+    #
+    # This is only done if a variable_ids query parameter is not provided.
+    @variable_ids = JSON.parse(request.raw_post)["variable_ids"] if @variable_ids.empty?
+
     # Checks that variable_ids is not empty and doesn't contain empty variable ids
     raise ArgumentError, 'variable_ids' if @variable_ids.empty? ||
       @variable_ids.count != @variable_ids.reject(&:empty?).count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
       get     "/secrets/:account/:kind/*identifier" => 'secrets#show'
       post    "/secrets/:account/:kind/*identifier" => 'secrets#create'
       get     "/secrets"                            => 'secrets#batch'
+      post    "/secrets"                            => 'secrets#batch'
 
       put     "/policies/:account/:kind/*identifier" => 'policies#put'
       patch   "/policies/:account/:kind/*identifier" => 'policies#patch'

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -139,7 +139,7 @@ When(/^I( (?:can|successfully))? POST(( \d+) times)? "([^"]*)" with( JSON)? body
   (1..requests_num.to_i).each do
     try_request can do
       if json
-        post_json path, body, options = {:headers => {:content_type => 'application/json'}}
+        post_json path, body, { headers: { content_type: 'application/json' } }
       else
         post_json path, body
       end

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -133,12 +133,16 @@ When(/^I( (?:successfully|can))? authenticate Alice (?:(\d+) times? in (\d+) thr
   )
 end
 
-When(/^I( (?:can|successfully))? POST(( \d+) times)? "([^"]*)" with body:$/) do |can, requests_num, path, body|
+When(/^I( (?:can|successfully))? POST(( \d+) times)? "([^"]*)" with( JSON)? body:$/) do |can, requests_num, path, json, body|
   requests_num ||= 1
 
   (1..requests_num.to_i).each do
     try_request can do
-      post_json path, body
+      if json
+        post_json path, body, options = {:headers => {:content_type => 'application/json'}}
+      else
+        post_json path, body
+      end
     end
   end
 end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -14,6 +14,7 @@ module RestHelpers
   def post_json path, body, options = {}
     path = denormalize(path)
     body = denormalize(body)
+    @headers = options[:headers] if options.key?(:headers)
     result = rest_resource(options)[path].post(body)
     set_result(result)
   end


### PR DESCRIPTION
### Desired Outcome

Inspired by a Salesforce case where users encountered a 414 Request-URI Too Large when batch-retrieving 75+ variables.

### Implemented Changes

Accept POST requests to `/secrets` endpoint, where variable IDs are passed as part of a JSON response body instead of as a query parameter.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
