### PR TITLE
AuthnOIDC client: wrap Discovery and Callback in optional cert logic

### DIFF
--- a/app/domain/errors.rb
+++ b/app/domain/errors.rb
@@ -265,6 +265,11 @@ module Errors
         msg: "Access Token retrieval failure: '{0-error}'",
         code: "CONJ00133E"
       )
+
+      InvalidCertificate = ::Util::TrackableErrorClass.new(
+        msg: "Invalid certificate: {0-message}",
+        code: "CONJ00135E"
+      )
     end
 
     module AuthnIam

--- a/dev/start
+++ b/dev/start
@@ -234,6 +234,7 @@ setup_keycloak() {
   pushd "../ci"
   # CC servers can't find it for some reason.  Local shellcheck is fine.
   # shellcheck disable=SC1091
+  export COMPOSE="docker compose"
   source "oauth/keycloak/keycloak_functions.sh"
   popd
 

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -88,8 +88,21 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
             -----END CERTIFICATE-----
           EOF
           }
-          let(:expected_hash) { OpenSSL::X509::Certificate.new(cert).subject.hash.to_s(16) }
-          let(:symlink_path) { File.join(OpenSSL::X509::DEFAULT_CERT_DIR, "#{expected_hash}.0") }
+          let(:cert_subject_hash) { OpenSSL::X509::Certificate.new(cert).subject.hash.to_s(16) }
+          let(:symlink_path) { File.join(OpenSSL::X509::DEFAULT_CERT_DIR, "#{cert_subject_hash}.0") }
+
+          it 'cleans up the temporary certificate file' do
+            travel_to(Time.parse(config[:auth_time])) do
+              expect(File.exist?(symlink_path)).to be false
+              client(config).callback_with_temporary_cert(
+                code: config[:code],
+                code_verifier: config[:code_verifier],
+                nonce: config[:nonce],
+                cert_string: cert
+              )
+              expect(File.exist?(symlink_path)).to be false
+            end
+          end
 
           context 'if a symlink for the certificate subject already exists' do
             before(:each) do
@@ -98,8 +111,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
             end
 
             after(:each) do
-              @tempfile.close
-              @tempfile.unlink
+              @tempfile.close!
               File.unlink(symlink_path)
             end
 
@@ -112,21 +124,6 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
                   cert_string: cert
                 )
                 expect(File.exist?(symlink_path)).to be true
-              end
-            end
-          end
-
-          context 'if the certificate does not already exist in the default cert store' do
-            it 'cleans up the temporary certificate file' do
-              travel_to(Time.parse(config[:auth_time])) do
-                expect(File.exist?(symlink_path)).to be false
-                client(config).callback_with_temporary_cert(
-                  code: config[:code],
-                  code_verifier: config[:code_verifier],
-                  nonce: config[:nonce],
-                  cert_string: cert
-                )
-                expect(File.exist?(symlink_path)).to be false
               end
             end
           end
@@ -168,7 +165,7 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
           )
         end
       end
-  
+
       context 'when code has expired', vcr: "authenticators/authn-oidc/v2/#{config[:service_id]}/client_callback-expired_code-valid_oidc_credentials" do
         it 'raise an exception' do
           expect do
@@ -186,16 +183,40 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
     end
 
     describe '.callback_with_temporary_cert', type: 'unit' do
-      context 'when invalid certificate is provided', vcr: "enabled" do
-        it 'raises an error' do
-          expect do
-            client(config).callback_with_temporary_cert(
-              code: config[:code],
-              code_verifier: config[:code_verifier],
-              nonce: config[:nonce],
-              cert_string: "invalid certificate"
-            )
-          end.to raise_error(OpenSSL::X509::CertificateError)
+      context 'when invalid cert is provided', vcr: 'enabled' do
+        context 'string does not contain a certificate' do
+          let(:cert) { "does not contain a certificate" }
+
+          it 'raises an error' do
+            expect do
+              client(config).callback_with_temporary_cert(
+                code: config[:code],
+                code_verifier: config[:code_verifier],
+                nonce: config[:nonce],
+                cert_string: cert
+              )
+            end.to raise_error(Errors::Authentication::AuthnOidc::InvalidCertificate)
+          end
+        end
+
+        context 'string contains malformed certificate' do
+          let(:cert) { <<~EOF
+            -----BEGIN CERTIFICATE-----
+            hello future contributor :)
+            -----END CERTIFICATE-----
+          EOF
+          }
+
+          it 'raises an error' do
+            expect do
+              client(config).callback_with_temporary_cert(
+                code: config[:code],
+                code_verifier: config[:code_verifier],
+                nonce: config[:nonce],
+                cert_string: cert
+              )
+            end.to raise_error(Errors::Authentication::AuthnOidc::InvalidCertificate)
+          end
         end
       end
     end
@@ -291,188 +312,6 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
         end
       end
     end
-
-    describe '.discover', type: 'unit' do
-      let(:target) { Authentication::AuthnOidc::V2::Client }
-      let(:provider_uri) { "https://oidcprovider.com" }
-      let(:mock_discovery) { double("Mock Discovery Config") }
-      let(:mock_response) { "Mock Discovery Response" }
-
-      before(:each) do
-        @cert_dir = Dir.mktmpdir
-      end
-
-      after(:each) do
-        FileUtils.remove_entry @cert_dir
-      end
-
-      context 'when no cert is required' do
-        context 'when credentials are valid', vcr: "authenticators/authn-oidc/v2/#{config[:service_id]}/discovery_endpoint-valid_oidc_credentials" do
-          it 'endpoint return valid data' do
-            resp = target.discover(provider_uri: config[:provider_uri])
-
-            expect(resp.authorization_endpoint).to eq("https://#{config[:host]}#{config[:expected_authz]}")
-            expect(resp.token_endpoint).to eq("https://#{config[:host]}#{config[:expected_token]}")
-            expect(resp.userinfo_endpoint).to eq("https://#{config[:host]}#{config[:expected_userinfo]}")
-            expect(resp.jwks_uri).to eq("https://#{config[:host]}#{config[:expected_keys]}")
-          end
-        end
-
-        context 'when provider URI is invalid', vcr: "authenticators/authn-oidc/v2/#{config[:service_id]}/discovery_endpoint-invalid_oidc_provider" do
-          it 'raises an error' do
-            expect do
-              target.discover(provider_uri: "https://foo.bar.com")
-            end.to raise_error(
-              OpenIDConnect::Discovery::DiscoveryFailed
-            )
-          end
-        end
-      end
-
-      context 'when cert is not provided' do
-        it 'does not write the certificate' do
-          allow(mock_discovery).to receive(:discover!).with(String) do
-            expect(Dir.entries(@cert_dir).select do |entry|
-              entry unless [".", ".."].include?(entry)
-            end).to be_empty
-          end
-
-          target.discover(
-            provider_uri: provider_uri,
-            discovery_configuration: mock_discovery,
-            cert_dir: @cert_dir,
-            cert_string: ""
-          )
-        end
-
-        it 'returns the discovery response' do
-          allow(mock_discovery).to receive(:discover!).with(String).and_return(
-            mock_response
-          )
-
-          expect(target.discover(
-            provider_uri: provider_uri,
-            discovery_configuration: mock_discovery,
-            cert_dir: @cert_dir,
-            cert_string: ""
-          )).to eq(mock_response)
-        end
-      end
-
-      context 'when valid cert is provided' do
-        let(:cert) { <<~EOF
-          -----BEGIN CERTIFICATE-----
-          MIIDqzCCApOgAwIBAgIJAP9vSJDyPfQdMA0GCSqGSIb3DQEBCwUAMGwxCzAJBgNV
-          BAYTAlVTMRYwFAYDVQQIDA1NYXNzYWNodXNldHRzMQ8wDQYDVQQHDAZOZXd0b24x
-          ETAPBgNVBAoMCEN5YmVyQXJrMQ8wDQYDVQQLDAZDb25qdXIxEDAOBgNVBAMMB1Jv
-          b3QgQ0EwHhcNMjMwODIzMjIyMjU1WhcNMzExMTA5MjIyMjU1WjBsMQswCQYDVQQG
-          EwJVUzEWMBQGA1UECAwNTWFzc2FjaHVzZXR0czEPMA0GA1UEBwwGTmV3dG9uMREw
-          DwYDVQQKDAhDeWJlckFyazEPMA0GA1UECwwGQ29uanVyMRAwDgYDVQQDDAdSb290
-          IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7YPg2tpJYygd37RB
-          JQrAEnqtMctB01jSB4Snm3oQVz33z1OfLulTeJA56gwWN4OVm737zUJM1GET6fFC
-          ZIVsrhk8WsKeilnyE3FeVMmpbbteUt7DcTS2bpmk6p0MlaN8Y3EoDmVLKmcAoRXS
-          xLi8iOkClJPbpSbjQDg2ZnpyfEFBE+jhOWaFkgaSVt2tTUrAt3+F/3o6rRtsXplC
-          m2Fj/qK9x4Yw5sw098ztLNNomMCmhSD4ACn4jSZoq0HTH9QrZ9agXTpKkDOeAjMJ
-          O08T4XqW61o1YJRPjgIYqwtyCs5DHSzj4AmuYRSDRBgK/mIDDiQd9XL0VFW8CcKP
-          DnxSdQIDAQABo1AwTjAdBgNVHQ4EFgQU2/KbZMd7y7ZBfK884/4vB0AAg+AwHwYD
-          VR0jBBgwFoAU2/KbZMd7y7ZBfK884/4vB0AAg+AwDAYDVR0TBAUwAwEB/zANBgkq
-          hkiG9w0BAQsFAAOCAQEAr2UxJLH5j+3iez0mSwPY2m6QqK57mUWDzgMFHCtuohYT
-          saqhBXzsgHqFElw2WM2fQpeSxHqr0R1MrDz+qBg/tgFJ6AnVkW56v41oJb+kZsi/
-          fhk7OhU9MhOqG9Wlnptp4QiLCCuKeDUUfQCnu15peR9vxQt0cLlzmr8MQdTuMvb9
-          Vi7jey+Y5P04D8sqNP4BNUSRW8TwAKWkPJ4r3GybMsoCwqhb9+zAeYUj30TaxzKK
-          VSC0BRw+2QY8OllJPYIE3SCPK+v4SZp72KZ9ooSV+52ezmOCARuNWaNZKCbdPSme
-          DBHPd2jZXDVr5nrOEppAnma6VgmlRSN393j6GOiNIw==
-          -----END CERTIFICATE-----
-        EOF
-        }
-        let(:cert_subject_hash) { OpenSSL::X509::Certificate.new(cert).subject.hash.to_s(16) }
-        let(:symlink_path) { File.join(@cert_dir, "#{cert_subject_hash}.0") }
-
-        context 'when target symlink does not already exist' do
-          it 'writes the certificate to the specified directory' do
-            allow(mock_discovery).to receive(:discover!).with(String) do
-              expect(File.exist?(symlink_path)).to be true
-              expect(File.read(symlink_path)).to eq(cert)
-            end
-
-            target.discover(
-              provider_uri: provider_uri,
-              discovery_configuration: mock_discovery,
-              cert_dir: @cert_dir,
-              cert_string: cert
-            )
-          end
-
-          it 'cleans up the certificate after fetching discovery information' do
-            allow(mock_discovery).to receive(:discover!).with(String)
-
-            target.discover(
-              provider_uri: provider_uri,
-              discovery_configuration: mock_discovery,
-              cert_dir: @cert_dir,
-              cert_string: cert
-            )
-
-            expect(File.exist?(symlink_path)).to be false
-          end
-        end
-
-        context 'when target symlink already exists' do
-          before(:each) do
-            @tempfile = Tempfile.new("rspec.pem")
-            @tempfile.write("existing content")
-            @tempfile.flush
-            @tempfile.close
-            File.symlink(@tempfile, symlink_path)
-          end
-
-          after(:each) do
-            @tempfile.unlink
-            File.unlink(symlink_path)
-          end
-
-          it 'does not write the new certificate data to the specified directory' do
-            allow(mock_discovery).to receive(:discover!).with(String) do
-              expect(File.read(@tempfile.path)).to eq("existing content")
-            end
-
-            target.discover(
-              provider_uri: provider_uri,
-              discovery_configuration: mock_discovery,
-              cert_dir: @cert_dir,
-              cert_string: cert
-            )
-          end
-
-          it 'maintains the certificate after fetching discovery information' do
-            allow(mock_discovery).to receive(:discover!).with(String)
-
-            target.discover(
-              provider_uri: provider_uri,
-              discovery_configuration: mock_discovery,
-              cert_dir: @cert_dir,
-              cert_string: cert
-            )
-
-            expect(File.exist?(symlink_path)).to be true
-            expect(File.read(@tempfile.path)).to eq("existing content")
-          end
-        end
-      end
-
-      context 'when invalid cert is provided' do
-        it 'raises an error' do
-          expect do
-            target.discover(
-              provider_uri: provider_uri,
-              discovery_configuration: mock_discovery,
-              cert_dir: @cert_dir,
-              cert_string: "invalid certificate"
-            )
-          end.to raise_error(OpenSSL::X509::CertificateError)
-        end
-      end
-    end
   end
 
   describe 'OIDC client targeting Okta' do
@@ -518,5 +357,273 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
 
     include_examples 'client setup', config
     include_examples 'token retrieval failures', config
+  end
+
+  describe '.discover', type: 'unit' do
+    let(:target) { Authentication::AuthnOidc::V2::Client }
+    let(:provider_uri) { "https://oidcprovider.com" }
+    let(:mock_discovery) { double("Mock Discovery Config") }
+    let(:mock_response) { "Mock Discovery Response" }
+
+    before(:each) do
+      @cert_dir = Dir.mktmpdir
+    end
+
+    after(:each) do
+      FileUtils.remove_entry @cert_dir
+    end
+
+    context 'when cert is not provided' do
+      it 'does not write the certificate' do
+        allow(mock_discovery).to receive(:discover!).with(String) do
+          expect(Dir.entries(@cert_dir).select do |entry|
+            entry unless [".", ".."].include?(entry)
+          end).to be_empty
+        end
+
+        target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: ""
+        )
+      end
+
+      it 'returns the discovery response' do
+        allow(mock_discovery).to receive(:discover!).with(String).and_return(
+          mock_response
+        )
+
+        expect(target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: ""
+        )).to eq(mock_response)
+      end
+    end
+
+    context 'when valid cert is provided' do
+      let(:cert) { <<~EOF
+        -----BEGIN CERTIFICATE-----
+        MIIDqzCCApOgAwIBAgIJAP9vSJDyPfQdMA0GCSqGSIb3DQEBCwUAMGwxCzAJBgNV
+        BAYTAlVTMRYwFAYDVQQIDA1NYXNzYWNodXNldHRzMQ8wDQYDVQQHDAZOZXd0b24x
+        ETAPBgNVBAoMCEN5YmVyQXJrMQ8wDQYDVQQLDAZDb25qdXIxEDAOBgNVBAMMB1Jv
+        b3QgQ0EwHhcNMjMwODIzMjIyMjU1WhcNMzExMTA5MjIyMjU1WjBsMQswCQYDVQQG
+        EwJVUzEWMBQGA1UECAwNTWFzc2FjaHVzZXR0czEPMA0GA1UEBwwGTmV3dG9uMREw
+        DwYDVQQKDAhDeWJlckFyazEPMA0GA1UECwwGQ29uanVyMRAwDgYDVQQDDAdSb290
+        IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7YPg2tpJYygd37RB
+        JQrAEnqtMctB01jSB4Snm3oQVz33z1OfLulTeJA56gwWN4OVm737zUJM1GET6fFC
+        ZIVsrhk8WsKeilnyE3FeVMmpbbteUt7DcTS2bpmk6p0MlaN8Y3EoDmVLKmcAoRXS
+        xLi8iOkClJPbpSbjQDg2ZnpyfEFBE+jhOWaFkgaSVt2tTUrAt3+F/3o6rRtsXplC
+        m2Fj/qK9x4Yw5sw098ztLNNomMCmhSD4ACn4jSZoq0HTH9QrZ9agXTpKkDOeAjMJ
+        O08T4XqW61o1YJRPjgIYqwtyCs5DHSzj4AmuYRSDRBgK/mIDDiQd9XL0VFW8CcKP
+        DnxSdQIDAQABo1AwTjAdBgNVHQ4EFgQU2/KbZMd7y7ZBfK884/4vB0AAg+AwHwYD
+        VR0jBBgwFoAU2/KbZMd7y7ZBfK884/4vB0AAg+AwDAYDVR0TBAUwAwEB/zANBgkq
+        hkiG9w0BAQsFAAOCAQEAr2UxJLH5j+3iez0mSwPY2m6QqK57mUWDzgMFHCtuohYT
+        saqhBXzsgHqFElw2WM2fQpeSxHqr0R1MrDz+qBg/tgFJ6AnVkW56v41oJb+kZsi/
+        fhk7OhU9MhOqG9Wlnptp4QiLCCuKeDUUfQCnu15peR9vxQt0cLlzmr8MQdTuMvb9
+        Vi7jey+Y5P04D8sqNP4BNUSRW8TwAKWkPJ4r3GybMsoCwqhb9+zAeYUj30TaxzKK
+        VSC0BRw+2QY8OllJPYIE3SCPK+v4SZp72KZ9ooSV+52ezmOCARuNWaNZKCbdPSme
+        DBHPd2jZXDVr5nrOEppAnma6VgmlRSN393j6GOiNIw==
+        -----END CERTIFICATE-----
+      EOF
+      }
+      let(:cert_subject_hash) { OpenSSL::X509::Certificate.new(cert).subject.hash.to_s(16) }
+      let(:symlink_path) { File.join(@cert_dir, "#{cert_subject_hash}.0") }
+
+      it 'writes the certificate to the specified directory' do
+        allow(mock_discovery).to receive(:discover!).with(String) do
+          expect(File.exist?(symlink_path)).to be true
+          expect(File.read(symlink_path)).to eq(cert)
+        end
+
+        target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: cert
+        )
+      end
+
+      it 'cleans up the certificate after fetching discovery information' do
+        allow(mock_discovery).to receive(:discover!).with(String)
+
+        target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: cert
+        )
+
+        expect(File.exist?(symlink_path)).to be false
+      end
+
+      context 'when target symlink already exists' do
+        before(:each) do
+          @tempfile = Tempfile.new("rspec.pem")
+          File.symlink(@tempfile, symlink_path)
+        end
+
+        after(:each) do
+          @tempfile.close!
+          File.unlink(symlink_path)
+        end
+
+        it 'writes the certificate to the specified directory with incremented name' do
+          allow(mock_discovery).to receive(:discover!).with(String) do
+            expect(File.exist?(symlink_path)).to be true
+
+            incremented = File.join(@cert_dir, "#{cert_subject_hash}.1")
+            expect(File.exist?(incremented))
+            expect(File.read(incremented)).to eq(cert)
+          end
+
+          target.discover(
+            provider_uri: provider_uri,
+            discovery_configuration: mock_discovery,
+            cert_dir: @cert_dir,
+            cert_string: cert
+          )
+        end
+
+        it 'maintains the original while cleaning up the created cert' do
+          allow(mock_discovery).to receive(:discover!).with(String)
+
+          target.discover(
+            provider_uri: provider_uri,
+            discovery_configuration: mock_discovery,
+            cert_dir: @cert_dir,
+            cert_string: cert
+          )
+
+          expect(File.exist?(symlink_path)).to be true
+          expect(File.exist?(File.join(@cert_dir, "#{cert_subject_hash}.1"))).to be false
+        end
+      end
+    end
+
+    context 'when valid cert chain is provided' do
+      let(:client_cert) { <<~EOF
+        -----BEGIN CERTIFICATE-----
+        MIIC6zCCAlQCAQEwDQYJKoZIhvcNAQELBQAwdjELMAkGA1UEBhMCVVMxFjAUBgNV
+        BAgMDU1hc3NhY2h1c2V0dHMxDzANBgNVBAcMBk5ld3RvbjERMA8GA1UECgwIQ3li
+        ZXJBcmsxDzANBgNVBAsMBkNvbmp1cjEaMBgGA1UEAwwRVW5pdCBUZXN0IFJvb3Qg
+        Q0EwHhcNMjMwODI1MTgxMzM1WhcNMzMwODIyMTgxMzM1WjCBgTELMAkGA1UEBhMC
+        VVMxFjAUBgNVBAgMDU1hc3NhY2h1c2V0dHMxDzANBgNVBAcMBk5ld3RvbjERMA8G
+        A1UECgwIQ3liZXJBcmsxDzANBgNVBAsMBkNvbmp1cjElMCMGA1UEAwwcVW5pdCBU
+        ZXN0IENsaWVudCBDZXJ0aWZpY2F0ZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+        AQoCggEBAMPeuIWmjgF381jSV2/lgS2tZYkD53ukM9nlnIEI3N4QZ46aD0+tcet+
+        2gZ5+TdwceZMc8R8krSuA25Kojn2tvKInyrmWWbIGV2JA+iBeRiMSjbbh4keAWYW
+        /HKawCRfdxmYheBEFbbKtFcsKxuIqEmFEdwG7TeJx6wr2zIayenC7I8HzAk7LQSW
+        pJb6Fv/gpbagNmnoITeIC58s+ibF77OVk5XW0hFkyO/La46R+WhATp8ayYmXpwWT
+        yVemxs4P60N5AK8NvmvRPxuQfOSAP154W0WYD5FtKUcPP3CdOQEZhGjWGiScZ7mr
+        6aLYuac4gS7b/kOC+Fzqw3NNY7vUs6MCAwEAATANBgkqhkiG9w0BAQsFAAOBgQB5
+        O4a3Qs5zPO2cGW4fX92nmB9jj1sxik+3hVV/aTHNUfAYJ0aula+kKqghbVlrlsAm
+        6Oqdw3WCoBkUjqUQqqPlLqmmxA/AW+izqLzvaZnBCGyHiFGYUFhMilk9mfE/m63v
+        EhjKF017l50ptBaUYiD1W9IXGWZJ9b1nxnr/S+CXCQ==
+        -----END CERTIFICATE-----
+      EOF
+      }
+      let(:client_hash) { OpenSSL::X509::Certificate.new(client_cert).subject.hash.to_s(16) }
+      let(:ca_cert) { <<~EOF
+        -----BEGIN CERTIFICATE-----
+        MIICYzCCAcwCCQCtimZfxnGkRTANBgkqhkiG9w0BAQsFADB2MQswCQYDVQQGEwJV
+        UzEWMBQGA1UECAwNTWFzc2FjaHVzZXR0czEPMA0GA1UEBwwGTmV3dG9uMREwDwYD
+        VQQKDAhDeWJlckFyazEPMA0GA1UECwwGQ29uanVyMRowGAYDVQQDDBFVbml0IFRl
+        c3QgUm9vdCBDQTAeFw0yMzA4MjUxODA5MjJaFw0zMzA4MjIxODA5MjJaMHYxCzAJ
+        BgNVBAYTAlVTMRYwFAYDVQQIDA1NYXNzYWNodXNldHRzMQ8wDQYDVQQHDAZOZXd0
+        b24xETAPBgNVBAoMCEN5YmVyQXJrMQ8wDQYDVQQLDAZDb25qdXIxGjAYBgNVBAMM
+        EVVuaXQgVGVzdCBSb290IENBMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD0
+        r78pu6hJZTKXR4qLHNbZ8sM4IWrTBRerBumf5Qjq3LmNhvMCXYee1Z9YmHOh5UrA
+        JbONCM3ASt1INbf3pD52JJEEWA8udEvGhONsnrjuXI2DoBg/W/4rye9p6+SagOSF
+        O9oLUIczL4XxIgE1CXi89uwCwn0BxjLnaLraMxvbgQIDAQABMA0GCSqGSIb3DQEB
+        CwUAA4GBANUZ4iQLe83CIb4DV73a+OUwZ19YJ0DCMvXDMWW0CTwVv4DhxM8ZkTpu
+        1FQ/uXrA9FP/kulYAMLqo8RkYiE+u64Jbs/vWebupyV89dh5sFEsp0PafQa415C6
+        h1Tg+4C+eSkQIEIGVm8tLVG8JQL4sweo/gQGdzcxfCSfPZHqInzD
+        -----END CERTIFICATE-----
+      EOF
+      }
+      let(:ca_hash) { OpenSSL::X509::Certificate.new(ca_cert).subject.hash.to_s(16) }
+      let(:cert_strings) { [ client_cert, ca_cert ] }
+      let(:hashes) { [ client_hash, ca_hash ] }
+      let(:cert_chain) { "#{client_cert}\n#{ca_cert}" }
+
+      it 'writes all certificates to the specified directory' do
+        allow(mock_discovery).to receive(:discover!).with(String) do
+          hashes.each_with_index do |hash, i|
+            cert_path = File.join(@cert_dir, "#{hash}.0")
+            expect(File.exist?(cert_path)).to be true
+            expect(File.symlink?(cert_path)).to be true
+            expect(File.read(cert_path)).to eq(cert_strings[i])
+          end
+        end
+
+        target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: cert_chain
+        )
+      end
+
+      it 'cleans up all certificates after fetching discovery information' do
+        allow(mock_discovery).to receive(:discover!).with(String)
+
+        target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: cert_chain
+        )
+
+        hashes.each do |hash|
+          cert_path = File.join(@cert_dir, "#{hash}.0")
+          expect(File.exist?(cert_path)).to be false
+        end
+      end
+    end
+
+    context 'when invalid cert is provided' do
+      context 'string does not contain a certificate' do
+        let(:cert) { "does not contain a certificate" }
+
+        it 'raises an error' do
+          expect do
+            target.discover(
+              provider_uri: provider_uri,
+              discovery_configuration: mock_discovery,
+              cert_dir: @cert_dir,
+              cert_string: cert
+            )
+          end.to raise_error(Errors::Authentication::AuthnOidc::InvalidCertificate) do |e|
+            expect(e.message).to include("provided string does not contain a certificate")
+          end
+        end
+      end
+
+      context 'string contains malformed certificate' do
+        let(:cert) { <<~EOF
+          -----BEGIN CERTIFICATE-----
+          hellofuturecontributor:)
+          -----END CERTIFICATE-----
+        EOF
+        }
+
+        it 'raises an error' do
+          expect do
+            target.discover(
+              provider_uri: provider_uri,
+              discovery_configuration: mock_discovery,
+              cert_dir: @cert_dir,
+              cert_string: cert
+            )
+          end.to raise_error(Errors::Authentication::AuthnOidc::InvalidCertificate) do |e|
+            expect(e.message).to include(cert)
+            expect(e.message).to include("nested asn1 error")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Desired Outcome

From CNJR-2474:
> We need two wrapper methods to inject certs into the OpenSSL truststore before reaching out to the provider. One for `discover!` and one for `access_token!`. Include tests to ensure cleanup occurs and that hash collisions are handled correctly

### Implemented Changes

- Added class method `self.discover` to `Authentication::AuthnOIDC::V2::Client` class

  `self.discover` wraps `::OpenIDConnect::Discovery::Provider::Config.discover!` with commands to write & clean up a certificate to & from the default Conjur container certificate store.

  `self.discover` is a class method, because there are a few contexts outside this class where the underlying `discover!` method is used. Call it by running:

  ```rb
  Authentication::AuthnOIDC::Client.discover(...).
  ```

- Added instance method `callback_with_temporary_cert` to `Authentication::AuthnOIDC::V2::Client` class

  `callback_with_temporary_cert` wraps the `callback` method with commands to write & clean up a certificate to & from Conjur's default certificate store.

  Unlike `self.discover`, which wraps a single `::OpenIDConnect` method, `callback_with_temporary_cert` wraps the entire `callback` method, which includes multiple calls to the OIDC provider, all of which require the temporary certs to be successful:

  - `callback` uses the `discovery_information` method to get the provider metadata. This will be covered by using the new `self.discover`.
  - `callback` calls `::OpenIDConnect::Client.access_token!`
  - `callback` calls the `jwks` method on the `discovery_information` response object, which sends a request to the provider's JWKS endpoint.


- Added unit tests for each
  - Ensure requests that do not rely on a provided certificate pass as expected
  - Ensure temp cert is written when underlying method is called
  - Ensure temp cert is cleaned up when each method returns
  - Ensure providing a malformed cert raises and error
  - Ensure that if a symlink for the provided cert subject already exists, it is not overwritten or cleaned up when the function returns

### Open Questions for Reviewer

1. Right now, I have the AuthnOIDC client:

   - Verify the cert string isn't empty
   - Verify the target symlink doesn't already exist

   What else can we do to make this foolproof?

   - Verify cert CN/SAN against `provider_uri`?
   - Verify cert is not expired?

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2474

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
