### PR TITLE
Allows Policy Factories with variables to be set in the root policy

### DIFF
--- a/app/domain/factories/create_from_policy_factory.rb
+++ b/app/domain/factories/create_from_policy_factory.rb
@@ -65,7 +65,10 @@ module Factories
               return @success.new(result) unless factory_template.schema['properties'].key?('variables')
 
               # Set Policy Factory variables
-              @renderer.render(template: "#{factory_template.policy_branch}/<%= id %>", variables: template_variables)
+              variables_path = ["<%= id %>"]
+              # If the variables are headed for the "root" namespace, we don't want the namespace in the path
+              variables_path.prepend(factory_template.policy_branch) unless policy_load_path == 'root'
+              @renderer.render(template: variables_path.join('/'), variables: template_variables)
                 .bind do |variable_path|
                   set_factory_variables(
                     schema_variables: factory_template.schema['properties']['variables']['properties'],


### PR DESCRIPTION
This commit fixes a Policy Factory bug where variables for complex factories were not being successfully created in the root policy. Prior to this commit, the "root" policy was appended to the variable ids.  This creates an invalid variable ID.

### Desired Outcome

This fixes a bug that was discovered while manually testing the UI.

### Implemented Changes

This commit strips the defined policy from the variables if the policy is "root".

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

I'll be adding tests to this section of the code in a future refactor.

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
