### PR TITLE
ONYX-45965: API key modified by annotation change

### DIFF
--- a/app/controllers/workload_controller.rb
+++ b/app/controllers/workload_controller.rb
@@ -48,7 +48,7 @@ end
 private
 
 def validateId(name)
-  validate_params({"workload_name" => name}, ->(k,v){
+  validate_params({"id" => name}, ->(k,v){
     !v.nil? && !v.empty? &&
       v.match?(/^[a-zA-Z0-9_-]+$/) && string_length_validator(3, 60).call(k, v)
   })

--- a/app/controllers/wrappers/policy_wrapper.rb
+++ b/app/controllers/wrappers/policy_wrapper.rb
@@ -49,7 +49,9 @@ module PolicyWrapper
   def perform(policy_action)
     policy_action.call
     new_actor_roles = actor_roles(policy_action.new_roles)
-    create_roles(new_actor_roles)
+    created_roles = create_roles(new_actor_roles)
+    updated_roles = update_roles
+    created_roles.merge(updated_roles)
   end
 
   def actor_roles(roles)
@@ -62,6 +64,13 @@ module PolicyWrapper
     actor_roles.each_with_object({}) do |role, memo|
       credentials = Credentials[role: role] || Credentials.create(role: role)
       role_id = role.id
+      memo[role_id] = { id: role_id, api_key: credentials.api_key }
+    end
+  end
+
+  def update_roles
+    Credentials.where(api_key: 'APIKEY').each_with_object({}) do |credentials, memo|
+      role_id = credentials.role_id
       memo[role_id] = { id: role_id, api_key: credentials.api_key }
     end
   end

--- a/app/domain/authentication/optional_api_key.rb
+++ b/app/domain/authentication/optional_api_key.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Authentication
+  module OptionalApiKey
+
+    AUTHN_ANNOTATION = 'authn/api-key'
+
+    def annotation_relevant?(annotation)
+      annotation.name == AUTHN_ANNOTATION
+    end
+
+    def annotation_true?(annotation)
+      annotation_relevant?(annotation) && annotation.value.downcase == 'true'
+    end
+
+  end
+end

--- a/app/models/credentials.rb
+++ b/app/models/credentials.rb
@@ -95,6 +95,16 @@ class Credentials < Sequel::Model
     self.api_key ||= self.class.random_api_key if self.role.api_key_expected?
   end
 
+  def api_key
+    # api_key is set to 'APIKEY' by trigger in case authn/api-key is set to true
+    # In this case, we want to rotate the api key to a real value
+    if self[:api_key] == 'APIKEY'
+      rotate_api_key
+      save_changes
+    end
+    super()
+  end
+
   def rotate_api_key
     if self.role.api_key_expected?
       self.api_key = self.class.random_api_key

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,6 +3,7 @@
 class Role < Sequel::Model
   extend Forwardable
   include HasId
+  include Authentication::OptionalApiKey
 
   unrestrict_primary_key
 
@@ -121,7 +122,6 @@ class Role < Sequel::Model
   end
 
   def api_key
-    return nil unless api_key_expected?
 
     unless self.credentials
       _, kind, id = self.id.split(":", 3)
@@ -137,7 +137,7 @@ class Role < Sequel::Model
   def api_key_expected?
     self.kind == 'user' ||
     Rails.application.config.conjur_config.authn_api_key_default ||
-    self.annotations.any? { |a| a.name == 'authn/api-key' && a.value.downcase == 'true' }
+    self.annotations.any? { |a| annotation_true?(a) }
   end
 
   def login

--- a/cucumber/api/features/authn_optional_api_key.feature
+++ b/cucumber/api/features/authn_optional_api_key.feature
@@ -1,0 +1,86 @@
+@api @skip
+Feature: API key for host is created and removed based on host's annotation
+  Background:
+    Given I am the super-user
+
+  Scenario: Host Creation with true annotation impacts API key
+    Given I have host "optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+
+  Scenario: Host Creation with false annotation impacts API key
+    Given I have host "optional" without api key
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401
+
+  Scenario: Host Creation via wrapper with true annotation impacts API key
+    Given I set the "Content-Type" header to "application/json"
+    And I successfully POST "/hosts/cucumber/root" with body:
+    """
+    { "id": "optional", "annotations": { "authn/api-key": "true" } }
+    """
+    Then the role "cucumber:host:optional" has non-empty API key
+
+  Scenario: Host Creation via wrapper with false annotation impacts API key
+    Given I set the "Content-Type" header to "application/json"
+    And I successfully POST "/hosts/cucumber/root" with body:
+    """
+    { "id": "optional", "annotations": { "authn/api-key": "false" } }
+    """
+    Then the role "cucumber:host:optional" has empty API key
+
+  Scenario: Host Creation via wrapper with no annotation impacts API key
+    Given I set the "Content-Type" header to "application/json"
+    And I successfully POST "/hosts/cucumber/root" with body:
+    """
+    { "id": "optional" }
+    """
+    Then the role "cucumber:host:optional" has empty API key
+
+  Scenario: Only Host Annotation authn/api-key Modification impacts API key
+    Given I have host "optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+    When I set annotation "other-annotation" to "false" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+    When I set annotation "authn/api-key" to "false" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401
+    When I set annotation "other-annotation" to "true" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401
+    When I set annotation "authn/api-key" to "true" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+
+  Scenario: Only Host Annotation authn/api-key Addition impacts API key
+    Given I have host "optional" without api key
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401
+    When I set annotation "other-annotation" to "true" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401
+    When I set annotation "authn/api-key" to "true" on role "cucumber:host:optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+
+  Scenario: Host Annotation Removal impacts API key
+    Given I have host "optional"
+    Then the role "cucumber:host:optional" has non-empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 200
+    When I remove all annotations from host "optional"
+    Then the role "cucumber:host:optional" has empty API key
+    When I POST "/authn/cucumber/host%2Foptional/authenticate" with plain text body ":cucumber:host:optional_api_key"
+    Then the HTTP response status code is 401

--- a/cucumber/api/features/step_definitions/request_steps.rb
+++ b/cucumber/api/features/step_definitions/request_steps.rb
@@ -192,6 +192,16 @@ Then(/^the result is the API key for ([^"]*) "([^"]*)"$/) do |kind, login|
   expect(@result).to eq(role.credentials.api_key)
 end
 
+Then(/^the role "([^"]*)" has (:?non-)?empty API key$/) do |role_name, full|
+  role = lookup_role(role_name)
+  role.reload
+  if full
+    expect(role.credentials.api_key).to be
+  else
+    expect(role.credentials.api_key).to be_nil
+  end
+end
+
 Then(/^it's confirmed$/) do
   expect(@http_status).to be_blank
 end

--- a/cucumber/api/features/step_definitions/user_steps.rb
+++ b/cucumber/api/features/step_definitions/user_steps.rb
@@ -30,6 +30,16 @@ Given("I have host {string} without api key") do |login|
   end
 end
 
+When(/^I set annotation "([^"]*)" to "([^"]*)" on role "([^"]*)"$/)  do |name, value, role|
+  Annotation[resource_id: role, name: name].tap do |a|
+    if a.nil?
+      Annotation.create(resource_id: role, name: name, value: value)
+    else
+      a.update(value: value)
+    end
+  end
+end
+
 Given("I create a new admin-owned user {string}") do |login|
   create_user login, admin_user
 end

--- a/cucumber/api/features/support/rest_helpers.rb
+++ b/cucumber/api/features/support/rest_helpers.rb
@@ -3,6 +3,7 @@
 require('net/http')
 require('uri')
 
+include Authentication::OptionalApiKey
 # Utility methods for making API requests
 #
 module RestHelpers
@@ -265,7 +266,7 @@ module RestHelpers
       if api_key_annotation
         role.annotations <<
           Annotation.create(resource: resource,
-                            name: "authn/api-key",
+                            name: AUTHN_ANNOTATION,
                             value: "true")
       end
       Credentials[role: role] || Credentials.new(role: role).save(raise_on_save_failure: true)

--- a/db/migrate/20231005150946_optional_api_key_trigger.rb
+++ b/db/migrate/20231005150946_optional_api_key_trigger.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require_relative '../../app/models/schemata'
+
+Sequel.migration do
+  up do
+    execute Functions.create_authn_ann_trigger_sql(Schemata.new.primary_schema)
+  end
+
+  down do
+    execute Functions.drop_authn_anno_trigger_sql
+  end
+end

--- a/spec/app/domain/authentication/optional_api_key_spec.rb
+++ b/spec/app/domain/authentication/optional_api_key_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Authentication::OptionalApiKey do
+
+  context "annotation check" do
+
+    subject do
+      Class.new { include Authentication::OptionalApiKey }.new
+    end
+
+    it { subject.annotation_true?(Annotation.new(name: 'authn/api-key', value: 'true')).should be_truthy }
+
+    it { subject.annotation_true?(Annotation.new(name: 'authn/api-key', value: 'false')).should be_falsey }
+
+    it { subject.annotation_true?(Annotation.new(name: 'authn/other-key', value: 'true')).should be_falsey }
+  end
+end
+

--- a/spec/models/credentials_spec.rb
+++ b/spec/models/credentials_spec.rb
@@ -153,6 +153,13 @@ describe Credentials, :type => :model do
       end
     end
 
+    describe "role with APIKEY api key" do
+      it "replaces temp APIKEY with real value" do
+        credentials[:api_key] = 'APIKEY'
+        expect(credentials.api_key).not_to eq('APIKEY')
+      end
+    end
+
     describe "with expiration" do
       let(:now) { Time.now }
       let(:past) { now - 1.second }

--- a/spec/models/host_factory_spec.rb
+++ b/spec/models/host_factory_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 
+include Authentication::OptionalApiKey
 describe "HostFactory" do
   include_context "create user"
 
@@ -96,12 +97,12 @@ describe "HostFactory" do
         end
 
         context 'when creating host with api-key annotation true' do
-          let(:options) { {annotations: {'authn/api-key' => true}} }
+          let(:options) { {annotations: { AUTHN_ANNOTATION => true}} }
           it { expect { host_builder.create_host }.to_not raise_error }
         end
 
         context 'when creating host with api-key annotation false' do
-          let(:options) { {annotations: {'authn/api-key' => false}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => false}} }
           it { expect { host_builder.create_host }.to_not raise_error }
         end
 
@@ -116,17 +117,17 @@ describe "HostFactory" do
         end
 
         context 'when creating host with api-key annotation true' do
-          let(:options) { {annotations: {'authn/api-key' => true}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => true}} }
           it { expect { host_builder.create_host }.to_not raise_error }
         end
 
         context 'when creating host with api-key annotation false' do
-          let(:options) { {annotations: {'authn/api-key' => false}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => false}} }
           it { expect { host_builder.create_host }.to raise_error }
         end
 
         context 'when creating host with api-key annotation False capital' do
-          let(:options) { {annotations: {'authn/api-key' => "FALSE"}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => "FALSE"}} }
           it { expect { host_builder.create_host }.to raise_error }
         end
 
@@ -142,22 +143,22 @@ describe "HostFactory" do
         end
 
         context 'when creating host with api-key annotation true' do
-          let(:options) { {annotations: {'authn/api-key' => 'true'}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => 'true'}} }
           it { expect(host_builder.create_host[1]).not_to be_nil } # create_host returns [host, api_key]
         end
 
         context 'when creating host with api-key annotation true' do
-          let(:options) { {annotations: {'authn/api-key' => 'TRUE'}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => 'TRUE'}} }
           it { expect(host_builder.create_host[1]).not_to be_nil } # create_host returns [host, api_key]
         end
 
         context 'when creating host with api-key annotation false' do
-          let(:options) { {annotations: {'authn/api-key' => false}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => false}} }
           it { expect(host_builder.create_host[1]).to be_nil } # create_host returns [host, api_key]
         end
 
         context 'when creating host with api-key annotation False capital' do
-          let(:options) { {annotations: {'authn/api-key' => "FALSE"}} }
+          let(:options) { {annotations: {AUTHN_ANNOTATION => "FALSE"}} }
           it { expect(host_builder.create_host[1]).to be_nil } # create_host returns [host, api_key]
         end
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+include Authentication::OptionalApiKey
+
 describe Role, :type => :model do
   include_context "create user"
 
@@ -46,17 +48,17 @@ describe Role, :type => :model do
     subject(:role) {  Role.create(role_id: "rspec:host:#{login}") }
 
     it "has API key when annotation is set to true" do
-      allow(subject).to receive(:annotations).and_return([Annotation.new(name: "authn/api-key", value: "true")])
+      allow(subject).to receive(:annotations).and_return([Annotation.new(name: AUTHN_ANNOTATION, value: "true")])
       expect(subject.api_key).to be_present
     end
 
     it "has API key when annotation is set to false" do
-      allow(subject).to receive(:annotations).and_return([Annotation.new(name: "authn/api-key", value: "false")])
+      allow(subject).to receive(:annotations).and_return([Annotation.new(name: AUTHN_ANNOTATION, value: "false")])
       expect(subject.api_key).to be_nil
     end
 
     it "has API key when annotation is set to blabla" do
-      allow(subject).to receive(:annotations).and_return([Annotation.new(name: "authn/api-key", value: "blabla")])
+      allow(subject).to receive(:annotations).and_return([Annotation.new(name: AUTHN_ANNOTATION, value: "blabla")])
       expect(subject.api_key).to be_nil
     end
 


### PR DESCRIPTION
### Desired Outcome

Host api-key needs to be aligned with the annotation authn/api-key

### Implemented Changes
Database trigger on annotation table sets value to credentials table.
When API-key needs to be set it puts some constant, which is later replaced in the code

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
