### PR TITLE
Add flag to conjurctl server to skip migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Telemetry support
   [cyberark/conjur#2854](https://github.com/cyberark/conjur/pull/2854)
 
+### Added
+- New flag to `conjurctl server` command called `--no-migrate` which allows for skipping
+  the database migration step when starting the server.
+  [cyberark/conjur#2895](https://github.com/cyberark/conjur/pull/2895)
+
 ### Fixed
 - Support Authn-IAM regional requests when host value is missing from signed headers.
   [cyberark/conjur#2827](https://github.com/cyberark/conjur/pull/2827)

--- a/bin/conjur-cli.rb
+++ b/bin/conjur-cli.rb
@@ -42,6 +42,10 @@ command :server do |c|
   c.default_value(ENV['PORT'] || '80')
   c.flag [ :p, :port ]
 
+  c.desc 'Skip running database migrations on start'
+  c.default_value false
+  c.switch :'no-migrate'
+
   c.desc 'Server bind address'
   c.default_value(ENV['BIND_ADDRESS'] || '0.0.0.0')
   c.arg_name :ip
@@ -55,7 +59,8 @@ command :server do |c|
       password_from_stdin: options["password-from-stdin"],
       file_name: options[:file],
       bind_address: options[:'bind-address'],
-      port: options[:port]
+      port: options[:port],
+      no_migrate: options[:'no-migrate']
     )
   end
 end

--- a/spec/conjurctl/commands/server_spec.rb
+++ b/spec/conjurctl/commands/server_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+require 'commands/server'
+
+describe Commands::Server do
+
+  let(:account) { "demo" }
+  let(:password_from_stdin) { false }
+  let(:file_name) { nil }
+  let(:bind_address) { "0.0.0.0" }
+  let(:port) { 80 }
+  let(:no_migrate) { false }
+
+  let(:migrate_database) {
+    double('DB::Migrate').tap do |migrate|
+      allow(migrate).to receive(:call).with(preview: false)
+    end
+  }
+  let(:connect_database) {
+    double('ConnectDatabase').tap do |connect|
+      allow(connect).to receive(:call)
+    end
+  }
+
+  before do
+    # Squash process forking for these tests as we have not implemented a full test
+    # suite and it causes issues
+    allow(Process).to receive(:fork).and_return(nil)
+    allow(Process).to receive(:waitall).and_return(nil)
+  end
+
+  def delete_account(name)
+    system("conjurctl account delete #{name}")
+  end
+
+  after(:each) do
+    delete_account("demo")
+  end
+
+
+  subject do
+    Commands::Server.new(
+      migrate_database: migrate_database,
+      connect_database: connect_database
+    ).call(
+      account: account,
+      password_from_stdin: password_from_stdin,
+      file_name: file_name,
+      bind_address: bind_address,
+      port: port,
+      no_migrate: no_migrate
+    )
+  end
+
+  it "performs migrations" do
+    expect(migrate_database).to receive(:call)
+
+    subject
+  end
+
+  context "With the no_migrate variable set to true" do
+    let(:no_migrate) { true }
+
+    it "doesn't perform migrations" do
+      expect(migrate_database).not_to receive(:call)
+
+      subject
+    end
+
+    it "connects to the database" do
+      expect(connect_database).to receive(:call)
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
### Desired Outcome
Adds new flag to the `conjurctl server` command which allows for skipping the migrations step even when the Sequel gem would normally think we need to. This change is required by a k8s follower using selective replication. When a k8s follower boots with selective replication enabled it performs a schema dump instead of a full database backup which means the `schema_migrations` and `schema_info` tables containing what migrations the database has had applied is missing and therefore the Sequel gem attempts to apply all of them. This then causes errors when the migration attempts to create schema elements already present in the database.

### Implemented Changes

If the new `--no-migrate` flag is used the migration step is skipped when booting Conjur.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [CNJR-1599]

### Definition of Done

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
