### PR TITLE
Log warning of dropped updates to existing resources in policy POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   mitigates the possibility of a web worker becoming starved while waiting for
   a connection to become available.
   [cyberark/conjur#2875](https://github.com/cyberark/conjur/pull/2875)
+- Additive policy requests submitted via POST are rejected with a 400 status if
+  they attempt to update an existing resource.
+  [cyberark/conjur#2888](https://github.com/cyberark/conjur/pull/2888)
 - Changed base-image tagging strategy
   [cyberark/conjur#2926](https://github.com/cyberark/conjur/pull/2926)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   mitigates the possibility of a web worker becoming starved while waiting for
   a connection to become available.
   [cyberark/conjur#2875](https://github.com/cyberark/conjur/pull/2875)
-- Additive policy requests submitted via POST are rejected with a 400 status if
+- Additive policy requests submitted via POST are rejected with a 422 status if
   they attempt to update an existing resource.
   [cyberark/conjur#2888](https://github.com/cyberark/conjur/pull/2888)
 - Changed base-image tagging strategy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,7 @@ class ApplicationController < ActionController::API
   rescue_from Sequel::ForeignKeyConstraintViolation, with: :foreign_key_constraint_violation
   rescue_from Conjur::PolicyParser::Invalid, with: :policy_invalid
   rescue_from Exceptions::InvalidPolicyObject, with: :policy_invalid
+  rescue_from Exceptions::DisallowedPolicyOperation, with: :disallowed_policy_operation
   rescue_from ArgumentError, with: :argument_error
   rescue_from ActionController::ParameterMissing, with: :argument_error
   rescue_from UnprocessableEntity, with: :unprocessable_entity
@@ -191,6 +192,17 @@ class ApplicationController < ActionController::API
     end
 
     render(json: { error: error }, status: :unprocessable_entity)
+  end
+
+  def disallowed_policy_operation e
+    logger.debug("#{e}\n#{e.backtrace.join("\n")}")
+
+    render(json: {
+      error: {
+        code: "disallowed_policy_operation",
+        message: e.message
+      }
+    }, status: :unprocessable_entity)
   end
 
   def argument_error e

--- a/app/models/exceptions/disallowed_policy_operation.rb
+++ b/app/models/exceptions/disallowed_policy_operation.rb
@@ -3,9 +3,19 @@
 module Exceptions
   class DisallowedPolicyOperation < RuntimeError
 
-    def initialize
-      super("Updating existing resource disallowed in additive policy operation")
+    def initialize(context)
+      super(self.class.build_message(context))
+
+      @context = context
     end
 
+    class << self
+      def build_message(context)
+        "WARNING: Updating existing resource disallowed in additive policy operations (POST). " \
+        "In a future release, loading this policy file will fail with a 422 error code. " \
+        "The following updates have not been applied, and have been discarded: " \
+        "#{context.inspect}"
+      end
+    end
   end
 end

--- a/app/models/exceptions/disallowed_policy_operation.rb
+++ b/app/models/exceptions/disallowed_policy_operation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Exceptions
+  class DisallowedPolicyOperation < RuntimeError
+
+    def initialize
+      super("Updating existing resource disallowed in additive policy operation")
+    end
+
+  end
+end

--- a/app/models/loader/create_policy.rb
+++ b/app/models/loader/create_policy.rb
@@ -16,7 +16,7 @@ module Loader
 
       @loader.delete_shadowed_and_duplicate_rows
 
-      @loader.store_policy_in_db
+      @loader.store_policy_in_db(reject_duplicates: true)
 
       @loader.release_db_connection
     end

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -122,7 +122,7 @@ module Loader
     # TODO: consider renaming this method
     def store_policy_in_db(reject_duplicates: false)
       removed_duplicates_count = eliminate_duplicates_pk
-      raise ApplicationController::BadRequest, "Updating existing resource disallowed in additive policy operation" if removed_duplicates_count.positive? && reject_duplicates
+      raise Exceptions::DisallowedPolicyOperation if removed_duplicates_count.positive? && reject_duplicates
 
       insert_new
 

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -120,8 +120,9 @@ module Loader
     end
 
     # TODO: consider renaming this method
-    def store_policy_in_db
-      eliminate_duplicates_pk
+    def store_policy_in_db(reject_duplicates: false)
+      removed_duplicates_count = eliminate_duplicates_pk
+      raise ApplicationController::BadRequest, "Updating existing resource disallowed in additive policy operation" if removed_duplicates_count.positive? && reject_duplicates
 
       insert_new
 
@@ -243,8 +244,9 @@ module Loader
     end
 
     # Delete rows from the new policy which have the same primary keys as existing rows.
+    # Returns the total number of deleted rows.
     def eliminate_duplicates_pk
-      TABLES.each do |table|
+      TABLES.sum do |table|
         eliminate_duplicates(table, Array(model_for_table(table).primary_key) + [ :policy_id ])
       end
     end

--- a/app/models/loader/orchestrate.rb
+++ b/app/models/loader/orchestrate.rb
@@ -121,8 +121,12 @@ module Loader
 
     # TODO: consider renaming this method
     def store_policy_in_db(reject_duplicates: false)
-      removed_duplicates_count = eliminate_duplicates_pk
-      raise Exceptions::DisallowedPolicyOperation if removed_duplicates_count.positive? && reject_duplicates
+      if reject_duplicates
+        duplicates = detect_duplicates_pk
+        Rails.logger.warn(Exceptions::DisallowedPolicyOperation.new(duplicates)) if duplicates.present?
+      end
+
+      eliminate_duplicates_pk
 
       insert_new
 
@@ -249,6 +253,92 @@ module Loader
       TABLES.sum do |table|
         eliminate_duplicates(table, Array(model_for_table(table).primary_key) + [ :policy_id ])
       end
+    end
+
+    # Returns a hash of table names related to an array of hashes describing
+    # changes to existing resources made by the current policy load operation.
+    def detect_duplicates_pk
+      TABLES.each_with_object({}) do |table, duplicates|
+        table_dupes = duplicates_in_table(
+          table,
+          primary_keys(table) + [ :policy_id ],
+          non_primary_keys(table)
+        )
+        duplicates[table] = table_dupes if table_dupes.present?
+      end
+    end
+
+    # Finds entries in the temporary incoming schema's table that duplicate
+    # entries in the primary schema's table along it's primary_columns. Returns
+    # an array of hashes, where each hash describes an existing resource, and
+    # has a :diff entry describes changes made to the resource by the current
+    # policy load operation.
+    def duplicates_in_table table, primary_columns, non_primary_columns
+      primary_selections = primary_columns.map do |column|
+        "new_#{table}.#{column}"
+      end.join(', ')
+
+      non_primary_selections = non_primary_columns.map do |column|
+        "new_#{table}.#{column} AS new_#{column}, old_#{table}.#{column} AS old_#{column}"
+      end.join(', ')
+
+      selections = "#{primary_selections}"
+      selections << ", #{non_primary_selections}" unless non_primary_selections.blank?
+
+      comparisons = primary_columns.map do |column|
+        "new_#{table}.#{column} = old_#{table}.#{column}"
+      end.join(' AND ')
+
+      # This query returns an array of hashes. Each hash describes an existing
+      # resource that is being updated by the current policy load operation and
+      # the desired updates. Each hash contains:
+      # - a single entry for each primary key in the target table, and
+      # - two entries for each non-primary key in the target table, prepended
+      #   with "old_" and "new_".
+      query = <<~QUERY
+        SELECT #{selections}
+        FROM #{table} AS new_#{table}
+        JOIN #{qualify_table(table)} AS old_#{table}
+        ON #{comparisons}
+      QUERY
+
+      # Convert the hash returned by query into an easily consumable format.
+      consumable_diff(table, db[query].all)
+    end
+
+    # This method expects the duplicates argument to be an array of hashes as
+    # described in the method above. This method returns an array of hashes,
+    # where each contains:
+    # - a single entry for each primary key in the target table, and
+    # - a :diff entry, which stores a hash of non-primary keys related to both
+    #   its original and updated values.
+    def consumable_diff table, duplicates
+      duplicates.each_with_object([]) do |duplicate, dupes_a|
+        dupe_h = {}
+        pk_columns = primary_keys(table)
+        pk_columns.each do |column|
+          dupe_h[column] = duplicate[column]
+        end
+
+        dupe_h[:diff] = non_primary_keys(table).each_with_object({}) do |column, diff|
+          if duplicate["old_#{column}".to_sym] != duplicate["new_#{column}".to_sym]
+            diff[column] = [
+              duplicate["old_#{column}".to_sym],
+              duplicate["new_#{column}".to_sym]
+            ]
+          end
+        end
+
+        dupes_a << dupe_h
+      end
+    end
+
+    def primary_keys table
+      Array(model_for_table(table).primary_key)
+    end
+
+    def non_primary_keys table
+      TABLE_EQUIVALENCE_COLUMNS[table] - primary_keys(table)
     end
 
     # Eliminate duplicates from a table, using the specified comparison columns.

--- a/cucumber/api/features/policy_load_annotations.feature
+++ b/cucumber/api/features/policy_load_annotations.feature
@@ -17,7 +17,7 @@ Feature: Updating Policies with Annotations
   - create / add new         / POST  :   EXPECTED SUCCESS
   - create / add new         / PATCH :   EXPECTED FAIL - 403 on policy load
   - create / update existing / PUT   :   EXPECTED FAIL - 403 on policy load
-  - create / update existing / POST  :   EXPECTED FAIL - 400 on policy load
+  - create / update existing / POST  :   EXPECTED FAIL - 422 on policy load
   - create / update existing / PATCH :   EXPECTED FAIL - 403 on policy load
   - update / add new         / PUT   :   EXPECTED SUCCESS
   - update / add new         / POST  :   EXPECTED FAIL - 403 on policy load
@@ -186,7 +186,7 @@ Feature: Updating Policies with Annotations
       annotations:
         description: Success
     """
-    Then the HTTP response status code is 400
+    Then the HTTP response status code is 422
     And The following appears in the log after my savepoint:
     """
     Updating existing resource disallowed in additive policy operation

--- a/cucumber/api/features/policy_load_annotations.feature
+++ b/cucumber/api/features/policy_load_annotations.feature
@@ -186,10 +186,10 @@ Feature: Updating Policies with Annotations
       annotations:
         description: Success
     """
-    Then the HTTP response status code is 422
+    Then the HTTP response status code is 201
     And The following appears in the log after my savepoint:
     """
-    Updating existing resource disallowed in additive policy operation
+    WARNING: Updating existing resource disallowed in additive policy operations (POST). In a future release, loading this policy file will fail with a 422 error code. The following updates have not been applied, and have been discarded: {:annotations=>[{:resource_id=>"cucumber:host:hosts/annotated", :name=>"description", :diff=>{:value=>["Already annotated", "Success"]}}]}
     """
 
   @negative

--- a/cucumber/api/features/policy_load_annotations.feature
+++ b/cucumber/api/features/policy_load_annotations.feature
@@ -17,7 +17,7 @@ Feature: Updating Policies with Annotations
   - create / add new         / POST  :   EXPECTED SUCCESS
   - create / add new         / PATCH :   EXPECTED FAIL - 403 on policy load
   - create / update existing / PUT   :   EXPECTED FAIL - 403 on policy load
-  - create / update existing / POST  :   EXPECTED FAIL - 20x on policy load, annot not updated
+  - create / update existing / POST  :   EXPECTED FAIL - 400 on policy load
   - create / update existing / PATCH :   EXPECTED FAIL - 403 on policy load
   - update / add new         / PUT   :   EXPECTED SUCCESS
   - update / add new         / POST  :   EXPECTED FAIL - 403 on policy load
@@ -25,13 +25,6 @@ Feature: Updating Policies with Annotations
   - update / update existing / PUT   :   EXPECTED SUCCESS
   - update / update existing / POST  :   EXPECTED FAIL - 403 on policy load
   - update / update existing / PATCH :   EXPECTED SUCCESS
-
-  All these outcomes align with our expectations, but one may not align with
-  user expectations: ( create / update existing / POST ). A user may expect that
-  a policy load that tries and fails to update the content of a given annotation
-  should either provide a warning or fail outright.
-
-  How can we update how we handle policy to fail in this case?
 
   Background:
     Given I am the super-user
@@ -183,45 +176,20 @@ Feature: Updating Policies with Annotations
 
   @negative
   @acceptance
-  Scenario: User with create privilege CAN NOT update existing annotations with POST, but policy loads successfully
+  Scenario: User with create privilege CAN NOT update existing annotations with POST
     When I login as "alice"
-    Then I successfully POST "/policies/cucumber/policy/hosts" with body:
+    And I save my place in the log file
+    Then I POST "/policies/cucumber/policy/hosts" with body:
     """
     - !host
       id: annotated
       annotations:
         description: Success
     """
-    And I successfully GET "/resources/cucumber/host/hosts%2Fannotated"
-    Then the JSON should be:
+    Then the HTTP response status code is 400
+    And The following appears in the log after my savepoint:
     """
-    {
-      "annotations": [
-        {
-          "name": "description",
-          "policy": "cucumber:policy:hosts",
-          "value": "Already annotated"
-        }
-      ],
-      "id": "cucumber:host:hosts/annotated",
-      "owner": "cucumber:policy:hosts",
-      "permissions": [
-        {
-          "policy": "cucumber:policy:root",
-          "privilege": "read",
-          "role": "cucumber:user:bob"
-        },
-        {
-          "policy": "cucumber:policy:root",
-          "privilege": "read",
-          "role": "cucumber:user:alice"
-        }
-      ],
-      "policy": "cucumber:policy:hosts",
-      "restricted_to": [
-
-      ]
-    }
+    Updating existing resource disallowed in additive policy operation
     """
 
   @negative

--- a/cucumber/api/features/policy_load_modes.feature
+++ b/cucumber/api/features/policy_load_modes.feature
@@ -172,22 +172,17 @@ Feature: Updating policies
 
   @acceptance
   Scenario: POST cannot update existing policy records
-    When I successfully POST "/policies/cucumber/policy/dev/db" with body:
+    When I save my place in the log file
+    And I POST "/policies/cucumber/policy/dev/db" with body:
     """
     - !variable
       id: b
       kind: private key
     """
-    When I successfully GET "/resources/cucumber/variable/dev/db/b"
-    Then the JSON at "annotations" should be:
+    Then the HTTP response status code is 400
+    And The following appears in the log after my savepoint:
     """
-    [
-      {
-        "name": "conjur/kind",
-        "policy": "cucumber:policy:dev/db",
-        "value": "password"
-      }
-    ]
+    Updating existing resource disallowed in additive policy operation
     """
 
   @negative @acceptance

--- a/cucumber/api/features/policy_load_modes.feature
+++ b/cucumber/api/features/policy_load_modes.feature
@@ -179,7 +179,7 @@ Feature: Updating policies
       id: b
       kind: private key
     """
-    Then the HTTP response status code is 400
+    Then the HTTP response status code is 422
     And The following appears in the log after my savepoint:
     """
     Updating existing resource disallowed in additive policy operation


### PR DESCRIPTION
### Desired Outcome

This PR reinstates changes committed in #2888 and reverted in #2940.

Additive policy loads (those that use `POST`) currently has unexpected behavior. If a policy POST attempts to update an existing resource, the attempted update is silently discarded.

From #2888:

> [POSTing a policy that updates an existing annotation] does not add a new annotation - as expected - but the policy load operation succeeds, which could be misleading to a user. This is caused by how the different policy loader classes - [`Loader::ReplacePolicy`](https://github.com/cyberark/conjur/blob/master/app/models/loader/replace_policy.rb) (`PUT`), [`Loader::CreatePolicy`](https://github.com/cyberark/conjur/blob/master/app/models/loader/create_policy.rb) (`POST`), and [`Loader::ModifyPolicy`](https://github.com/cyberark/conjur/blob/master/app/models/loader/modify_policy.rb) (`PATCH`) - use the `Loader::Orchastrate` methods `eliminate_duplicates_exact`, `eliminate_duplicates_pk` and `update_changed`.
>
> - [`eliminate_duplicates_exact`](https://github.com/cyberark/conjur/blob/master/app/models/loader/orchestrate.rb#L239) is used to cull objects specified in the incoming policy file that already existing in the current policy. Incoming updated annotations are not culled by this method.
> - [`update_changed`](https://github.com/cyberark/conjur/blob/master/app/models/loader/orchestrate.rb#L267) is used to persist updated objects from the incoming policy into the current policy.
> - [`eliminate_duplicates_pk`](https://github.com/cyberark/conjur/blob/master/app/models/loader/orchestrate.rb#L246) is used to cull objects that exist in the current policy that may have been updated by the incoming policy. Incoming updated annotations are always culled by this method, regardless of whether they have been persisted.
>
> The `Loader::CreatePolicy` (`POST`) loader is the only loader class that does not call `update_changed` - this means `eliminate_duplicates_exact` and `eliminate_duplicates_pk` are run in sequence, deleting all objects that appear in both the existing and incoming policy files, regardless of updates.

#2888 includes a new error, raised when the `Loader::Orchastrate` finds itself eliminating non-exact duplicates in additive policy operations.

#2940 reverts these changes to avoid:
- Introducing breaking API changes without either a major version release or a versioned API.
- New, ambiguous error messages blocking customer's previously-functional policy operations

### Implemented Changes

- Reinstate the changes made in #2888.
- Log a descriptive warning instead of raising an error. Example message:

  ```
  WARNING: Updating existing resource disallowed in additive policy operations (POST). In a future release, loading this policy file will fail with a 422 error code. The following updates have not been applied, and have been discarded: {:annotations=>[{:resource_id=>"cucumber:host:hosts/annotated", :name=>"description", :diff=>{:value=>["Already annotated", "Success"]}}]}
  ```
- Method `Loader::Orchastrate.detect_duplicates_pk`, which returns a hash of tables to updated resources, and is only invokes by additive policy operations.


### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
