### PR TITLE
AuthnJWT: support claims with hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update bundler to 2.2.33 to remove CVE-2021-43809
   [cyberark/conjur#2804](https://github.com/cyberark/conjur/pull/2804/files)
 
+### Fixed
+- AuthnJWT now supports claims that include hyphens and inline namespaces.
+  [cyberark/conjur#2792](https://github.com/cyberark/conjur/pull/2792)
+
 ## [1.19.4] - 2023-05-12
 
 ### Changed
 - OIDC tokens will now have a default ttl of 60 mins
   [cyberark/conjur#2800](https://github.com/cyberark/conjur/pull/2800)
-
-### Fixed
-- AuthnJWT can now support claims that include hyphens.
-  [cyberark/conjur#2792](https://github.com/cyberark/conjur/pull/2792)
 
 ## [1.19.3] - 2023-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - OIDC tokens will now have a default ttl of 60 mins
   [cyberark/conjur#2800](https://github.com/cyberark/conjur/pull/2800)
 
+### Fixed
+- AuthnJWT can now support claims that include hyphens.
+  [cyberark/conjur#2792](https://github.com/cyberark/conjur/pull/2792)
+
 ## [1.19.3] - 2023-04-17
 
 ### Added

--- a/app/domain/authentication/authn_jwt/consts.rb
+++ b/app/domain/authentication/authn_jwt/consts.rb
@@ -38,7 +38,7 @@ module Authentication
     CLAIMS_CHARACTER_DELIMITER = ","
     TUPLE_CHARACTER_DELIMITER = ":"
 
-    PURE_CLAIM_NAME_REGEX = /[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*/.freeze
+    PURE_CLAIM_NAME_REGEX = /[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*/.freeze
     PURE_NESTED_CLAIM_NAME_REGEX = /^#{PURE_CLAIM_NAME_REGEX.source}(#{PATH_DELIMITER}#{PURE_CLAIM_NAME_REGEX.source})*$/.freeze
 
     SIGNING_KEY_RESOURCES_NAMES = [

--- a/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
+++ b/app/domain/authentication/authn_jwt/identity_providers/identity_from_decoded_token_provider.rb
@@ -85,7 +85,16 @@ module Authentication
         def id_claim_value
           return @id_claim_value if @id_claim_value
 
-          @id_claim_value = @jwt_authenticator_input.decoded_token.dig(
+          token = @jwt_authenticator_input.decoded_token
+          # Parsing the claim path means claims with slashes are interpreted
+          # as nested claims - for example 'a/b/c' corresponds to the doubly-
+          # nested claim: {"a":{"b":{"c":"value"}}}.
+          #
+          # We should also support claims that contain slashes as namespace
+          # indicators, such as 'namespace.com/claim', which would correspond
+          # to the top-level claim: {"namespace.com/claim":"value"}.
+          @id_claim_value = token[@id_claim_key]
+          @id_claim_value ||= token.dig(
             *parsed_claim_path
           )
         end

--- a/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
@@ -700,7 +700,7 @@ Feature: JWT Authenticator - Token Schema
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-    CONJ00104E Failed to validate claim: claim name '%@^#[{]}$~=-+_?.><&^@*@#*sdhj812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)'.>
+    CONJ00104E Failed to validate claim: claim name '%@^#[{]}$~=-+_?.><&^@*@#*sdhj812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*)*$)'.>
     """
 
   @negative @acceptance
@@ -732,7 +732,7 @@ Feature: JWT Authenticator - Token Schema
     Then the HTTP response status code is 401
     And The following appears in the log after my savepoint:
     """
-    CONJ00104E Failed to validate claim: claim name '%@^#&^[{]}$~=-+_?.><812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)'.
+    CONJ00104E Failed to validate claim: claim name '%@^#&^[{]}$~=-+_?.><812ehd' does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*)*$)'.
     """
 
   @acceptance

--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -1108,7 +1108,7 @@ Feature: JWT Authenticator - Status Check
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.]*)*$)"
+    And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|-|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|-|0-9|.]*)*$)"
 
   @negative @acceptance
   Scenario Outline: ONYX-10958: claim-aliases configured with invalid value, 500 Error

--- a/dev/start
+++ b/dev/start
@@ -125,7 +125,7 @@ parse_options() {
       --authn-azure ) ENABLE_AUTHN_AZURE=true ; shift ;;
       --authn-gcp ) ENABLE_AUTHN_GCP=true ; shift ;;
       --authn-iam ) ENABLE_AUTHN_IAM=true ; shift ;;
-      --authn-jwt ) ENABLE_AUTHN_JWT=true ; shift ;;
+      --authn-jwt ) ENABLE_AUTHN_JWT=true ; ENABLE_OIDC_KEYCLOAK=true ; shift ;;
       --authn-ldap ) ENABLE_AUTHN_LDAP=true ; shift ;;
       -h | --help ) print_help ; shift ;;
       --identity-user ) IDENTITY_USER="$2" ; shift ; shift ;;
@@ -433,7 +433,8 @@ init_jwt() {
 
   # OIDC is a special case on JWT, JWT automation tests contain scenarios with
   # OIDC providers.
-  configure_oidc_providers
+  configure_oidc_authenticators
+  enable_oidc_authenticators
 
   echo "Configure jwks provider"
   docker-compose exec jwks "/tmp/create_nginx_certificate.sh"

--- a/spec/app/domain/authentication/authn-jwt/input_validation/parse_claim_aliases_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/parse_claim_aliases_spec.rb
@@ -120,15 +120,15 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ParseClaimAliases') d
         end
       end
 
-      context "When input has illegal - character in claim name" do
+      context "When input has legal - character in claim name" do
         subject do
           ::Authentication::AuthnJwt::InputValidation::ParseClaimAliases.new().call(
             claim_aliases: "my-claim:a"
           )
         end
 
-        it "raises an error" do
-          expect { subject }.to raise_error(Errors::Authentication::AuthnJwt::ClaimAliasInvalidClaimFormat)
+        it "does not raise an error" do
+          expect { subject }.not_to raise_error
         end
       end
 

--- a/spec/app/domain/authentication/authn-jwt/input_validation/validate_claim_name_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/input_validation/validate_claim_name_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ValidateClaimName') d
     "When claim name is 1 dot character '.'": [".", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When claim name is just 1 forbidden character '*'": ["*", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When claim name contains 1 forbidden character '*'": ["a*b", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
-    "When claim name contains 1 forbidden character '-": ["a-b", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When claim name contains 1 forbidden character '%'": ["a%b", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When claim name contains 1 forbidden character '!'": ["a!b", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When claim name contains 1 forbidden character '('": ["a(b", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
@@ -44,7 +43,6 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ValidateClaimName') d
     "When claim name contains spaces": ["claim  name", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When input has illegal [ character in claim name": ["my[claim", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When input has illegal [ ] characters in claim name": ["my[1]claim", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
-    "When input has illegal - character in claim name": ["my-claim", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName],
     "When input has illegal : character in claim name": ["a:", Errors::Authentication::AuthnJwt::FailedToValidateClaimForbiddenClaimName]
   }
 
@@ -53,6 +51,7 @@ RSpec.describe('Authentication::AuthnJwt::InputValidation::ValidateClaimName') d
     "When claim name contains 1 allowed char 'f'": "f",
     "When claim name contains 1 allowed char '_'": "_",
     "When claim name contains value with allowed char '/'": "a/a",
+    "When claim name contains value with allowed char '-'": "a-b",
     "When claim name contains value with multiple allowed chars '/'": "a/a/a/a",
     "When claim name contains 1 allowed char '$'": "$",
     "When claim name contains digits in the middle": "$2w",

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restriction_name_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restriction_name_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
       Authentication::ResourceRestrictions::ResourceRestriction.new(name: "x.k8s", value: "val"),
     "annotation with _ in the name":
       Authentication::ResourceRestrictions::ResourceRestriction.new(name: "project_id", value: "val"),
+    "- in annotation":
+      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "project-id", value: "val")
   }
 
   invalid_cases = {
@@ -30,8 +32,6 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
       Authentication::ResourceRestrictions::ResourceRestriction.new(name: "a[2]/c", value: "val"),
     "Array element Access":
       Authentication::ResourceRestrictions::ResourceRestriction.new(name: "a/b/c[2]", value: "val"),
-    "- in annotation":
-      Authentication::ResourceRestrictions::ResourceRestriction.new(name: "project-id", value: "val"),
     ": in annotation":
       Authentication::ResourceRestrictions::ResourceRestriction.new(name: "project:id", value: "val")
   }

--- a/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restrictions_one_to_one_spec.rb
+++ b/spec/app/domain/authentication/authn-jwt/restriction_validation/validate_restrictions_one_to_one_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
   let(:spaced_email) { "  " }
   let(:right_login) { "cucumber" }
   let(:wrong_login) { "tomato" }
+  let(:namespaced_value) { "some-value" }
 
   let(:decoded_token) {
     {
@@ -35,6 +36,7 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
         "team_name" => "myteam",
         "team_id" => "team76"
       },
+      "namespaced/inline" => "some-value",
       "iat" => 1619352275,
       "nbf" => 1619352270,
       "exp" => 1619355875,
@@ -75,6 +77,10 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
 
   let(:non_existing_nested_restriction) {
     Authentication::ResourceRestrictions::ResourceRestriction.new(name: "additional_data/namespace", value: wrong_email)
+  }
+
+  let(:existing_namespaced_inline_restriction) {
+    Authentication::ResourceRestrictions::ResourceRestriction.new(name: "namespaced/inline", value: namespaced_value)
   }
 
   let(:empty_annotation_restriction) {
@@ -138,6 +144,10 @@ RSpec.describe('Authentication::AuthnJwt::RestrictionValidation::ValidateRestric
                                                                              Errors::Authentication::AuthnJwt::JwtTokenClaimIsMissing,
                                                                              /.*'additional_data\/namespace'.*/
                                                                            )
+      end
+
+      it "returns true when the restriction is for namespaced field and its value equals the token" do
+        expect(subject.valid_restriction?(existing_namespaced_inline_restriction)).to eql(true)
       end
 
       it "raises EmptyAnnotationGiven when annotation is empty" do


### PR DESCRIPTION
### Desired Outcome

AuthnJWT uses the regex `^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.](\/[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.])*$` to validate token claims, and therefore does not support claims including hyphens. An example of a claim that fails this validation is [CircleCI's additional token claims](https://circleci.com/docs/openid-connect-tokens/#format-of-the-openid-connect-id-token): `oidc.circleci.com/project-id` et al.

AuthnJWT also currently does not support claims with inline namespaces (`namespace.com/claim-key`), instead digesting slash-delimited claims as nested. The CircleCI example above still applies.

### Implemented Changes

- Updated the regex to include hyphens as supported characters: `^[a-zA-Z|$|_][a-zA-Z|$|_|0-9|.](\/[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.])*$`
- Update claim parsing to attempt to use the raw claim before decomposing it and searching for a nested claim.
- Update unit and integration tests for AuthnJWT input validation

### Connected Issue/Story

ONYX-29842

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
