### PR TITLE
PoC for managing write-only permission at the Sequel level

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,7 @@ class ApplicationController < ActionController::API
   rescue_from Errors::Authorization::AccessToResourceIsForbiddenForRole, with: :forbidden
   rescue_from Errors::Conjur::RequestedResourceNotFound, with: :resource_not_found
   rescue_from Errors::Authorization::InsufficientResourcePrivileges, with: :forbidden
+  rescue_from Errors::Conjur::ReadOnly::ActionNotPermitted, with: :method_not_allowed
 
   around_action :run_with_transaction
 

--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -57,6 +57,13 @@ module Errors
       msg: "Resource '{0-resource}' requested by role '{1-role}' not found",
       code: "CONJ00123E"
     )
+
+    module ReadOnly
+      ActionNotPermitted = ::Util::TrackableErrorClass.new(
+        msg: "This action is not permitted when the server is in read-only mode",
+        code: "CONJ00153E"
+      )
+    end
   end
 
   module Authorization

--- a/app/models/read_only.rb
+++ b/app/models/read_only.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Removes persistence if Conjur is operating as a read-only instance
+class Sequel::Model
+  def before_save
+    check_if_writes_permitted
+    super
+  end
+
+  def before_destroy
+    check_if_writes_permitted
+    super
+  end
+
+  def check_if_writes_permitted
+    return unless Rails.configuration.read_only
+
+    raise ::Errors::Conjur::ReadOnly::ActionNotPermitted
+  end
+end

--- a/config/environments/appliance.rb
+++ b/config/environments/appliance.rb
@@ -10,4 +10,5 @@ Rails.application.configure do
   config.middleware.use(Rack::RememberUuid)
   config.audit_socket = '/run/conjur/audit.socket'
   config.audit_database ||= 'postgres://:5433/audit'
+  config.read_only = false
 end

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Put Conjur into "read-only" mode
+Rails.application.configure do
+  config.read_only = true
+end

--- a/dev/start
+++ b/dev/start
@@ -15,7 +15,7 @@ fi
 # Minimal set of services.  We add to this list based on cmd line flags.
 services=(pg conjur client)
 
-# Authenticators to enable. 
+# Authenticators to enable.
 default_authenticators="authn,authn-k8s/test"
 enabled_authenticators="$default_authenticators"
 
@@ -80,7 +80,7 @@ main() {
 
   # Updates CONJUR_AUTHENTICATORS and restarts required services.
   start_auth_services
-  create_alice
+  # create_alice
   kill_conjur # so dev's can restart it manually
   enter_container
 }
@@ -97,7 +97,7 @@ Usage: start [options]
     --authn-gcp     Starts with authn-gcp as authenticator
     --authn-iam     Starts with authn-iam/prod as authenticator
     --authn-jwt     Starts with authn-jwt as authenticator
-    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable 
+    --authn-ldap    Starts OpenLDAP server and loads a demo policy to enable
                     authentication via:
                     'curl -X POST -d "alice" http://localhost:3000/authn-ldap/test/cucumber/alice/authenticate'
     -h, --help      Shows this help message.


### PR DESCRIPTION
This creates a "write-only" follower by tying into the Sequel persistence layer.


### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
