### PR TITLE
Add optional ca-cert variable to authn-oidc and retrieval functions

### DIFF
--- a/app/domain/authentication/authn_azure/authenticator.rb
+++ b/app/domain/authentication/authn_azure/authenticator.rb
@@ -36,7 +36,8 @@ module Authentication
             claims_to_verify: {
               verify_iss: true,
               iss: provider_uri
-            }
+            },
+            ca_cert: nil
           ),
           logger: @logger
         )

--- a/app/domain/authentication/authn_azure/validate_status.rb
+++ b/app/domain/authentication/authn_azure/validate_status.rb
@@ -34,7 +34,8 @@ module Authentication
 
       def validate_provider_is_responsive
         @discover_identity_provider.(
-          provider_uri: provider_uri
+          provider_uri: provider_uri,
+          ca_cert: nil
         )
       end
 

--- a/app/domain/authentication/authn_gcp/update_authenticator_input.rb
+++ b/app/domain/authentication/authn_gcp/update_authenticator_input.rb
@@ -50,7 +50,8 @@ module Authentication
               iss: PROVIDER_URI,
               verify_iat: true,
               verify_expiration: true
-            }
+            },
+            ca_cert: nil
           ),
           logger: @logger
         )

--- a/app/domain/authentication/authn_gcp/validate_status.rb
+++ b/app/domain/authentication/authn_gcp/validate_status.rb
@@ -15,7 +15,8 @@ module Authentication
 
       def validate_provider_is_responsive
         @discover_identity_provider.(
-          provider_uri: PROVIDER_URI
+          provider_uri: PROVIDER_URI,
+          ca_cert: nil
         )
       end
     end

--- a/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
+++ b/app/domain/authentication/authn_jwt/signing_key/fetch_provider_uri_signing_key.rb
@@ -39,7 +39,8 @@ module Authentication
 
         def discovered_provider
           @discovered_provider ||= @discover_identity_provider.call(
-            provider_uri: @provider_uri
+            provider_uri: @provider_uri,
+            ca_cert: nil
           )
         end
 

--- a/app/domain/authentication/authn_oidc/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/authenticator.rb
@@ -39,7 +39,8 @@ module Authentication
         # If successful, validate the new set of required variables
         if authenticator.present?
           Authentication::AuthnOidc::ValidateStatus.new(
-            required_variable_names: %w[provider-uri client-id client-secret claim-mapping]
+            required_variable_names: %w[provider-uri client-id client-secret claim-mapping],
+            optional_variable_names: %w[ca-cert]
           ).(
             account: authenticator_status_input.account,
             service_id: authenticator_status_input.service_id

--- a/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
+++ b/app/domain/authentication/authn_oidc/v2/data_objects/authenticator.rb
@@ -5,7 +5,7 @@ module Authentication
         class Authenticator
 
           REQUIRED_VARIABLES = %i[provider_uri client_id client_secret claim_mapping].freeze
-          OPTIONAL_VARIABLES = %i[redirect_uri response_type provider_scope name token_ttl].freeze
+          OPTIONAL_VARIABLES = %i[redirect_uri response_type provider_scope name token_ttl ca_cert].freeze
 
           attr_reader(
             :provider_uri,
@@ -15,7 +15,8 @@ module Authentication
             :account,
             :service_id,
             :redirect_uri,
-            :response_type
+            :response_type,
+            :ca_cert
           )
 
           def initialize(
@@ -29,7 +30,8 @@ module Authentication
             name: nil,
             response_type: 'code',
             provider_scope: nil,
-            token_ttl: 'PT60M'
+            token_ttl: 'PT60M',
+            ca_cert: nil
           )
             @account = account
             @provider_uri = provider_uri
@@ -42,6 +44,7 @@ module Authentication
             @provider_scope = provider_scope
             @redirect_uri = redirect_uri
             @token_ttl = token_ttl
+            @ca_cert = ca_cert
           end
 
           def scope

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -6,7 +6,7 @@ module Authentication
         logger: Rails.logger,
         open_id_discovery_service: OpenIDConnect::Discovery::Provider::Config
       },
-      inputs: %i[provider_uri]
+      inputs: %i[provider_uri ca_cert]
     ) do
       def call
         log_provider_uri

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -8,7 +8,7 @@ module Authentication
         logger: Rails.logger,
         discover_identity_provider: DiscoverIdentityProvider.new
       },
-      inputs: %i[provider_uri]
+      inputs: %i[provider_uri ca_cert]
     ) do
       def call
         discover_provider
@@ -23,7 +23,8 @@ module Authentication
 
       def discovered_provider
         @discovered_provider ||= @discover_identity_provider.(
-          provider_uri: @provider_uri
+          provider_uri: @provider_uri,
+          ca_cert: @ca_cert
         )
       end
 

--- a/app/domain/authentication/o_auth/verify_and_decode_token.rb
+++ b/app/domain/authentication/o_auth/verify_and_decode_token.rb
@@ -23,7 +23,7 @@ module Authentication
         verify_and_decode_token: ::Authentication::Jwt::VerifyAndDecodeToken.new,
         logger: Rails.logger
       },
-      inputs: %i[provider_uri token_jwt claims_to_verify]
+      inputs: %i[provider_uri token_jwt claims_to_verify ca_cert]
     ) do
       def call
         fetch_provider_keys
@@ -35,7 +35,8 @@ module Authentication
       def fetch_provider_keys(force_read: false)
         provider_keys = @fetch_provider_keys.call(
           provider_uri: @provider_uri,
-          refresh: force_read
+          refresh: force_read,
+          ca_cert: @ca_cert
         )
 
         @jwks = provider_keys.jwks

--- a/app/domain/authentication/util/fetch_authenticator_secrets.rb
+++ b/app/domain/authentication/util/fetch_authenticator_secrets.rb
@@ -13,7 +13,7 @@ module Authentication
       inputs: %i[conjur_account authenticator_name service_id required_variable_names]
     ) do
       def call
-        secret_map_for(@required_variable_names, required_secrets).merge(secret_map_for(@optional_variable_names, optional_secrets))
+        secret_map_for(required_secrets).merge(secret_map_for(optional_secrets))
       end
 
       private
@@ -26,10 +26,10 @@ module Authentication
         @optional_secrets ||= @fetch_optional_secrets.(resource_ids: resource_ids_for(@optional_variable_names))
       end
 
-      def secret_map_for(variable_names, secret_values)
-        variable_names.each_with_object({}) do |variable_name, secrets|
-          full_variable_name     = full_variable_name(variable_name)
-          secrets[variable_name] = secret_values[full_variable_name]
+      def secret_map_for(secret_values)
+        secret_values.each_with_object({}) do |(full_name, value), secrets|
+          short_name = full_name.to_s.split('/')[-1]
+          secrets[short_name] = value
         end
       end
 

--- a/app/domain/authentication/util/fetch_authenticator_secrets.rb
+++ b/app/domain/authentication/util/fetch_authenticator_secrets.rb
@@ -6,25 +6,35 @@ module Authentication
 
     FetchAuthenticatorSecrets = CommandClass.new(
       dependencies: {
-        fetch_secrets: ::Conjur::FetchRequiredSecrets.new
+        fetch_required_secrets: ::Conjur::FetchRequiredSecrets.new,
+        fetch_optional_secrets: ::Conjur::FetchOptionalSecrets.new,
+        optional_variable_names: []
       },
       inputs: %i[conjur_account authenticator_name service_id required_variable_names]
     ) do
       def call
-        @required_variable_names.each_with_object({}) do |variable_name, secrets|
-          full_variable_name     = full_variable_name(variable_name)
-          secrets[variable_name] = required_secrets[full_variable_name]
-        end
+        secret_map_for(@required_variable_names, required_secrets).merge(secret_map_for(@optional_variable_names, optional_secrets))
       end
 
       private
 
       def required_secrets
-        @required_secrets ||= @fetch_secrets.(resource_ids: required_resource_ids)
+        @required_secrets ||= @fetch_required_secrets.(resource_ids: resource_ids_for(@required_variable_names))
       end
 
-      def required_resource_ids
-        @required_variable_names.map { |var_name| full_variable_name(var_name) }
+      def optional_secrets
+        @optional_secrets ||= @fetch_optional_secrets.(resource_ids: resource_ids_for(@optional_variable_names))
+      end
+
+      def secret_map_for(variable_names, secret_values)
+        variable_names.each_with_object({}) do |variable_name, secrets|
+          full_variable_name     = full_variable_name(variable_name)
+          secrets[variable_name] = secret_values[full_variable_name]
+        end
+      end
+
+      def resource_ids_for(variable_names)
+        variable_names.map { |var_name| full_variable_name(var_name) }
       end
 
       def full_variable_name(var_name)

--- a/app/domain/conjur/fetch_optional_secrets.rb
+++ b/app/domain/conjur/fetch_optional_secrets.rb
@@ -13,21 +13,19 @@ module Conjur
     private
 
     def secret_values
-      transformed_secrets = secrets.transform_values do |secret|
+      secrets.transform_values do |secret|
         secret ? secret.value : nil
       end
-      transformed_secrets
     end 
     
     def resources
-      @resource_ids.map { |id| [id, @resource_class[id]] }.to_h
+      @resources ||= @resource_ids.map { |id| [id, @resource_class[id]] }.to_h
     end
     
     def secrets
-      transformed_secrets = resources.transform_values do |resource|
+      @secrets ||= resources.transform_values do |resource|
         resource ? resource.secret : nil
       end
-      @secrets ||= transformed_secrets
     end
   end
 end

--- a/app/domain/conjur/fetch_optional_secrets.rb
+++ b/app/domain/conjur/fetch_optional_secrets.rb
@@ -1,0 +1,33 @@
+require 'command_class'
+
+module Conjur
+
+  FetchOptionalSecrets ||= CommandClass.new(
+    dependencies: { resource_class: ::Resource },
+    inputs: [:resource_ids]
+  ) do
+    def call
+      secret_values
+    end
+
+    private
+
+    def secret_values
+      transformed_secrets = secrets.transform_values do |secret|
+        secret ? secret.value : nil
+      end
+      transformed_secrets
+    end 
+    
+    def resources
+      @resource_ids.map { |id| [id, @resource_class[id]] }.to_h
+    end
+    
+    def secrets
+      transformed_secrets = resources.transform_values do |resource|
+        resource ? resource.secret : nil
+      end
+      @secrets ||= transformed_secrets
+    end
+  end
+end

--- a/ci/oauth/keycloak/fetch_certificate
+++ b/ci/oauth/keycloak/fetch_certificate
@@ -14,5 +14,4 @@ openssl s_client \
     >/etc/ssl/certs/keycloak.pem
 
 hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
-
 ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0" || true

--- a/ci/test_suites/authenticators_oidc/policy.yml
+++ b/ci/test_suites/authenticators_oidc/policy.yml
@@ -19,6 +19,9 @@
   - !variable
     id: id-token-user-property
 
+  - !variable
+    id: ca-cert
+
   - !group
     id: users
     annotations:

--- a/dev/policies/authenticators/authn-oidc/keycloak2.yml
+++ b/dev/policies/authenticators/authn-oidc/keycloak2.yml
@@ -8,6 +8,11 @@
           id: keycloak2
           body:
           - !webservice
+            id: status
+            annotations:
+              description: Status service to check that the authenticator is configured correctly
+
+          - !webservice
 
           - !variable provider-uri
           - !variable client-id
@@ -15,6 +20,9 @@
 
           # URI of Conjur instance
           - !variable redirect_uri
+
+          # Defines the cert chain to be used for TLS verification
+          - !variable ca-cert
 
           # Defines the JWT claim to use as the Conjur identifier
           - !variable claim-mapping

--- a/dev/start
+++ b/dev/start
@@ -37,6 +37,7 @@ ENABLE_OIDC_KEYCLOAK=false
 ENABLE_OIDC_OKTA=false
 ENABLE_ROTATORS=false
 IDENTITY_USER=""
+COMPOSE="docker compose"
 
 declare -a required_envvars
 required_envvars[identity]="IDENTITY_CLIENT_ID IDENTITY_CLIENT_SECRET IDENTITY_PROVIDER_URI"
@@ -300,6 +301,9 @@ configure_oidc_v1() {
   client_load_policy "/src/conjur-server/$policy_path"
   client_add_secret "conjur/authn-oidc/$service_id/provider-uri" "$provider_uri"
   client_add_secret "conjur/authn-oidc/$service_id/id-token-user-property" "$token_property"
+  if [ "$service_id" = "keycloak" ]; then
+    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+  fi
 }
 
 configure_oidc_v2() {
@@ -315,6 +319,9 @@ configure_oidc_v2() {
   client_add_secret "conjur/authn-oidc/$service_id/client-secret" "$client_secret"
   client_add_secret "conjur/authn-oidc/$service_id/claim-mapping" "$claim_mapping"
   client_add_secret "conjur/authn-oidc/$service_id/redirect_uri" "http://localhost:3000/authn-oidc/$service_id/cucumber/authenticate"
+  if [ "$service_id" = "keycloak2" ]; then
+    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+  fi
 
   client_load_policy "/src/conjur-server/dev/policies/authenticators/authn-oidc/$service_id-users.yml"
 }

--- a/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/data_objects/authenticator_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
 
   describe '.token_ttl', type: 'unit' do
     context 'with default initializer' do
-      it { expect(authenticator.token_ttl).to eq(8.minutes) }
+      it { expect(authenticator.token_ttl).to eq(1.hour) }
     end
 
     context 'when initialized with a valid duration' do
-      let (:args) { default_args.merge({ token_ttl: 'PT1H'}) }
-      it { expect(authenticator.token_ttl).to eq(1.hour)}
+      let (:args) { default_args.merge({ token_ttl: 'PT2H'}) }
+      it { expect(authenticator.token_ttl).to eq(2.hour)}
     end
 
     context 'when initialized with an invalid duration' do
@@ -87,6 +87,17 @@ RSpec.describe(Authentication::AuthnOidc::V2::DataObjects::Authenticator) do
       it { expect {
         authenticator.token_ttl
       }.to raise_error(Errors::Authentication::DataObjects::InvalidTokenTTL) }
+    end
+  end
+
+  describe '.ca_cert', type: 'unit' do
+    context 'with default initializer' do
+      it { expect(authenticator.ca_cert).to eq(nil) }
+    end
+
+    context 'when initialized with a value' do
+      let (:args) { default_args.merge({ ca_cert: 'cert'}) }
+      it { expect(authenticator.ca_cert).to eq('cert')}
     end
   end
 end

--- a/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/validate_status_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(Authentication::AuthnOidc::ValidateStatus) do
   let(:account) { "my-acct" }
   let(:service) { "my-service" }
 
-  include_context "fetch secrets", %w[provider-uri id-token-user-property]
+  include_context "fetch secrets", %w[provider-uri id-token-user-property ca-cert]
 
   let(:test_oidc_discovery_error) { "test-oidc-discovery-error" }
 

--- a/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
+++ b/spec/app/domain/authentication/o_auth/discover_identity_provider_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe(Authentication::OAuth::DiscoverIdentityProvider) do
       Authentication::OAuth::DiscoverIdentityProvider.new(
         open_id_discovery_service: mock_discovery_provider(error: nil)
       ).call(
-        provider_uri: test_provider_uri
+        provider_uri: test_provider_uri,
+        ca_cert: nil
       )
     end
 
@@ -41,7 +42,8 @@ RSpec.describe(Authentication::OAuth::DiscoverIdentityProvider) do
         Authentication::OAuth::DiscoverIdentityProvider.new(
           open_id_discovery_service: mock_discovery_provider(error: Errno::ETIMEDOUT)
         ).call(
-          provider_uri: test_provider_uri
+          provider_uri: test_provider_uri,
+          ca_cert: nil
         )
       end
 
@@ -54,7 +56,8 @@ RSpec.describe(Authentication::OAuth::DiscoverIdentityProvider) do
           Authentication::OAuth::DiscoverIdentityProvider.new(
             open_id_discovery_service: mock_discovery_provider(error: test_error)
           ).call(
-            provider_uri: test_provider_uri
+            provider_uri: test_provider_uri,
+            ca_cert: nil
           )
         end
 

--- a/spec/app/domain/conjur/fetch_optional_secrets_spec.rb
+++ b/spec/app/domain/conjur/fetch_optional_secrets_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'conjur/fetch_optional_secrets'
+require 'util/stubs/deep_double'
+
+RSpec.describe('Conjur::FetchOptionalSecrets') do
+  def fetch_secrets(repo)
+    Conjur::FetchOptionalSecrets
+      .new(resource_class: repo)
+      .(resource_ids: %w[resource1 resource2])
+  end
+
+  DeepDouble = Util::Stubs::DeepDouble
+
+  context 'when the secrets exist' do
+    let(:repo_with_secrets) do
+      DeepDouble.new('ResourceRepo',
+                     '[]': {
+                       'resource1' => { secret: { value: 'secret1' } },
+                       'resource2' => { secret: { value: 'secret2' } }
+                     })
+    end
+
+    it 'returns a hash of the secret values indexed by resource id' do
+      expect(fetch_secrets(repo_with_secrets)).to eq(
+        { 'resource1' => 'secret1', 'resource2' => 'secret2' }
+      )
+    end
+  end
+
+  context 'when resources are missing' do
+    let(:repo_missing_resource) do
+      DeepDouble.new('ResourceRepo',
+                     '[]': {
+                       'resource1' => nil,
+                       'resource2' => { secret: { value: 'secret2' } }
+                     })
+    end
+
+    it 'returns a hash of the requested resources with nil values' do
+      expect(fetch_secrets(repo_missing_resource)).to eq(
+        { 'resource1' => nil, 'resource2' => 'secret2' }
+      )
+    end
+  end
+
+  context 'when secrets are missing' do
+    let(:repo_missing_secret) do
+      DeepDouble.new('ResourceRepo',
+                     '[]': {
+                       'resource1' => { secret: { value: 'secret1' } },
+                       'resource2' => { secret: nil }
+                     })
+    end
+
+    it 'returns a hash of the secret values with nil values' do
+      expect(fetch_secrets(repo_missing_secret)).to eq(
+        { 'resource1' => 'secret1', 'resource2' => nil }
+      )
+    end
+  end
+end

--- a/spec/app/domain/conjur/fetch_optional_secrets_spec.rb
+++ b/spec/app/domain/conjur/fetch_optional_secrets_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe('Conjur::FetchOptionalSecrets') do
       .(resource_ids: %w[resource1 resource2])
   end
 
-  DeepDouble = Util::Stubs::DeepDouble
-
   context 'when the secrets exist' do
     let(:repo_with_secrets) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('OptionalResourceRepo',
                      '[]': {
                        'resource1' => { secret: { value: 'secret1' } },
                        'resource2' => { secret: { value: 'secret2' } }
@@ -29,7 +27,7 @@ RSpec.describe('Conjur::FetchOptionalSecrets') do
 
   context 'when resources are missing' do
     let(:repo_missing_resource) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('ResourceRepo',
                      '[]': {
                        'resource1' => nil,
                        'resource2' => { secret: { value: 'secret2' } }
@@ -45,7 +43,7 @@ RSpec.describe('Conjur::FetchOptionalSecrets') do
 
   context 'when secrets are missing' do
     let(:repo_missing_secret) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('ResourceRepo',
                      '[]': {
                        'resource1' => { secret: { value: 'secret1' } },
                        'resource2' => { secret: nil }

--- a/spec/app/domain/conjur/fetch_required_secrets_spec.rb
+++ b/spec/app/domain/conjur/fetch_required_secrets_spec.rb
@@ -9,11 +9,10 @@ RSpec.describe('Conjur::FetchRequiredSecrets') do
       .(resource_ids: %w[resource1 resource2])
   end
 
-  DeepDouble = Util::Stubs::DeepDouble
 
   context 'when the secrets exist' do
     let(:repo_with_secrets) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('ResourceRepo',
                      '[]': {
                        'resource1' => { secret: { value: 'secret1' } },
                        'resource2' => { secret: { value: 'secret2' } }
@@ -29,7 +28,7 @@ RSpec.describe('Conjur::FetchRequiredSecrets') do
 
   context 'when resources are missing' do
     let(:repo_missing_resource) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('ResourceRepo',
                      '[]': {
                        'resource1' => nil,
                        'resource2' => { secret: { value: 'secret2' } }
@@ -45,7 +44,7 @@ RSpec.describe('Conjur::FetchRequiredSecrets') do
 
   context 'when secrets are missing' do
     let(:repo_missing_secret) do
-      DeepDouble.new('ResourceRepo',
+      Util::Stubs::DeepDouble.new('ResourceRepo',
                      '[]': {
                        'resource1' => { secret: { value: 'secret1' } },
                        'resource2' => { secret: nil }


### PR DESCRIPTION
### Desired Outcome

Add support for a `ca-cert` variable to be set in the authenticator policy config. This will eventually be used to inform the TLS verification for connections opened by the OpenIDConnect gem.

There are a few flows within the OIDC authenticator which need access to this optional value:
1. `ValidateStatus` -> `DiscoveryIdentityProvider` -> `::OpenIDConnect::Discovery::Provider::Config.discover!`
1. `UpdateInputWithUsernameFromIdToken` -> `VerifyAndDecodeToken` -> `FetchProviderKeys` -> `DiscoverIdentityProvider`  -> `::OpenIDConnect::Discovery::Provider::Config.discover!`
1.  Client -> `::OpenIDConnect::Discovery::Provider::Config.discover!` ->  `::OpenIDConnect::Client.access_token!`

This change has the unfortunate side effect of bleeding into some other authenticators (authn-gcp, authn-azure, authn-jwt) slightly. This mainly due to our heavy usage of command classes. This pattern does not allow for optional parameters, so by introducing a new `ca-cert` input for the `DiscoverIdentityProvider` class, it must be included by all callers regardless of whether they support the same configuration.

### Implemented Changes

- Updated authenticator data object to include optional `ca-cert` (default = `nil`)
- Adds support for optional authenticator secrets
- Updated relevant authenticator code to include optional variable
- Unit tests for new additions
- Updated keycloak policies and start script to include `ca-cert` variable from keycloak container

### Connected Issue/Story

CNJR-2475

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
