### PR TITLE
Fix AuthnJWT test case ONYX-10960

### DIFF
--- a/cucumber/authenticators_jwt/features/authn_status_jwt.feature
+++ b/cucumber/authenticators_jwt/features/authn_status_jwt.feature
@@ -1108,7 +1108,7 @@ Feature: JWT Authenticator - Status Check
     And I save my place in the log file
     When I GET "/authn-jwt/raw/cucumber/status"
     Then the HTTP response status code is 500
-    And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|-|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|-|0-9|.]*)*$)"
+    And the authenticator status check fails with error "does not match regular expression: '(?-mix:^[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*(\/[a-zA-Z|$|_][a-zA-Z|$|_|\-|0-9|.]*)*$)"
 
   @negative @acceptance
   Scenario Outline: ONYX-10958: claim-aliases configured with invalid value, 500 Error


### PR DESCRIPTION
### Desired Outcome

Fix AuthnJWT failing test case ONYX-10960.
Failure caused by regex update in cyberark/conjur#2792.

### Implemented Changes

Updated expected regex in test case failure message.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
