### PR TITLE
Support running cucumber tests in parallel:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem 'faye-websocket'
   gem 'net-ssh'
   gem 'parallel'
+  gem 'parallel_tests'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,8 @@ GEM
       validate_url
       webfinger (>= 1.0.1)
     parallel (1.21.0)
+    parallel_tests (4.2.0)
+      parallel
     parser (3.0.3.2)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -536,6 +538,7 @@ DEPENDENCIES
   nokogiri (>= 1.8.2)
   openid_connect
   parallel
+  parallel_tests
   pg
   pry-byebug
   pry-rails

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -14,6 +14,20 @@ services:
       #   PostgreSQL documentation about "trust"
       POSTGRES_HOST_AUTH_METHOD: trust
 
+  pg2:
+    image: postgres:10.16
+    environment:
+      # To avoid the following error:
+      #
+      #   Error: Database is uninitialized and superuser password is not
+      #   specified.  You must specify POSTGRES_PASSWORD for the superuser. Use
+      #   "-e POSTGRES_PASSWORD=password" to set it in "docker run".
+      #
+      #   You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all
+      #   connections without a password. This is *not* recommended. See
+      #   PostgreSQL documentation about "trust"
+      POSTGRES_HOST_AUTH_METHOD: trust
+
   audit:
     image: postgres:10.16
     environment:
@@ -21,6 +35,20 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   testdb:
+    image: postgres:10.16
+    environment:
+      # To avoid the following error:
+      #
+      #   Error: Database is uninitialized and superuser password is not
+      #   specified.  You must specify POSTGRES_PASSWORD for the superuser. Use
+      #   "-e POSTGRES_PASSWORD=password" to set it in "docker run".
+      #
+      #   You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all
+      #   connections without a password. This is *not* recommended. See
+      #   PostgreSQL documentation about "trust"
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  testdb2:
     image: postgres:10.16
     environment:
       # To avoid the following error:
@@ -67,14 +95,45 @@ services:
       - ldap-server
       - keycloak
 
+  conjur2:
+    image: "conjur-test:${TAG}"
+    environment:
+      DATABASE_URL: postgres://postgres@pg2/postgres
+      CONJUR_ADMIN_PASSWORD: ADmin123!!!!
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_DATA_KEY:
+      RAILS_ENV:
+      REQUIRE_SIMPLECOV: "true"
+      CONJUR_LOG_LEVEL: debug
+      CONJUR_AUTHENTICATORS: authn-ldap/test,authn-ldap/secure,authn-oidc/keycloak,authn-oidc,authn-k8s/test,authn-azure/prod,authn-gcp,authn-jwt/raw,authn-jwt/keycloak,authn-oidc/keycloak2,authn-oidc/okta-2
+      LDAP_URI: ldap://ldap-server:389
+      LDAP_BASE: dc=conjur,dc=net
+      LDAP_FILTER: '(uid=%s)'
+      LDAP_BINDDN: cn=admin,dc=conjur,dc=net
+      LDAP_BINDPW: ldapsecret
+      WEB_CONCURRENCY: 0
+      RAILS_MAX_THREADS: 10
+    command: server
+    volumes:
+      # TODO: authenticators_oidc/test has a dep on this
+      - authn-local2:/run/authn-local
+      - ./oauth/keycloak:/oauth/keycloak/scripts
+      - ./ldap-certs:/ldap-certs:ro
+      - log-volume:/opt/conjur-server/log
+      - ../coverage:/opt/conjur-server/coverage
+    expose:
+      - "80"
+    links:
+      - pg2
+      - ldap-server
+      - keycloak
+
   cucumber:
     image: conjur-test:$TAG
     entrypoint: bash
     working_dir: /src/conjur-server
     environment:
-      CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: cucumber
-      DATABASE_URL: postgres://postgres@pg/postgres
       AUDIT_DATABASE_URL:
       RAILS_ENV: test
       CONJUR_LOG_LEVEL: debug
@@ -88,14 +147,18 @@ services:
     volumes:
       - ..:/src/conjur-server
       - authn-local:/run/authn-local
+      - authn-local2:/run/authn-local
       - ./ldap-certs:/ldap-certs:ro
       - log-volume:/src/conjur-server/log
       - jwks-volume:/var/jwks
       - ./oauth/keycloak:/oauth/keycloak/scripts
     links:
       - conjur
+      - conjur2
       - pg
+      - pg2
       - testdb
+      - testdb2
       - keycloak
 
   ldap-server:
@@ -168,5 +231,6 @@ services:
 
 volumes:
   authn-local:
+  authn-local2:
   log-volume:
   jwks-volume:

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -2,6 +2,38 @@
 
 export REPORT_ROOT=/src/conjur-server
 
+# Sets the number of parallel processes for cucumber tests
+# Due to naming conventions for parallel_cucumber this begins at 1 NOT 0
+PARALLEL_PROCESSES=2
+
+get_parallel_services() {
+  # get_parallel_services converts docker service names
+  # to the appropriate naming conventions expected for
+  # parallel cucumber tests.
+
+  # Args:
+  #   $1: A string of space delimited docker service name(s)
+
+  # Returns:
+  #  An array of docker service names matching the expected
+  #  parallel cucumber naming convention.
+  local services
+  local parallel_services
+  read -ra services <<< "$1"
+
+  for service in "${services[@]}"; do
+    for (( i=1; i<=PARALLEL_PROCESSES; i++ )); do
+      if (( i == 1 )) ; then
+        parallel_services+=("$service")
+      else
+        parallel_services+=("$service${i}")
+      fi
+    done
+  done
+
+  echo "${parallel_services[@]}"
+}
+
 # Note: This function is long but purposefully not split up.  None of its parts
 # are re-used, and the split-up version is harder to follow and duplicates
 # argument processing.
@@ -30,12 +62,25 @@ _run_cucumber_tests() {
 
   echo "Start all services..."
 
-  docker-compose up --no-deps --no-recreate -d pg conjur "${services[@]}"
-  docker-compose exec -T conjur conjurctl wait --retries 180
+  local parallel_services
+  read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
+
+  if (( ${#services[@]} )); then
+    docker-compose up --no-deps --no-recreate -d "${parallel_services[@]}" "${services[@]}"
+  else
+    docker-compose up --no-deps --no-recreate -d "${parallel_services[@]}"
+  fi
+
+  read -ra parallel_services <<< "$(get_parallel_services 'conjur')"
+  for parallel_service in "${parallel_services[@]}"; do
+    docker-compose exec -T "$parallel_service" conjurctl wait --retries 180
+  done
 
   echo "Create cucumber account..."
 
-  docker-compose exec -T conjur conjurctl account create cucumber
+  for parallel_service in "${parallel_services[@]}"; do
+    docker-compose exec -T "$parallel_service" conjurctl account create cucumber
+  done
 
   # Stage 2: Prepare cucumber environment args
   # -----------------------------------------------------------
@@ -56,15 +101,30 @@ _run_cucumber_tests() {
     env_var_flags+=(-e "$item")
   done
 
+  # Generate api key ENV variables based on the
+  # number of parallel processes.
+  for (( i=1; i <= ${#parallel_services[@]}; ++i )); do
+    index=$(( i - 1 ))
+    if (( i == 1 )) ; then
+        api_keys+=("CONJUR_AUTHN_API_KEY=$(_get_api_key "${parallel_services[$index]}")")
+    else
+        api_keys+=("CONJUR_AUTHN_API_KEY${i}=$(_get_api_key "${parallel_services[$index]}")")
+    fi
+  done
+
   # Add the cucumber env vars that we always want to send.
   # Note: These are args for docker-compose run, and as such the right hand
   # sides of the = do NOT require escaped quotes.  docker-compose takes the
   # entire arg, splits on the =, and uses the rhs as the value,
   env_var_flags+=(
-    -e "CONJUR_AUTHN_API_KEY=$(_get_api_key)"
     -e "CUCUMBER_NETWORK=$(_find_cucumber_network)"
     -e "CUCUMBER_FILTER_TAGS=$CUCUMBER_FILTER_TAGS"
   )
+
+  # Add parallel process api_keys to the env_var_flags
+  for api_key in "${api_keys[@]}"; do
+    env_var_flags+=(-e "$api_key")
+  done
 
   # If there's no tty (e.g. we're running as a Jenkins job), pass -T to
   # docker-compose.
@@ -84,16 +144,23 @@ _run_cucumber_tests() {
   # Stage 3: Run Cucumber
   # -----------------------------------------------------------
 
+  echo "ENV_ARG_FN: ${env_arg_fn}" >&2
+  echo "RUN_FLAGS: ${run_flags[*]}" >&2
+  echo "ENV_VAR_FLAGS: ${env_var_flags[*]}" >&2
+  echo "CUCUMBER TAGS: ${cucumber_tags_arg}" >&2
+  echo "CUCUMBER PROFILE: ${profile}" >&2
+
+
+  # Have to add tags in profile for parallel to run properly
+  # ${cucumber_tags_arg} should overwrite the profile tags in a way for @smoke to work correctly
   docker-compose run "${run_flags[@]}" "${env_var_flags[@]}" \
     cucumber -ec "\
       /oauth/keycloak/scripts/fetch_certificate &&
-      bundle exec cucumber \
-       --strict \
-       ${cucumber_tags_arg} \
-       -p \"$profile\" \
+      bundle exec parallel_cucumber . -n ${PARALLEL_PROCESSES} \
+       -o '--strict --profile \"${profile}\" ${cucumber_tags_arg} \
        --format json --out \"cucumber/$profile/cucumber_results.json\" \
        --format html --out \"cucumber/$profile/cucumber_results.html\" \
-       --format junit --out \"cucumber/$profile/features/reports\""
+       --format junit --out \"cucumber/$profile/features/reports\"'"
 
   # Stage 4: Coverage results
   # -----------------------------------------------------------
@@ -102,21 +169,26 @@ _run_cucumber_tests() {
   # killed before ruby, the report doesn't get written. So here we kill the
   # process to write the report. The container is kept alive using an infinite
   # sleep in the at_exit hook (see .simplecov).
-  docker-compose exec -T conjur bash -c "pkill -f 'puma 5'"
+  for parallel_service in "${parallel_services[@]}"; do
+    docker-compose exec -T "$parallel_service" bash -c "pkill -f 'puma 5'"
+  done
 }
 
 _get_api_key() {
-  docker-compose exec -T conjur conjurctl \
+  local service=$1
+
+  docker-compose exec -T "${service}" conjurctl \
     role retrieve-key cucumber:user:admin | tr -d '\r'
 }
 
 _find_cucumber_network() {
   local net
 
-  net=$(
-    docker inspect "$(docker-compose ps -q conjur)" \
-      --format '{{.HostConfig.NetworkMode}}'
-  )
+  # Docker compose conjur/pg services use the same
+  # network for 1 or more instances so only conjur is passed
+  # and not other parallel services.
+  conjur_id=$(docker-compose ps -q conjur)
+  net=$(docker inspect "${conjur_id}" --format '{{.HostConfig.NetworkMode}}')
 
   docker network inspect "$net" \
     --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
@@ -180,5 +252,6 @@ start_ldap_server() {
     echo 'LDAP server failed to start in time'
     exit 1
   fi
+
   echo "Done."
 }

--- a/ci/test
+++ b/ci/test
@@ -86,9 +86,8 @@ docker_diagnostics() {
   # its _value_ in the regex.
   #
   # Docker Note: container name is always the last field.  Hence $NF gets it.
-  readarray -t cont_names < <(
-    docker ps --all | awk "/${COMPOSE_PROJECT_NAME}/{print \$NF}"
-  )
+  declare -a cont_names
+  while IFS=$'\n' read -r line; do cont_names+=("$line"); done < <(docker ps --all | awk "/${COMPOSE_PROJECT_NAME}/{print \$NF}")
 
   # Store container logs for archiving.
   echo "Writing Container logs to" \

--- a/ci/test_suites/authenticators_jwt/test
+++ b/ci/test_suites/authenticators_jwt/test
@@ -8,7 +8,9 @@ source "./shared.sh"
 source "./oauth/keycloak/keycloak_functions.sh"
 
 function main() {
-  docker-compose up --no-deps -d pg conjur jwks jwks_py keycloak
+  local parallel_services
+  read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
+  docker-compose up --no-deps -d "${parallel_services[@]}" jwks jwks_py keycloak
 
   wait_for_keycloak_server
   create_keycloak_users

--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -36,7 +36,9 @@ function _hydrate_all_env_args() {
 }
 
 function main() {
-  docker-compose up --no-deps -d pg conjur keycloak
+  local parallel_services
+  read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
+  docker-compose up --no-deps -d "${parallel_services[@]}" keycloak
 
   # We also run an ldap-server container for testing the OIDC & LDAP combined
   # use-case.  We can't run this use-case in a separate Jenkins step because

--- a/ci/test_suites/rotators/test
+++ b/ci/test_suites/rotators/test
@@ -5,5 +5,14 @@ set -e
 # shellcheck disable=SC1091
 source "./shared.sh"
 
-additional_services='testdb'
-_run_cucumber_tests rotators "$additional_services"
+read -ra parallel_services <<< "$(get_parallel_services 'testdb')"
+additional_services=''
+for service in "${parallel_services[@]}"; do
+    if [[ "$additional_services" == '' ]]; then
+        additional_services+="${service}"
+    else
+        additional_services+=" ${service}"
+    fi
+done
+
+_run_cucumber_tests rotators "${additional_services}"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,9 @@ Rails.application.configure do
   # Whitelist conjur hostname for tests
   # For more information, refer to:
   # https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
-  config.hosts << "conjur"
+
+  # Accept multiple hosts for parallel tests
+  config.hosts << /^conjur[0-9]*$/
 
   # eager_load needed to make authentication work without the hacky
   # loading code...

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -3,6 +3,17 @@
 require 'logger/formatter/conjur_formatter'
 require 'test/audit_sink'
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,9 +1,11 @@
 policy: >
+  --tags @policy
   --format pretty
   -r cucumber/policy
   cucumber/policy
 
 api: >
+  --tags @api
   --format pretty
   -r cucumber/api/features/support/logs_helpers.rb
   -r cucumber/api/features/step_definitions/logs_steps.rb
@@ -20,6 +22,7 @@ api: >
 #       directory is above it (e.g authenticators_azure is above authenticators_common)
 #       then we will not be able to load the methods defined in authenticators_common
 authenticators_config: >
+  --tags @authenticators_config
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -34,6 +37,7 @@ authenticators_config: >
   cucumber/authenticators_config
 
 authenticators_status: >
+  --tags @authenticators_status
   --format pretty
   -r cucumber/api/features/support/rest_helpers.rb
   -r cucumber/api/features/support/step_def_transforms.rb
@@ -50,6 +54,7 @@ authenticators_status: >
   cucumber/authenticators_status
 
 authenticators_ldap: >
+  --tags @authenticators_ldap
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -66,6 +71,7 @@ authenticators_ldap: >
   cucumber/authenticators_ldap
 
 authenticators_oidc: >
+  --tags @authenticators_oidc
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -87,6 +93,7 @@ authenticators_oidc: >
   cucumber/authenticators_oidc
 
 authenticators_gcp: >
+  --tags @authenticators_gcp
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -105,6 +112,7 @@ authenticators_gcp: >
   cucumber/authenticators_gcp
 
 authenticators_azure: >
+  --tags @authenticators_azure
   --format pretty
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -123,8 +131,8 @@ authenticators_azure: >
   cucumber/authenticators_azure
 
 authenticators_jwt: >
+  --tags "not @skip and @authenticators_jwt"
   --format pretty
-  --tags "not @skip"
   -r cucumber/api/features/step_definitions/user_steps.rb
   -r cucumber/api/features/step_definitions/request_steps.rb
   -r cucumber/api/features/support/step_def_transforms.rb
@@ -148,8 +156,8 @@ authenticators_jwt: >
 #       profiles need to be thought through better and refactored most likely.
 #       
 rotators: >
+  --tags 'not @manual and @rotators'
   --format pretty
-  -t 'not @manual'
   -r cucumber/authenticators/features/support/hooks.rb
   -r cucumber/api/features/support/step_def_transforms.rb
   -r cucumber/api/features/support/rest_helpers.rb
@@ -161,8 +169,8 @@ rotators: >
   cucumber/rotators
 
 manual-rotators: >
-  --format pretty
   --tags @manual
+  --format pretty
   -r cucumber/rotators/features/support
   -r cucumber/rotators/features/step_definitions
   cucumber/rotators

--- a/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
+++ b/cucumber/_authenticators_common/features/support/authenticator_helpers.rb
@@ -104,7 +104,7 @@ module AuthenticatorHelpers
   end
 
   def conjur_hostname
-    ENV.fetch('CONJUR_APPLIANCE_URL', 'http://conjur')
+    ENV.fetch('CONJUR_APPLIANCE_URL', "http://conjur#{ENV['TEST_ENV_NUMBER']}")
   end
 
   private

--- a/cucumber/_authenticators_common/features/support/env.rb
+++ b/cucumber/_authenticators_common/features/support/env.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 $LOAD_PATH.unshift(Dir.pwd)
 require 'config/environment'
 
@@ -9,5 +20,5 @@ require 'aruba/cucumber'
 require 'conjur-api'
 require 'json_spec/cucumber'
 
-Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
+Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/cucumber/_authenticators_common/features/support/hooks.rb
+++ b/cucumber/_authenticators_common/features/support/hooks.rb
@@ -9,6 +9,15 @@ end
 # Prior to this hook, our tests had hidden coupling.  This ensures each test is
 # run independently.
 Before do
+  parallel_cuke_vars = {}
+  parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+  parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+  parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+  parallel_cuke_vars.each do |key, value|
+    ENV[key] = value
+  end
+
   @user_index = 0
   @host_index = 0
 

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -4,6 +4,17 @@ ENV['CONJUR_ACCOUNT'] = 'cucumber'
 ENV['RAILS_ENV'] ||= 'test'
 ENV['CONJUR_LOG_LEVEL'] ||= 'debug'
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 # so that we can require relative to the project root
 $LOAD_PATH.unshift(File.expand_path('../../../..', __dir__))
 require 'config/environment'

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -10,6 +10,15 @@ require 'fileutils'
 # Prior to this hook, our tests had hidden coupling.  This ensures each test is
 # run independently.
 Before do
+  parallel_cuke_vars = {}
+  parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+  parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+  parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+  parallel_cuke_vars.each do |key, value|
+    ENV[key] = value
+  end
+
   @user_index = 0
   @host_index = 0
 

--- a/cucumber/authenticators/features/support/hooks.rb
+++ b/cucumber/authenticators/features/support/hooks.rb
@@ -5,6 +5,15 @@
 # Prior to this hook, our tests had hidden coupling.  This ensures each test is
 # run independently.
 Before do
+  parallel_cuke_vars = {}
+  parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+  parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+  parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+  parallel_cuke_vars.each do |key, value|
+    ENV[key] = value
+  end
+
   @user_index = 0
 
   Role.truncate(cascade: true)

--- a/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
+++ b/cucumber/authenticators_jwt/features/authn_jwt_token_schema.feature
@@ -875,32 +875,32 @@ Feature: JWT Authenticator - Token Schema
     - !variable conjur/authn-jwt/raw/enforced-claims
 
     - !host
-      id: myapp
+      id: myapp-01
       annotations:
         authn-jwt/raw/conjur.org/enforced-property: valid
 
     - !grant
       role: !group conjur/authn-jwt/raw/hosts
-      member: !host myapp
+      member: !host myapp-01
     """
     And I successfully set authn-jwt "enforced-claims" variable to value "conjur.org/enforced-property"
     And I successfully set authn-jwt "token-app-property" variable to value "conjur.org/host-property"
     And I add the secret value "test-secret" to the resource "cucumber:variable:test-variable"
-    And I permit host "myapp" to "execute" it
+    And I permit host "myapp-01" to "execute" it
     And I am using file "authn-jwt-token-schema" and alg "RS256" for remotely issue token:
     """
     {
       "conjur.org/enforced-property":"valid",
-      "conjur.org/host-property":"myapp"
+      "conjur.org/host-property":"myapp-01"
     }
     """
     And I save my place in the log file
     When I authenticate via authn-jwt with the JWT token
-    Then host "myapp" has been authorized by Conjur
+    Then host "myapp-01" has been authorized by Conjur
     And I successfully GET "/secrets/cucumber/variable/test-variable" with authorized user
     And The following appears in the log after my savepoint:
     """
-    cucumber:host:myapp successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
+    cucumber:host:myapp-01 successfully authenticated with authenticator authn-jwt service cucumber:webservice:conjur/authn-jwt/raw
     """
 
   @sanity

--- a/cucumber/authenticators_k8s/features/support/env.rb
+++ b/cucumber/authenticators_k8s/features/support/env.rb
@@ -2,6 +2,17 @@ require 'cucumber/rails'
 require 'rack/test'
 require 'json_spec/cucumber'
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://nginx#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@postgres#{ENV['TEST_ENV_NUMBER']}:5432/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 def app
   Rails.application
 end

--- a/cucumber/authenticators_k8s/features/support/hooks.rb
+++ b/cucumber/authenticators_k8s/features/support/hooks.rb
@@ -7,6 +7,15 @@ Before('@k8s_skip') do
 end
 
 Before do
+  parallel_cuke_vars = {}
+  parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "https://nginx#{ENV['TEST_ENV_NUMBER']}"
+  parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@postgres#{ENV['TEST_ENV_NUMBER']}:5432/postgres"
+  parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+  parallel_cuke_vars.each do |key, value|
+    ENV[key] = value
+  end
+
   # Erase the certificate and cert injection logs from each container.
   kube_client.get_pods(namespace: namespace).select{|p| p.metadata.namespace == namespace}.each do |pod|
     next unless (ready_status = pod.status.conditions.find { |c| c.type == "Ready" })

--- a/cucumber/policy/features/support/client.rb
+++ b/cucumber/policy/features/support/client.rb
@@ -13,7 +13,7 @@ require_relative 'rest_client_wrapper'
 class Client
   ADMIN_PASSWORD = 'SEcret12!!!!'
   ACCOUNT = ENV['CONJUR_ACCOUNT'] || 'cucumber'
-  APPLIANCE_URL =  ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
+  APPLIANCE_URL =  ENV['CONJUR_APPLIANCE_URL'] || "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 
   class User
     def initialize(user_type, id)

--- a/cucumber/policy/features/support/env.rb
+++ b/cucumber/policy/features/support/env.rb
@@ -5,7 +5,18 @@ require 'aruba/cucumber'
 require 'conjur-api'
 require 'rest-client'
 
-Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
+Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'
 
 # This is needed to run the cucumber --profile policy successfully

--- a/cucumber/policy/features/support/hooks.rb
+++ b/cucumber/policy/features/support/hooks.rb
@@ -18,6 +18,15 @@ end
 # Prior to this hook, our tests had hidden coupling.  This ensures each test is
 # run independently.
 Before do
+  parallel_cuke_vars = {}
+  parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+  parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+  parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+  parallel_cuke_vars.each do |key, value|
+    ENV[key] = value
+  end
+
   @user_index = 0
 
   Role.truncate(cascade: true)

--- a/cucumber/rotators/features/step_definitions/rotator_steps.rb
+++ b/cucumber/rotators/features/step_definitions/rotator_steps.rb
@@ -69,6 +69,9 @@ Given(/^I reset my root policy$/) do
 end
 
 Given(/^I add the value "(.*)" to variable "(.+)"$/) do |val, id|
+  if val == "testdb"
+    val = "#{val}#{ENV['TEST_ENV_NUMBER']}"
+  end
   @client.add_secret(id: id, value: val)
 end
 

--- a/cucumber/rotators/features/support/env.rb
+++ b/cucumber/rotators/features/support/env.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 # so that we can require relative to the project root
 $LOAD_PATH.unshift(Dir.pwd)
 require 'config/environment'
@@ -7,5 +18,5 @@ require 'config/environment'
 ENV['RAILS_ENV'] ||= 'test'
 ENV['CONJUR_LOG_LEVEL'] ||= 'debug'
 
-Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || 'http://conjur'
+Conjur.configuration.appliance_url = ENV['CONJUR_APPLIANCE_URL'] || "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 Conjur.configuration.account = ENV['CONJUR_ACCOUNT'] || 'cucumber'

--- a/cucumber/rotators/features/support/rotator_helpers.rb
+++ b/cucumber/rotators/features/support/rotator_helpers.rb
@@ -11,7 +11,7 @@ module RotatorHelpers
   # Utility for the postgres rotator
 
   def run_sql_in_testdb(sql, user="postgres", pw="postgres_secret")
-    system("PGPASSWORD=#{pw} psql -h testdb -U #{user} -c \"#{sql}\"")
+    system("PGPASSWORD=#{pw} psql -h testdb#{ENV['TEST_ENV_NUMBER']} -U #{user} -c \"#{sql}\"")
   end
 
   def variable(id)
@@ -75,7 +75,7 @@ module RotatorHelpers
     # is hardcoded here.  This shouldn't be problematic as there's likely no
     # need to make it dynamic.
     def pg_login_result(user, pw)
-      system("PGPASSWORD=#{pw} psql -c \"\\q\" -h testdb -U #{user}")
+      system("PGPASSWORD=#{pw} psql -c \"\\q\" -h testdb#{ENV['TEST_ENV_NUMBER']} -U #{user}")
     end
   end
 

--- a/engines/conjur_audit/config/routes.rb
+++ b/engines/conjur_audit/config/routes.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 ConjurAudit::Engine.routes.draw do
   scope format: false do
     root 'messages#index'

--- a/engines/conjur_audit/spec/dummy/config/environments/test.rb
+++ b/engines/conjur_audit/spec/dummy/config/environments/test.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+parallel_cuke_vars = {}
+parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
+parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
+parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+
+parallel_cuke_vars.each do |key, value|
+  if ENV[key].nil? || ENV[key].empty?
+    ENV[key] = value
+  end
+end
+
 Rails.application.configure do
   config.cache_classes = true
   config.eager_load = false


### PR DESCRIPTION
 - Spawn multiple processes to execute cucumber tests in parallel. Each process contains it's own indipendent conjur instance and postgresql database to avoid colisions.
 - Dynamically alter Ruby ENV variables based on the process executing the cucumber feature tests.
 - Dockerfile has been altered to support replicated services for parallel tests (this has not been altered to be dynamic and consists of static changes).
 - Alter cucumber.yml profiles to support parallel_tests ruby gem cmd usage

The following tests have not been parallelized:
 - authenticators_k8s
 - rspec tests