### PR TITLE
CONJSE-1783: Support plural syntax for revoke and deny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+### Fixed
+- Support plural syntax for revoke and deny 
+  [CONJSE-1783](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1783)
+
 ## [1.20.0] - 2023-07-11
 
 ### Added

--- a/app/models/loader/types.rb
+++ b/app/models/loader/types.rb
@@ -354,15 +354,25 @@ module Loader
 
     class Deny < Deletion
       def delete!
-        permission = ::Permission[role_id: policy_object.role.roleid, privilege: policy_object.privilege, resource_id: policy_object.resource.resourceid, policy_id: policy_id]
-        permission.destroy if permission
+        Array(policy_object.resource).each do |r|
+          Array(policy_object.privilege).each do |p|
+            Array(policy_object.role).each do |m|
+              permission = ::Permission[role_id: m.roleid, privilege: p, resource_id: r.resourceid, policy_id: policy_id]
+              permission.destroy if permission
+            end
+          end
+        end
       end
     end
 
     class Revoke < Deletion
       def delete!
-        membership = ::RoleMembership[role_id: policy_object.role.roleid, member_id: policy_object.member.roleid, policy_id: policy_id]
-        membership.destroy if membership
+        Array(policy_object.role).each do |r|
+          Array(policy_object.member).each do |m|
+            membership = ::RoleMembership[role_id: r.roleid, member_id: m.roleid, policy_id: policy_id]
+            membership.destroy if membership
+          end
+        end
       end
     end
 

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -168,7 +168,7 @@ module RestHelpers
   # Write a command to the authn-local Unix socket.
   def authn_local_request command
     require 'socket'
-    socket_file = '/run/authn-local/.socket'
+    socket_file = ENV['AUTHN_LOCAL_SOCKET']
     raise "Socket #{socket_file} does not exist" unless File.exist?(socket_file)
 
     UNIXSocket.open(socket_file) do |sock|


### PR DESCRIPTION
### Desired Outcome

Extend deny and revoke policy statements to support multiple roles/members/privileges.

### Implemented Changes

Loop over these 3 parameters, rather than taking the first. 
Similarly to what their counterparts grant and permit do.

Also, fix issues of tests running in parallel and attempting to access the same resource

### Connected Issue/Story

CyberArk internal issue ID: [https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1783]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
