### PR TITLE
CNJR-1461: Increase OIDC ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.19.4] - 2023-05-12
+
+### Changed
+- OIDC tokens will now have a default ttl of 60 mins
+  [cyberark/conjur#2800](https://github.com/cyberark/conjur/pull/2800)
+
 ## [1.19.3] - 2023-04-17
 
 ### Added

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -29,7 +29,7 @@ module Authentication
             name: nil,
             response_type: 'code',
             provider_scope: nil,
-            token_ttl: 'PT8M'
+            token_ttl: 'PT60M'
           )
             @account = account
             @provider_uri = provider_uri

--- a/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
@@ -100,7 +100,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
     And I fetch a code for username "alice" and password "alice" from "keycloak2"
     And I save my place in the audit log file
     And I authenticate via OIDC V2 with code and service-id "keycloak2"
-    Then user "alice" has been authorized by Conjur for 8 minutes
+    Then user "alice" has been authorized by Conjur for 60 minutes
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the audit log after my savepoint:
     """


### PR DESCRIPTION
### Desired Outcome
For OIDC the token should have a 60 min lifespan, currently it is set to 8min. This pr changes the default ttl to PT60M and updates the test to confirm this as the default time. 

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
set the default ttl varibale to be set to pt60m

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [CNJR-1461](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-1461)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
