### PR TITLE
Add build tools to policy-parser image for compiling bigdecimal

### DIFF
--- a/gems/policy-parser/Dockerfile.test
+++ b/gems/policy-parser/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM cyberark/ubuntu-ruby-fips:latest
+FROM cyberark/ubuntu-ruby-builder:latest
 
 RUN mkdir /src
 WORKDIR /src
@@ -11,3 +11,5 @@ COPY lib/conjur-policy-parser-version.rb lib/conjur-policy-parser-version.rb
 ENV BUNDLER_VERSION=2.4.14
 RUN gem install bundler -v ${BUNDLER_VERSION} && \
     bundle install
+
+ENV OPENSSL_CONF=/usr/lib/ssl/openssl.cnf


### PR DESCRIPTION
Recently active support was released (7.1.0), this new version was picked up
by an unpinned dependency in conjur-policy-parser. Active support 7.1.0
adds a dependency on bigdecimal which has a native extension and couldn't be 
built within the policy parser test docker image due to lack of dev tools.

This commit adds the necessary dev tools and libs for big decimal's native
extensions to be compiled.