### PR TITLE
Allows Policy Factory to detect the correct port

### DIFF
--- a/app/domain/factories/create_from_policy_factory.rb
+++ b/app/domain/factories/create_from_policy_factory.rb
@@ -130,7 +130,7 @@ module Factories
       ).bind do |rendered_policy|
         begin
           response = @http.post(
-            "http://localhost:3000/policies/#{account}/policy/#{policy_load_path}",
+            "http://localhost:#{ENV['PORT']}/policies/#{account}/policy/#{policy_load_path}",
             rendered_policy,
             'Authorization' => authorization
           )
@@ -175,7 +175,7 @@ module Factories
         secret_path = "secrets/#{account}/variable/#{variable_id}"
 
         @http.post(
-          "http://localhost:3000/#{secret_path}",
+          "http://localhost:#{ENV['PORT']}/#{secret_path}",
           factory_variables[factory_variable].to_s,
           { 'Authorization' => authorization }
         )


### PR DESCRIPTION
This fix allows the Policy Factory to work on Open Source as well as Enterprise (Conjur runs on port 5000 in the appliance).

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
