### PR TITLE
fix unwanted certs removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN bundle config set --local without 'test development' && \
     bundle config --local jobs "$(nproc --all)" && \
     bundle install && \
     # Remove private keys brought in by gems in their test data
-    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \; && \
+    find / -name 'openid_connect-*' -type d -exec find {} -name '*.pem' -type f -delete \; && \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
-    find / -name httpclient -type d -exec find {} -name '*.pem' -type f -delete \;
+    find / -name 'httpclient-*' -type d -exec find {} -name '*.pem' -type f -delete \;
 
 FROM cyberark/ubuntu-ruby-fips:latest
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -17,7 +17,7 @@ RUN bundle config set --local without 'test development' && \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.pem' -type f -delete \; && \
     find / -name 'httpclient-*' -type d -exec find {} -name '*.key' -type f -delete \; && \
     # remove the private key in the oidc_connect gem spec directory
-    find / -name openid_connect -type d -exec find {} -name '*.pem' -type f -delete \;
+    find / -name 'openid_connect-*' -type d -exec find {} -name '*.pem' -type f -delete \;
 
 # Conjur Base Image (UBI)
 FROM cyberark/ubi-ruby-fips:latest


### PR DESCRIPTION
### Desired Outcome

it seems that the changes introduced by the following PR were overwritten on master:
https://github.com/cyberark/conjur/pull/2932/files

### Implemented Changes

reapply fix for certificate removal

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: CNJR-2591

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
