### PR TITLE
Change from docker-compose to docker compose in scripts

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,29 +19,29 @@ that was used when you originally deployed your Conjur server.
 
 3. Pull the new Conjur image version:
    ```
-   docker-compose pull conjur
+   docker compose pull conjur
    ```
 
 4. Stop the Conjur container:
    ```
-   docker-compose stop conjur
+   docker compose stop conjur
    ```
 
 5. Bring up the Conjur service using the new image version without changing
    linked services:
    ```
-   docker-compose up -d --no-deps conjur
+   docker compose up -d --no-deps conjur
    ```
 
 6. View Docker containers and verify all are healthy, up and running:
    ```
-   docker-compose ps -a
+   docker compose ps -a
    ```
 
    It may also be useful to check if Conjur started successfully, which can be
    done by running
    ```
-   $ docker-compose exec conjur conjurctl wait
+   $ docker compose exec conjur conjurctl wait
     Waiting for Conjur to be ready...
     ...
     Conjur is ready!
@@ -56,7 +56,7 @@ environment variable first, you will be able to complete the steps without an
 visible/explicit error message, but the logs of the new Conjur container will
 show an error like:
 ```
-$ docker-compose logs conjur_server
+$ docker compose logs conjur_server
 rake aborted!
 No CONJUR_DATA_KEY
 ...
@@ -66,7 +66,7 @@ To fix this, set the `CONJUR_DATA_KEY` environment variable and run through
 the [process](#standard-process) again. This time when you check the logs of the Conjur server
 container you should see the service starting as expected:
 ```
-$ docker-compose logs conjur_server
+$ docker compose logs conjur_server
 ...
 => Booting Puma
 => Rails 5.2.4.3 application starting in production 

--- a/ci/oauth/keycloak/keycloak_functions.sh
+++ b/ci/oauth/keycloak/keycloak_functions.sh
@@ -16,7 +16,7 @@ function _hydrate_keycloak_env_args() {
     set -o pipefail
     # Note: This prints all lines that look like:
     # KEYCLOAK_XXX=someval
-    docker-compose exec -T ${KEYCLOAK_SERVICE_NAME} printenv | awk '/KEYCLOAK/'
+    docker compose exec -T ${KEYCLOAK_SERVICE_NAME} printenv | awk '/KEYCLOAK/'
   )
 
   # shellcheck disable=SC2034
@@ -34,14 +34,14 @@ function _hydrate_keycloak_env_args() {
 # _create_keycloak_user '$APP_USER' '$APP_PW' '$APP_EMAIL'
 #
 # This is because those variables are not available to this script. They are
-# available to bash commands run via "docker-compose exec keycloak bash
+# available to bash commands run via "docker compose exec keycloak bash
 # -c...", since they're defined in the docker-compose.yml.
 function _create_keycloak_user() {
   local user_var=$1
   local pw_var=$2
   local email_var=$3
 
-  docker-compose exec -T \
+  docker compose exec -T \
     ${KEYCLOAK_SERVICE_NAME} \
     bash -c "/scripts/create_user \"$user_var\" \"$pw_var\" \"$email_var\""
 }
@@ -49,7 +49,7 @@ function _create_keycloak_user() {
 function create_keycloak_users() {
   echo "Defining keycloak client"
 
-  docker-compose exec -T ${KEYCLOAK_SERVICE_NAME} /scripts/create_client
+  docker compose exec -T ${KEYCLOAK_SERVICE_NAME} /scripts/create_client
 
   echo "Creating user 'alice' in Keycloak"
 
@@ -80,7 +80,7 @@ function create_keycloak_users() {
 }
 
 function wait_for_keycloak_server() {
-  docker-compose exec -T \
+  docker compose exec -T \
     ${KEYCLOAK_SERVICE_NAME} /scripts/wait_for_server
 }
 
@@ -93,7 +93,7 @@ function fetch_keycloak_certificate() {
   read -ra parallel_services <<< "$(get_parallel_services 'conjur')"
 
   for parallel_service in "${parallel_services[@]}"; do
-    docker-compose exec -T \
+    docker compose exec -T \
       "${parallel_service}" /oauth/keycloak/scripts/fetch_certificate
   done
 }

--- a/ci/test
+++ b/ci/test
@@ -117,7 +117,7 @@ finish() {
   # TODO: More reliable approach to this.
   # Give SimpleCov time to generate reports.
   sleep 15
-  docker-compose down --rmi 'local' --volumes || true
+  docker compose down --rmi 'local' --volumes || true
 }
 
 # main is always called with at least the first arg. When the 2nd arg, the

--- a/ci/test_suites/authenticators_jwt/test
+++ b/ci/test_suites/authenticators_jwt/test
@@ -10,14 +10,14 @@ source "./oauth/keycloak/keycloak_functions.sh"
 function main() {
   local parallel_services
   read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
-  docker-compose up --no-deps -d "${parallel_services[@]}" jwks jwks_py keycloak
+  docker compose up --no-deps -d "${parallel_services[@]}" jwks jwks_py keycloak
 
   wait_for_keycloak_server
   create_keycloak_users
   fetch_keycloak_certificate
 
   echo "Configure jwks provider"
-  docker-compose exec -T jwks "${JWKS_CREATE_CERTIFICATE_SCRIPT_PATH}"
+  docker compose exec -T jwks "${JWKS_CREATE_CERTIFICATE_SCRIPT_PATH}"
 
   additional_services='jwks jwks_py keycloak'
   _run_cucumber_tests authenticators_jwt "$additional_services" \

--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -17,7 +17,7 @@ function _hydrate_all_env_args() {
     set -o pipefail
     # Note: This prints all lines that look like:
     # KEYCLOAK_XXX=someval
-    docker-compose exec -T "${KEYCLOAK_SERVICE_NAME}" printenv | awk '/KEYCLOAK/'
+    docker compose exec -T "${KEYCLOAK_SERVICE_NAME}" printenv | awk '/KEYCLOAK/'
   )
 
   # shellcheck disable=SC2034
@@ -38,7 +38,7 @@ function _hydrate_all_env_args() {
 function main() {
   local parallel_services
   read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
-  docker-compose up --no-deps -d "${parallel_services[@]}" keycloak
+  docker compose up --no-deps -d "${parallel_services[@]}" keycloak
 
   # We also run an ldap-server container for testing the OIDC & LDAP combined
   # use-case.  We can't run this use-case in a separate Jenkins step because

--- a/ci/test_suites/rspec/test
+++ b/ci/test_suites/rspec/test
@@ -6,13 +6,13 @@ set -e
 # shellcheck disable=SC1091
 source "./shared.sh"
 
-docker-compose up --no-deps -d pg
+docker compose up --no-deps -d pg
 
 _wait_for_pg pg
 
 # Note: The nested, escaped double quotes are needed in case $REPORT_ROOT
 # ever changes to a path containing a space.
-docker-compose run -T --rm --no-deps cucumber -ec "
+docker compose run -T --rm --no-deps cucumber -ec "
   bundle exec rake db:migrate
 
   rm -rf \"$REPORT_ROOT/spec/reports\"

--- a/ci/test_suites/rspec_audit/test
+++ b/ci/test_suites/rspec_audit/test
@@ -7,7 +7,7 @@ set -e
 source "./shared.sh"
 
 # Start Conjur with the audit database
-docker-compose up --no-deps -d audit pg
+docker compose up --no-deps -d audit pg
 
 _wait_for_pg audit
 
@@ -15,7 +15,7 @@ _wait_for_pg audit
 # $REPORT_ROOT but not for the 2nd one where it appears in the variable
 # assignment.
 AUDIT_DATABASE_URL=postgres://postgres@audit/postgres \
-  docker-compose run \
+  docker compose run \
     -T --rm --no-deps --workdir=/src/conjur-server cucumber -ec "
       pwd
       ci/rspec-audit/migratedb

--- a/dev/cli
+++ b/dev/cli
@@ -196,7 +196,7 @@ function add_keycloak_env_vars_to_env_args() {
   echo "Extracting keycloak variables & setting as env variables"
 
   local keycloak_env_args=''
-  keycloak_env_args="$(set -o pipefail; docker-compose exec -T keycloak printenv | grep KEYCLOAK | sed 's/.*/-e &/') \
+  keycloak_env_args="$(set -o pipefail; docker compose exec -T keycloak printenv | grep KEYCLOAK | sed 's/.*/-e &/') \
                      -e PROVIDER_URI=https://keycloak:8443/auth/realms/master \
                      -e PROVIDER_INTERNAL_URI=http://keycloak:8080/auth/realms/master/protocol/openid-connect \
                      -e PROVIDER_ISSUER=http://keycloak:8080/auth/realms/master \
@@ -234,7 +234,7 @@ while true ; do
   case "$1" in
     -h | --help ) print_help ; shift ;;
     exec )
-      api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
+      api_key=$(docker compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin | tr -d '\r')
       env_args="-e CONJUR_AUTHN_API_KEY=$api_key"
 
       case "$2" in
@@ -246,18 +246,18 @@ while true ; do
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 
-      docker exec $env_args -it --detach-keys 'ctrl-\' $(docker-compose ps -q conjur) bash
+      docker exec "$env_args" -it --detach-keys "ctrl-\'" "$(docker compose ps -q conjur)" bash
      shift ;;
     policy )
       case "$2" in
         load )
           account="$3"
           policy_file=$4
-          docker-compose exec conjur conjurctl policy load "$account" "/src/conjur-server/$policy_file"
+          docker compose exec conjur conjurctl policy load "$account" "/src/conjur-server/$policy_file"
           shift 4 ;;
         * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
       esac ;;
-    key ) docker-compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin ; shift ;;
+    key ) docker compose exec -T conjur conjurctl role retrieve-key cucumber:user:admin ; shift ;;
      * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
   esac
 done

--- a/dev/start
+++ b/dev/start
@@ -56,16 +56,16 @@ main() {
   fi
 
   # Build docker images.
-  docker-compose build --pull
+  docker compose build --pull
 
   init_data_key
   init_audit_service
 
   # Install gems, create DB, and create cucumber account.
-  docker-compose up -d --no-deps "${services[@]}"
-  docker-compose exec conjur bundle
-  docker-compose exec conjur conjurctl db migrate
-  docker-compose exec conjur conjurctl account create cucumber || true
+  docker compose up -d --no-deps "${services[@]}"
+  docker compose exec conjur bundle
+  docker compose exec conjur conjurctl db migrate
+  docker compose exec conjur conjurctl account create cucumber || true
 
   migrate_audit_db
 
@@ -179,7 +179,7 @@ check_env_vars() {
 client_load_policy() {
   local policy_file=$1
 
-  docker-compose exec client \
+  docker compose exec client \
     conjur policy load root "$policy_file"
 }
 
@@ -187,13 +187,13 @@ client_add_secret() {
   local variable=$1
   local value=$2
 
-  docker-compose exec client \
+  docker compose exec client \
     conjur variable values add "$variable" "$value"
 }
 
 start_conjur_server() {
   echo "Starting Conjur server"
-  docker-compose exec -d conjur conjurctl server
+  docker compose exec -d conjur conjurctl server
 
   echo 'Checking if Conjur server is ready'
   wait_for_conjur
@@ -201,13 +201,13 @@ start_conjur_server() {
 
 wait_for_conjur() {
   api_key=$(
-    docker-compose exec -T conjur \
+    docker compose exec -T conjur \
       conjurctl role retrieve-key cucumber:user:admin | tr -d '\r'
   )
 
-  docker-compose exec -T conjur conjurctl wait
+  docker compose exec -T conjur conjurctl wait
 
-  docker-compose exec client conjur authn login -u admin -p "$api_key"
+  docker compose exec client conjur authn login -u admin -p "$api_key"
 }
 
 configure_oidc_authenticators() {
@@ -229,11 +229,11 @@ configure_oidc_authenticators() {
 }
 
 setup_keycloak() {
-  # Start keycloak docker-compose service
+  # Start keycloak docker compose service
   services+=(keycloak)
-  docker-compose up -d --no-deps "${services[@]}"
+  docker compose up -d --no-deps "${services[@]}"
 
-  # Start conjur again, since it is recreating by docker-compose because of
+  # Start conjur again, since it is recreating by docker compose because of
   # dependency with keycloak
   start_conjur_server
   wait_for_keycloak_server
@@ -263,7 +263,7 @@ setup_okta() {
 
 setup_adfs() {
   echo "Initialize ADFS certificate in conjur server"
-  docker-compose exec conjur \
+  docker compose exec conjur \
     /src/conjur-server/dev/files/authn-oidc/adfs/fetchCertificate
 
   configure_oidc_v1 \
@@ -358,10 +358,10 @@ migrate_audit_db() {
 
   # Run database migration to create audit database schema.
   #
-  # SC2016: We want docker-compose to expand $AUDIT_DATABASE_URL.
+  # SC2016: We want docker compose to expand $AUDIT_DATABASE_URL.
   # SC1004: Literal backslash will be interpreted away by bash.
   # shellcheck disable=SC2016,SC1004
-  docker-compose exec -T conjur bash -c '
+  docker compose exec -T conjur bash -c '
   BUNDLE_GEMFILE=/src/conjur-server/Gemfile \
     bundle exec sequel $AUDIT_DATABASE_URL \
     -E -m /src/conjur-server/engines/conjur_audit/db/migrate/
@@ -383,7 +383,7 @@ init_ldap() {
   enabled_authenticators="$enabled_authenticators,authn-ldap/test,authn-ldap/secure"
 
   # Using conjur policy load doesn't work here (not sure why).
-  docker-compose exec conjur \
+  docker compose exec conjur \
     conjurctl policy load cucumber \
     "/src/conjur-server/dev/files/authn-ldap/policy.yml"
 }
@@ -400,7 +400,7 @@ init_azure() {
   client_load_policy \
     "/src/conjur-server/ci/test_suites/authenticators_azure/policies/policy.yml"
 
-  docker-compose exec client \
+  docker compose exec client \
     conjur variable values add \
     conjur/authn-azure/prod/provider-uri "https://sts.windows.net/$AZURE_TENANT_ID/"
 
@@ -430,7 +430,7 @@ init_jwt() {
 
   enabled_authenticators="$enabled_authenticators,authn-jwt/raw,authn-jwt/keycloak"
   services+=(jwks jwks_py keycloak)
-  docker-compose up -d --no-deps "${services[@]}"
+  docker compose up -d --no-deps "${services[@]}"
 
   # OIDC is a special case on JWT, JWT automation tests contain scenarios with
   # OIDC providers.
@@ -438,7 +438,7 @@ init_jwt() {
   enable_oidc_authenticators
 
   echo "Configure jwks provider"
-  docker-compose exec jwks "/tmp/create_nginx_certificate.sh"
+  docker compose exec jwks "/tmp/create_nginx_certificate.sh"
 }
 
 init_oidc() {
@@ -452,10 +452,10 @@ init_oidc() {
   if [[ $ENABLE_AUTHN_LDAP = true && $ENABLE_OIDC_OKTA = true ]]; then
     echo "Building & configuring Okta-LDAP agent"
     services+=(okta-ldap-agent)
-    docker-compose up -d --no-deps "${services[@]}"
+    docker compose up -d --no-deps "${services[@]}"
 
     echo "Starting Okta agent service"
-    docker exec "$(docker-compose ps -q okta-ldap-agent)" \
+    docker exec "$(docker compose ps -q okta-ldap-agent)" \
       "/opt/Okta/OktaLDAPAgent/scripts/OktaLDAPAgent"
   fi
 }
@@ -475,7 +475,7 @@ init_iam() {
   enabled_authenticators="$enabled_authenticators,authn-iam/prod"
 
   # Using conjur policy load doesn't work here (not sure why).
-  docker-compose exec conjur \
+  docker compose exec conjur \
     conjurctl policy load cucumber \
     "/src/conjur-server/dev/files/authn-iam/policy.yml"
 }
@@ -486,7 +486,7 @@ start_auth_services() {
 
   # Will restart services if configuration has changed.  I think this happens
   # when additional authenticators are enabled.
-  docker-compose up -d --no-deps "${services[@]}"
+  docker compose up -d --no-deps "${services[@]}"
 
   # If that happens, we need to restart Conjur server.
   if [[ "$enabled_authenticators" != "$default_authenticators" ]]; then
@@ -501,13 +501,13 @@ create_alice() {
 
 kill_conjur() {
   echo "killing the conjur server process"
-  docker-compose exec conjur /src/conjur-server/dev/files/killConjurServer
+  docker compose exec conjur /src/conjur-server/dev/files/killConjurServer
 }
 
 enter_container() {
   env_args+=(-e "CONJUR_AUTHN_API_KEY=$api_key")
   docker exec "${env_args[@]}" -it --detach-keys ctrl-\\ \
-    "$(docker-compose ps -q conjur)" bash
+    "$(docker compose ps -q conjur)" bash
 }
 
 main "$@"

--- a/dev/stop
+++ b/dev/stop
@@ -2,6 +2,6 @@
 
 unset COMPOSE_PROJECT_NAME
 
-docker-compose down -v
+docker compose down -v
 
 rm -f data_key


### PR DESCRIPTION
### Desired Outcome

Migrate to docker compose v2.  Docker compose no longer recommends 'docker-compose' in compose v2. 

### Implemented Changes

- All code using `docker-compose` change to `docker compose`. 
[Source](https://docs.docker.com/compose/migrate/)

### Connected Issue/Story

CyberArk internal issue ID: [CNJR-569](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-569)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
