### PR TITLE
Telemetry tests

### DIFF
--- a/spec/lib/monitoring/metrics_spec.rb
+++ b/spec/lib/monitoring/metrics_spec.rb
@@ -1,75 +1,39 @@
-require 'prometheus/client/formats/text'
-require 'monitoring/prometheus'
+require 'monitoring/metrics'
+require 'prometheus/client'
 
-class SampleMetric
-  def setup(registry, pubsub)
-    registry.register(::Prometheus::Client::Gauge.new(
-      :test_gauge,
-      docstring: '...',
-      labels: [:test_label]
-    ))
-
-    pubsub.subscribe("sample_test_gauge") do |payload|
-      metric = registry.get(:test_gauge)
-      metric.set(payload[:value], labels: payload[:labels])
-    end
-  end
-end
-
-describe Monitoring::Prometheus do
-  let(:registry) {
-    Monitoring::Prometheus.setup
-    Monitoring::Prometheus.registry
-  }
-
-  it 'creates a valid registry and allows metrics' do
-    gauge = registry.gauge(:foo, docstring: '...', labels: [:bar])
-    gauge.set(21.534, labels: { bar: 'test' })
-
-    expect(gauge.get(labels: { bar: 'test' })).to eql(21.534)
+RSpec.describe Monitoring::Metrics do
+  class MockMetric
+    # does nothing
   end
 
-  it 'can use Pub/Sub events to update metrics on the registry' do
-    gauge = registry.gauge(:foo, docstring: '...', labels: [:bar])
+  describe '#create_metric' do
+    context 'with valid metric type' do
+      it 'creates a gauge metric' do
+        expect(Monitoring::Metrics).to receive(:create_gauge_metric).with(MockMetric)
+        Monitoring::Metrics.create_metric(MockMetric, :gauge)
+      end
 
-    pub_sub = Monitoring::PubSub.instance
-    pub_sub.subscribe("foo_event_name") do |payload|
-      labels = {
-        bar: payload[:bar]
-      }
-      gauge.set(payload[:value], labels: labels)
+      it 'creates a counter metric' do
+        expect(Monitoring::Metrics).to receive(:create_counter_metric).with(MockMetric)
+        Monitoring::Metrics.create_metric(MockMetric, :counter)
+      end
+
+      it 'creates a histogram metric' do
+        expect(Monitoring::Metrics).to receive(:create_histogram_metric).with(MockMetric)
+        Monitoring::Metrics.create_metric(MockMetric, :histogram)
+      end
+
+      it 'creates a histogram metric (string)' do
+        expect(Monitoring::Metrics).to receive(:create_histogram_metric).with(MockMetric)
+        Monitoring::Metrics.create_metric(MockMetric, 'histogram')
+      end
     end
 
-    pub_sub.publish("foo_event_name", value: 100, bar: "omicron")
-    expect(gauge.get(labels: { bar: "omicron" })).to eql(100.0)
-  end
-
-  context 'when given a list of metrics to setup' do
-    before do
-      @metric_obj = SampleMetric.new
-      @registry = ::Prometheus::Client::Registry.new
-      @mock_pubsub = double("Mock Monitoring::PubSub")
-    end
-
-    def prometheus_setup
-      Monitoring::Prometheus.setup(
-        registry: @registry,
-        metrics: [ @metric_obj ],
-        pubsub: @mock_pubsub
-      )
-    end
-
-    it 'calls .setup for the metric class' do
-      expect(@metric_obj).to receive(:setup).with(@registry, @mock_pubsub)
-      prometheus_setup
-    end
-
-    it 'adds custom metric definitions to the global registry and subscribes to related Pub/Sub events' do
-      expect(@mock_pubsub).to receive(:subscribe).with("sample_test_gauge")
-      prometheus_setup
-
-      sample_metric = @registry.get(:test_gauge)
-      expect(sample_metric).not_to be_nil
+    context 'with invalid metric type' do
+      it 'raises an error' do
+        expect { Monitoring::Metrics.create_metric(MockMetric, :invalid_type) }
+          .to raise_error(Errors::Monitoring::InvalidOrMissingMetricType)
+      end
     end
   end
 end

--- a/spec/lib/monitoring/prometheus_spec.rb
+++ b/spec/lib/monitoring/prometheus_spec.rb
@@ -1,0 +1,75 @@
+require 'prometheus/client/formats/text'
+require 'monitoring/prometheus'
+
+class SampleMetric
+  def setup(registry, pubsub)
+    registry.register(::Prometheus::Client::Gauge.new(
+      :test_gauge,
+      docstring: '...',
+      labels: [:test_label]
+    ))
+
+    pubsub.subscribe("sample_test_gauge") do |payload|
+      metric = registry.get(:test_gauge)
+      metric.set(payload[:value], labels: payload[:labels])
+    end
+  end
+end
+
+describe Monitoring::Prometheus do
+  let(:registry) {
+    Monitoring::Prometheus.setup
+    Monitoring::Prometheus.registry
+  }
+
+  it 'creates a valid registry and allows metrics' do
+    gauge = registry.gauge(:foo, docstring: '...', labels: [:bar])
+    gauge.set(21.534, labels: { bar: 'test' })
+
+    expect(gauge.get(labels: { bar: 'test' })).to eql(21.534)
+  end
+
+  it 'can use Pub/Sub events to update metrics on the registry' do
+    gauge = registry.gauge(:foo, docstring: '...', labels: [:bar])
+
+    pub_sub = Monitoring::PubSub.instance
+    pub_sub.subscribe("foo_event_name") do |payload|
+      labels = {
+        bar: payload[:bar]
+      }
+      gauge.set(payload[:value], labels: labels)
+    end
+
+    pub_sub.publish("foo_event_name", value: 100, bar: "omicron")
+    expect(gauge.get(labels: { bar: "omicron" })).to eql(100.0)
+  end
+
+  context 'when given a list of metrics to setup' do
+    before do
+      @metric_obj = SampleMetric.new
+      @registry = ::Prometheus::Client::Registry.new
+      @mock_pubsub = double("Mock Monitoring::PubSub")
+    end
+
+    def prometheus_setup
+      Monitoring::Prometheus.setup(
+        registry: @registry,
+        metrics: [ @metric_obj ],
+        pubsub: @mock_pubsub
+      )
+    end
+
+    it 'calls .setup for the metric class' do
+      expect(@metric_obj).to receive(:setup).with(@registry, @mock_pubsub)
+      prometheus_setup
+    end
+
+    it 'adds custom metric definitions to the global registry and subscribes to related Pub/Sub events' do
+      expect(@mock_pubsub).to receive(:subscribe).with("sample_test_gauge")
+      prometheus_setup
+
+      sample_metric = @registry.get(:test_gauge)
+      expect(sample_metric).not_to be_nil
+    end
+  end
+end

--- a/spec/lib/monitoring/query_helper_spec.rb
+++ b/spec/lib/monitoring/query_helper_spec.rb
@@ -1,37 +1,46 @@
 require 'monitoring/query_helper'
 require 'spec_helper'
 
-describe Monitoring::QueryHelper, type: :request do
-  let(:queryhelper) { Monitoring::QueryHelper.instance }
+RSpec.describe Monitoring::QueryHelper do
+  describe '#policy_resource_counts' do
+    it 'returns the correct resource counts' do
+      allow(Resource).to receive(:group_and_count).and_return([
+        { kind: 'resource1', count: 10 },
+        { kind: 'resource2', count: 20 }
+      ])
 
-  let(:policies_url) { '/policies/rspec/policy/root' }
+      counts = Monitoring::QueryHelper.instance.policy_resource_counts
 
-  let(:current_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+      expect(counts).to eq({ 'resource1' => 10, 'resource2' => 20 })
+    end
 
-  let(:token_auth_header) do
-    bearer_token = Slosilo["authn:rspec"].signed_token(current_user.login)
-    token_auth_str =
-      "Token token=\"#{Base64.strict_encode64(bearer_token.to_json)}\""
-    { 'HTTP_AUTHORIZATION' => token_auth_str }
+    it 'returns an empty hash if there are no resources' do
+      allow(Resource).to receive(:group_and_count).and_return([])
+
+      counts = Monitoring::QueryHelper.instance.policy_resource_counts
+
+      expect(counts).to eq({})
+    end
   end
 
-  def headers_with_auth(payload)
-    token_auth_header.merge({ 'RAW_POST_DATA' => payload })
-  end
+  describe '#policy_role_counts' do
+    it 'returns the correct role counts' do
+      allow(Role).to receive(:group_and_count).and_return([
+        { kind: 'role1', count: 5 },
+        { kind: 'role2', count: 15 }
+      ])
 
-  before do
-    Slosilo["authn:rspec"] ||= Slosilo::Key.new
-    post(policies_url, env: headers_with_auth('[!group test]'))
-  end
+      counts = Monitoring::QueryHelper.instance.policy_role_counts
 
-  it 'returns policy resource counts' do
-    resource_counts = queryhelper.policy_resource_counts
-    expect(resource_counts['group']).to equal(1)
-  end
+      expect(counts).to eq({ 'role1' => 5, 'role2' => 15 })
+    end
 
-  it 'returns policy role counts' do
-    role_counts = queryhelper.policy_role_counts
-    expect(role_counts['group']).to equal(1)
-  end
+    it 'returns an empty hash if there are no roles' do
+      allow(Role).to receive(:group_and_count).and_return([])
 
+      counts = Monitoring::QueryHelper.instance.policy_role_counts
+
+      expect(counts).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Adds a few new unit tests and refactors some integration tests into unit tests

The tests previously under `metrics_spec.rb` have been moved to `prometheus_spec.rb` which seemed more appropriate