### PR TITLE
Update trivy ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,7 +4,7 @@
 # base image, trivy flags a number of OpenSSL issues in Conjur because the fix
 # for most Ubuntu users is to move to 1.1.1 instead of having the continued support
 # in the 1.0.2 line. Additionally, trivy flages 1.0.2zf as vulnerable to issues that
-# only affect 1.1.x. As of the time of this writing, we use 1.0.2zf which either 
+# only affect 1.1.x. As of the time of this writing, we use 1.0.2zf which either
 # has the fix or is unaffected by these issues.
 CVE-2022-2097
 CVE-2022-2068
@@ -86,3 +86,6 @@ CVE-2020-1971
 # The vulnerability is not affected Conjur's version of OpenSSL 1.0.2u (https://www.openssl.org/news/secadv/20210824.txt)
 # Conjur does not use SM2 algorithm (https://www.openssl.org/docs/manmaster/man7/SM2.html)
 CVE-2021-3711
+
+# Temporarily ignore CVE-2023-0286 until OpenSSL is updated in the base image
+CVE-2023-0286


### PR DESCRIPTION
Temporarily ignore CVE-2023-0286 until OpenSSL is updated in the base image.

