### PR TITLE
K8s authenticator now supports no_proxy env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use base images with newer Ubuntu and UBI.
   Display FIPS Mode status in the UI (requires temporary fix for OpenSSL gem).
   [cyberark/conjur#2874](https://github.com/cyberark/conjur/pull/2874)
+- Support for the no_proxy & NO_PROXY environment variables for the k8s authenticator.
+  [CNJR-2759](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-2759)
 
 ### Changed
 - The database thread pool max connection size is now based on the number of

--- a/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
+++ b/app/domain/authentication/authn_k8s/k8s_object_lookup.rb
@@ -60,7 +60,7 @@ module Authentication
             cert_store: @cert_store,
             verify_ssl: OpenSSL::SSL::VERIFY_PEER
           },
-          http_proxy_uri: ENV['https_proxy'] || ENV['http_proxy']
+          http_proxy_uri: URI.parse(api_url).find_proxy
         }
       end
 

--- a/app/domain/authentication/authn_k8s/web_socket_client.rb
+++ b/app/domain/authentication/authn_k8s/web_socket_client.rb
@@ -134,17 +134,7 @@ module Authentication
       # environment. If the server connection uses TLS, then use the
       # https_proxy value, otherwise use the http_proxy value.
       def proxy_uri
-        @proxy_uri ||= begin
-          proxy_url = if secure?
-            ENV['https_proxy'] || ENV['HTTPS_PROXY']
-          else
-            ENV['http_proxy'] || ENV['HTTP_PROXY']
-          end
-
-          URI.parse(proxy_url)
-        rescue URI::InvalidURIError
-          nil
-        end
+        @proxy_uri ||= @uri.find_proxy
       end
 
       def secure?

--- a/ci/test_suites/authenticators_k8s/dev/dev_conjur.template.yaml
+++ b/ci/test_suites/authenticators_k8s/dev/dev_conjur.template.yaml
@@ -86,6 +86,12 @@ spec:
         name: conjur
         command: ["conjurctl", "server"]
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: kubernetes.default.svc
+        - name: https_proxy
+          value: 'http://nonexistent_proxy.local'
+        - name: NO_PROXY
+          value: kubernetes.default.svc
         - name: DATABASE_URL
           value: postgres://postgres@postgres:5432/postgres
         - name: CONJUR_ADMIN_PASSWORD

--- a/spec/app/domain/authentication/authn_k8s/k8s_object_lookup_spec.rb
+++ b/spec/app/domain/authentication/authn_k8s/k8s_object_lookup_spec.rb
@@ -10,10 +10,17 @@ RSpec.describe(Authentication::AuthnK8s::K8sObjectLookup) do
       authenticator_name: 'authn-k8s',
       service_id: 'MockService'
     )
-  end  
+  end
+
+  let(:proxy_uri) { URI.parse("http://uri") }
 
   context "inside of kubernetes" do
     include_context "running in kubernetes"
+
+    before do
+      allow(URI).to receive_message_chain(:parse, :find_proxy)
+        .and_return(proxy_uri)
+    end
 
     context "instantiation" do
       it "does not require a webservice" do
@@ -33,6 +40,10 @@ RSpec.describe(Authentication::AuthnK8s::K8sObjectLookup) do
 
     it "has the correct auth options" do
       expect(subject.options[:auth_options]).to include(bearer_token: kubernetes_service_token)
+    end
+
+    it "has the correct proxy uri" do
+      expect(subject.options[:http_proxy_uri]).to equal(proxy_uri)
     end
   end
 


### PR DESCRIPTION
### Desired Outcome

Allow the k8s authenticator to properly utilize the `no_proxy` and `NO_PROXY` environment variables when

### Implemented Changes

When accessing the kubernetes api URL now we first run it through the `URI#find_proxy` function which will automatically apply the `http/s_proxy` variables and `no_proxy` as well. New unit and integration tests were also added.

### Connected Issue/Story
CyberArk internal issue ID: [CNJR-2792]

### Definition of Done

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [x] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
