### PR TITLE
Quote and wildcard gem directory when removing unneeded certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ COPY gems/ gems/
 
 RUN bundle --without test development && \
     # Remove private keys brought in by gems in their test data
-    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \; && \
+    find / -name 'openid_connect-*' -type d -exec find {} -name '*.pem' -type f -delete \; && \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
-    find / -name httpclient -type d -exec find {} -name '*.pem' -type f -delete \;
+    find / -name 'httpclient-*' -type d -exec find {} -name '*.pem' -type f -delete \;
 
 COPY . .
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -78,7 +78,7 @@ RUN INSTALL_PKGS="gcc \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.pem' -type f -delete \; && \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
     # remove the private key in the oidc_connect gem spec directory
-    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \;
+    find / -name 'openid_connect-*' -type d -exec find {} -name '*.pem' -type f -delete \;
 
 COPY . .
 


### PR DESCRIPTION
### Desired Outcome

The delete I added in #2921 didn't actually work because the find command was looking in sub-directories of the openid_connect-* dir, not the main dir. It then didn't find the private key and thus didn't delete anything.

### Implemented Changes

Add quotes and a wildcard to the directory name to find the top-level gem directory (and thus the *.pem file several layers underneath it).