### PR TITLE
Fix promotions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,5 +89,6 @@ fi
 if image_doesnt_exist "conjur-ubi:$TAG"; then
   echo "Building image conjur-ubi:$TAG container"
   docker build --pull --build-arg "VERSION=$TAG" --tag "conjur-ubi:$TAG" --file Dockerfile.ubi .
-  flatten "conjur-ubi:$TAG"
+  # Avoid flattening RH image for now, otherwise it fails to pass RH's preflight scan
+  # flatten "conjur-ubi:$TAG"
 fi


### PR DESCRIPTION
### Desired Outcome

Fix promotions which are failing due to missing labels and layers on the `conjur-ubi` image. This is causing failing preflight scans when attempting to push the image to Redhat.

### Implemented Changes

- Avoid flattening the `conjur-ubi` image

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
