### PR TITLE
ONYX-42284 Platforms endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [1.0.3-cloud] - 2023-07-30
+## [1.0.3-cloud] - 2023-07-31
 ### Added
 - Endpoint for edge installation token generation https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-41981
 - Endpoint for creating edge host https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-41980
+- Added create, update, delete and list REST APIs for Platforms https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-42284
 
 ## [1.0.2-cloud] - 2023-07-20
 ### Changed

--- a/app/controllers/concerns/find_platform_resource.rb
+++ b/app/controllers/concerns/find_platform_resource.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module FindPlatformResource
+  include FindResource
+  extend ActiveSupport::Concern
+
+  def resource_id
+    if request.request_method == "GET" && request.filtered_parameters[:action] == "get"
+      [ account, "policy", "data/platforms/#{params[:identifier]}" ].join(":")
+    else
+      [ account, "policy", "data/platforms" ].join(":")
+    end
+  end
+
+  def find_or_create_root_policy
+    Loader::Types.find_or_create_root_policy(account)
+  end
+
+  def account
+    @account ||= params[:account]
+  end
+
+end

--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require_relative '../controllers/wrappers/policy_wrapper'
+require_relative '../controllers/wrappers/policy_audit'
+require_relative '../controllers/wrappers/templates_renderer'
+require_relative '../domain/platforms/platform_types/platform_type_factory'
+#
+class PlatformsController < RestController
+  include AuthorizeResource
+  include PolicyAudit
+  include PolicyWrapper
+  include PolicyTemplates::TemplatesRenderer
+  include BodyParser
+  include FindPlatformResource
+
+  before_action :current_user
+  before_action :find_or_create_root_policy
+
+  rescue_from Sequel::UniqueConstraintViolation, with: :concurrent_load
+
+  PLATFORM_NOT_FOUND = "Platform not found"
+
+  def create
+    logger.info(LogMessages::Endpoints::EndpointRequested.new("POST platforms/#{params[:account]}"))
+    action = :create
+    authorize(action, resource)
+    
+    platform_type = PlatformTypeFactory.new.create_platform_type(params[:type])
+    platform_type.validate(params)
+
+    policy_fields = input_create_yaml(params[:id], platform_type.default_secret_method)
+    create_platform_policy(policy_fields)
+
+    save_platform(params)
+    platform = get_platform_from_db(params[:account], params[:id])
+    raise ApplicationController::InternalServerError, "There was an error saving the platform" unless platform
+    platform_audit_success(platform.account, platform.platform_id, "create")
+
+    render(json: platform.as_json, status: :created)
+    
+    logger.info(LogMessages::Endpoints::EndpointFinishedSuccessfully.new("POST platforms/#{params[:account]}"))
+  rescue Exceptions::RecordNotFound => e
+    logger.error(LogMessages::Platforms::PlatformEndpointForbidden.new("create"))
+    audit_failure(e, action)
+    platform_audit_failure(params[:account], params[:id], "create", e.message)
+    raise Exceptions::Forbidden, "platforms"
+  rescue ApplicationController::BadRequest => e
+    logger.error("Input validation error for platform [#{params[:id]}]: #{e.message}")
+    audit_failure(e, action)
+    render(json: {
+             error: {
+               code: "bad_request",
+               message: e.message
+             }
+           }, status: :bad_request)
+  rescue Sequel::UniqueConstraintViolation => e
+    logger.error("Platform [#{params[:id]}] already exists")
+    audit_failure(e, action)
+    platform_audit_failure(params[:account], params[:id], "create", e.message)
+    raise Exceptions::RecordExists.new("platform", params[:id])
+  rescue => e
+    audit_failure(e, action)
+    platform_audit_failure(params[:account], params[:id], "create", e.message)
+    head :internal_server_error
+  end
+
+  def delete
+    logger.info(LogMessages::Endpoints::EndpointRequested.new("DELETE platforms/#{params[:account]}/#{params[:identifier]}"))
+    action = :update
+    authorize(action, resource)
+
+    platform = get_platform_from_db(params[:account], params[:identifier])
+    if platform
+      policy_fields = input_delete_yaml(params[:identifier])
+      delete_platform_policy(policy_fields)
+      platform_audit_success(platform.account, platform.platform_id, "delete")
+      # Deleting the platform causes a cascade delete of the record in the platforms table as well
+      head :ok
+    else
+      raise Exceptions::RecordNotFound.new(params[:identifier], message: PLATFORM_NOT_FOUND)
+    end
+
+    logger.info(LogMessages::Endpoints::EndpointFinishedSuccessfully.new("DELETE platforms/#{params[:account]}/#{params[:identifier]}"))
+  rescue Exceptions::RecordNotFound => e
+    logger.error(LogMessages::Platforms::PlatformPolicyNotFound.new(resource_id))
+    audit_failure(e, action)
+    platform_audit_failure(params[:account], params[:identifier], "delete", e.message)
+    raise Exceptions::RecordNotFound.new(params[:identifier], message: PLATFORM_NOT_FOUND)
+  rescue => e
+    audit_failure(e, action)
+    platform_audit_failure(params[:account], params[:identifier], "delete", e.message)
+    raise e
+  end
+
+  def get
+    logger.info(LogMessages::Endpoints::EndpointRequested.new("GET platforms/#{params[:account]}/#{params[:identifier]}"))
+    # If I can update the platform policy, it means I am allowed to view it as well
+    action = :update
+    authorize(action, resource)
+
+    platform = get_platform_from_db(params[:account], params[:identifier])
+    if platform
+      platform_audit_success(platform.account, platform.platform_id, "get")
+      render(json: platform.as_json, status: :ok)
+    else
+      # platform_audit_failure(platform.account, platform.platform_id, "get", PLATFORM_NOT_FOUND)
+      raise Exceptions::RecordNotFound.new(params[:identifier], message: PLATFORM_NOT_FOUND)
+    end
+
+    logger.info(LogMessages::Endpoints::EndpointFinishedSuccessfully.new("GET platforms/#{params[:account]}/#{params[:identifier]}"))
+  rescue Exceptions::RecordNotFound => e
+    platform_audit_failure(params[:account], params[:identifier], "get", PLATFORM_NOT_FOUND)
+    logger.error(LogMessages::Platforms::PlatformPolicyNotFound.new(resource_id))
+    logger.info(LogMessages::Endpoints::EndpointFinishedSuccessfully.new("GET platforms/#{params[:account]}/#{params[:identifier]}"))
+    raise Exceptions::RecordNotFound.new(params[:identifier], message: PLATFORM_NOT_FOUND)
+  rescue => e
+    platform_audit_failure(params[:account], params[:identifier], "get", e.message)
+    raise e
+  end
+
+  def list
+    logger.info(LogMessages::Endpoints::EndpointRequested.new("GET platforms/#{params[:account]}"))
+    # If I can update the platform policy, it means I am allowed to view it as well
+    action = :update
+    authorize(action, resource)
+
+    platforms = list_platforms_from_db(params[:account])
+    result = []
+    platforms.each do |item|
+      result.push(item.as_json)
+    end
+    platform_audit_success(params[:account], "*", "list")
+    render(json: { platforms: result }, status: :ok)
+
+    logger.info(LogMessages::Endpoints::EndpointFinishedSuccessfully.new("GET platforms/#{params[:account]}"))
+  rescue Exceptions::RecordNotFound => e
+    logger.error(LogMessages::Platforms::PlatformEndpointForbidden.new("list"))
+    platform_audit_failure(params[:account], "*", "list", e.message)
+    raise Exceptions::Forbidden, "platforms"
+  rescue => e
+    platform_audit_failure(params[:account], "*", "list", e.message)
+    raise e
+  end
+end
+
+private
+
+def create_platform_policy(policy_fields)
+  result_yaml = renderer(PolicyTemplates::CreatePlatform.new(), policy_fields)
+  set_raw_policy(result_yaml)
+  result = load_policy(Loader::CreatePolicy, false)
+  policy = result[:policy]
+  audit_success(policy)
+end
+
+def delete_platform_policy(policy_fields)
+  result_yaml = renderer(PolicyTemplates::DeletePlatform.new(), policy_fields)
+  set_raw_policy(result_yaml)
+  result = load_policy(Loader::ModifyPolicy, true)
+  policy = result[:policy]
+  audit_success(policy)
+end
+
+def save_platform(request_input)
+  platform = Platform.new(platform_id: request_input[:id], account: request_input[:account],
+                          platform_type: request_input[:type],
+                          max_ttl: request_input[:max_ttl], data: request_input[:data].to_json,
+                          modified_at: Sequel::CURRENT_TIMESTAMP,
+                          policy_id: "#{request_input[:account]}:policy:data/platforms/#{request_input[:id]}")
+  platform.save
+end
+
+def get_platform_from_db(account, platform_id)
+  Platform.where(account: account, platform_id: platform_id).first
+end
+
+def list_platforms_from_db(account)
+  Platform.where(account: account).all
+end
+
+def input_create_yaml(platform_id, secret_method)
+  return input = {
+    "id" => platform_id,
+    "default_secret_method" => secret_method
+  }
+end
+
+def input_delete_yaml(platform_id)
+  return input = {
+    "id" => platform_id
+  }
+end
+
+def platform_audit_success(account, platform_id, operation)
+  subject = { account: account, platform: platform_id }
+  Audit.logger.log(
+    Audit::Event::Platform.new(
+      user_id: current_user.role_id,
+      client_ip: request.ip,
+      subject: subject,
+      message_id: "platform",
+      success: true,
+      operation: operation
+    )
+  )
+end
+
+def platform_audit_failure(account, platform_id, operation, error_message)
+  subject = { account: account, platform: platform_id }
+  Audit.logger.log(
+    Audit::Event::Platform.new(
+      user_id: current_user.role_id,
+      client_ip: request.ip,
+      subject: subject,
+      message_id: "platform",
+      success: false,
+      operation: operation,
+      error_message: error_message
+    )
+  )
+end

--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -148,7 +148,7 @@ private
 def create_platform_policy(policy_fields)
   result_yaml = renderer(PolicyTemplates::CreatePlatform.new(), policy_fields)
   set_raw_policy(result_yaml)
-  result = load_policy(Loader::CreatePolicy, false)
+  result = load_policy(Loader::CreatePolicy, false, resource)
   policy = result[:policy]
   audit_success(policy)
 end
@@ -156,7 +156,7 @@ end
 def delete_platform_policy(policy_fields)
   result_yaml = renderer(PolicyTemplates::DeletePlatform.new(), policy_fields)
   set_raw_policy(result_yaml)
-  result = load_policy(Loader::ModifyPolicy, true)
+  result = load_policy(Loader::ModifyPolicy, true, resource)
   policy = result[:policy]
   audit_success(policy)
 end

--- a/app/domain/logs.rb
+++ b/app/domain/logs.rb
@@ -780,6 +780,20 @@ module LogMessages
       )
     end
   end
+  
+  module Platforms
+
+    PlatformPolicyNotFound = ::Util::TrackableErrorClass.new(
+      msg: "The policy of platform {0} was not found",
+      code: "CONJ00158E"
+    )
+
+    PlatformEndpointForbidden = ::Util::TrackableErrorClass.new(
+      msg: "Action {0} is not allowed on the platforms endpoint",
+      code: "CONJ00159E"
+    )
+    
+  end
 
   # This are log messages so its okay there are many
   # :reek:TooManyConstants

--- a/app/domain/platforms/platform_types/aws_platform_type.rb
+++ b/app/domain/platforms/platform_types/aws_platform_type.rb
@@ -1,0 +1,41 @@
+require_relative './platform_base_type'
+
+class AwsPlatformType < PlatformBaseType
+  REQUIRED_DATA_PARAM_MISSING = "%s is a required parameter in data and must be specified".freeze
+  
+  def validate(params)
+    super
+    validate_data(params[:data])
+  end
+
+  def default_secret_method
+    "iam_session"
+  end
+end
+
+private
+
+def validate_data(data)
+  unless data.is_a?(ActionController::Parameters)
+    raise ApplicationController::BadRequest, "data must be a valid JSON object"
+  end
+
+  data_fields = {
+    access_key_id: "access_key_id",
+    access_key_secret: "access_key_secret"
+  }
+
+  data_fields.each do |field_symbol, field_string|
+    if data[field_symbol].nil?
+      raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, field_string)
+    end
+    
+    unless data[field_symbol].is_a?(String)
+      raise ApplicationController::BadRequest, format(PlatformBaseType::WRONG_PARAM_TYPE, field_string, "string")
+    end
+
+    if data[field_symbol].empty?
+      raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, field_string)
+    end
+  end
+end

--- a/app/domain/platforms/platform_types/platform_base_type.rb
+++ b/app/domain/platforms/platform_types/platform_base_type.rb
@@ -1,0 +1,66 @@
+class PlatformBaseType
+  REQUIRED_PARAM_MISSING = "%s is a required parameter and must be specified".freeze
+  WRONG_PARAM_TYPE       = "%s param must be a %s".freeze
+
+  ID_FIELD_ALLOWED_CHARACTERS = /\A[a-zA-Z0-9+\-_]+\z/
+  ID_FIELD_MAX_ALLOWED_LENGTH = 60
+  
+  def validate(params)
+    validate_id(params[:id])
+    validate_max_ttl(params[:max_ttl])
+    validate_type(params[:type])
+  end
+
+  def default_secret_method
+    raise NotImplementedError, "This method is not implemented because it's a base class"
+  end
+end
+
+private
+
+def validate_id(id)
+  if id.nil?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, "id")
+  end
+  
+  unless id.is_a?(String)
+    raise ApplicationController::BadRequest, format(PlatformBaseType::WRONG_PARAM_TYPE, "id", "string")
+  end
+
+  if id.empty?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, "id")
+  end
+
+  unless id.match?(PlatformBaseType::ID_FIELD_ALLOWED_CHARACTERS)
+    raise ApplicationController::BadRequest, "id param only supports alpha numeric characters and +-_"
+  end
+
+  if id.length > PlatformBaseType::ID_FIELD_MAX_ALLOWED_LENGTH
+    raise ApplicationController::BadRequest, "id param must be up to #{PlatformBaseType::ID_FIELD_MAX_ALLOWED_LENGTH} characters"
+  end
+end
+
+def validate_max_ttl(max_ttl)
+  if max_ttl.nil?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, "max_ttl")
+  end
+  
+  unless max_ttl.is_a?(Integer) && max_ttl.positive?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::WRONG_PARAM_TYPE, "max_ttl", "positive integer")
+  end
+
+end
+
+def validate_type(type)
+  if type.nil?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, "type")
+  end
+  
+  unless type.is_a?(String)
+    raise ApplicationController::BadRequest, format(PlatformBaseType::WRONG_PARAM_TYPE, "type", "string")
+  end
+
+  if type.empty?
+    raise ApplicationController::BadRequest, format(PlatformBaseType::REQUIRED_PARAM_MISSING, "type")
+  end
+end

--- a/app/domain/platforms/platform_types/platform_type_factory.rb
+++ b/app/domain/platforms/platform_types/platform_type_factory.rb
@@ -1,0 +1,11 @@
+require_relative './aws_platform_type'
+
+class PlatformTypeFactory
+  def create_platform_type(type)
+    if !type.nil? && type.casecmp("aws").zero?
+      AwsPlatformType.new
+    else
+      raise ApplicationController::BadRequest, "platform type must be aws"
+    end
+  end
+end

--- a/app/domain/policy-templates/platforms/create_platform.rb
+++ b/app/domain/policy-templates/platforms/create_platform.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require_relative '../base_template'
+
+module PolicyTemplates
+  class CreatePlatform < PolicyTemplates::BaseTemplate
+    def template
+      <<~TEMPLATE
+        - !policy
+          id: <%= id %>
+          body:
+          - !permit
+            role: !group delegation/secrets-creators
+            privileges: [ use ]
+            resource: !policy
+
+          - !permit
+            role: !group delegation/secrets-creators
+            privileges: [ read, execute ]
+            resource: !variable secrets/default
+
+          - !permit
+            role: !group delegation/secrets-creators
+            privileges: [ update ]
+            resource: !policy secrets
+
+          - !permit
+            role: !group delegation/consumers
+            privileges: [ read, execute ]
+            resource: !variable secrets/default
+           
+          - !policy
+            id: delegation
+            body:
+            - !group secrets-creators
+            - !group consumers
+
+          - !policy
+            id: secrets
+            body:
+            - !variable
+              id: default
+              annotations:
+                platform/id: <%= id %>
+                platform/method: <%= default_secret_method %>
+      TEMPLATE
+    end
+  end
+end

--- a/app/domain/policy-templates/platforms/delete_platform.rb
+++ b/app/domain/policy-templates/platforms/delete_platform.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require_relative '../base_template'
+
+module PolicyTemplates
+  class DeletePlatform < PolicyTemplates::BaseTemplate
+    def template
+      <<~TEMPLATE
+        - !delete
+          record: !variable <%= id %>/secrets/default       
+ 
+        - !delete
+          record: !policy <%= id %>/secrets
+       
+        - !delete
+          record: !group <%= id %>/delegation/consumers
+
+        - !delete
+          record: !group <%= id %>/delegation/secrets-creators
+
+        - !delete
+          record: !policy <%= id %>/delegation
+        
+        - !delete
+          record: !policy <%= id %>
+      TEMPLATE
+    end
+  end
+end

--- a/app/models/audit/event/platform.rb
+++ b/app/models/audit/event/platform.rb
@@ -1,0 +1,100 @@
+module Audit
+  module Event
+    # NOTE: Breaking this class up further would harm clarity.
+    # :reek:TooManyInstanceVariables and :reek:TooManyParameters
+    class Platform
+
+      attr_reader :message_id
+
+      def initialize(
+        user_id:,
+        client_ip:,
+        subject:,
+        message_id:,
+        success:,
+        operation:,
+        error_message: nil
+      )
+        @user_id = user_id
+        @subject = subject
+        @client_ip = client_ip
+        @success = success
+        @operation = operation
+        @message_id=message_id
+        @error_message = error_message
+
+        # Implements `==` for audit events
+        @comparable_evt = ComparableEvent.new(self)
+      end
+
+      # NOTE: We want this class to be responsible for providing `progname`.
+      # At the same time, `progname` is currently always "conjur" and this is
+      # unlikely to change.  Moving `progname` into the constructor now
+      # feels like premature optimization, so we ignore reek here.
+      # :reek:UtilityFunction
+      def progname
+        Event.progname
+      end
+
+      # action_sd means "action structured data"
+      def action_sd
+        attempted_action.action_sd
+      end
+
+      def severity
+        attempted_action.severity
+      end
+
+      def to_s
+        message
+      end
+
+      def message
+        if @operation == "list"
+          attempted_action.message(
+            success_msg: "#{@user_id} listed platforms #{@subject[:account]}:platform:#{@subject[:platform]}",
+            failure_msg: "#{@user_id} tried to list platforms #{@subject[:account]}:platform:#{@subject[:platform]}",
+            error_msg: @error_message
+          )
+        else
+          attempted_action.message(
+            success_msg: "#{@user_id} performed #{@operation} on platform #{@subject[:account]}:platform:#{@subject[:platform]}",
+            failure_msg: "#{@user_id} tried to #{@operation} platform #{@subject[:account]}:platform:#{@subject[:platform]}",
+            error_msg: @error_message
+          )
+        end
+      end
+
+      def structured_data
+        {
+          SDID::AUTH => { user: @user_id },
+          SDID::SUBJECT => @subject,
+          SDID::CLIENT => { ip: @client_ip }
+        }.merge(
+          attempted_action.action_sd
+        )
+      end
+
+      def facility
+        # Security or authorization messages which should be kept private. See:
+        # https://github.com/ruby/ruby/blob/master/ext/syslog/syslog.c#L109
+        # Note: Changed this to from LOG_AUTH to LOG_AUTHPRIV because the former
+        # is deprecated.
+        Syslog::LOG_AUTHPRIV
+      end
+
+      def ==(other)
+        @comparable_evt == other
+      end
+
+      private
+
+      def attempted_action
+        @attempted_action ||= AttemptedAction.new(
+          success: @success,
+          operation: @operation
+        )
+      end
+    end
+  end
+end

--- a/app/models/audit/subject.rb
+++ b/app/models/audit/subject.rb
@@ -24,6 +24,12 @@ module Audit
       to_s { format "resource %s", resource_id }
     end
 
+    class Platform < Subject
+      field :platform_id
+      to_h {{ resource: platform_id }}
+      to_s { format "platform %s", platform_id }
+    end
+
     class Role < Subject
       field :role_id
       to_h {{ role: role_id }}

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'json'
+
+class Platform < Sequel::Model
+  
+  attr_encrypted :data, aad: :platform_id
+
+  unrestrict_primary_key
+
+  def as_json
+    {
+      id: self.platform_id,
+      max_ttl: self.max_ttl,
+      type: self.platform_type,
+      data: JSON.parse(self.data),
+      created_at: self.created_at,
+      modified_at: self.modified_at
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,11 @@ Rails.application.routes.draw do
       post    "/edge/data/:account"                 => 'edge#report_edge_data', :constraints => QueryParameterActionRecognizer.new("data_type")
       get     "/edge/slosilo_keys/:account"         => 'edge#slosilo_keys'
 
+      post    "/platforms/:account"             => 'platforms#create'
+      delete  "/platforms/:account/:identifier" => 'platforms#delete'
+      get     "/platforms/:account/:identifier" => 'platforms#get'
+      get     "/platforms/:account"             => 'platforms#list'
+
       put     "/policies/:account/:kind/*identifier" => 'policies#put'
       patch   "/policies/:account/:kind/*identifier" => 'policies#patch'
       post    "/policies/:account/:kind/*identifier" => 'policies#post'

--- a/cucumber/api/features/platforms.feature
+++ b/cucumber/api/features/platforms.feature
@@ -1,0 +1,190 @@
+@api
+@logged-in
+Feature: Platforms audits tests
+
+  Background:
+    Given I am the super-user
+    And I successfully POST "/policies/cucumber/policy/root" with body:
+    """
+    - !policy
+      id: data/platforms
+      body: []
+    """
+    And I set the "Content-Type" header to "application/json"
+    And I successfully POST "/platforms/cucumber" with body:
+    """
+    {
+      "id": "aws-platform-1",
+      "max_ttl": 3000,
+      "type": "aws",
+      "data": {
+        "access_key_id": "my-key-id",
+        "access_key_secret": "my-key-secret"
+      }
+    }
+    """
+
+  @smoke
+  Scenario: Successful audit when creating a platform
+
+    Given I am the super-user
+    And I save my place in the audit log file for remote
+    When I set the "Content-Type" header to "application/json"
+    And I successfully POST "/platforms/cucumber" with body:
+    """
+    {
+      "id": "aws-new-platform",
+      "max_ttl": 3000,
+      "type": "aws",
+      "data": {
+        "access_key_id": "my-key-id",
+        "access_key_secret": "my-key-secret"
+      }
+    }
+    """
+    Then the HTTP response status code is 201
+    And there is an audit record matching:
+    """
+      <86>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" platform="aws-new-platform"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="create"]
+      cucumber:user:admin performed create on platform cucumber:platform:aws-new-platform
+    """
+
+  @smoke
+  Scenario: Failure audit when creating a platform
+
+    Given I am a user named "alice"
+    And I save my place in the audit log file for remote
+    When I set the "Content-Type" header to "application/json"
+    And I POST "/platforms/cucumber" with body:
+    """
+    {
+      "id": "aws-new-platform",
+      "max_ttl": 3000,
+      "type": "aws",
+      "data": {
+        "access_key_id": "my-key-id",
+        "access_key_secret": "my-key-secret"
+      }
+    }
+    """
+    Then the HTTP response status code is 403
+    And there is an audit record matching:
+    """
+      <84>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 account="cucumber" platform="aws-new-platform"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="create"]
+      cucumber:user:alice tried to create platform cucumber:platform:aws-new-platform: Policy 'data/platforms' not found in account 'cucumber'
+    """
+
+  @smoke
+  Scenario: Successful audit when getting a platform
+
+    Given I am the super-user
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I successfully GET "/platforms/cucumber/aws-platform-1"
+    Then the HTTP response status code is 200
+    And there is an audit record matching:
+    """
+      <86>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" platform="aws-platform-1"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="get"]
+      cucumber:user:admin performed get on platform cucumber:platform:aws-platform-1
+    """
+
+  @smoke
+  Scenario: Failure audit when getting a platform
+
+    Given I am a user named "alice"
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I GET "/platforms/cucumber/aws-platform-1"
+    Then the HTTP response status code is 404
+    And there is an audit record matching:
+    """
+      <84>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 account="cucumber" platform="aws-platform-1"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="get"]
+      cucumber:user:alice tried to get platform cucumber:platform:aws-platform-1: Platform not found
+    """
+
+  @smoke
+  Scenario: Successful audit when listing platforms
+
+    Given I am the super-user
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I successfully GET "/platforms/cucumber"
+    Then the HTTP response status code is 200
+    And there is an audit record matching:
+    """
+      <86>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" platform="*"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="list"]
+      cucumber:user:admin listed platforms cucumber:platform:*
+    """
+
+  @smoke
+  Scenario: Failure audit when listing platforms
+
+    Given I am a user named "alice"
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I GET "/platforms/cucumber"
+    Then the HTTP response status code is 403
+    And there is an audit record matching:
+    """
+      <84>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 account="cucumber" platform="*"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="failure" operation="list"]
+      cucumber:user:alice tried to list platforms cucumber:platform:*: Policy 'data/platforms' not found in account 'cucumber'
+    """
+
+  @smoke
+  Scenario: Failure audit when deleting a platform
+
+    Given I am a user named "alice"
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I DELETE "/platforms/cucumber/aws-platform-1"
+    Then the HTTP response status code is 404
+    And there is an audit record matching:
+    """
+      <84>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:alice"]
+      [subject@43868 account="cucumber" platform="aws-platform-1"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"][action@43868 result="failure" operation="delete"]
+      cucumber:user:alice tried to delete platform cucumber:platform:aws-platform-1: Policy 'data/platforms' not found in account 'cucumber'
+    """
+
+  @smoke
+  Scenario: Successful audit when deleting a platform
+
+    Given I am the super-user
+    And I save my place in the audit log file for remote
+    When I clear the "Content-Type" header
+    And I successfully DELETE "/platforms/cucumber/aws-platform-1"
+    Then the HTTP response status code is 200
+    And there is an audit record matching:
+    """
+      <86>1 * - conjur * platform
+      [auth@43868 user="cucumber:user:admin"]
+      [subject@43868 account="cucumber" platform="aws-platform-1"]
+      [client@43868 ip="\d+\.\d+\.\d+\.\d+"]
+      [action@43868 result="success" operation="delete"]
+      cucumber:user:admin performed delete on platform cucumber:platform:aws-platform-1
+    """

--- a/db/migrate/20230706085100_create_platforms.rb
+++ b/db/migrate/20230706085100_create_platforms.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table :platforms do
+      String :platform_id
+      String :account
+      String :platform_type, null: false
+      Integer :max_ttl, null: false
+      column :data, "bytea"
+      Timestamp :created_at, null: false, default: Sequel.function(:transaction_timestamp)
+      Timestamp :modified_at, null: false
+      primary_key [:account, :platform_id], name: :platforms_pk
+      foreign_key :policy_id, :resources, type: String, null: false, on_delete: :cascade
+    end
+  end
+end

--- a/spec/app/domain/platforms/platform_types/aws_platform_type_spec.rb
+++ b/spec/app/domain/platforms/platform_types/aws_platform_type_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe "AwsPlatformType input validation" do
+  context "when all input is valid" do
+    it "then the input validation succeeds" do
+      params = ActionController::Parameters.new(id: "aws-platform-1",
+                                                max_ttl: 2000,
+                                                type: "aws",
+                                                data: {
+                                                  access_key_id: "a", 
+                                                  access_key_secret: "a" 
+                                                })
+      
+      expect { AwsPlatformType.new.validate(params) }
+        .to_not raise_error
+    end
+  end
+
+  context "when key id is not given in the data field" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_secret: "a" 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when key secret is not given in the data field" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_id: "a" 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when key id is not a string" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_id: 1, 
+                                                  access_key_secret: "a" 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when key id is an empty string" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_id: "", 
+                                                  access_key_secret: "a" 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when key secret is not a string" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_id: "a", 
+                                                  access_key_secret: 1 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when key secret is an empty string" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws", 
+                                                data: { 
+                                                  access_key_id: "a", 
+                                                  access_key_secret: "" 
+                                                })
+      expect { AwsPlatformType.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+end

--- a/spec/app/domain/platforms/platform_types/platform_base_type_spec.rb
+++ b/spec/app/domain/platforms/platform_types/platform_base_type_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+class BaseTypeTest < PlatformBaseType
+  def validate(params)
+    super
+  end
+
+  def default_secret_method
+    super
+  end
+end
+
+describe "PlatformBaseType input validation" do
+  
+  context "when all base input is valid" do
+    it "then the input validation succeeds" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 2000, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to_not raise_error
+    end
+  end
+
+  context "when max_ttl is a negative number" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: -2000, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when max_ttl is 0" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 0, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when max_ttl is a floating number" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "aws-platform-1", 
+                                                max_ttl: 4.5, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when id is a number" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: 1, 
+                                                max_ttl: 2000, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when id is longer than 60 characters" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "a" * 61,
+                                                max_ttl: 2000,
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when id has invalid character ^" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "a^", 
+                                                max_ttl: 2000, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+
+  context "when id has invalid character of a space" do
+    it "then the input validation fails" do
+      params = ActionController::Parameters.new(id: "a hf", 
+                                                max_ttl: 2000, 
+                                                type: "aws")
+      expect { BaseTypeTest.new.validate(params) }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+end

--- a/spec/app/domain/platforms/platform_types/platform_type_factory_spec.rb
+++ b/spec/app/domain/platforms/platform_types/platform_type_factory_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe "PlatformTypeFactory input validation" do
+
+  context "when platform type is supported" do
+    it "then relevant platform type is being created" do
+      expect { PlatformTypeFactory.new.create_platform_type("aws") }
+        .to_not raise_error
+    end
+  end
+
+  context "when platform type is supported but with upper case" do
+    it "then relevant platform type is being created" do
+      expect { PlatformTypeFactory.new.create_platform_type("AWS") }
+        .to_not raise_error
+    end
+  end
+
+  context "when platform type is not supported" do
+    it "then the factory returns an error" do
+      expect { PlatformTypeFactory.new.create_platform_type("abc") }
+        .to raise_error(ApplicationController::BadRequest)
+    end
+  end
+end

--- a/spec/controllers/concerns/find_platform_resource_spec.rb
+++ b/spec/controllers/concerns/find_platform_resource_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe FindPlatformResource do
+  context "when resource cannot be found" do
+    let(:resource) { nil }
+    describe '#resource' do
+      it "raises an error" do
+        expect { controller.send(:resource) }
+          .to raise_error(Exceptions::RecordNotFound)
+      end
+    end
+  end
+
+  before do
+    allow(Resource).to receive(:[]).with(resource_id).and_return(resource)
+    allow(controller).to receive(:resource_id) { resource_id }
+  end
+
+  let(:resource_id) { 'test:policy:resource' }
+
+  # Test controller class
+  class Controller
+    include FindPlatformResource
+  end
+
+  subject(:controller) { Controller.new }
+end

--- a/spec/controllers/platforms_controller_spec.rb
+++ b/spec/controllers/platforms_controller_spec.rb
@@ -1,0 +1,423 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+DatabaseCleaner.strategy = :truncation
+
+describe PlatformsController, type: :request do
+  let(:url_resource) { "/resources/rspec" }
+  before do
+    init_slosilo_keys("rspec")
+    # Load the base data/platforms policies into Conjur
+
+    put(
+      '/policies/rspec/policy/root',
+      env: token_auth_header(role: admin_user).merge(
+        'RAW_POST_DATA' => data_platforms_policy
+      )
+    )
+    assert_response :success
+
+  end
+
+  let(:data_platforms_policy) do
+    <<~POLICY
+      - !policy
+        id: data/platforms
+        body: []
+    POLICY
+  end
+
+  let(:admin_user) { Role.find_or_create(role_id: 'rspec:user:admin') }
+  let(:current_user) { Role.find_or_create(role_id: current_user_id) }
+  let(:current_user_id) { 'rspec:user:admin' }
+  let(:alice_user) { Role.find_or_create(role_id: alice_user_id) }
+  let(:alice_user_id) { 'rspec:user:alice' }
+
+  describe "#create" do
+    context "when a user sends body with id only" do
+      let(:payload_create_platforms_only_id) do
+        <<~BODY
+          { "id": "new-platform" }
+        BODY
+      end
+      it 'returns bad request' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platforms_only_id,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :bad_request
+      end
+    end
+
+    context "when user sends body with id, max_ttl, type and data" do
+      let(:payload_create_platforms_complete_input) do
+        <<~BODY
+          {
+            "id": "aws-platform-1",
+            "max_ttl": 3000,
+            "type": "aws",
+            "data": {
+              "access_key_id": "my-key-id",
+              "access_key_secret": "my-key-secret"
+            }
+          }
+        BODY
+      end
+      it 'it returns created' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platforms_complete_input,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body["id"]).to eq("aws-platform-1")
+        expect(parsed_body["max_ttl"]).to eq(3000)
+        expect(parsed_body["type"]).to eq("aws")
+        expect(parsed_body["data"]["access_key_id"]).to eq("my-key-id")
+        expect(parsed_body["data"]["access_key_secret"]).to eq("my-key-secret")
+        expect(response.body).to include("\"created_at\"")
+        expect(response.body).to include("\"modified_at\"")
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-1")).not_to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-1/delegation")).not_to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/aws-platform-1/delegation/consumers")).not_to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/aws-platform-1/delegation/secrets-creators")).not_to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-1/secrets")).not_to eq(nil)
+        expect(Resource.find(resource_id: "rspec:variable:data/platforms/aws-platform-1/secrets/default")).not_to eq(nil)
+      end
+    end
+
+    context "when user creates a policy with unsupported symbols in its name" do
+      let(:payload_create_platforms_symbols_input) do
+        <<~BODY
+          {
+            "id": "aws-platform-!@\#$%^*()[]",
+            "max_ttl": 3000,
+            "type": "aws",
+            "data": {
+              "access_key_id": "my-key-id",
+              "access_key_secret": "my-key-secret"
+            }
+          }
+        BODY
+      end
+      it 'it returns created' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platforms_symbols_input,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :bad_request
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body["error"]["code"]).to eq("bad_request")
+        expect(parsed_body["error"]["message"]).to eq("id param only supports alpha numeric characters and +-_")
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-!@#$%^*()[]")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-!@#$%^*()[]/delegation")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/aws-platform-!@#$%^*()[]/delegation/consumers")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/aws-platform-!@#$%^*()[]/delegation/secrets-creators")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/aws-platform-!@#$%^*()[]/secrets")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:variable:data/platforms/aws-platform-!@#$%^*()[]/secrets/default")).to eq(nil)
+      end
+    end
+
+    context "when user sends an empty body" do
+      let(:payload_empty) do
+        <<~BODY
+          {
+          }
+        BODY
+      end
+      it 'it returns bad_request' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_empty,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :bad_request
+      end
+    end
+
+    context "when user sends an empty id" do
+      let(:payload_blank_id) do
+        <<~BODY
+          {
+            "id": ""
+          }
+        BODY
+      end
+      it "it returns bad_request" do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_blank_id,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :bad_request
+  
+      end
+    end
+
+    context "when user sends a valid creation request but without permissions" do
+      let(:payload_create_platforms_valid_input) do
+        <<~BODY
+          {
+            "id": "valid-platform",
+            "max_ttl": 1000,
+            "type": "aws",
+            "data": {
+              "access_key_id": "my-key-id",
+              "access_key_secret": "my-key-secret"
+            }
+          }
+        BODY
+      end
+      it 'returns forbidden' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: alice_user).merge(
+               'RAW_POST_DATA' => payload_create_platforms_valid_input,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :forbidden
+        expect(response.body).to eq("")
+      end
+    end
+  end
+
+  describe "#delete" do
+    context "when a user deletes a platform that does not exist" do
+      it 'it returns not found' do
+        delete("/platforms/rspec/non-existing-platform",
+             env: token_auth_header(role: admin_user))
+        assert_response :not_found
+        expect(response.body).to eq("{\"error\":{\"code\":\"not_found\",\"message\":\"Platform not found\",\"target\":null,\"details\":{\"code\":\"not_found\",\"target\":\"id\",\"message\":\"non-existing-platform\"}}}")
+      end
+    end
+
+    context "when a user deletes an existing platform" do
+      let(:payload_create_platform) do
+        <<~BODY
+          {
+            "id": "my-new-aws-platform",
+            "max_ttl": 200,
+            "type": "aws",
+            "data": {
+              "access_key_id": "aaa",
+              "access_key_secret": "a"
+            }
+          }
+        BODY
+      end
+      it 'it is deleted successfully' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+
+        delete("/platforms/rspec/my-new-aws-platform", env: token_auth_header(role: admin_user))
+        assert_response :success
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/my-new-aws-platform")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/my-new-aws-platform/delegation")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/my-new-aws-platform/delegation/consumers")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:group:data/platforms/my-new-aws-platform/delegation/secrets-creators")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:policy:data/platforms/my-new-aws-platform/secrets")).to eq(nil)
+        expect(Resource.find(resource_id: "rspec:variable:data/platforms/my-new-aws-platform/secrets/default")).to eq(nil)
+      end
+
+      context "when a user deletes a non existing platform without permissions" do
+        it 'it returns not found' do
+          delete("/platforms/rspec/non-existing-platform", env: token_auth_header(role: alice_user))
+          assert_response :not_found
+        end
+      end
+    end
+
+    context "when a user tries to delete a platform without the correct permissions" do
+      let(:payload_create_platform) do
+        <<~BODY
+          {
+            "id": "platform-1",
+            "max_ttl": 200,
+            "type": "aws",
+            "data": {
+              "access_key_id": "a",
+              "access_key_secret": "a"
+            }
+          }
+        BODY
+      end
+      it 'it returns not found' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+
+        delete("/platforms/rspec/platform-1",
+               env: token_auth_header(role: alice_user))
+        assert_response :not_found
+        expect(response.body).to eq("{\"error\":{\"code\":\"not_found\",\"message\":\"Platform not found\",\"target\":null,\"details\":{\"code\":\"not_found\",\"target\":\"id\",\"message\":\"platform-1\"}}}")
+      end
+    end
+  end
+
+  describe "#get" do
+    context "when a user gets a platform that exists" do
+      let(:payload_create_platform) do
+        <<~BODY
+          {
+            "id": "platform-1",
+            "max_ttl": 200,
+            "type": "aws",
+            "data": {
+              "access_key_id": "a",
+              "access_key_secret": "a"
+            }
+          }
+        BODY
+      end
+      it 'the platform is returned' do
+
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+
+        get("/platforms/rspec/platform-1",
+             env: token_auth_header(role: admin_user))
+        assert_response :success
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body["id"]).to eq("platform-1")
+        expect(parsed_body["max_ttl"]).to eq(200)
+        expect(parsed_body["type"]).to eq("aws")
+        expect(parsed_body["data"]["access_key_id"]).to eq("a")
+        expect(parsed_body["data"]["access_key_secret"]).to eq("a")
+        expect(response.body).to include("\"created_at\"")
+        expect(response.body).to include("\"modified_at\"")
+      end
+    end
+
+    context "when a user gets a platform that does not exist" do
+      it 'the response is not found' do
+        get("/platforms/rspec/non-existing-platform",
+            env: token_auth_header(role: admin_user))
+        assert_response :not_found
+        expect(response.body).to eq("{\"error\":{\"code\":\"not_found\",\"message\":\"Platform not found\",\"target\":null,\"details\":{\"code\":\"not_found\",\"target\":\"id\",\"message\":\"non-existing-platform\"}}}")
+      end
+    end
+
+    context "when a user that does not have permissions on platforms, gets a platform" do
+      let(:payload_create_platform) do
+        <<~BODY
+          {
+            "id": "platform-1",
+            "max_ttl": 200,
+            "type": "aws",
+            "data": {
+              "access_key_id": "a",
+              "access_key_secret": "a"
+            }
+          }
+        BODY
+      end
+      it 'the response is not found' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+
+        get("/platforms/rspec/platform-1",
+            env: token_auth_header(role: alice_user))
+        assert_response :not_found
+        expect(response.body).to eq("{\"error\":{\"code\":\"not_found\",\"message\":\"Platform not found\",\"target\":null,\"details\":{\"code\":\"not_found\",\"target\":\"id\",\"message\":\"platform-1\"}}}")
+      end
+    end
+  end
+
+  describe "#list" do
+    context "when a user lists the platforms" do
+      let(:payload_create_platform_1) do
+        <<~BODY
+          {
+            "id": "platform-1",
+            "max_ttl": 200,
+            "type": "aws",
+            "data": {
+              "access_key_id": "a",
+              "access_key_secret": "a"
+            }
+          }
+        BODY
+      end
+      let(:payload_create_platform_2) do
+        <<~BODY
+          {
+            "id": "platform-2",
+            "max_ttl": 300,
+            "type": "aws",
+            "data": {
+              "access_key_id": "aaa",
+              "access_key_secret": "aaa"
+            }
+          }
+        BODY
+      end
+      it 'the platforms are returned' do
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform_1,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+        post("/platforms/rspec",
+             env: token_auth_header(role: admin_user).merge(
+               'RAW_POST_DATA' => payload_create_platform_2,
+               'CONTENT_TYPE' => "application/json"
+             ))
+        assert_response :created
+
+        get("/platforms/rspec",
+            env: token_auth_header(role: admin_user))
+        assert_response :success
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body["platforms"].length).to eq(2)
+
+        expect(parsed_body["platforms"][0]["id"]).to eq("platform-1")
+        expect(parsed_body["platforms"][0]["max_ttl"]).to eq(200)
+        expect(parsed_body["platforms"][0]["type"]).to eq("aws")
+        expect(parsed_body["platforms"][0]["data"]["access_key_id"]).to eq("a")
+        expect(parsed_body["platforms"][0]["data"]["access_key_secret"]).to eq("a")
+
+        expect(parsed_body["platforms"][1]["id"]).to eq("platform-2")
+        expect(parsed_body["platforms"][1]["max_ttl"]).to eq(300)
+        expect(parsed_body["platforms"][1]["type"]).to eq("aws")
+        expect(parsed_body["platforms"][1]["data"]["access_key_id"]).to eq("aaa")
+        expect(parsed_body["platforms"][1]["data"]["access_key_secret"]).to eq("aaa")
+      end
+    end
+
+    context "when a user lists the platforms, and there are no platforms" do
+      it 'the response is an object with an empty array' do
+        get("/platforms/rspec",
+            env: token_auth_header(role: admin_user))
+        assert_response :success
+        expect(response.body).to eq("{\"platforms\":[]}")
+      end
+    end
+
+    context "when a user that does not have permissions to list platforms" do
+      it 'the response is forbidden' do
+        get("/platforms/rspec",
+            env: token_auth_header(role: alice_user))
+        assert_response :forbidden
+        expect(response.body).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is having new create, get, list, delete APIs for platforms.

### Implemented Changes

- There is a new platforms controller that handles the request.
- There are new RSPEC and cucumber tests to verify the behavior of the APIs and audits written by the endpoints.
- There is a DB migration file to create the new table that contains the platform data.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done

An admin user is able to perform create, get, list and delete of platforms.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
