### PR TITLE
Add read-only configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,7 @@ class ApplicationController < ActionController::API
   rescue_from GatewayTimeout, with: :gateway_timeout
   rescue_from BadGateway, with: :bad_gateway
   rescue_from Exceptions::NotImplemented, with: :not_implemented
+  rescue_from Errors::Conjur::ReadOnly::ActionNotPermitted, with: :method_not_allowed
   rescue_from Sequel::ValidationFailed, with: :validation_failed
   rescue_from Sequel::NoMatchingRow, with: :no_matching_row
   rescue_from Sequel::ForeignKeyConstraintViolation, with: :foreign_key_constraint_violation

--- a/app/controllers/concerns/prepend.rb
+++ b/app/controllers/concerns/prepend.rb
@@ -1,0 +1,15 @@
+module ReadOnlyPrepender
+    # Given a list of method symbols, preempt calls to them using a proxy that
+    # raises an error if read_only is enabled.
+    def write_protected(*method_names)
+      method_names.each do |m|
+        proxy = Module.new do
+          define_method(m) do |*args|
+            raise ::Errors::Conjur::ReadOnly::ActionNotPermitted unless !Rails.configuration.read_only
+            super *args
+          end
+        end
+        self.prepend proxy
+      end
+    end
+  end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -3,8 +3,11 @@
 class PoliciesController < RestController
   include FindResource
   include AuthorizeResource
+  extend ReadOnlyPrepender
+
   before_action :current_user
   before_action :find_or_create_root_policy
+  write_protected :put, :patch, :post
   after_action :publish_event, if: -> { response.successful? }
   
   rescue_from Sequel::UniqueConstraintViolation, with: :concurrent_load

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -5,8 +5,10 @@ require 'English'
 class SecretsController < RestController
   include FindResource
   include AuthorizeResource
+  extend ReadOnlyPrepender
 
   before_action :current_user
+  write_protected :create, :expire
 
   def create
     authorize(:update)

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -57,6 +57,13 @@ module Errors
       msg: "Resource '{0-resource}' requested by role '{1-role}' not found",
       code: "CONJ00123E"
     )
+
+    module ReadOnly
+      ActionNotPermitted = ::Util::TrackableErrorClass.new(
+        msg: "This action is not permitted when the server is in read-only mode",
+        code: "CONJ00153E"
+      )
+    end
   end
 
   module Authorization

--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -10,4 +10,5 @@ Rails.application.configure do
   config.middleware.use(Rack::RememberUuid)
   config.audit_socket = '/run/conjur/audit.socket'
   config.audit_database ||= 'postgres://:5433/audit'
+  config.read_only = false
 end

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+    # Determines whether or not writable API endpoints are enabled.
+    #
+    # The `read_only` arguement is a boolean. By default, `read_only` is "Off".
+    # This means that any of the writable API endpoints will function as intended.
+    #
+    # A writable API endpoint is one whose controller method is decorated with the
+    # `@read_safe` decorator. When `read_only` is "On", such endpoints will return
+    # an HTTP 405 Method Not Allowed response code.
+    #
+    config.read_only = false
+  end
+  


### PR DESCRIPTION
- When read-only mode is enabled via rails config, controller endpoints that are explicitly enrolled into a `read_safe` list return a HTTP 405 Method Not Allowed when invoked, also throwing Conjur error code: `CONJ00153E`
- Implemented using [module prepending](https://ruby-doc.org/core-2.0.0/Module.html#method-i-prepend)

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
