### PR TITLE
AuthnOIDC V2: write custom certs to non-default directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.20.1] - 2023-10-13
+
+### Fixed
+- OIDC Authenticator now writes custom certs to a non-default directory instead
+  of the system default certificate store.
+  [cyberark/conjur#2988](https://github.com/cyberark/conjur/pull/2988)
+
 ## [1.20.0] - 2023-09-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of the system default certificate store.
   [cyberark/conjur#2988](https://github.com/cyberark/conjur/pull/2988)
 
+### Added
+- Support for the no_proxy & NO_PROXY environment variables for the k8s authenticator.
+  [CNJR-2759](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-2759)
+
+### Security
+- Upgrade google/cloud-sdk in ci/test_suites/authenticators_k8s/dev/Dockerfile/test
+  to use latest version (448.0.0)
+  [cyberark/conjur#2972](https://github.com/cyberark/conjur/pull/2972)
+
 ## [1.20.0] - 2023-09-21
 
 ### Fixed
@@ -41,8 +50,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use base images with newer Ubuntu and UBI.
   Display FIPS Mode status in the UI (requires temporary fix for OpenSSL gem).
   [cyberark/conjur#2874](https://github.com/cyberark/conjur/pull/2874)
-- Support for the no_proxy & NO_PROXY environment variables for the k8s authenticator.
-  [CNJR-2759](https://ca-il-jira.il.cyber-ark.com:8443/browse/CNJR-2759)
 
 ### Changed
 - The database thread pool max connection size is now based on the number of
@@ -58,9 +65,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur#2827](https://github.com/cyberark/conjur/pull/2827)
 
 ### Security
-- Upgrade google/cloud-sdk in ci/test_suites/authenticators_k8s/dev/Dockerfile/test
-  to use latest version (448.0.0)
-  [cyberark/conjur#2972](https://github.com/cyberark/conjur/pull/2972)
 - Support plural syntax for revoke and deny
   [cyberark/conjur#2901](https://github.com/cyberark/conjur/pull/2901)
 - Previously, attempting to add and remove a privilege in the same policy load

--- a/app/domain/authentication/authn_oidc/v2/client.rb
+++ b/app/domain/authentication/authn_oidc/v2/client.rb
@@ -18,6 +18,19 @@ module Authentication
           @logger = logger
         end
 
+        # Writing certificates to the default system cert store requires
+        # superuser privilege. Instead, Conjur will use ${CONJUR_ROOT}/tmp/certs.
+        def self.default_cert_dir(dir: Dir, fileutils: FileUtils)
+          if @default_cert_dir.blank?
+            conjur_root = __dir__.slice(0..(__dir__.index('/app')))
+            @default_cert_dir = File.join(conjur_root, "tmp/certs")
+          end
+
+          fileutils.mkdir_p(@default_cert_dir) unless dir.exist?(@default_cert_dir.to_s)
+
+          @default_cert_dir
+        end
+
         def oidc_client
           @oidc_client ||= begin
             issuer_uri = URI(@authenticator.provider_uri)
@@ -99,7 +112,7 @@ module Authentication
 
         # callback_with_temporary_cert wraps the callback method with commands
         # to write & clean up a given certificate or cert chain in a given
-        # directory. By default, Conjur's default cert store is used.
+        # directory. By default, ${CONJUR_ROOT}/tmp/certs is used.
         #
         # The temporary certificate file name is "x.n", where x is the hash of
         # the certificate subject name, and n is incrememnted from 0 in case of
@@ -114,7 +127,7 @@ module Authentication
           code:,
           nonce:,
           code_verifier: nil,
-          cert_dir: OpenSSL::X509::DEFAULT_CERT_DIR,
+          cert_dir: Authentication::AuthnOidc::V2::Client.default_cert_dir,
           cert_string: nil
         )
           c = -> { callback(code: code, nonce: nonce, code_verifier: code_verifier) }
@@ -148,6 +161,27 @@ module Authentication
               symlink_a << symlink
             end
 
+            if OpenIDConnect.http_config.nil? || OpenIDConnect.http_client.ssl.ca_path != cert_dir
+              config_proc = proc do |config|
+                config.ssl.ca_path = cert_dir
+                config.ssl.verify_mode = OpenSSL::SSL::VERIFY_PEER
+              end
+
+              # OpenIDConnect gem only accepts a single Faraday configuration
+              # through calls to its .http_config method, and future calls to
+              # the #http_config method return the first config instance.
+              #
+              # On the first call to OpenIDConnect.http_config, it will pass the
+              # new Faraday configuration to its dependency gems that also have
+              # nil configs. We can't be certain that each gem is configured
+              # with the same Faraday config and need them synchronized, so we
+              # inject them manually.
+              OpenIDConnect.class_variable_set(:@@http_config, config_proc)
+              WebFinger.instance_variable_set(:@http_config, config_proc)
+              SWD.class_variable_set(:@@http_config, config_proc)
+              Rack::OAuth2.class_variable_set(:@@http_config, config_proc)
+            end
+
             c.call
           ensure
             symlink_a.each{ |s| File.unlink(s) if s.present? && File.symlink?(s) }
@@ -174,7 +208,7 @@ module Authentication
 
         # discover wraps ::OpenIDConnect::Discovery::Provider::Config.discover!
         # with commands to write & clean up a given certificate or cert chain in
-        # a given directory. By default, Conjur's default cert store is used.
+        # a given directory. By default, ${CONJUR_ROOT}/tmp/certs is used.
         #
         # The temporary certificate file name is "x.n", where x is the hash of
         # the certificate subject name, and n is incremented from 0 in case of
@@ -186,7 +220,7 @@ module Authentication
         def self.discover(
           provider_uri:,
           discovery_configuration: ::OpenIDConnect::Discovery::Provider::Config,
-          cert_dir: OpenSSL::X509::DEFAULT_CERT_DIR,
+          cert_dir: default_cert_dir,
           cert_string: nil,
           jwks: false
         )
@@ -224,6 +258,27 @@ module Authentication
 
               File.symlink(tmp_file, symlink)
               symlink_a << symlink
+            end
+
+            if OpenIDConnect.http_config.nil? || OpenIDConnect.http_client.ssl.ca_path != cert_dir
+              config_proc = proc do |config|
+                config.ssl.ca_path = cert_dir
+                config.ssl.verify_mode = OpenSSL::SSL::VERIFY_PEER
+              end
+
+              # OpenIDConnect gem only accepts a single Faraday configuration
+              # through calls to its .http_config method, and future calls to
+              # the #http_config method return the first config instance.
+              #
+              # On the first call to OpenIDConnect.http_config, it will pass the
+              # new Faraday configuration to its dependency gems that also have
+              # nil configs. We can't be certain that each gem is configured
+              # with the same Faraday config and need them synchronized, so we
+              # inject them manually.
+              OpenIDConnect.class_variable_set(:@@http_config, config_proc)
+              WebFinger.instance_variable_set(:@http_config, config_proc)
+              SWD.class_variable_set(:@@http_config, config_proc)
+              Rack::OAuth2.class_variable_set(:@@http_config, config_proc)
             end
 
             d.call

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -170,7 +170,6 @@ _run_cucumber_tests() {
   # ${cucumber_tags_arg} should overwrite the profile tags in a way for @smoke to work correctly
   $COMPOSE run "${run_flags[@]}" "${env_var_flags[@]}" \
     cucumber -ec "\
-      /oauth/keycloak/scripts/fetch_certificate &&
       bundle exec parallel_cucumber . -n ${PARALLEL_PROCESSES} \
        -o '--strict --profile \"${profile}\" ${cucumber_tags_arg} \
        --format json --out \"cucumber/$profile/cucumber_results.json\" \

--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -54,7 +54,7 @@ function main() {
   local conjur_parallel_services
   read -ra conjur_parallel_services <<< "$(get_parallel_services 'conjur')"
   for parallel_service in "${conjur_parallel_services[@]}"; do
-    hash=$($COMPOSE exec "${parallel_service}" openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+    hash=$($COMPOSE exec "${parallel_service}" openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
     $COMPOSE exec "${parallel_service}" rm "/etc/ssl/certs/$hash.0" || true
   done
 

--- a/dev/start
+++ b/dev/start
@@ -322,7 +322,7 @@ configure_oidc_v2() {
   if [ "$service_id" = "keycloak2" ]; then
     client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
     # Delete the symlink so we can test with the 'ca-cert' variable
-    hash=$($COMPOSE exec conjur openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+    hash=$($COMPOSE exec conjur openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
     $COMPOSE exec conjur rm "/etc/ssl/certs/$hash.0" || true
   fi
 

--- a/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
+++ b/spec/app/domain/authentication/authn-oidc/v2/client_spec.rb
@@ -644,4 +644,76 @@ RSpec.describe(Authentication::AuthnOidc::V2::Client) do
       end
     end
   end
+
+  describe '.default_cert_dir', type: 'unit' do
+    let(:target)      { Authentication::AuthnOidc::V2::Client }
+    let(:conjur_root) { "/src/conjur-server" }
+    let(:dir)         { double("Mock Dir") }
+    let(:fileutils)   { double("Mock FileUtils") }
+
+    context 'when @default_cert_dir is blank' do
+      before(:each) do
+        target.instance_variable_set(:@default_cert_dir, nil)
+      end
+
+      context 'when default cert dir exists in filesystem' do
+        before(:each) do
+          allow(dir).to receive(:exist?).with(String).and_return(true)
+        end
+
+        it 'returns the default path' do
+          expect(target.default_cert_dir(dir: dir, fileutils: fileutils)).to eq("#{conjur_root}/tmp/certs")
+          expect(target.instance_variable_get(:@default_cert_dir)).to eq("#{conjur_root}/tmp/certs")
+        end
+      end
+
+      context 'when the default cert dir does not exist in filesystem' do
+        before(:each) do
+          allow(dir).to receive(:exist?).with(String).and_return(false)
+          allow(fileutils).to receive(:mkdir_p).with(String) do |s|
+            [s]
+          end
+        end
+
+        it 'creates the dir and returns the default path' do
+          expect(fileutils).to receive(:mkdir_p).with(String)
+          expect(target.default_cert_dir(dir: dir, fileutils: fileutils)).to eq("#{conjur_root}/tmp/certs")
+          expect(target.instance_variable_get(:@default_cert_dir)).to eq("#{conjur_root}/tmp/certs")
+        end
+      end
+
+    end
+
+    context 'when @default_cert_dir is not blank' do
+      before(:each) do
+        target.instance_variable_set(:@default_cert_dir, "/path/to/dir")
+      end
+
+      context 'when @default_cert_dir exists in filesystem' do
+        before(:each) do
+          allow(dir).to receive(:exist?).with(String).and_return(true)
+        end
+
+        it 'returns existing path' do
+          expect(target.default_cert_dir(dir: dir, fileutils: fileutils)).to eq("/path/to/dir")
+          expect(target.instance_variable_get(:@default_cert_dir)).to eq("/path/to/dir")
+        end
+      end
+
+      context 'when @default_cert_dir does not exist in filesystem' do
+        before(:each) do
+          allow(dir).to receive(:exist?).with(String).and_return(false)
+          allow(fileutils).to receive(:mkdir_p).with(String) do |s|
+            [s]
+          end
+        end
+
+        it 'creates the dir and returns the existing path' do
+          expect(fileutils).to receive(:mkdir_p).with(String)
+          expect(target.default_cert_dir(dir: dir, fileutils: fileutils)).to eq("/path/to/dir")
+          expect(target.instance_variable_get(:@default_cert_dir)).to eq("/path/to/dir")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Desired Outcome

Authn-OIDC with `ca-cert` variable fails on Conjur Enterprise.

```
Errno::EACCES: Permission denied @ rb_file_s_symlink - (/tmp/d20231006-289-9u7rno/conjur-oidc-client.0.pem, /usr/lib/ssl/certs/bb3ed97b.0)
```

When Authn-OIDC V2 is configured with a `ca-cert` variable, it writes the provided certificate content into a temporary file, and creates a symlink to the file in the Conjur container's default certificate directory, meaning it would be trusted for outbound requests to the configured OIDC provider. After a successful request, the symlinks are deleted, and the temp files destroyed.

In Conjur Enterprise, the Conjur server is running as a user `conjur`, which lacks write permissions on the container's default cert store.

### Implemented Changes

Instead of creating symlinks in the default cert store, instead create them in the Conjur project directory tree - the Conjur process is able to write to the `${conjur_root}/etc/certs` in both Conjur Open Source and Enterprise.

In the previous solution iteration, if a custom certificate was established in the `ca-cert` variable but connecting to the OIDC provider did not require that particular certificate, Authn-OIDC could fall back on any trusted certificate in the default cert store. No longer - if the `ca-cert` variable is set, it must contain the full certificate chain required for connecting to the OIDC provider. No certificates included in the system's default store will be considered.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2844

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
