### PR TITLE
Temporarily enable all tests on all branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
   parameters {
     booleanParam(
       name: 'NIGHTLY',
-      defaultValue: false,
+      defaultValue: true,  // Temporarily set to true for all branches
       description: 'Run tests on all agents and environment including: FIPS'
     )
     string(
@@ -1170,5 +1170,9 @@ def defaultCucumberFilterTags(env) {
   }
 
   // For all other branch builds, only run the @smoke tests by default
-  return '@smoke'
+  // return '@smoke'
+
+  // Temporarily run all tests on all branches. The above line should be
+  // uncommented when 13.1 is released.
+  return ''
 }


### PR DESCRIPTION
### Desired Outcome

Temporarily enable all tests on all branch builds. There are some substantial PRs coming up that introduce some potential for breakage. This is a preventative measure ensuring the full suite of tests have passed prior to merge.

### Implemented Changes

Set the nightly flag and remove `@smoke` filter for branch builds

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
