### PR TITLE
Migrates conjur-rack gem into Conjur

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "loofah", ">= 2.2.3"
 # the branch doesn't immediately break this link
 gem 'conjur-api', '~> 5.pre'
 gem 'conjur-policy-parser', path: 'gems/policy-parser'
-gem 'conjur-rack'
+gem 'conjur-rack', path: 'gems/conjur-rack'
 gem 'conjur-rack-heartbeat'
 gem 'rack-rewrite'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 PATH
+  remote: gems/conjur-rack
+  specs:
+    conjur-rack (5.0.0)
+      conjur-api (< 6)
+      rack (~> 2)
+      slosilo (~> 3.0)
+
+PATH
   remote: gems/policy-parser
   specs:
     conjur-policy-parser (3.0.4)
@@ -126,10 +134,6 @@ GEM
       conjur-cli (~> 6)
       docker-api (~> 2.0)
       gli
-    conjur-rack (5.0.0)
-      conjur-api (< 6)
-      rack (~> 2)
-      slosilo (~> 3.0)
     conjur-rack-heartbeat (2.2.0)
       rack
     contracts (0.17)
@@ -505,7 +509,7 @@ DEPENDENCIES
   conjur-cli (~> 6.2)
   conjur-debify
   conjur-policy-parser!
-  conjur-rack
+  conjur-rack!
   conjur-rack-heartbeat
   csr
   cucumber (~> 7.1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ These are defined in runConjurTests, and also include the one-offs
     authenticators_k8s
     rspec_audit
     policy_parser
+    conjur_rack
     azure_authenticator
     gcp_authenticator
 */
@@ -308,6 +309,7 @@ pipeline {
                     container_logs/*/*,
                     spec/reports/*.xml,
                     spec/reports-audit/*.xml,
+                    gems/conjur-rack/spec/reports/*.xml,
                     cucumber/*/features/reports/**/*.xml
                   '''
                 )
@@ -673,9 +675,11 @@ pipeline {
             junit('''
               spec/reports/*.xml,
               spec/reports-audit/*.xml,
+              gems/conjur-rack/spec/reports/*.xml,
               cucumber/*/features/reports/**/*.xml,
               ee-test/spec/reports/*.xml,
               ee-test/spec/reports-audit/*.xml,
+              ee-test/gems/conjur-rack/spec/reports/*.xml,
               ee-test/cucumber/*/features/reports/**/*.xml
             '''
             )
@@ -826,6 +830,11 @@ def runConjurTests(run_only_str) {
     "policy_parser": [
       "Policy Parser - ${env.STAGE_NAME}": {
         sh 'cd gems/policy-parser && ./test.sh'
+      }
+    ],
+    "conjur_rack": [
+      "Rack - ${env.STAGE_NAME}": {
+        sh 'cd gems/conjur-rack && ./test.sh'
       }
     ]
   ]

--- a/gems/conjur-rack/CHANGELOG.md
+++ b/gems/conjur-rack/CHANGELOG.md
@@ -1,0 +1,54 @@
+**This Gem has been moved into Conjur. All Conjur Rack Changelog entries should
+appear in the main Changelog.**
+
+# unreleased version
+
+# v5.0.0
+
+* Support Ruby 3.
+* Bump `slosilo` to v3.0 with ruby 3.
+* Remove pinned `bundler` version, use default system bundler.
+
+# v4.2.0
+
+* Bump `slosilo` to v2.2 in order to be FIPS compliant
+
+# v4.0.0
+
+* Bump `rack` to v2, `bundler` to v1.16 in gemspec
+* Add Jenkinsfile to project
+* Ignore headers such as Conjur-Privilege or Conjur-Audit if they're not
+supported by the API (instead of erroring out).
+
+# v3.1.0
+
+* Support for JWT Slosilo tokens.
+
+# v3.0.0.pre
+
+* Initial support for Conjur 5.
+
+# v2.3.0
+
+* Add TRUSTED_PROXIES support
+
+# v2.2.0
+
+* resolve 'own' token to CONJUR_ACCOUNT env var
+* add #optional paths to Conjur::Rack authenticator
+
+# v2.1.0
+
+* Add handling for `Conjur-Audit-Roles` and `Conjur-Audit-Resources`
+
+# v2.0.0
+
+* Change `global_sudo?` to `global_elevate?`
+
+# v1.4.0
+
+* Add `validated_global_privilege` helper function to get the global privilege, if any, which has been submitted with the request and verified by the Conjur server.
+
+# v1.3.0
+
+* Add handling for `X-Forwarded-For` and `X-Conjur-Privilege`

--- a/gems/conjur-rack/CONTRIBUTING.md
+++ b/gems/conjur-rack/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+  
+For general contribution and community guidelines, please see the [community repo](https://github.com/cyberark/community).
+
+## Contributing Workflow
+
+1. [Fork the project](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)
+2. [Clone your fork](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)
+3. Make local changes to your fork by editing files
+3. [Commit your changes](https://help.github.com/en/github/managing-files-in-a-repository/adding-a-file-to-a-repository-using-the-command-line)
+4. [Push your local changes to the remote server](https://help.github.com/en/github/using-git/pushing-commits-to-a-remote-repository)
+5. [Create new Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork)
+
+From here your pull request will be reviewed and once you've responded to all
+feedback it will be merged into the project. Congratulations, you're a
+contributor!

--- a/gems/conjur-rack/Gemfile
+++ b/gems/conjur-rack/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# make sure github uses TLS
+git_source(:github) { |name| "https://github.com/#{name}.git" }
+
+#ruby=ruby-3.0
+#ruby-gemset=conjur-rack
+
+# Specify your gem's dependencies in conjur-rack.gemspec
+gemspec
+
+# gem 'conjur-api', github: 'cyberark/conjur-api-ruby', branch: 'master'

--- a/gems/conjur-rack/LICENSE.txt
+++ b/gems/conjur-rack/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gems/conjur-rack/README.md
+++ b/gems/conjur-rack/README.md
@@ -1,0 +1,27 @@
+# Conjur::Rack
+
+TODO: Write a gem description
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'conjur-rack'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install conjur-rack
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Contributing
+
+We welcome contributions of all kinds to this repository. For instructions on
+how to get started and descriptions of our development workflows, please see our
+[contributing guide](CONTRIBUTING.md).

--- a/gems/conjur-rack/Rakefile
+++ b/gems/conjur-rack/Rakefile
@@ -1,0 +1,14 @@
+require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+require 'ci/reporter/rake/rspec'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--format doc"
+  unless ENV["CONJUR_ENV"] == "ci"
+    t.rspec_opts << " --color"
+  else 
+    Rake::Task["ci:setup:rspec"].invoke
+  end
+end
+
+task :default => :spec

--- a/gems/conjur-rack/conjur-rack.gemspec
+++ b/gems/conjur-rack/conjur-rack.gemspec
@@ -1,32 +1,28 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'conjur/rack/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "conjur-rack"
-  spec.version       = Conjur::Rack::VERSION
-  spec.authors       = ["Kevin Gilpin"]
-  spec.email         = ["kgilpin@conjur.net"]
-  spec.description   = %q{Rack authenticator and basic User struct}
-  spec.summary       = %q{Rack authenticator and basic User struct}
-  spec.homepage      = "http://github.com/conjurinc/conjur-rack"
-  spec.license       = "Private"
+  spec.name                   = 'conjur-rack'
+  spec.version                = Conjur::Rack::VERSION
+  spec.authors                = ['Cyberark R&D']
+  spec.summary                = 'Rack authenticator and basic User struct'
+  spec.homepage               = 'http://github.com/conjurinc/conjur-rack'
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files                  = Dir.glob("lib/**/*") + %w[README.md]
+  spec.executables            = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files             = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths          = ['lib']
+  spec.required_ruby_version  = '>= 2.5'
 
-  spec.add_dependency "slosilo", "~> 3.0"
-  spec.add_dependency "conjur-api", "< 6"
-  spec.add_dependency "rack", "~> 2"
-  
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "activesupport", "< 7"
-  spec.add_development_dependency 'ci_reporter_rspec'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rspec-its'
+  spec.add_dependency('conjur-api', '< 6')
+  spec.add_dependency('rack', '~> 2')
+  spec.add_dependency('slosilo', '~> 3.0')
 
+  spec.add_development_dependency('activesupport', '< 7')
+  spec.add_development_dependency('ci_reporter_rspec')
+  spec.add_development_dependency('pry-byebug')
+  spec.add_development_dependency('rake')
+  spec.add_development_dependency('rspec')
+  spec.add_development_dependency('rspec-its')
 end

--- a/gems/conjur-rack/conjur-rack.gemspec
+++ b/gems/conjur-rack/conjur-rack.gemspec
@@ -1,0 +1,32 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'conjur/rack/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "conjur-rack"
+  spec.version       = Conjur::Rack::VERSION
+  spec.authors       = ["Kevin Gilpin"]
+  spec.email         = ["kgilpin@conjur.net"]
+  spec.description   = %q{Rack authenticator and basic User struct}
+  spec.summary       = %q{Rack authenticator and basic User struct}
+  spec.homepage      = "http://github.com/conjurinc/conjur-rack"
+  spec.license       = "Private"
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "slosilo", "~> 3.0"
+  spec.add_dependency "conjur-api", "< 6"
+  spec.add_dependency "rack", "~> 2"
+  
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "activesupport", "< 7"
+  spec.add_development_dependency 'ci_reporter_rspec'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rspec-its'
+
+end

--- a/gems/conjur-rack/lib/conjur/rack.rb
+++ b/gems/conjur-rack/lib/conjur/rack.rb
@@ -1,0 +1,26 @@
+require "conjur/rack/version"
+require "conjur/rack/authenticator"
+require "conjur/rack/path_prefix"
+require 'ipaddr'
+require 'set'
+
+module TrustedProxies
+  
+  def trusted_proxy?(ip)
+    trusted_proxies ? trusted_proxies.any? { |cidr| cidr.include?(ip) } : super
+  end
+  
+  def trusted_proxies
+    @trusted_proxies || ENV['TRUSTED_PROXIES'].try do |proxies|
+      cidrs = Set.new(proxies.split(',') + ['127.0.0.1'])
+      @trusted_proxies = cidrs.collect {|cidr| IPAddr.new(cidr) }
+    end
+  end
+  
+end
+
+module Rack
+  class Request
+    prepend TrustedProxies
+  end
+end

--- a/gems/conjur-rack/lib/conjur/rack/authenticator.rb
+++ b/gems/conjur-rack/lib/conjur/rack/authenticator.rb
@@ -1,0 +1,196 @@
+require "conjur/rack/user"
+
+module Conjur
+  module Rack
+
+    class << self
+      def conjur_rack
+        Thread.current[:conjur_rack] ||= {}
+      end
+
+      def identity?
+        !conjur_rack[:identity].nil?
+      end
+      
+      def user
+        User.new(identity[0], identity[1], 
+          :privilege => privilege, 
+          :remote_ip => remote_ip, 
+          :audit_roles => audit_roles, 
+          :audit_resources => audit_resources
+          )
+      end
+      
+      def identity
+        conjur_rack[:identity] or raise "No Conjur identity for current request"
+      end
+
+      # class attributes
+      [:privilege, :remote_ip, :audit_roles, :audit_resources].each do |a|
+        define_method(a) do
+          conjur_rack[a]
+        end
+      end
+    end
+
+  
+    class Authenticator
+      class AuthorizationError < SecurityError
+      end
+      class SignatureError < SecurityError
+      end
+      class Forbidden < SecurityError
+      end
+      
+      attr_reader :app, :options
+      
+      # +options+:
+      # :except :: a list of request path patterns for which to skip authentication.
+      # :optional :: request path patterns for which authentication is optional.
+      def initialize app, options = {}
+        @app = app
+        @options = options
+      end
+
+      # threadsafe accessors, values are established explicitly below
+      def env; Thread.current[:rack_env] ; end
+
+      # instance attributes
+      [:token, :account, :privilege, :remote_ip, :audit_roles, :audit_resources].each do |a|
+        define_method(a) do
+          conjur_rack[a]
+        end
+      end
+ 
+      def call rackenv
+        # never store request-specific variables as application attributes 
+        Thread.current[:rack_env] = rackenv
+        if authenticate?
+          begin
+            identity = verify_authorization_and_get_identity # [token, account]
+            
+            if identity
+              conjur_rack[:token] = identity[0]
+              conjur_rack[:account] = identity[1]
+              conjur_rack[:identity] = identity
+              conjur_rack[:privilege] = http_privilege
+              conjur_rack[:remote_ip] = http_remote_ip
+              conjur_rack[:audit_roles] = http_audit_roles
+              conjur_rack[:audit_resources] = http_audit_resources
+            end
+
+          rescue Forbidden
+            return error 403, $!.message
+          rescue SecurityError, RestClient::Exception
+            return error 401, $!.message
+          end
+        end
+        begin
+          @app.call rackenv
+        ensure
+          Thread.current[:rack_env] = nil
+          Thread.current[:conjur_rack] = {}
+        end
+      end
+      
+      protected
+      
+      def conjur_rack
+        Conjur::Rack.conjur_rack
+      end
+
+      def validate_token_and_get_account token
+        failure = SignatureError.new("Unauthorized: Invalid token")
+        raise failure unless (signer = Slosilo.token_signer token)
+        if signer == 'own'
+          ENV['CONJUR_ACCOUNT'] or raise failure
+        else
+          raise failure unless signer =~ /\Aauthn:(.+)\z/
+          $1
+        end
+      end
+      
+      def error status, message
+        [status, { 'Content-Type' => 'text/plain', 'Content-Length' => message.length.to_s }, [message] ]
+      end
+
+      def parsed_token
+        token = http_authorization.to_s[/^Token token="(.*)"/, 1]
+        token = token && JSON.parse(Base64.decode64(token))
+        token = Slosilo::JWT token rescue token
+      rescue JSON::ParserError
+        raise AuthorizationError.new("Malformed authorization token")
+      end
+      
+      RECOGNIZED_CLAIMS = [
+        'iat', 'exp', # recognized by Slosilo
+        'cidr', 'sub',
+        'iss', 'aud', 'jti' # RFC 7519, not handled but recognized
+      ].freeze
+
+      def verify_authorization_and_get_identity
+        if token = parsed_token
+          begin
+            account = validate_token_and_get_account token
+            if token.respond_to?(:claims)
+              claims = token.claims
+              raise AuthorizationError, "token contains unrecognized claims" unless \
+                  (claims.keys.map(&:to_s) - RECOGNIZED_CLAIMS).empty?
+              if (cidr = claims['cidr'])
+                raise Forbidden, "IP address rejected" unless \
+                    cidr.map(&IPAddr.method(:new)).any? { |c| c.include? http_remote_ip }
+              end
+            end
+            return [token, account]
+          end
+        else
+          path = http_path
+          if optional_paths.find{|p| p.match(path)}.nil?
+            raise AuthorizationError.new("Authorization missing")
+          else
+            nil
+          end
+        end
+      end
+      
+      def authenticate?
+        path = http_path
+        if options[:except]
+          options[:except].find{|p| p.match(path)}.nil?
+        else
+          true
+        end
+      end
+      
+      def optional_paths
+        options[:optional] || []
+      end
+
+      def http_authorization
+        env['HTTP_AUTHORIZATION']
+      end
+
+      def http_privilege
+        env['HTTP_X_CONJUR_PRIVILEGE']
+      end
+
+      def http_remote_ip
+        require 'rack/request'
+        ::Rack::Request.new(env).ip
+      end
+
+      def http_audit_roles
+        env['HTTP_CONJUR_AUDIT_ROLES']
+      end
+
+      def http_audit_resources
+        env['HTTP_CONJUR_AUDIT_RESOURCES']
+      end
+
+      def http_path
+        [ env['SCRIPT_NAME'], env['PATH_INFO'] ].join
+      end
+
+    end
+  end
+end

--- a/gems/conjur-rack/lib/conjur/rack/path_prefix.rb
+++ b/gems/conjur-rack/lib/conjur/rack/path_prefix.rb
@@ -1,0 +1,31 @@
+# https://raw.github.com/merb/merb/master/merb-core/lib/merb-core/rack/middleware/path_prefix.rb
+module Conjur
+  module Rack
+    class PathPrefix
+      EMPTY_STRING = ""
+      SLASH = "/"
+      
+      # @api private
+      def initialize(app, path_prefix = nil)
+        @app = app
+        @path_prefix = /^#{Regexp.escape(path_prefix)}/
+      end
+
+      # @api plugin
+      def call(env)
+        strip_path_prefix(env) 
+        @app.call(env)
+      end
+
+      # @api private
+      def strip_path_prefix(env)
+        ['PATH_INFO', 'REQUEST_URI'].each do |path_key|
+          if env[path_key] =~ @path_prefix
+            env[path_key].sub!(@path_prefix, EMPTY_STRING)
+            env[path_key] = SLASH if env[path_key].empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/conjur-rack/lib/conjur/rack/user.rb
+++ b/gems/conjur-rack/lib/conjur/rack/user.rb
@@ -1,0 +1,141 @@
+require 'conjur/api'
+
+module Conjur
+  module Rack
+    # Token data can be a string (which is the user login), or a Hash.
+    # If it's a hash, it should contain the user login keyed by the string 'login'.
+    # The rest of the payload is available as +attributes+.
+    class User
+      attr_reader :token, :account, :privilege, :remote_ip, :audit_roles, :audit_resources
+      
+      def initialize(token, account, options = {})
+        @token = token
+        @account = account
+        # Third argument used to be the name of privilege, be
+        # backwards compatible:
+        if options.respond_to?(:to_str)
+          @privilege = options
+        else
+          @privilege = options[:privilege]
+          @remote_ip = options[:remote_ip]
+          @audit_roles = options[:audit_roles]
+          @audit_resources = options[:audit_resources]
+        end
+      end
+      
+      # This file was accidently calling account conjur_account,
+      # I'm adding an alias in case that's going on anywhere else.
+      # -- Jon
+      alias :conjur_account :account
+      # alias :conjur_account= :account=
+      
+      # Returns the global privilege which was present on the request, if and only
+      # if the user actually has that privilege.
+      #
+      # Returns nil if no global privilege was present in the request headers, 
+      # or if a global privilege was present in the request headers, but the user doesn't
+      # actually have that privilege according to the Conjur server.
+      def validated_global_privilege
+        unless @validated_global_privilege
+          @privilege = nil unless @privilege &&
+                  api.respond_to?(:global_privilege_permitted?) &&
+                  api.global_privilege_permitted?(@privilege)
+          @validated_global_privilege = true
+        end
+        @privilege
+      end
+      
+      # True if and only if the user has valid global 'reveal' privilege.
+      def global_reveal?
+        validated_global_privilege == "reveal"
+      end
+      
+      # True if and only if the user has valid global 'elevate' privilege.
+      def global_elevate?
+        validated_global_privilege == "elevate"
+      end
+      
+      def login
+        parse_token
+
+        @login
+      end
+
+      def attributes
+        parse_token
+
+        @attributes || {}
+      end
+      
+      def roleid
+        tokens = login.split('/')
+        role_kind, roleid = if tokens.length == 1
+          [ 'user', login ]
+        else
+          [ tokens[0], tokens[1..-1].join('/') ]
+        end
+        [ account, role_kind, roleid ].join(':')
+      end
+      
+      def role
+        api.role(roleid)
+      end
+
+      def audit_resources
+        Conjur::API.decode_audit_ids(@audit_resources) if @audit_resources
+      end
+
+      def audit_roles
+        Conjur::API.decode_audit_ids(@audit_roles) if @audit_roles
+      end
+
+      def api(cls = Conjur::API)
+        args = [ token ]
+        args.push remote_ip if remote_ip
+        api = cls.new_from_token(*args)
+
+        # These are features not present in some API versions.
+        # Test for them and only apply if it makes sense. Ignore otherwise.
+        %i(privilege audit_resources audit_roles).each do |feature|
+          meth = "with_#{feature}".intern
+          if api.respond_to?(meth) && (value = send(feature))
+            api = api.send meth, value
+          end
+        end
+
+        api
+      end
+
+      protected
+
+      def parse_token
+        return if @login
+
+        @token = Slosilo::JWT token
+        load_jwt token
+      rescue ArgumentError
+        if data = token['data']
+          return load_legacy data
+        else
+          raise "malformed token"
+        end
+      end
+
+      def load_legacy data
+        if data.is_a?(String)
+          @login = token['data']
+        elsif data.is_a?(Hash)
+          @attributes = token['data'].clone
+          @login = @attributes.delete('login') or raise "No 'login' field in token data"
+        else
+          raise "Expecting String or Hash token data, got #{data.class.name}"
+        end
+      end
+
+      def load_jwt jwt
+        @attributes = jwt.claims.merge (jwt.header || {}) # just pass all the info
+        @login = jwt.claims['sub'] or raise "No 'sub' field in claims"
+      end
+    end
+  end
+end

--- a/gems/conjur-rack/lib/conjur/rack/version.rb
+++ b/gems/conjur-rack/lib/conjur/rack/version.rb
@@ -1,0 +1,5 @@
+module Conjur
+  module Rack
+    VERSION = "5.0.0"
+  end
+end

--- a/gems/conjur-rack/spec/rack/authenticator_spec.rb
+++ b/gems/conjur-rack/spec/rack/authenticator_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+require 'conjur/rack/authenticator'
+
+describe Conjur::Rack::Authenticator do
+  include_context "with authenticator"
+
+  describe "#call" do
+    context "to an unprotected path" do
+      let(:except) { [ /^\/foo/ ] }
+      let(:env) { { 'SCRIPT_NAME' => '', 'PATH_INFO' => '/foo/bar' } }
+      before {
+        options[:except] = except
+        expect(app).to receive(:call).with(env).and_return app
+      }
+      context "without authorization" do
+        it "proceeds" do
+          expect(call).to eq(app)
+          expect(Conjur::Rack.identity?).to be(false)
+        end
+      end
+      context "with authorization" do
+        include_context "with authorization"
+        it "ignores the authorization" do
+          expect(call).to eq(app)
+          expect(Conjur::Rack.identity?).to be(false)
+        end
+      end
+    end
+
+    context "to a protected path" do
+      let(:env) { { 'SCRIPT_NAME' => '/pathname' } }
+      context "without authorization" do
+        it "returns a 401 error" do
+          expect(call).to return_http 401, "Authorization missing"
+        end
+      end
+      context "with Conjur authorization" do
+        include_context "with authorization"
+
+        context "with CIDR restriction" do
+          let(:claims) { { 'sub' => 'test-user', 'cidr' => %w(192.168.2.0/24 2001:db8::/32) } }
+          let(:token) { Slosilo::JWT.new(claims) }
+          before do
+            allow(subject).to receive_messages \
+                parsed_token: token,
+                http_remote_ip: remote_ip
+          end
+
+          %w(10.0.0.2 fdda:5cc1:23:4::1f).each do |addr|
+            context "with address #{addr} out of range" do
+              let(:remote_ip) { addr }
+              it "returns 403" do
+                expect(call).to return_http 403, "IP address rejected"
+              end
+            end
+          end
+
+          %w(192.168.2.3 2001:db8::22).each do |addr|
+            context "with address #{addr} in range" do
+              let(:remote_ip) { addr }
+              it "passes the request" do
+                expect(call.login).to eq 'test-user'
+              end
+            end
+          end
+        end
+
+        context "of a valid token" do
+          it 'launches app' do
+            expect(app).to receive(:call).with(env).and_return app
+            expect(call).to eq(app)
+          end
+        end
+        context "of an invalid token" do
+          it "returns a 401 error" do
+            allow(Slosilo).to receive(:token_signer).and_return(nil)
+            expect(call).to return_http 401, "Unauthorized: Invalid token"
+          end
+        end
+        context "of a token invalid for authn" do
+          it "returns a 401 error" do
+            allow(Slosilo).to receive(:token_signer).and_return('a-totally-different-key')
+            expect(call).to return_http 401, "Unauthorized: Invalid token"
+          end
+        end
+        context "of 'own' token" do
+          it "returns ENV['CONJUR_ACCOUNT']" do
+            expect(ENV).to receive(:[]).with("CONJUR_ACCOUNT").and_return("test-account")
+            expect(app).to receive(:call) do |*args|
+              expect(Conjur::Rack.identity?).to be(true)
+              expect(Conjur::Rack.user.account).to eq('test-account')
+              :done
+            end
+            allow(Slosilo).to receive(:token_signer).and_return('own')
+            expect(call).to eq(:done)
+          end
+          it "requires ENV['CONJUR_ACCOUNT']" do
+            expect(ENV).to receive(:[]).with("CONJUR_ACCOUNT").and_return(nil)
+            allow(Slosilo).to receive(:token_signer).and_return('own')
+            expect(call).to return_http 401, "Unauthorized: Invalid token"
+          end
+        end
+      end
+
+      context "with junk in token" do
+        let(:env) { { 'HTTP_AUTHORIZATION' => 'Token token="open sesame"' } }
+        it "returns 401" do
+          expect(call).to return_http 401, "Malformed authorization token"
+        end
+      end
+
+      context "with JSON junk in token" do
+        let(:env) { { 'HTTP_AUTHORIZATION' => 'Token token="eyJmb28iOiAiYmFyIn0="' } }
+        before do
+          allow(Slosilo).to receive(:token_signer).and_return(nil)
+        end
+
+        it "returns 401" do
+            expect(call).to return_http 401, "Unauthorized: Invalid token"
+        end
+      end
+    end
+    context "to an optional path" do
+      let(:optional) { [ /^\/foo/ ] }
+      let(:env) { { 'SCRIPT_NAME' => '', 'PATH_INFO' => '/foo/bar' } }
+      before {
+        options[:optional] = optional
+      }
+      context "without authorization" do
+        it "proceeds" do
+          expect(app).to receive(:call) do |*args|
+            expect(Conjur::Rack.identity?).to be(false)
+            :done
+          end
+          expect(call).to eq(:done)
+        end
+      end
+      context "with authorization" do
+        include_context "with authorization"
+        it "processes the authorization" do
+          expect(app).to receive(:call) do |*args|
+            expect(Conjur::Rack.identity?).to be(true)
+            :done
+          end
+          expect(call).to eq(:done)
+        end
+      end
+    end
+
+    RSpec::Matchers.define :return_http do |status, message|
+      match do |actual|
+        status, headers, body = actual
+        expect(status).to eq status
+        expect(headers).to eq "Content-Type" => "text/plain", "Content-Length" => message.length.to_s
+        expect(body.join).to eq message
+      end
+    end
+  end
+
+  # protected internal methods
+
+  describe '#verify_authorization_and_get_identity' do
+    it "accepts JWT tokens without CIDR restrictions" do
+      mock_jwt sub: 'user'
+      expect { subject.send :verify_authorization_and_get_identity }.to_not raise_error
+    end
+
+    it "rejects JWT tokens with unrecognized claims" do
+      mock_jwt extra: 'field'
+      expect { subject.send :verify_authorization_and_get_identity }.to raise_error \
+          Conjur::Rack::Authenticator::AuthorizationError
+    end
+
+    def mock_jwt claims
+      token = Slosilo::JWT.new(claims).add_signature(alg: 'none') {}
+      allow(subject).to receive(:parsed_token) { token }
+      allow(Slosilo).to receive(:token_signer).with(token).and_return 'authn:test'
+    end
+  end
+end

--- a/gems/conjur-rack/spec/rack/path_prefix_spec.rb
+++ b/gems/conjur-rack/spec/rack/path_prefix_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+require 'conjur/rack/path_prefix'
+
+describe Conjur::Rack::PathPrefix do
+  let(:app) { double(:app) }
+  let(:prefix) { "/api" }
+  let(:path_prefix) { Conjur::Rack::PathPrefix.new(app, prefix) }
+  let(:call) { path_prefix.call env }
+  let(:env) {
+    {
+      'PATH_INFO' => path
+    }
+  }
+
+  context "#call" do
+    context "/api/hosts" do
+      let(:path) { "/api/hosts" }
+      it "matches" do
+        expect(app).to receive(:call).with({ 'PATH_INFO' => '/hosts' }).and_return app
+        call
+      end
+    end
+    context "/api" do
+      let(:path) { "/api" }
+      it "doesn't erase the path completely" do
+        expect(app).to receive(:call).with({ 'PATH_INFO' => '/' }).and_return app
+        call
+      end
+    end
+    context "with non-matching prefix" do
+      let(:path) { "/hosts" }
+      it "doesn't match" do
+        expect(app).to receive(:call).with({ 'PATH_INFO' => '/hosts' }).and_return app
+        call
+      end
+    end
+  end
+  
+end

--- a/gems/conjur-rack/spec/rack/user_spec.rb
+++ b/gems/conjur-rack/spec/rack/user_spec.rb
@@ -1,0 +1,221 @@
+require 'spec_helper'
+require 'conjur/rack/user'
+
+describe Conjur::Rack::User do
+  let(:login){ 'admin' }
+  let(:token){ {'data' => login} }
+  let(:account){ 'acct' }
+  let(:privilege) { nil }
+  let(:remote_ip) { nil }
+  let(:audit_roles) { nil }
+  let(:audit_resources) { nil }
+  
+  subject(:user) { 
+    described_class.new(token, account, 
+      :privilege => privilege, 
+      :remote_ip => remote_ip, 
+      :audit_roles => audit_roles, 
+      :audit_resources => audit_resources 
+    )
+  }
+  
+  it 'provides field accessors' do
+    expect(user.token).to eq token
+    expect(user.account).to eq account
+    expect(user.conjur_account).to eq account
+    expect(user.login).to eq login
+  end
+  
+  describe '#roleid' do
+    let(:login){ tokens.join('/') }
+
+    context "when login contains one token" do
+      let(:tokens) { %w(foobar) }
+
+      it "is expanded to account:user:token" do
+        expect(subject.roleid).to eq "#{account}:user:foobar"
+      end
+    end
+
+    context "when login contains two tokens" do
+      let(:tokens) { %w(foo bar) }
+
+      it "is expanded to account:first:second" do
+        expect(subject.roleid).to eq "#{account}:foo:bar"
+      end
+    end
+
+    context "when login contains three tokens" do
+      let(:tokens) { %w(foo bar baz) }
+
+      it "is expanded to account:first:second/third" do
+        expect(subject.roleid).to eq "#{account}:foo:bar/baz"
+      end
+    end
+  end
+  
+  describe '#role' do
+    let(:roleid){ 'the role id' }
+    let(:api){ double('conjur api') }
+    before do
+      allow(subject).to receive(:roleid).and_return roleid
+      allow(subject).to receive(:api).and_return api
+    end
+    
+    it 'passes roleid to api.role' do
+      expect(api).to receive(:role).with(roleid).and_return 'the role'
+      expect(subject.role).to eq('the role')
+    end
+  end
+  
+  describe "#global_reveal?" do
+    let(:api){ double "conjur-api" }
+    before { allow(subject).to receive(:api).and_return(api) }
+
+    context "with global privilege" do
+      let(:privilege) { "reveal" }
+
+      context "when not supported" do
+        before { expect(api).not_to respond_to :global_privilege_permitted? }
+        it "simply returns false" do
+          expect(subject.global_reveal?).to be false
+        end
+      end
+
+      context "when supported" do
+        before do
+          allow(api).to receive(:global_privilege_permitted?).with('reveal') { true }
+        end
+        it "checks the API function global_privilege_permitted?" do
+          expect(subject.global_reveal?).to be true
+          # The result is cached
+          expect(api).not_to receive :global_privilege_permitted?
+          subject.global_reveal?
+        end
+      end
+    end
+
+    context "without a global privilege" do
+      it "simply returns false" do
+        expect(subject.global_reveal?).to be false
+      end
+    end
+  end
+  
+  describe '#api' do
+    context "when given a class" do
+      let(:cls){ double('API class') }
+      it "calls cls.new_from_token with its token" do
+        expect(cls).to receive(:new_from_token).with(token).and_return 'the api'
+        expect(subject.api(cls)).to eq('the api')
+      end
+    end
+
+    context 'when not given args' do
+      let(:api) { double :api }
+      before do
+        allow(Conjur::API).to receive(:new_from_token).with(token).and_return(api)
+      end
+
+      it "builds the api from token" do
+        expect(subject.api).to eq api
+      end
+
+      context "with remote_ip" do
+        let(:remote_ip) { "the-ip" }
+        it "passes the IP to the API constructor" do
+          expect(Conjur::API).to receive(:new_from_token).with(token, 'the-ip').and_return(api)
+          expect(subject.api).to eq api
+        end
+      end
+
+      context "with privilege" do
+        let(:privilege) { "elevate" }
+        it "applies the privilege on the API object" do
+          expect(api).to receive(:with_privilege).with("elevate").and_return "privileged api"
+          expect(subject.api).to eq "privileged api"
+        end
+      end
+
+      context "when audit supported" do
+        before do
+          # If we're testing on an API version that doesn't
+          # support audit this method will be missing, so stub.
+          unless Conjur::API.respond_to? :decode_audit_ids
+            # not exactly a faithful reimplementation, but good enough for here
+            allow(Conjur::API).to receive(:decode_audit_ids) {|x|[x]}
+          end
+        end
+
+        context "with audit resource" do
+          let (:audit_resources) { 'food:bacon' }
+          it "applies the audit resource on the API object" do
+            expect(api).to receive(:with_audit_resources).with(['food:bacon']).and_return('the api')
+            expect(subject.api).to eq 'the api'
+          end
+        end
+
+        context "with audit roles" do
+          let (:audit_roles) { 'user:cook' }
+          it "applies the audit role on the API object" do
+            expect(api).to receive(:with_audit_roles).with(['user:cook']).and_return('the api')
+            expect(subject.api).to eq 'the api'
+          end
+        end
+      end
+
+      context "when audit not supported" do
+        before do
+          expect(api).not_to respond_to :with_audit_resources
+          expect(api).not_to respond_to :with_audit_roles
+        end
+        let (:audit_resources) { 'food:bacon' }
+        let (:audit_roles) { 'user:cook' }
+        it "ignores audit roles and resources" do
+          expect(subject.api).to eq api
+        end
+      end
+    end
+  end
+
+  context "with invalid type payload" do
+    let(:token){ { "data" => :alice } }
+    it "raises an error on trying to access the content" do
+      expect{ subject.login }.to raise_error("Expecting String or Hash token data, got Symbol")
+    end
+  end
+
+  context "with hash payload" do
+    let(:token){ { "data" => { "login" => "alice", "capabilities" => { "fry" => "bacon" } } } }
+
+    it "processes the login and attributes" do
+      original_token = token.deep_dup
+
+      expect(subject.login).to eq('alice')
+      expect(subject.attributes).to eq({"capabilities" => { "fry" => "bacon" }})
+
+      expect(token).to eq original_token
+    end
+  end
+
+  context "with JWT token" do
+    let(:token) { {"protected"=>"eyJhbGciOiJ0ZXN0IiwidHlwIjoiSldUIn0=",
+ "payload"=>"eyJzdWIiOiJhbGljZSIsImlhdCI6MTUwNDU1NDI2NX0=",
+ "signature"=>"dGVzdHNpZw=="} }
+
+    it "processes the login and attributes" do
+      original_token = token.deep_dup
+
+      expect(subject.login).to eq('alice')
+
+      # TODO: should we only pass unrecognized attrs here?
+      expect(subject.attributes).to eq \
+          'alg' => 'test',
+          'iat' => 1504554265,
+          'sub' => 'alice',
+          'typ' => 'JWT'
+
+      expect(token).to eq original_token
+    end
+  end
+end

--- a/gems/conjur-rack/spec/rack_spec.rb
+++ b/gems/conjur-rack/spec/rack_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'conjur/rack'
+
+describe Conjur::Rack do
+  describe '.user' do
+    include_context "with authorization"
+    let(:stubuser) { double :stubuser }
+    before do
+      allow(Conjur::Rack::User).to receive(:new)
+        .with(token, 'someacc', {:privilege => privilege, :remote_ip => remote_ip, :audit_roles => audit_roles, :audit_resources => audit_resources})
+        .and_return(stubuser)
+    end
+
+    context 'when called in app context' do
+      shared_examples_for :returns_user do
+        it "returns user built from token" do
+          expect(call).to eq stubuser
+        end
+      end
+
+      include_examples :returns_user
+
+      context 'with X-Conjur-Privilege' do
+        let(:privilege) { "elevate" }
+        include_examples :returns_user
+      end
+
+      context 'with X-Forwarded-For' do
+        let(:remote_ip) { "66.0.0.1" }
+        include_examples :returns_user
+      end
+
+      context 'with Conjur-Audit-Roles' do
+        let (:audit_roles) { 'user%3Acook' }
+        include_examples :returns_user
+      end
+
+      context 'with Conjur-Audit-Resources' do
+        let (:audit_resources) { 'food%3Abacon' }
+        include_examples :returns_user
+      end
+
+    end
+
+    it "raises error if called out of app context" do
+      expect { Conjur::Rack.user }.to raise_error('No Conjur identity for current request')
+    end
+  end
+end

--- a/gems/conjur-rack/spec/spec_helper.rb
+++ b/gems/conjur-rack/spec/spec_helper.rb
@@ -1,0 +1,47 @@
+require 'rubygems'
+$:.unshift File.join(File.dirname(__FILE__), "..", "lib")
+$:.unshift File.join(File.dirname(__FILE__), "lib")
+
+# Allows loading of an environment config based on the environment
+require 'rspec'
+require 'rspec/its'
+require 'securerandom'
+require 'slosilo'
+
+RSpec.configure do |config|
+end
+
+RSpec.shared_context "with authenticator" do
+  let(:options) { {} }
+  let(:app) { double(:app) }
+  subject(:authenticator) { Conjur::Rack::Authenticator.new(app, options) }
+  let(:call) { authenticator.call env }
+end
+
+RSpec.shared_context "with authorization" do
+  include_context "with authenticator"
+  let(:token_signer) { "authn:someacc" }
+  let(:audit_resources) { nil }
+  let(:privilege) { nil }
+  let(:remote_ip) { nil }
+  let(:audit_roles) { nil }
+
+  before do
+    allow(app).to receive(:call) { Conjur::Rack.user }
+    allow(Slosilo).to receive(:token_signer).and_return(token_signer)
+  end
+
+  let(:env) do
+    {
+      'HTTP_AUTHORIZATION' => "Token token=\"#{basic_64}\""
+    }.tap do |e|
+      e['HTTP_X_CONJUR_PRIVILEGE'] = privilege if privilege
+      e['HTTP_X_FORWARDED_FOR'] = remote_ip if remote_ip
+      e['HTTP_CONJUR_AUDIT_ROLES'] = audit_roles if audit_roles
+      e['HTTP_CONJUR_AUDIT_RESOURCES'] = audit_resources if audit_resources
+    end
+  end
+
+  let(:basic_64) { Base64.strict_encode64(token.to_json) }
+  let(:token) { { "data" => "foobar" } }
+end

--- a/gems/conjur-rack/test.sh
+++ b/gems/conjur-rack/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+TEST_IMAGE='ruby:3.0'
+
+rm -f Gemfile.lock
+
+docker run --rm \
+  -v "$PWD:/usr/src/app" \
+  -w /usr/src/app \
+  -e CONJUR_ENV=ci \
+  $TEST_IMAGE \
+  bash -c "gem update --system && bundle update && bundle exec rake spec"


### PR DESCRIPTION
### Desired Outcome

Conjur is currently the only project which uses the conjur-rack gem. This PR brings it into Conjur to simplify the authorization process.

### Implemented Changes

This commit adds `conjur-rack` as a local gem.

### Connected Issue/Story

N/A - This is being done in support of Conjur SaaS.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
