### PR TITLE
CNJR-3008 Ensure compose execs specify -T

### DIFF
--- a/ci/test_suites/authenticators_oidc/test
+++ b/ci/test_suites/authenticators_oidc/test
@@ -23,7 +23,7 @@ function _hydrate_all_env_args() {
   # shellcheck disable=SC2034
   arr=(
     "${keycloak_items[@]}"
-    "KEYCLOAK_CA_CERT=$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+    "KEYCLOAK_CA_CERT=$($COMPOSE exec -T conjur cat /etc/ssl/certs/keycloak.pem)"
     "PROVIDER_URI=https://keycloak:8443/auth/realms/master"
     "PROVIDER_INTERNAL_URI=http://keycloak:8080/auth/realms/master/protocol/openid-connect"
     "PROVIDER_ISSUER=http://keycloak:8080/auth/realms/master"
@@ -54,8 +54,8 @@ function main() {
   local conjur_parallel_services
   read -ra conjur_parallel_services <<< "$(get_parallel_services 'conjur')"
   for parallel_service in "${conjur_parallel_services[@]}"; do
-    hash=$($COMPOSE exec "${parallel_service}" openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
-    $COMPOSE exec "${parallel_service}" rm "/etc/ssl/certs/$hash.0" || true
+    hash=$($COMPOSE exec -T "${parallel_service}" openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
+    $COMPOSE exec -T "${parallel_service}" rm "/etc/ssl/certs/$hash.0" || true
   done
 
   additional_services='ldap-server keycloak'

--- a/dev/cli
+++ b/dev/cli
@@ -253,7 +253,7 @@ while true ; do
         load )
           account="$3"
           policy_file=$4
-          docker compose exec conjur conjurctl policy load "$account" "/src/conjur-server/$policy_file"
+          docker compose exec -T conjur conjurctl policy load "$account" "/src/conjur-server/$policy_file"
           shift 4 ;;
         * ) if [ -z "$1" ]; then break; else echo "$1 is not a valid option"; exit 1; fi;;
       esac ;;

--- a/dev/start
+++ b/dev/start
@@ -62,9 +62,9 @@ main() {
 
   # Install gems, create DB, and create cucumber account.
   docker compose up -d --no-deps "${services[@]}"
-  docker compose exec conjur bundle
-  docker compose exec conjur conjurctl db migrate
-  docker compose exec conjur conjurctl account create cucumber || true
+  docker compose exec -T conjur bundle
+  docker compose exec -T conjur conjurctl db migrate
+  docker compose exec -T conjur conjurctl account create cucumber || true
 
   migrate_audit_db
 
@@ -181,7 +181,7 @@ check_env_vars() {
 client_load_policy() {
   local policy_file=$1
 
-  docker compose exec client \
+  docker compose exec -T client \
     conjur policy load root "$policy_file"
 }
 
@@ -189,13 +189,13 @@ client_add_secret() {
   local variable=$1
   local value=$2
 
-  docker compose exec client \
+  docker compose exec -T client \
     conjur variable values add "$variable" "$value"
 }
 
 start_conjur_server() {
   echo "Starting Conjur server"
-  docker compose exec -d conjur conjurctl server
+  docker compose exec -T -d conjur conjurctl server
 
   echo 'Checking if Conjur server is ready'
   wait_for_conjur
@@ -209,7 +209,7 @@ wait_for_conjur() {
 
   docker compose exec -T conjur conjurctl wait
 
-  docker compose exec client conjur authn login -u admin -p "$api_key"
+  docker compose exec -T client conjur authn login -u admin -p "$api_key"
 }
 
 configure_oidc_authenticators() {
@@ -273,7 +273,7 @@ setup_okta() {
 
 setup_adfs() {
   echo "Initialize ADFS certificate in conjur server"
-  docker compose exec conjur \
+  docker compose exec -T conjur \
     /src/conjur-server/dev/files/authn-oidc/adfs/fetchCertificate
 
   configure_oidc_v1 \
@@ -302,7 +302,7 @@ configure_oidc_v1() {
   client_add_secret "conjur/authn-oidc/$service_id/provider-uri" "$provider_uri"
   client_add_secret "conjur/authn-oidc/$service_id/id-token-user-property" "$token_property"
   if [ "$service_id" = "keycloak" ]; then
-    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec -T conjur cat /etc/ssl/certs/keycloak.pem)"
   fi
 }
 
@@ -320,10 +320,10 @@ configure_oidc_v2() {
   client_add_secret "conjur/authn-oidc/$service_id/claim-mapping" "$claim_mapping"
   client_add_secret "conjur/authn-oidc/$service_id/redirect_uri" "http://localhost:3000/authn-oidc/$service_id/cucumber/authenticate"
   if [ "$service_id" = "keycloak2" ]; then
-    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec conjur cat /etc/ssl/certs/keycloak.pem)"
+    client_add_secret "conjur/authn-oidc/$service_id/ca-cert" "$($COMPOSE exec -T conjur cat /etc/ssl/certs/keycloak.pem)"
     # Delete the symlink so we can test with the 'ca-cert' variable
-    hash=$($COMPOSE exec conjur openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
-    $COMPOSE exec conjur rm "/etc/ssl/certs/$hash.0" || true
+    hash=$($COMPOSE exec -T conjur openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout)
+    $COMPOSE exec -T conjur rm "/etc/ssl/certs/$hash.0" || true
   fi
 
   client_load_policy "/src/conjur-server/dev/policies/authenticators/authn-oidc/$service_id-users.yml"
@@ -402,7 +402,7 @@ init_ldap() {
   enabled_authenticators="$enabled_authenticators,authn-ldap/test,authn-ldap/secure"
 
   # Using conjur policy load doesn't work here (not sure why).
-  docker compose exec conjur \
+  docker compose exec -T conjur \
     conjurctl policy load cucumber \
     "/src/conjur-server/dev/files/authn-ldap/policy.yml"
 }
@@ -419,7 +419,7 @@ init_azure() {
   client_load_policy \
     "/src/conjur-server/ci/test_suites/authenticators_azure/policies/policy.yml"
 
-  docker compose exec client \
+  docker compose exec -T client \
     conjur variable values add \
     conjur/authn-azure/prod/provider-uri "https://sts.windows.net/$AZURE_TENANT_ID/"
 
@@ -457,7 +457,7 @@ init_jwt() {
   enable_oidc_authenticators
 
   echo "Configure jwks provider"
-  docker compose exec jwks "/tmp/create_nginx_certificate.sh"
+  docker compose exec -T jwks "/tmp/create_nginx_certificate.sh"
 }
 
 init_oidc() {
@@ -494,7 +494,7 @@ init_iam() {
   enabled_authenticators="$enabled_authenticators,authn-iam/prod"
 
   # Using conjur policy load doesn't work here (not sure why).
-  docker compose exec conjur \
+  docker compose exec -T conjur \
     conjurctl policy load cucumber \
     "/src/conjur-server/dev/files/authn-iam/policy.yml"
 }
@@ -528,7 +528,7 @@ create_alice() {
 
 kill_conjur() {
   echo "killing the conjur server process"
-  docker compose exec conjur /src/conjur-server/dev/files/killConjurServer
+  docker compose exec -T conjur /src/conjur-server/dev/files/killConjurServer
 }
 
 enter_container() {


### PR DESCRIPTION
This is to make sure they are CI-safe and won't attempt to allocate a TTY.

### Desired Outcome

Reliable CI builds.


### Implemented Changes

Ensure all docker compose invocations specify `-T`
This ensures that docker will not attempt to allocate a TTY when it isn't possible to do so (eg in Jenkins). 

### Connected Issue/Story

CyberArk internal issue ID: CNJR-3008

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
