### PR TITLE
Remove openid_connect gem test private key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,13 @@ COPY Gemfile \
 COPY gems/ gems/
 
 
-RUN bundle --without test development
+RUN bundle --without test development && \
+    # Remove private keys brought in by gems in their test data
+    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \; && \
+    find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
+    find / -name httpclient -type d -exec find {} -name '*.pem' -type f -delete \;
 
 COPY . .
-
-# removing CA bundle of httpclient gem
-RUN find / -name httpclient -type d -exec find {} -name *.pem -type f -delete \;
 
 RUN ln -sf /opt/conjur-server/bin/conjurctl /usr/local/bin/
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -76,7 +76,9 @@ RUN INSTALL_PKGS="gcc \
     yum -y clean all --enablerepo='*' && \
     # removing CA bundle of httpclient gem
     find / -name 'httpclient-*' -type d -exec find {} -name '*.pem' -type f -delete \; && \
-    find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \;
+    find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
+    # remove the private key in the oidc_connect gem spec directory
+    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \;
 
 COPY . .
 


### PR DESCRIPTION
### Desired Outcome

Remove the private key that the openid_connect gem brings in with its test data.

### Implemented Changes

Added command to find any *.pem files in an openid_connect directory and delete them. 