### PR TITLE
Update CONJ00013E error message to apply to AuthnOIDC V1 and V2

### DIFF
--- a/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
+++ b/app/domain/authentication/authn_oidc/update_input_with_username_from_id_token.rb
@@ -100,8 +100,10 @@ module Authentication
 
       def validate_conjur_username
         if conjur_username.to_s.empty?
-          raise Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty,
-                id_token_username_field
+          raise Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty.new(
+            id_token_username_field,
+            "id-token-user-property"
+          )
         end
 
         if conjur_username == "admin"

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -28,8 +28,10 @@ module Authentication
             )
           )
           unless identity.present?
-            raise Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty,
-                  @authenticator.claim_mapping
+            raise Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty.new(
+              @authenticator.claim_mapping,
+              "claim-mapping"
+            )
           end
           identity
         end

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -237,7 +237,7 @@ module Errors
     module AuthnOidc
       IdTokenClaimNotFoundOrEmpty = ::Util::TrackableErrorClass.new(
         msg: "Claim '{0-claim-name}' not found or empty in ID token. " \
-            "This claim is defined in the id-token-user-property variable.",
+            "This claim is defined in the {1-config-var} variable.",
         code: "CONJ00013E"
       )
 

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -147,7 +147,7 @@ services:
     volumes:
       - ..:/src/conjur-server
       - authn-local:/run/authn-local
-      - authn-local2:/run/authn-local
+      - authn-local2:/run/authn-local2
       - ./ldap-certs:/ldap-certs:ro
       - log-volume:/src/conjur-server/log
       - jwks-volume:/var/jwks

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -112,6 +112,16 @@ _run_cucumber_tests() {
     fi
   done
 
+  # Generate authn_local socket ENV variables based on the
+  # number of parallel processes.
+  for (( i=1; i <= ${#parallel_services[@]}; ++i )); do
+    if (( i == 1 )) ; then
+      sockets+=("AUTHN_LOCAL_SOCKET=/run/authn-local/.socket")
+    else
+      sockets+=("AUTHN_LOCAL_SOCKET${i}=/run/authn-local${i}/.socket")
+    fi
+  done
+
   # Add the cucumber env vars that we always want to send.
   # Note: These are args for docker compose run, and as such the right hand
   # sides of the = do NOT require escaped quotes.  docker compose takes the
@@ -124,6 +134,11 @@ _run_cucumber_tests() {
   # Add parallel process api_keys to the env_var_flags
   for api_key in "${api_keys[@]}"; do
     env_var_flags+=(-e "$api_key")
+  done
+
+  # Add parallel process authn_local sockets to the env_var_flags
+  for socket in "${sockets[@]}"; do
+    env_var_flags+=(-e "$socket")
   done
 
   # If there's no tty (e.g. we're running as a Jenkins job), pass -T to

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -4,7 +4,7 @@ export REPORT_ROOT=/src/conjur-server
 
 # Sets the number of parallel processes for cucumber tests
 # Due to naming conventions for parallel_cucumber this begins at 1 NOT 0
-PARALLEL_PROCESSES=2
+PARALLEL_PROCESSES=${PARALLEL_PROCESSES:-2}
 
 get_parallel_services() {
   # get_parallel_services converts docker service names

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,7 @@ parallel_cuke_vars = {}
 parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
 parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+parallel_cuke_vars['AUTHN_LOCAL_SOCKET'] = ENV["AUTHN_LOCAL_SOCKET#{ENV['TEST_ENV_NUMBER']}"]
 
 parallel_cuke_vars.each do |key, value|
   if ENV[key].nil? || ENV[key].empty?

--- a/cucumber/api/features/support/env.rb
+++ b/cucumber/api/features/support/env.rb
@@ -8,6 +8,7 @@ parallel_cuke_vars = {}
 parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
 parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
 parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+parallel_cuke_vars['AUTHN_LOCAL_SOCKET'] = ENV["AUTHN_LOCAL_SOCKET#{ENV['TEST_ENV_NUMBER']}"]
 
 parallel_cuke_vars.each do |key, value|
   if ENV[key].nil? || ENV[key].empty?

--- a/cucumber/api/features/support/hooks.rb
+++ b/cucumber/api/features/support/hooks.rb
@@ -14,6 +14,7 @@ Before do
   parallel_cuke_vars['CONJUR_APPLIANCE_URL'] = "http://conjur#{ENV['TEST_ENV_NUMBER']}"
   parallel_cuke_vars['DATABASE_URL'] = "postgres://postgres@pg#{ENV['TEST_ENV_NUMBER']}/postgres"
   parallel_cuke_vars['CONJUR_AUTHN_API_KEY'] = ENV["CONJUR_AUTHN_API_KEY#{ENV['TEST_ENV_NUMBER']}"]
+  parallel_cuke_vars['AUTHN_LOCAL_SOCKET'] = ENV["AUTHN_LOCAL_SOCKET#{ENV['TEST_ENV_NUMBER']}"]
 
   parallel_cuke_vars.each do |key, value|
     ENV[key] = value

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -155,7 +155,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty
+    Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty: CONJ00013E Claim 'non_existing_field' not found or empty in ID token. This claim is defined in the id-token-user-property variable.
     """
 
   @negative @acceptance

--- a/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
@@ -190,7 +190,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
     Then it is unauthorized
     And The following appears in the log after my savepoint:
     """
-    Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty
+    Errors::Authentication::AuthnOidc::IdTokenClaimNotFoundOrEmpty: CONJ00013E Claim 'non_existing_field' not found or empty in ID token. This claim is defined in the claim-mapping variable.
     """
 
   @negative @acceptance

--- a/dev/cli
+++ b/dev/cli
@@ -246,7 +246,7 @@ while true ; do
         * ) if [ -z "$2" ]; then shift ; else echo "$2 is not a valid option"; exit 1; fi;;
       esac
 
-      docker exec "$env_args" -it --detach-keys "ctrl-\'" "$(docker compose ps -q conjur)" bash
+      docker exec "$env_args" -it --detach-keys 'ctrl-\' "$(docker compose ps -q conjur)" bash
      shift ;;
     policy )
       case "$2" in

--- a/dev/start
+++ b/dev/start
@@ -3,6 +3,7 @@
 # NOTE: You must execute this script from this directory (dev).
 set -ex
 set -o pipefail
+export PARALLEL_PROCESSES=1
 
 # SCRIPT GLOBAL STATE
 


### PR DESCRIPTION
### Desired Outcome

From CNJR-2106:
> CONJ00013E Claim 'login' not found or empty in ID token. This claim is defined in the id-token-user-property variable
>
> The docs have you define a non-existent claim in the claim-mapping original request to OKTA  (originating from the claim_mapping variable value), Okta returns a token without that claim mapping which is where the incorrect error message gets printed in Conjur.
>
> Steps to reproduce:
> 1. Docs have you define claim in "claim-mapping" variable - ie 'THIS-CLAIM-DOESNT-EXIST'
> 2. Okta returns a token without that claim mapping
> 3. An incorrect error message gets printed in Conjur
>
> Current Results:
> An incorrect error message gets printed in Conjur referencing id-token-user-property
>
> Expected Results:
> Error should reference variable : "claim-mapping" for OIDC v2

### Implemented Changes

- Update CONJ00013E to take a second argument, `{1-config-var}`, which changes the variable name displayed in the error message.
- Updates to fix dev environment

### Connected Issue/Story

CNJR-2106

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
