### PR TITLE
AuthnOIDC V2 compatibility updates

### DIFF
--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -31,15 +31,14 @@ module Authentication
               authorization_endpoint: URI(discovery_information.authorization_endpoint).path,
               token_endpoint: URI(discovery_information.token_endpoint).path,
               userinfo_endpoint: URI(discovery_information.userinfo_endpoint).path,
-              jwks_uri: URI(discovery_information.jwks_uri).path,
-              end_session_endpoint: URI(discovery_information.end_session_endpoint).path
+              jwks_uri: URI(discovery_information.jwks_uri).path
             )
           end
         end
 
         def callback(code:, nonce:, code_verifier: nil)
           oidc_client.authorization_code = code
-          access_token_args = { scope: true, client_auth_method: :basic }
+          access_token_args = { client_auth_method: :basic }
           access_token_args[:code_verifier] = code_verifier if code_verifier.present?
           begin
             bearer_token = oidc_client.access_token!(**access_token_args)

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -166,9 +166,6 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
         expect(discovery_information.jwks_uri).to eq(
           'https://dev-92899796.okta.com/oauth2/default/v1/keys'
         )
-        expect(discovery_information.end_session_endpoint).to eq(
-          'https://dev-92899796.okta.com/oauth2/default/v1/logout'
-        )
       end
     end
 

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-expired_code-valid_oidc_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
+      string: grant_type=authorization_code&code=SNSPeiQJ0-D6nUHTg-Ht9ZoDxIaaWBB80pnYuXY2VxU&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-invalid_code_verifier.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-invalid_code_verifier.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=GV48_SF4a19ghvBhVbbSG3Lr8BuFl8PhWVPZSbokV2o&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=3e6bd5235e4692b37ca1f04cb01b6e0cb177aa20dcef19e89f&code_verifier=bad-code-verifier
+      string: grant_type=authorization_code&code=GV48_SF4a19ghvBhVbbSG3Lr8BuFl8PhWVPZSbokV2o&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&nonce=3e6bd5235e4692b37ca1f04cb01b6e0cb177aa20dcef19e89f&code_verifier=bad-code-verifier
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-used_code-valid_oidc_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
+      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/client_callback-valid_oidc_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://dev-92899796.okta.com/oauth2/default/v1/token
     body:
       encoding: UTF-8
-      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&scope=true&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
+      string: grant_type=authorization_code&code=-QGREc_SONbbJIKdbpyYudA13c9PZlgqdxowkf45LOw&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauthn-oidc%2Fokta-2%2Fcucumber%2Fauthenticate&nonce=7efcbba36a9b96fdb5285a159665c3d382abd8b6b3288fcc8d&code_verifier=c1de7f1251849accd99d4839d79a637561b1181b909ed7dc1d
     headers:
       User-Agent:
       - Rack::OAuth2 (1.19.0) (2.8.3, ruby 3.0.4 (2022-04-12))


### PR DESCRIPTION
### Desired Outcome

Generalize AuthnOIDC V2, so a Conjur user could realistically use any popular OIDC provider.

The bugs fixed here were found when trying to use [PingFederate](https://docs.pingidentity.com/r/en-us/pingfederate-112/pf_pingfederate_landing_page) with Conjur and AuthnOIDC V2.

### Implemented Changes

- Hardcoded 'scope=true' query param attached to token requests has been removed. According to OIDC Core, [authz requests require a scope parameter](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest), but token requests, defined by [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3), do not. Including them may cause defensive OIDC providers to reject a token request that includes an unsupported scope.
- OIDC client is no longer configured with an 'end_session_endpoint'. Not only does Conjur not implement [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), but this endpoint is not required by OIDC Core or [Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) specifications. When targeting a minimal OIDC provider, we may be operating on a nil value.

### Connected Issue/Story

CNJR-1009 and CNJR-1010

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
