### PR TITLE
Create a resource for the account admin user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   successfully reading it. Conjur also now logs at the DEBUG level when it
   detects that either the directory or file do not exist.
   [cyberark/conjur#2715](https://github.com/cyberark/conjur/pull/2715)
+- Account admin roles now have a corresponding resource. This ensures that
+  access controls work as expected for this role to access itself.
+  [cyberark/conjur#2757](https://github.com/cyberark/conjur/pull/2757)
 
 ### Fixed
 - Fixed a thread-safety bug in secret retrieval when multiple threads attempt

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,7 +7,7 @@ Account = Struct.new(:id) do
         pkey = Slosilo::Key.new
         Slosilo["authn:!"] = pkey
       end
-  
+
       role_id     = "!:!:root"
       resource_id = "!:webservice:accounts"
       (role = Role[role_id]) || Role.create(role_id: role_id)
@@ -26,17 +26,15 @@ Account = Struct.new(:id) do
 
       Role.db.transaction do
         Slosilo["authn:#{id}"] = Slosilo::Key.new
-        
+
         role_id = "#{id}:user:admin"
         admin_user = Role.create(role_id: role_id)
 
-        # Create an owner resource that will allow another user to rotate this
-        # account's API key. This is used by the CPanel to enable the accounts
-        # admin credentials to be used for API key rotation.
-        unless owner_id.nil?
-          Resource.create(resource_id: role_id, owner_id: owner_id)
-        end
-        
+        # Ensure a resource record exists for the admin role so that permissions
+        # work as expected. If one isn't given, the admin will own itself.
+        owner_id ||= role_id
+        Resource.create(resource_id: role_id, owner_id: owner_id)
+
         admin_user.api_key
       end
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -6,6 +6,8 @@ DatabaseCleaner.strategy = :truncation
 
 NONEXISTING_GROUP_URL = '/roles/rspec/group/none'
 UNPERMITTED_HOST_ID = 'rspec:host:none'
+ADMIN_HOST_ID = 'rspec:user:admin'
+ADMIN_HOST_URL = '/roles/rspec/user/admin'
 
 describe RolesController, type: :request do
   before do
@@ -76,7 +78,12 @@ describe RolesController, type: :request do
     # read privilege on.
     [
       {
-        user_id: 'rspec:host:none',
+        user_id: ADMIN_HOST_ID,
+        role_url: ADMIN_HOST_URL,
+        expected_response: :not_found
+      },
+      {
+        user_id: UNPERMITTED_HOST_ID,
         role_url: '/roles/rspec/group/a',
         expected_response: :not_found
       },
@@ -109,6 +116,11 @@ describe RolesController, type: :request do
   describe '#all_memberships' do
     # Test cases
     [
+      {
+        user_id: ADMIN_HOST_ID,
+        role_url: ADMIN_HOST_URL,
+        expected_response: :not_found
+      },
       {
         user_id: UNPERMITTED_HOST_ID,
         role_url: '/roles/rspec/group/d',
@@ -144,6 +156,11 @@ describe RolesController, type: :request do
     # Test cases
     [
       {
+        user_id: ADMIN_HOST_ID,
+        role_url: ADMIN_HOST_URL,
+        expected_response: :not_found
+      },
+      {
         user_id: UNPERMITTED_HOST_ID,
         role_url: '/roles/rspec/group/d',
         expected_response: :not_found
@@ -178,6 +195,11 @@ describe RolesController, type: :request do
     # Test cases
     [
       {
+        user_id: ADMIN_HOST_ID,
+        role_url: ADMIN_HOST_URL,
+        expected_response: :not_found
+      },
+      {
         user_id: UNPERMITTED_HOST_ID,
         role_url: '/roles/rspec/group/a',
         expected_response: :not_found
@@ -211,6 +233,11 @@ describe RolesController, type: :request do
   describe '#graph' do
     # Test cases
     [
+      {
+        user_id: ADMIN_HOST_ID,
+        role_url: ADMIN_HOST_URL,
+        expected_response: :not_found
+      },
       {
         user_id: UNPERMITTED_HOST_ID,
         role_url: '/roles/rspec/group/c',


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is for the account admin to list its grants.

### Implemented Changes

This PR adds the account admin as a Resource in the Conjur database so that all existing authorization controls apply to it as well.

### Connected Issue/Story

Follow up to https://github.com/cyberark/conjur/pull/2755

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
