### PR TITLE
Update slosilo to resolve thread-safety bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   detects that either the directory or file do not exist.
   [cyberark/conjur#2715](https://github.com/cyberark/conjur/pull/2715)
 
+### Fixed
+- Fixed a thread-safety bug in secret retrieval when multiple threads attempt
+  to decrypt a secret value with Slosilo/OpenSSL.
+  [cyberark/slosilo#31](https://github.com/cyberark/slosilo/pull/31)
+  [cyberark/conjur#2718](https://github.com/cyberark/conjur/pull/2718)
+
 ## [1.19.2] - 2022-01-13
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    slosilo (3.0.0)
+    slosilo (3.0.1)
     spring (2.1.0)
     spring-commands-cucumber (1.0.1)
       spring (>= 0.9.1)

--- a/app/controllers/concerns/find_resource.rb
+++ b/app/controllers/concerns/find_resource.rb
@@ -18,11 +18,7 @@ module FindResource
   end
 
   def resource_exists?
-    begin
-      Resource[resource_id] ? true : false
-    rescue NotFound
-      false
-    end
+    Resource[resource_id] ? true : false
   end
 
   def resource_visible?


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is to resolve a thread-safety defect with decrypting secret values fixed upstream in https://github.com/cyberark/slosilo/pull/31.

### Implemented Changes

This PR updates Slosilo to version 3.0.1 to include the defect fix. It also includes a second commit to fix an uninitialized constant error I also observed while working on this change.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-479

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests (this is tested in slosilo)

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
