### PR TITLE
Wrap discovery and callback calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
 
 ### Added
+- Support an optional`ca-cert` variable for providing custom certs/chains to verify
+  OIDC providers or proxies when using the OIDC authenticator
+  [cyberark/conjur#2933](https://github.com/cyberark/conjur/pull/2933)
 - New flag to `conjurctl server` command called `--no-migrate` which allows for skipping
   the database migration step when starting the server.
   [cyberark/conjur#2895](https://github.com/cyberark/conjur/pull/2895)

--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -160,7 +160,10 @@ module Authentication
             force: invalidate,
             skip_nil: true
           ) do
-            @discovery_configuration.discover!(@authenticator.provider_uri)
+            self.discover(
+              provider_uri: @authenticator.provider_uri,
+              cert_string: @authenticator.ca_cert
+            )
           rescue Errno::ETIMEDOUT => e
             raise Errors::Authentication::OAuth::ProviderDiscoveryTimeout.new(@authenticator.provider_uri, e.message)
           rescue => e

--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -160,8 +160,9 @@ module Authentication
             force: invalidate,
             skip_nil: true
           ) do
-            self.discover(
+            self.class.discover(
               provider_uri: @authenticator.provider_uri,
+              discovery_configuration: @discovery_configuration,
               cert_string: @authenticator.ca_cert
             )
           rescue Errno::ETIMEDOUT => e
@@ -186,9 +187,15 @@ module Authentication
           provider_uri:,
           discovery_configuration: ::OpenIDConnect::Discovery::Provider::Config,
           cert_dir: OpenSSL::X509::DEFAULT_CERT_DIR,
-          cert_string: nil
+          cert_string: nil,
+          jwks: false
         )
-          d = -> { discovery_configuration.discover!(provider_uri) }
+          case jwks
+          when false
+            d = -> { discovery_configuration.discover!(provider_uri) }
+          when true
+            d = -> { discovery_configuration.discover!(provider_uri).jwks }
+          end
 
           return d.call if cert_string.blank?
 

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -21,10 +21,11 @@ module Authentication
           end
 
           identity = resolve_identity(
-            jwt: @client.callback(
+            jwt: @client.callback_with_temporary_cert(
               code: args[:code],
               nonce: args[:nonce],
-              code_verifier: args[:code_verifier]
+              code_verifier: args[:code_verifier],
+              ca_cert: @authenticator.ca_cert
             )
           )
           unless identity.present?

--- a/app/domain/authentication/authn_oidc/v2/strategy.rb
+++ b/app/domain/authentication/authn_oidc/v2/strategy.rb
@@ -25,7 +25,7 @@ module Authentication
               code: args[:code],
               nonce: args[:nonce],
               code_verifier: args[:code_verifier],
-              ca_cert: @authenticator.ca_cert
+              cert_string: @authenticator.ca_cert
             )
           )
           unless identity.present?

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -30,6 +30,7 @@ module Authentication
       def discover_provider
         @discovered_provider = Authentication::AuthnOidc::V2::Client.discover(
           provider_uri: @provider_uri,
+          discovery_configuration: @open_id_discovery_service,
           cert_string: @ca_cert
         )
         @logger.debug(

--- a/app/domain/authentication/o_auth/discover_identity_provider.rb
+++ b/app/domain/authentication/o_auth/discover_identity_provider.rb
@@ -28,7 +28,10 @@ module Authentication
       # is used is inside of FetchProviderKeys.  This is unlikely change, and hence
       # unlikely to be a problem
       def discover_provider
-        @discovered_provider = @open_id_discovery_service.discover!(@provider_uri)
+        @discovered_provider = Authentication::AuthnOidc::V2::Client.discover(
+          provider_uri: @provider_uri,
+          cert_string: @ca_cert
+        )
         @logger.debug(
           LogMessages::Authentication::OAuth::IdentityProviderDiscoverySuccess.new
         )

--- a/app/domain/authentication/o_auth/fetch_provider_keys.rb
+++ b/app/domain/authentication/o_auth/fetch_provider_keys.rb
@@ -29,8 +29,14 @@ module Authentication
       end
 
       def fetch_provider_keys
+        # We have to wrap the call to the JWKS URI separately to accomodate
+        # custom CA certs in authn-oidc
         jwks = {
-          keys: @discovered_provider.jwks
+          keys: Authentication::AuthnOidc::V2::Client.discover(
+            provider_uri: @provider_uri,
+            cert_string: @ca_cert,
+            jwks: true
+          )
         }
         algs = @discovered_provider.id_token_signing_alg_values_supported
         @logger.debug(LogMessages::Authentication::OAuth::FetchProviderKeysSuccess.new)

--- a/ci/oauth/keycloak/fetch_certificate
+++ b/ci/oauth/keycloak/fetch_certificate
@@ -13,6 +13,5 @@ openssl s_client \
     -outform PEM \
     >/etc/ssl/certs/keycloak.pem
 
-# Skip this step so we can test the 'ca-cert' variable configuration
-# hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
-# ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0" || true
+hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0" || true

--- a/ci/oauth/keycloak/fetch_certificate
+++ b/ci/oauth/keycloak/fetch_certificate
@@ -13,5 +13,6 @@ openssl s_client \
     -outform PEM \
     >/etc/ssl/certs/keycloak.pem
 
-hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
-ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0" || true
+# Skip this step so we can test the 'ca-cert' variable configuration
+# hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+# ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0" || true

--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -23,6 +23,7 @@ function _hydrate_all_env_args() {
   # shellcheck disable=SC2034
   arr=(
     "${keycloak_items[@]}"
+    "KEYCLOAK_CA_CERT=$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
     "PROVIDER_URI=https://keycloak:8443/auth/realms/master"
     "PROVIDER_INTERNAL_URI=http://keycloak:8080/auth/realms/master/protocol/openid-connect"
     "PROVIDER_ISSUER=http://keycloak:8080/auth/realms/master"
@@ -48,6 +49,14 @@ function main() {
   wait_for_keycloak_server
   create_keycloak_users
   fetch_keycloak_certificate
+
+  # Delete the symlink so we can test with the 'ca-cert' variable
+  local conjur_parallel_services
+  read -ra conjur_parallel_services <<< "$(get_parallel_services 'conjur')"
+  for parallel_service in "${conjur_parallel_services[@]}"; do
+    hash=$($COMPOSE exec "${parallel_service}" openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+    $COMPOSE exec "${parallel_service}" rm "/etc/ssl/certs/$hash.0" || true
+  done
 
   additional_services='ldap-server keycloak'
   _run_cucumber_tests authenticators_oidc "$additional_services" \

--- a/cucumber/authenticators_oidc/features/authn_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc.feature
@@ -15,6 +15,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
       | oidc_client_secret          | KEYCLOAK_CLIENT_SECRET | 1234                                                             |
       | oidc_provider_uri           | PROVIDER_URI           | https://keycloak:8443/auth/realms/master                         |
       | oidc_id_token_user_property | ID_TOKEN_USER_PROPERTY | preferred_username                                               |
+      | oidc_ca_cert                | KEYCLOAK_CA_CERT       |                                                                  |
 
     And I load a policy:
     """
@@ -30,6 +31,9 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
 
       - !variable
         id: id-token-user-property
+
+      - !variable
+        id: ca-cert
 
       - !group users
 
@@ -48,6 +52,7 @@ Feature: OIDC Authenticator - Hosts can authenticate with OIDC authenticator
       | variable_id                                       | context_variable            |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_id_token_user_property |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri           |
+      | conjur/authn-oidc/keycloak/ca-cert                | oidc_ca_cert                |
 
   @smoke
   Scenario: A valid id token in header to get Conjur access token

--- a/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_bad_policy.feature
@@ -15,6 +15,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
       | oidc_client_secret          | KEYCLOAK_CLIENT_SECRET  | 1234                                                            |
       | oidc_provider_uri           | PROVIDER_URI            | https://keycloak:8443/auth/realms/master                        |
       | oidc_id_token_user_property | ID_TOKEN_USER_PROPERTY  | preferred_username                                              |
+      | oidc_ca_cert                | KEYCLOAK_CA_CERT        |                                                                 |
 
   @negative @acceptance
   Scenario: id-token-user-property variable missing in policy is denied
@@ -29,6 +30,9 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
 
       - !variable
         id: provider-uri
+      
+      - !variable
+        id: ca-cert
 
       - !group users
 
@@ -46,6 +50,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
     And I set the following conjur variables:
       | variable_id                             | context_variable  |
       | conjur/authn-oidc/keycloak/provider-uri | oidc_provider_uri |
+      | conjur/authn-oidc/keycloak/ca-cert      | oidc_ca_cert      |
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the log file
     When I authenticate via OIDC with id token
@@ -108,6 +113,9 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
       - !variable
         id: id-token-user-property
 
+      - !variable
+        id: ca-cert
+
       - !group users
 
     - !user alice
@@ -120,6 +128,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
       | variable_id                                       | context_variable            |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_id_token_user_property |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri           |
+      | conjur/authn-oidc/keycloak/ca-cert                | oidc_ca_cert                |
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the log file
     When I authenticate via OIDC with id token
@@ -146,6 +155,9 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
         - !variable
           id: id-token-user-property
 
+        - !variable
+          id: ca-cert
+
         - !group users
 
         - !permit
@@ -163,6 +175,7 @@ Feature: OIDC Authenticator - Bad authenticator configuration leads to an error
       | variable_id                                       | context_variable            |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_id_token_user_property |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri           |
+      | conjur/authn-oidc/keycloak/ca-cert                | oidc_ca_cert                |
     And I fetch an ID Token for username "alice" and password "alice"
     And I save my place in the log file
     When I authenticate via OIDC with id token

--- a/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_performance.feature
@@ -15,6 +15,7 @@ Feature: OIDC Authenticator - Performance tests
       | oidc_client_secret          | KEYCLOAK_CLIENT_SECRET | 1234                                                            |
       | oidc_provider_uri           | PROVIDER_URI           | https://keycloak:8443/auth/realms/master                        |
       | oidc_id_token_user_property | ID_TOKEN_USER_PROPERTY | preferred_username                                              |
+      | oidc_ca_cert                | KEYCLOAK_CA_CERT       |                                                                 |
 
     And I load a policy:
     """
@@ -30,6 +31,9 @@ Feature: OIDC Authenticator - Performance tests
 
       - !variable
         id: id-token-user-property
+
+      - !variable
+        id: ca-cert
 
       - !group users
 
@@ -48,6 +52,7 @@ Feature: OIDC Authenticator - Performance tests
       | variable_id                                       | context_variable            |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_id_token_user_property |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri           |
+      | conjur/authn-oidc/keycloak/ca-cert                | oidc_ca_cert                |
 
   @performance
   Scenario: successful requests

--- a/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_v2.feature
@@ -16,6 +16,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
       | oidc_provider_uri          | PROVIDER_URI           | https://keycloak:8443/auth/realms/master                        |
       | oidc_claim_mapping         | ID_TOKEN_USER_PROPERTY | preferred_username                                              |
       | oidc_redirect_url          | KEYCLOAK_REDIRECT_URI  | http://conjur:3000/authn-oidc/keycloak2/cucumber/authenticate   |
+      | oidc_ca_cert               | KEYCLOAK_CA_CERT       |                                                                 |
 
     And I load a policy:
     """
@@ -36,6 +37,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
           - !variable redirect-uri
           - !variable provider-scope
           - !variable token-ttl
+          - !variable ca-cert
           - !group users
           - !permit
             role: !group users
@@ -59,6 +61,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
           - !variable redirect-uri
           - !variable provider-scope
           - !variable token-ttl
+          - !variable ca-cert
           - !group users
           - !permit
             role: !group users
@@ -83,6 +86,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
       | conjur/authn-oidc/keycloak2/claim-mapping             | oidc_claim_mapping  |               |
       | conjur/authn-oidc/keycloak2/redirect-uri              | oidc_redirect_url   |               |
       | conjur/authn-oidc/keycloak2/response-type             |                     | code          |
+      | conjur/authn-oidc/keycloak2/ca-cert                   | oidc_ca_cert        |               |
       | conjur/authn-oidc/keycloak2-long-lived/provider-uri   | oidc_provider_uri   |               |
       | conjur/authn-oidc/keycloak2-long-lived/client-id      | oidc_client_id      |               |
       | conjur/authn-oidc/keycloak2-long-lived/client-secret  | oidc_client_secret  |               |
@@ -90,6 +94,7 @@ Feature: OIDC Authenticator V2 - Users can authenticate with OIDC authenticator
       | conjur/authn-oidc/keycloak2-long-lived/redirect-uri   | oidc_redirect_url   |               |
       | conjur/authn-oidc/keycloak2-long-lived/response-type  |                     | code          |
       | conjur/authn-oidc/keycloak2-long-lived/token-ttl      |                     | PT2H          |
+      | conjur/authn-oidc/keycloak2-long-lived/ca-cert        | oidc_ca_cert        |               |
 
   @smoke
   Scenario: A valid code to get Conjur access token from webservice with default token TTL

--- a/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
+++ b/cucumber/authenticators_oidc/features/authn_oidc_with_ldap.feature
@@ -14,6 +14,7 @@ Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authentica
       | oidc_client_secret          | KEYCLOAK_CLIENT_SECRET  | 1234                                                            |
       | oidc_provider_uri           | PROVIDER_URI            | https://keycloak:8443/auth/realms/master                        |
       | oidc_id_token_user_property | ID_TOKEN_USER_PROPERTY  | preferred_username                                              |
+      | oidc_ca_cert                | KEYCLOAK_CA_CERT        |                                                                 |
 
     # Configure OIDC authenticator
     And I load a policy:
@@ -28,6 +29,8 @@ Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authentica
         id: provider-uri
       - !variable
         id: id-token-user-property
+      - !variable
+        id: ca-cert
       - !group users
       - !permit
         role: !group users
@@ -42,6 +45,7 @@ Feature: OIDC Authenticator - Users can authenticate with OIDC & LDAP authentica
       | variable_id                                       | context_variable            |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_id_token_user_property |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri           |
+      | conjur/authn-oidc/keycloak/ca-cert                | oidc_ca_cert                |
 
     # Configure LDAP authenticator
     And I extend the policy with:

--- a/cucumber/authenticators_oidc/features/authn_status_oidc.feature
+++ b/cucumber/authenticators_oidc/features/authn_status_oidc.feature
@@ -6,6 +6,7 @@ Feature: OIDC Authenticator - Status Check
       | context_variable           | environment_variable   | default_value                                                   |
       | oidc_provider_uri          | PROVIDER_URI           | https://keycloak:8443/auth/realms/master                        |
       | oidc_claim_mapping         | ID_TOKEN_USER_PROPERTY | preferred_username                                              |
+      | oidc_ca_cert               | KEYCLOAK_CA_CERT       |                                                                 |
 
   @smoke
   Scenario: A properly configured OIDC authenticator returns a successful response
@@ -28,6 +29,9 @@ Feature: OIDC Authenticator - Status Check
 
       - !variable
         id: id-token-user-property
+      
+      - !variable
+        id: ca-cert
 
       - !group users
 
@@ -60,7 +64,7 @@ Feature: OIDC Authenticator - Status Check
       | variable_id                                       | context_variable   | default_value  |
       | conjur/authn-oidc/keycloak/provider-uri           | oidc_provider_uri  |                |
       | conjur/authn-oidc/keycloak/id-token-user-property | oidc_claim_mapping |                |
-
+      | conjur/authn-oidc/keycloak/ca-cert | oidc_ca_cert |                    |
     And I login as "alice"
     When I GET "/authn-oidc/keycloak/cucumber/status"
     Then the HTTP response status code is 200

--- a/dev/start
+++ b/dev/start
@@ -321,6 +321,9 @@ configure_oidc_v2() {
   client_add_secret "conjur/authn-oidc/$service_id/redirect_uri" "http://localhost:3000/authn-oidc/$service_id/cucumber/authenticate"
   if [ "$service_id" = "keycloak2" ]; then
     client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+    # Delete the symlink so we can test with the 'ca-cert' variable
+    hash=$($COMPOSE exec conjur openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+    $COMPOSE exec conjur rm "/etc/ssl/certs/$hash.0" || true
   fi
 
   client_load_policy "/src/conjur-server/dev/policies/authenticators/authn-oidc/$service_id-users.yml"

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -363,7 +363,8 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
     let(:target) { Authentication::AuthnOidc::V2::Client }
     let(:provider_uri) { "https://oidcprovider.com" }
     let(:mock_discovery) { double("Mock Discovery Config") }
-    let(:mock_response) { "Mock Discovery Response" }
+    let(:mock_response) { double("Mock Discovery Response") }
+    let(:mock_jwks_response) { "Mock JWKS Response" }
 
     before(:each) do
       @cert_dir = Dir.mktmpdir
@@ -400,6 +401,23 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
           cert_dir: @cert_dir,
           cert_string: ""
         )).to eq(mock_response)
+      end
+
+      it 'invokes the jwks uri when requested' do
+        allow(mock_discovery).to receive(:discover!).with(String).and_return(
+          mock_response
+        )
+        allow(mock_response).to receive(:jwks).and_return(
+          mock_jwks_response
+        )
+
+        expect(target.discover(
+          provider_uri: provider_uri,
+          discovery_configuration: mock_discovery,
+          cert_dir: @cert_dir,
+          cert_string: "",
+          jwks: true
+        )).to eq(mock_jwks_response)
       end
     end
 


### PR DESCRIPTION
### Desired Outcome

Implement the wrapper methods introduced in https://github.com/cyberark/conjur/pull/2919 and the optional `ca-cert` config in https://github.com/cyberark/conjur/pull/2920 to allow custom certs to be provided in the OIDC authenticator config.

### Implemented Changes

- Added wrapper methods around:
  - OAuth discovery + JWKS retrieval
  - Identity resolution callback
  - OIDC configuration discovery
- Updated keycloak OIDC environment to use `ca-cert` variable instead of container truststore (includes integration tests)

### Connected Issue/Story

CNJR-2476

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: CNJR-2309
- [ ] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
