### PR TITLE
Allows option policy factory variable inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.20.0] - 2023-08-16
 
 ### Fixed
+- Allow Factories with optional variables to save without error
+  [cyberark/conjur#2956](https://github.com/cyberark/conjur/pull/2956)
 - OIDC authenticators support `https_proxy` and `HTTPS_PROXY` environment variables
   [cyberark/conjur#2902](https://github.com/cyberark/conjur/pull/2902)
-- Support plural syntax for revoke and deny 
+- Support plural syntax for revoke and deny
   [cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
 
 ### Added

--- a/app/domain/factories/create_from_policy_factory.rb
+++ b/app/domain/factories/create_from_policy_factory.rb
@@ -16,6 +16,7 @@ module Factories
       @http = http
       @schema_validator = schema_validator
       @utilities = utilities
+      @logger = Rails.logger
 
       # JSON and URI are defined here for visibility. They are not currently
       # mocked in testing, thus, we're not setting them in the initializer.
@@ -128,6 +129,8 @@ module Factories
         template: policy_template,
         variables: variables
       ).bind do |rendered_policy|
+        @logger.debug("Policy Factory is applying the following policy to '/policies/#{account}/policy/#{policy_load_path}'")
+        @logger.debug("\n#{rendered_policy}")
         begin
           response = @http.post(
             "http://localhost:#{ENV['PORT']}/policies/#{account}/policy/#{policy_load_path}",

--- a/app/domain/factories/create_from_policy_factory.rb
+++ b/app/domain/factories/create_from_policy_factory.rb
@@ -169,14 +169,15 @@ module Factories
     end
 
     def set_factory_variables(schema_variables:, factory_variables:, variable_path:, authorization:, account:)
-      # Only set secrets defined in the policy
-      schema_variables.each_key do |factory_variable|
-        variable_id = @uri.encode_www_form_component("#{variable_path}/#{factory_variable}")
+      # Only set secrets defined in the policy and present in factory payload
+      (schema_variables.keys & factory_variables.keys).each do |schema_variable|
+
+        variable_id = @uri.encode_www_form_component("#{variable_path}/#{schema_variable}")
         secret_path = "secrets/#{account}/variable/#{variable_id}"
 
         @http.post(
           "http://localhost:#{ENV['PORT']}/#{secret_path}",
-          factory_variables[factory_variable].to_s,
+          factory_variables[schema_variable].to_s,
           { 'Authorization' => authorization }
         )
       rescue RestClient::ExceptionWithResponse => e

--- a/app/domain/factories/renderer.rb
+++ b/app/domain/factories/renderer.rb
@@ -9,7 +9,7 @@ module Factories
     end
 
     def render(template:, variables:)
-      @success.new(@render_engine.new(template, nil, '-').result_with_hash(variables))
+      @success.new(@render_engine.new(template, trim_mode: '-').result_with_hash(variables))
 
     # If variable in template is missing from variable list
     rescue NameError => e

--- a/app/domain/factories/templates/connections/v1/database.rb
+++ b/app/domain/factories/templates/connections/v1/database.rb
@@ -24,6 +24,9 @@ module Factories
                     - !variable port
                     - !variable username
                     - !variable password
+                    - !variable ssl-certificate
+                    - !variable ssl-key
+                    - !variable ssl-ca-certificate
 
                   - !group consumers
                   - !group administrators
@@ -89,6 +92,18 @@ module Factories
                           "description": "Database Password",
                           "type": "string"
                         },
+                        "ssl-certificate": {
+                          "description": "Client SSL Certificate",
+                          "type": "string"
+                        },
+                        "ssl-key": {
+                          "description": "Client SSL Key",
+                          "type": "string"
+                        },
+                        "ssl-ca-certificate": {
+                          "description": "CA Root Certificate",
+                          "type": "string"
+                        }
                       },
                       "required": %w[url port username password]
                     }

--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -33,7 +33,9 @@ RUN bundle
 RUN find / -name httpclient -type d -exec find {} -name *.pem -type f -delete \;
 
 RUN ln -sf /src/conjur-server/bin/conjurctl /usr/local/bin/
-RUN rm /etc/service/syslog-ng/run
+
+# Stop Syslog-NG from starting
+# RUN touch /etc/service/syslog-ng/down
 
 ENV PORT 3000
 ENV TERM xterm


### PR DESCRIPTION
### Desired Outcome

This PR fixes a small bug where optional variables which are not present in the request body cause an error to occur when attempting to save the factory variables.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- Policy Factory now attempts to save variables at the intersection of those defined in the factory and those present in the request body.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
