### PR TITLE
Support HTTPS_PROXY env variable in authn-oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [1.20.0] - 2023-07-11
+## [1.20.0] - 2023-08-16
+
+### Fixed
+- OIDC authenticators support `https_proxy` and `HTTPS_PROXY` environment variables
+  [cyberark/conjur#2902](https://github.com/cyberark/conjur/pull/2902)
+- Support plural syntax for revoke and deny 
+  [cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
 
 ### Added
 - New flag to `conjurctl server` command called `--no-migrate` which allows for skipping

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'websocket'
 # authn-oidc, gcp, azure, jwt
 gem 'jwt', '2.2.2' # version frozen due to authn-jwt requirements
 # authn-oidc
-gem 'openid_connect'
+gem 'openid_connect', '~> 2.0'
 
 gem "anyway_config"
 gem 'i18n', '~> 1.8.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     base32-crockford (0.1.0)
     base58 (0.2.3)
     bcrypt (3.1.16)
-    bindata (2.4.10)
+    bindata (2.4.15)
     builder (3.2.4)
     byebug (11.1.3)
     childprocess (4.1.0)
@@ -213,6 +213,12 @@ GEM
     event_emitter (0.2.6)
     eventmachine (1.2.7)
     excon (0.91.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -238,7 +244,6 @@ GEM
     http-form_data (2.3.0)
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
-    httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -248,10 +253,12 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jmespath (1.6.1)
-    json-jwt (1.13.0)
+    json-jwt (1.16.3)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     json_schemer (0.2.24)
       ecma-re-validator (~> 0.3)
       hana (~> 1.3)
@@ -306,16 +313,19 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
-    openid_connect (1.3.0)
+    openid_connect (2.2.0)
       activemodel
       attr_required (>= 1.0.0)
-      json-jwt (>= 1.5.0)
-      rack-oauth2 (>= 1.6.1)
-      swd (>= 1.0.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      net-smtp
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
       tzinfo
       validate_email
       validate_url
-      webfinger (>= 1.0.1)
+      webfinger (~> 2.0)
     parallel (1.21.0)
     parallel_tests (4.2.0)
       parallel
@@ -337,10 +347,11 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.7)
-    rack-oauth2 (1.19.0)
+    rack-oauth2 (2.2.0)
       activesupport
       attr_required
-      httpclient
+      faraday (~> 2.0)
+      faraday-follow_redirects
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
     rack-rewrite (1.5.1)
@@ -437,6 +448,7 @@ GEM
       rake (>= 0.8.1)
     ruby-next-core (0.14.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
     sequel (5.51.0)
     sequel-pg_advisory_locking (1.0.1)
@@ -467,10 +479,11 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    swd (1.3.0)
+    swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
-      httpclient (>= 2.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     sys-uname (1.2.2)
       ffi (~> 1.1)
     table_print (1.5.7)
@@ -486,13 +499,14 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.13)
+    validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.1.0)
-    webfinger (1.2.0)
+    webfinger (2.1.2)
       activesupport
-      httpclient (>= 2.4)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -550,7 +564,7 @@ DEPENDENCIES
   net-ldap
   net-ssh
   nokogiri (>= 1.8.2)
-  openid_connect
+  openid_connect (= 2.2.0)
   parallel
   parallel_tests
   pg

--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -104,7 +104,7 @@ module Authentication
             skip_nil: true
           ) do
             @discovery_configuration.discover!(@authenticator.provider_uri)
-          rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
+          rescue Errno::ETIMEDOUT => e
             raise Errors::Authentication::OAuth::ProviderDiscoveryTimeout.new(@authenticator.provider_uri, e.message)
           rescue => e
             raise Errors::Authentication::OAuth::ProviderDiscoveryFailed.new(@authenticator.provider_uri, e.message)

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -33,7 +33,7 @@ module Authentication
           LogMessages::Authentication::OAuth::IdentityProviderDiscoverySuccess.new
         )
         @discovered_provider
-      rescue HTTPClient::ConnectTimeoutError, Errno::ETIMEDOUT => e
+      rescue Errno::ETIMEDOUT => e
         raise_error(Errors::Authentication::OAuth::ProviderDiscoveryTimeout, e)
       rescue => e
         raise_error(Errors::Authentication::OAuth::ProviderDiscoveryFailed, e)

--- a/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe(Authentication::OAuth::DiscoverIdentityProvider) do
     context "that fails on a timeout error" do
       subject do
         Authentication::OAuth::DiscoverIdentityProvider.new(
-          open_id_discovery_service: mock_discovery_provider(error: HTTPClient::ConnectTimeoutError)
+          open_id_discovery_service: mock_discovery_provider(error: Errno::ETIMEDOUT)
         ).call(
           provider_uri: test_provider_uri
         )

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/identity/client_load.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/identity/client_load.yml
@@ -4,42 +4,45 @@ http_interactions:
     method: get
     uri: https://redacted-host/redacted_app/.well-known/openid-configuration
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.6 (2023-03-30))
+      - SWD 2.0.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
-      Date:
-      - Mon, 10 Apr 2023 18:13:17 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
+      Content-Type:
+      - application/json; charset=utf-8
       Date:
       - Mon, 10 Apr 2023 18:13:17 GMT
       Content-Length:
-      - '1347'
+      - '440'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: "{\r\n  \"authorization_endpoint\": \"https://redacted-host/OAuth2/Authorize/redacted_app\",\r\n
-        \ \"code_challenge_methods_supported\": [\r\n    \"plain\",\r\n    \"S256\"\r\n
-        \ ],\r\n  \"jwks_uri\": \"https://redacted-host/OAuth2/Keys/redacted_app\",\r\n
+        \ \"issuer\": \"https://redacted-host/redacted_app/\",\r\n  \"introspection_endpoint\":
+        \"https://redacted-host/OAuth2/Introspect/redacted_app\",\r\n  \"userinfo_endpoint\":
+        \"https://redacted-host/OAuth2/UserInfo/redacted_app\",\r\n  \"code_challenge_methods_supported\":
+        [\r\n    \"plain\",\r\n    \"S256\"\r\n  ],\r\n  \"end_session_endpoint\":
+        \"https://redacted-host/OAuth2/EndSessionV2/redacted_app\",\r\n  \"claims_supported\":
+        [\r\n    \"sub\",\r\n    \"name\",\r\n    \"family_name\",\r\n    \"given_name\",\r\n
+        \   \"picture\",\r\n    \"preferred_username\",\r\n    \"email\",\r\n    \"email_verified\",\r\n
+        \   \"phone_number\",\r\n    \"phone_number_verified\",\r\n    \"address\",\r\n
+        \   \"auth_time\",\r\n    \"aud\",\r\n    \"iss\",\r\n    \"exp\",\r\n    \"iat\"\r\n
+        \ ],\r\n  \"id_token_signing_alg_values_supported\": [\r\n    \"RS256\"\r\n
+        \ ],\r\n  \"subject_types_supported\": [\r\n    \"public\"\r\n  ],\r\n  \"scopes_supported\":
+        [\r\n    \"openid\",\r\n    \"profile\",\r\n    \"email\",\r\n    \"address\",\r\n
+        \   \"phone\"\r\n  ],\r\n  \"token_endpoint\": \"https://redacted-host/OAuth2/Token/redacted_app\",\r\n
+        \ \"jwks_uri\": \"https://redacted-host/OAuth2/Keys/redacted_app\",\r\n
         \ \"response_types_supported\": [\r\n    \"code\",\r\n    \"id_token\",\r\n
         \   \"id_token token\",\r\n    \"code id_token\",\r\n    \"code token\",\r\n
-        \   \"code id_token token\"\r\n  ],\r\n  \"introspection_endpoint\": \"https://redacted-host/OAuth2/Introspect/redacted_app\",\r\n
-        \ \"id_token_signing_alg_values_supported\": [\r\n    \"RS256\"\r\n  ],\r\n
-        \ \"subject_types_supported\": [\r\n    \"public\"\r\n  ],\r\n  \"issuer\":
-        \"https://redacted-host/redacted_app/\",\r\n  \"userinfo_endpoint\":
-        \"https://redacted-host/OAuth2/UserInfo/redacted_app\",\r\n  \"token_endpoint\":
-        \"https://redacted-host/OAuth2/Token/redacted_app\",\r\n  \"scopes_supported\":
-        [\r\n    \"openid\",\r\n    \"profile\",\r\n    \"email\",\r\n    \"address\",\r\n
-        \   \"phone\"\r\n  ],\r\n  \"claims_supported\": [\r\n    \"sub\",\r\n    \"name\",\r\n
-        \   \"family_name\",\r\n    \"given_name\",\r\n    \"picture\",\r\n    \"preferred_username\",\r\n
-        \   \"email\",\r\n    \"email_verified\",\r\n    \"phone_number\",\r\n    \"phone_number_verified\",\r\n
-        \   \"address\",\r\n    \"auth_time\",\r\n    \"aud\",\r\n    \"iss\",\r\n
-        \   \"exp\",\r\n    \"iat\"\r\n  ],\r\n  \"end_session_endpoint\": \"https://redacted-host/OAuth2/EndSessionV2/redacted_app\"\r\n}"
+        \   \"code id_token token\"\r\n  ]\r\n}"
   recorded_at: Mon, 10 Apr 2023 18:13:17 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/identity/discovery_endpoint-valid_oidc_credentials.yml
+++ b/spec/fixtures/vcr_cassettes/authenticators/authn-oidc/v2/identity/discovery_endpoint-valid_oidc_credentials.yml
@@ -4,42 +4,45 @@ http_interactions:
     method: get
     uri: https://redacted-host/redacted_app/.well-known/openid-configuration
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - SWD (1.3.0) (2.8.3, ruby 3.0.6 (2023-03-30))
+      - SWD 2.0.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
-      Date:
-      - Mon, 10 Apr 2023 18:16:56 GMT
   response:
     status:
       code: 200
       message: OK
     headers:
+      Content-Type:
+      - application/json; charset=utf-8
       Date:
       - Mon, 10 Apr 2023 18:16:56 GMT
       Content-Length:
-      - '1347'
+      - '440'
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: "{\r\n  \"authorization_endpoint\": \"https://redacted-host/OAuth2/Authorize/redacted_app\",\r\n
-        \ \"code_challenge_methods_supported\": [\r\n    \"plain\",\r\n    \"S256\"\r\n
-        \ ],\r\n  \"jwks_uri\": \"https://redacted-host/OAuth2/Keys/redacted_app\",\r\n
+        \ \"issuer\": \"https://redacted-host/redacted_app/\",\r\n  \"introspection_endpoint\":
+        \"https://redacted-host/OAuth2/Introspect/redacted_app\",\r\n  \"userinfo_endpoint\":
+        \"https://redacted-host/OAuth2/UserInfo/redacted_app\",\r\n  \"code_challenge_methods_supported\":
+        [\r\n    \"plain\",\r\n    \"S256\"\r\n  ],\r\n  \"end_session_endpoint\":
+        \"https://redacted-host/OAuth2/EndSessionV2/redacted_app\",\r\n  \"claims_supported\":
+        [\r\n    \"sub\",\r\n    \"name\",\r\n    \"family_name\",\r\n    \"given_name\",\r\n
+        \   \"picture\",\r\n    \"preferred_username\",\r\n    \"email\",\r\n    \"email_verified\",\r\n
+        \   \"phone_number\",\r\n    \"phone_number_verified\",\r\n    \"address\",\r\n
+        \   \"auth_time\",\r\n    \"aud\",\r\n    \"iss\",\r\n    \"exp\",\r\n    \"iat\"\r\n
+        \ ],\r\n  \"id_token_signing_alg_values_supported\": [\r\n    \"RS256\"\r\n
+        \ ],\r\n  \"subject_types_supported\": [\r\n    \"public\"\r\n  ],\r\n  \"scopes_supported\":
+        [\r\n    \"openid\",\r\n    \"profile\",\r\n    \"email\",\r\n    \"address\",\r\n
+        \   \"phone\"\r\n  ],\r\n  \"token_endpoint\": \"https://redacted-host/OAuth2/Token/redacted_app\",\r\n
+        \ \"jwks_uri\": \"https://redacted-host/OAuth2/Keys/redacted_app\",\r\n
         \ \"response_types_supported\": [\r\n    \"code\",\r\n    \"id_token\",\r\n
         \   \"id_token token\",\r\n    \"code id_token\",\r\n    \"code token\",\r\n
-        \   \"code id_token token\"\r\n  ],\r\n  \"introspection_endpoint\": \"https://redacted-host/OAuth2/Introspect/redacted_app\",\r\n
-        \ \"id_token_signing_alg_values_supported\": [\r\n    \"RS256\"\r\n  ],\r\n
-        \ \"subject_types_supported\": [\r\n    \"public\"\r\n  ],\r\n  \"issuer\":
-        \"https://redacted-host/redacted_app/\",\r\n  \"userinfo_endpoint\":
-        \"https://redacted-host/OAuth2/UserInfo/redacted_app\",\r\n  \"token_endpoint\":
-        \"https://redacted-host/OAuth2/Token/redacted_app\",\r\n  \"scopes_supported\":
-        [\r\n    \"openid\",\r\n    \"profile\",\r\n    \"email\",\r\n    \"address\",\r\n
-        \   \"phone\"\r\n  ],\r\n  \"claims_supported\": [\r\n    \"sub\",\r\n    \"name\",\r\n
-        \   \"family_name\",\r\n    \"given_name\",\r\n    \"picture\",\r\n    \"preferred_username\",\r\n
-        \   \"email\",\r\n    \"email_verified\",\r\n    \"phone_number\",\r\n    \"phone_number_verified\",\r\n
-        \   \"address\",\r\n    \"auth_time\",\r\n    \"aud\",\r\n    \"iss\",\r\n
-        \   \"exp\",\r\n    \"iat\"\r\n  ],\r\n  \"end_session_endpoint\": \"https://redacted-host/OAuth2/EndSessionV2/redacted_app\"\r\n}"
+        \   \"code id_token token\"\r\n  ]\r\n}"
   recorded_at: Mon, 10 Apr 2023 18:16:56 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
### Desired Outcome

Fix support for `HTTPS_PROXY` variable when using authn-oidc. This issue was occuring due to the underlying HTTP client of the OpenIDConnect gem, and appears to be fixed in a more recent version when it switched to Faraday as its HTTP client.

### Implemented Changes

Updated OpenIDConnect gem to 2.x

### Connected Issue/Story

CNJR-2390

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
