### PR TITLE
Add trivyignore for CONJSE-1795

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -91,3 +91,7 @@ CVE-2021-3711
 # is only available in premium support, trivy thinks we should use something in the 1.1.1
 # line. We can't, due to FIPS compliance, so need to continue to ignore this issue.
 CVE-2023-0286
+
+# Scanners pick up this vulnerability in OpenSSL::ASN1 module in Ruby before 2.2.8, 2.3.x before 2.3.5, and 2.4.x through 2.4.1
+# however we use ruby 3+ in production so we can safely ignore it.
+CVE-2017-14033


### PR DESCRIPTION
Scanners pick up this vulnerability in OpenSSL::ASN1 module in Ruby before 2.2.8, 2.3.x before 2.3.5, and 2.4.x through 2.4.1 however we use ruby 3+ in production so we can safely ignore it.

### Desired Outcome

Prevent trivy from scanning this specific error, which we've already addressed.

### Implemented Changes

Add a trivyignore entry.

### Connected Issue/Story

CyberArk internal issue ID: CONJSE-1795

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [X] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
