### PR TITLE
Test fix nightly FIPS tests in jenkins 

### DIFF
--- a/ci/oauth/keycloak/keycloak_functions.sh
+++ b/ci/oauth/keycloak/keycloak_functions.sh
@@ -16,7 +16,7 @@ function _hydrate_keycloak_env_args() {
     set -o pipefail
     # Note: This prints all lines that look like:
     # KEYCLOAK_XXX=someval
-    docker compose exec -T ${KEYCLOAK_SERVICE_NAME} printenv | awk '/KEYCLOAK/'
+    $COMPOSE exec -T ${KEYCLOAK_SERVICE_NAME} printenv | awk '/KEYCLOAK/'
   )
 
   # shellcheck disable=SC2034
@@ -41,7 +41,7 @@ function _create_keycloak_user() {
   local pw_var=$2
   local email_var=$3
 
-  docker compose exec -T \
+  $COMPOSE exec -T \
     ${KEYCLOAK_SERVICE_NAME} \
     bash -c "/scripts/create_user \"$user_var\" \"$pw_var\" \"$email_var\""
 }
@@ -49,7 +49,7 @@ function _create_keycloak_user() {
 function create_keycloak_users() {
   echo "Defining keycloak client"
 
-  docker compose exec -T ${KEYCLOAK_SERVICE_NAME} /scripts/create_client
+  $COMPOSE exec -T ${KEYCLOAK_SERVICE_NAME} /scripts/create_client
 
   echo "Creating user 'alice' in Keycloak"
 
@@ -80,7 +80,7 @@ function create_keycloak_users() {
 }
 
 function wait_for_keycloak_server() {
-  docker compose exec -T \
+  $COMPOSE exec -T \
     ${KEYCLOAK_SERVICE_NAME} /scripts/wait_for_server
 }
 
@@ -93,7 +93,7 @@ function fetch_keycloak_certificate() {
   read -ra parallel_services <<< "$(get_parallel_services 'conjur')"
 
   for parallel_service in "${parallel_services[@]}"; do
-    docker compose exec -T \
+    $COMPOSE exec -T \
       "${parallel_service}" /oauth/keycloak/scripts/fetch_certificate
   done
 }

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -66,20 +66,20 @@ _run_cucumber_tests() {
   read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
 
   if (( ${#services[@]} )); then
-    docker compose up --no-deps --no-recreate -d "${parallel_services[@]}" "${services[@]}"
+    $COMPOSE up --no-deps --no-recreate -d "${parallel_services[@]}" "${services[@]}"
   else
-    docker compose up --no-deps --no-recreate -d "${parallel_services[@]}"
+    $COMPOSE up --no-deps --no-recreate -d "${parallel_services[@]}"
   fi
 
   read -ra parallel_services <<< "$(get_parallel_services 'conjur')"
   for parallel_service in "${parallel_services[@]}"; do
-    docker compose exec -T "$parallel_service" conjurctl wait --retries 180
+    $COMPOSE exec -T "$parallel_service" conjurctl wait --retries 180
   done
 
   echo "Create cucumber account..."
 
   for parallel_service in "${parallel_services[@]}"; do
-    docker compose exec -T "$parallel_service" conjurctl account create cucumber
+    $COMPOSE exec -T "$parallel_service" conjurctl account create cucumber
   done
 
   # Stage 2: Prepare cucumber environment args
@@ -168,7 +168,7 @@ _run_cucumber_tests() {
 
   # Have to add tags in profile for parallel to run properly
   # ${cucumber_tags_arg} should overwrite the profile tags in a way for @smoke to work correctly
-  docker compose run "${run_flags[@]}" "${env_var_flags[@]}" \
+  $COMPOSE run "${run_flags[@]}" "${env_var_flags[@]}" \
     cucumber -ec "\
       /oauth/keycloak/scripts/fetch_certificate &&
       bundle exec parallel_cucumber . -n ${PARALLEL_PROCESSES} \
@@ -185,24 +185,24 @@ _run_cucumber_tests() {
   # process to write the report. The container is kept alive using an infinite
   # sleep in the at_exit hook (see .simplecov).
   for parallel_service in "${parallel_services[@]}"; do
-    docker compose exec -T "$parallel_service" bash -c "pkill -f 'puma 5'"
+    $COMPOSE exec -T "$parallel_service" bash -c "pkill -f 'puma 5'"
   done
 }
 
 _get_api_key() {
   local service=$1
 
-  docker compose exec -T "${service}" conjurctl \
+  $COMPOSE exec -T "${service}" conjurctl \
     role retrieve-key cucumber:user:admin | tr -d '\r'
 }
 
 _find_cucumber_network() {
   local net
 
-  # Docker compose conjur/pg services use the same
+  # docker compose conjur/pg services use the same
   # network for 1 or more instances so only conjur is passed
   # and not other parallel services.
-  conjur_id=$(docker compose ps -q conjur)
+  conjur_id=$($COMPOSE ps -q conjur)
   net=$(docker inspect "${conjur_id}" --format '{{.HostConfig.NetworkMode}}')
 
   docker network inspect "$net" \
@@ -233,7 +233,7 @@ wait_for_cmd() {
 _wait_for_pg() {
   local svc=$1
   local pg_cmd=(psql -U postgres -c "select 1" -d postgres)
-  local dc_cmd=(docker compose exec -T "$svc" "${pg_cmd[@]}")
+  local dc_cmd=($COMPOSE exec -T "$svc" "${pg_cmd[@]}")
 
   echo "Waiting for pg to come up..."
 
@@ -252,14 +252,14 @@ is_ldap_up() {
   # Note: We need the subshell to group the commands.
   (
     set -o pipefail
-    docker compose exec -T ldap-server bash -c "$ldap_check_cmd" |
+    $COMPOSE exec -T ldap-server bash -c "$ldap_check_cmd" |
     grep '^search: 3$'
   ) >/dev/null 2>&1
 }
 
 start_ldap_server() {
   # Start LDAP.
-  docker compose up --no-deps --detach ldap-server
+  $COMPOSE up --no-deps --detach ldap-server
 
   # Wait for up to 90 seconds, since it's slow.
   echo "Ensuring that LDAP is up..."

--- a/ci/test
+++ b/ci/test
@@ -41,6 +41,14 @@ source "./ci/shared.sh"
 # shellcheck disable=SC1091
 source "build_utils.sh"
 
+# Create a value to determine if the runtime container
+# for Jenkins can run Compose v2 syntax
+COMPOSE="docker compose"
+if grep -m 1 'Red Hat' /etc/os-release; then
+  COMPOSE="docker-compose"
+fi
+export COMPOSE
+
 # Create default value if not set: allows compose to run in isolated namespace
 : "${COMPOSE_PROJECT_NAME:=$(openssl rand -hex 3)}"
 export COMPOSE_PROJECT_NAME
@@ -117,7 +125,7 @@ finish() {
   # TODO: More reliable approach to this.
   # Give SimpleCov time to generate reports.
   sleep 15
-  docker compose down --rmi 'local' --volumes || true
+  $COMPOSE down --rmi 'local' --volumes || true
 }
 
 # main is always called with at least the first arg. When the 2nd arg, the

--- a/ci/test_suites/authenticators_jwt/test
+++ b/ci/test_suites/authenticators_jwt/test
@@ -10,14 +10,14 @@ source "./oauth/keycloak/keycloak_functions.sh"
 function main() {
   local parallel_services
   read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
-  docker compose up --no-deps -d "${parallel_services[@]}" jwks jwks_py keycloak
+  $COMPOSE up --no-deps -d "${parallel_services[@]}" jwks jwks_py keycloak
 
   wait_for_keycloak_server
   create_keycloak_users
   fetch_keycloak_certificate
 
   echo "Configure jwks provider"
-  docker compose exec -T jwks "${JWKS_CREATE_CERTIFICATE_SCRIPT_PATH}"
+  $COMPOSE exec -T jwks "${JWKS_CREATE_CERTIFICATE_SCRIPT_PATH}"
 
   additional_services='jwks jwks_py keycloak'
   _run_cucumber_tests authenticators_jwt "$additional_services" \

--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -17,7 +17,7 @@ function _hydrate_all_env_args() {
     set -o pipefail
     # Note: This prints all lines that look like:
     # KEYCLOAK_XXX=someval
-    docker compose exec -T "${KEYCLOAK_SERVICE_NAME}" printenv | awk '/KEYCLOAK/'
+    $COMPOSE exec -T "${KEYCLOAK_SERVICE_NAME}" printenv | awk '/KEYCLOAK/'
   )
 
   # shellcheck disable=SC2034
@@ -38,7 +38,7 @@ function _hydrate_all_env_args() {
 function main() {
   local parallel_services
   read -ra parallel_services <<< "$(get_parallel_services 'conjur pg')"
-  docker compose up --no-deps -d "${parallel_services[@]}" keycloak
+  $COMPOSE up --no-deps -d "${parallel_services[@]}" keycloak
 
   # We also run an ldap-server container for testing the OIDC & LDAP combined
   # use-case.  We can't run this use-case in a separate Jenkins step because

--- a/ci/test_suites/rspec/test
+++ b/ci/test_suites/rspec/test
@@ -6,13 +6,13 @@ set -e
 # shellcheck disable=SC1091
 source "./shared.sh"
 
-docker compose up --no-deps -d pg
+$COMPOSE up --no-deps -d pg
 
 _wait_for_pg pg
 
 # Note: The nested, escaped double quotes are needed in case $REPORT_ROOT
 # ever changes to a path containing a space.
-docker compose run -T --rm --no-deps cucumber -ec "
+$COMPOSE run -T --rm --no-deps cucumber -ec "
   bundle exec rake db:migrate
 
   rm -rf \"$REPORT_ROOT/spec/reports\"

--- a/ci/test_suites/rspec_audit/test
+++ b/ci/test_suites/rspec_audit/test
@@ -7,7 +7,7 @@ set -e
 source "./shared.sh"
 
 # Start Conjur with the audit database
-docker compose up --no-deps -d audit pg
+$COMPOSE up --no-deps -d audit pg
 
 _wait_for_pg audit
 
@@ -15,7 +15,7 @@ _wait_for_pg audit
 # $REPORT_ROOT but not for the 2nd one where it appears in the variable
 # assignment.
 AUDIT_DATABASE_URL=postgres://postgres@audit/postgres \
-  docker compose run \
+  $COMPOSE run \
     -T --rm --no-deps --workdir=/src/conjur-server cucumber -ec "
       pwd
       ci/rspec-audit/migratedb


### PR DESCRIPTION
### Desired Outcome

Fix for failures in some of the nightly EE FIPS tests.`docker compose` is not being recognized in the pipeline specifically under the rehl executors. `Docker-compose` should instead be used when the system is on rehl since it uses an older docker version/and unable to run compose v2 syntax.

### Implemented Changes

ENV variable now used to determine the system the executor is on. `Docker-compose` if on Red Hat Enterprise Linux otherwise just do `Docker compose`. 

### Connected Issue/Story

CyberArk internal issue ID: [CNJR-2310](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-2310)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
