### PR TITLE
Remove change to enable single AWS key rotation

### DIFF
--- a/app/domain/rotation/rotators/aws/secret_key.rb
+++ b/app/domain/rotation/rotators/aws/secret_key.rb
@@ -31,21 +31,13 @@ module Rotation
             .select { |x| x['access_key_id'] != creds.access_key_id }
             .each { |x| client.delete_access_key(access_key_id: x['access_key_id']) }
 
-          # New key on AWS
           new_key = client.create_access_key.access_key
-
-          # Old key on AWS
-          old_key = creds.conjur_ids[:access_key_id]
 
           # Update in conjur
           facade.update_variables(Hash[
             creds.conjur_ids[:access_key_id]    , new_key.access_key_id,
             creds.conjur_ids[:secret_access_key], new_key.secret_access_key
           ])
-
-          # Delete key just used for rotation
-          # This prevents leaving two active access keys
-          client.delete_access_key(access_key_id: old_key)
         end
 
         private 


### PR DESCRIPTION
The single key rotation doesn't function appropriately.  This change will restore successful rotations

### Desired Outcome

The single key rotation doesn't function appropriately.  This change will restore successful rotations

### Implemented Changes

- Removed second key removal during rotation

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

