### PR TITLE
Bump google/cloud-sdk to 448.0.0 in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2827](https://github.com/cyberark/conjur/pull/2827)
 
 ### Security
+- Upgrade google/cloud-sdk in ci/test_suites/authenticators_k8s/dev/Dockerfile/test
+  to use latest version (448.0.0)
+  [cyberark/conjur#2972](https://github.com/cyberark/conjur/pull/2972)
 - Support plural syntax for revoke and deny
   [cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
 - Previously, attempting to add and remove a privilege in the same policy load

--- a/ci/test_suites/authenticators_k8s/dev/Dockerfile.test
+++ b/ci/test_suites/authenticators_k8s/dev/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:424.0.0
+FROM google/cloud-sdk:448.0.0
 
 RUN mkdir -p /src
 WORKDIR /src


### PR DESCRIPTION
### Desired Outcome

Remove base images that contain vulnerable versions of libwebp to remove possibility of exploit of CVE-2023-5129 / CVE-2023-4863.

### Implemented Changes

Upgrade google/cloud-sdk to latest version (448.0.0)

### Connected Issue/Story

CyberArk internal issue ID: CONJSE-1717

