### PR TITLE
Fix server boot failure with telemetry enabled (lazy-load app constants in AuthenticatorGauge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.24.1] - 2026-06-11
+
+### Fixed
+- Fixed the server failing to boot when telemetry is enabled
+  (`CONJUR_TELEMETRY_ENABLED=true`): `Monitoring::Metrics::AuthenticatorGauge`
+  no longer resolves autoloaded application constants
+  (`DB::Repository::AuthenticatorConfigRepository`,
+  `Authentication::ImplementedAuthenticators`) during Rails initialization;
+  they are now resolved lazily on the first metrics update.
+  [cyberark/conjur#3026](https://github.com/cyberark/conjur/issues/3026)
+
 ## [1.24.0] - 2025-11-10
 
 ### Changed

--- a/lib/monitoring/metrics/authenticator_gauge.rb
+++ b/lib/monitoring/metrics/authenticator_gauge.rb
@@ -3,10 +3,7 @@ module Monitoring
     class AuthenticatorGauge
       attr_reader :registry, :pubsub, :metric_name, :docstring, :labels, :sub_event_name
 
-      def initialize(
-        installed_authenticators: DB::Repository::AuthenticatorConfigRepository.new,
-        implemented_authenticators: Authentication::ImplementedAuthenticators
-      )
+      def initialize(installed_authenticators: nil, implemented_authenticators: nil)
         @metric_name = :conjur_server_authenticator
         @docstring = 'Number of authenticators enabled'
         @labels = %i[type status]
@@ -19,7 +16,7 @@ module Monitoring
       def setup(registry, pubsub)
         @registry = registry
         @pubsub = pubsub
-        
+
         # Create/register the metric
         Metrics.create_metric(self, :gauge)
 
@@ -28,6 +25,13 @@ module Monitoring
       end
 
       def update(*_payload)
+        # Resolve application constants lazily: this class is instantiated from
+        # config/initializers/prometheus.rb, before app constants under
+        # app/db and app/domain are autoloadable. By the time update runs
+        # (first request, via the initializer's lazy_init), autoloading is ready.
+        @installed_authenticators ||= DB::Repository::AuthenticatorConfigRepository.new
+        @implemented_authenticators ||= Authentication::ImplementedAuthenticators
+
         metric = registry.get(metric_name)
         update_enabled_authenticators(metric)
         update_installed_authenticators(metric)


### PR DESCRIPTION
### Desired Outcome

The telemetry feature can be enabled as documented in [TELEMETRY.md](https://github.com/cyberark/conjur/blob/master/TELEMETRY.md)
(`CONJUR_TELEMETRY_ENABLED=true`) without crashing the server on boot — as it
worked up to and including 1.22.3. Currently on 1.24.0 the server fails during
Rails initialization with
`NameError: uninitialized constant Monitoring::Metrics::AuthenticatorGauge::DB`
and crash-loops. Full analysis and reproduction in #3026.

### Implemented Changes

`Monitoring::Metrics::AuthenticatorGauge` resolved two autoloaded application
constants (`DB::Repository::AuthenticatorConfigRepository` and
`Authentication::ImplementedAuthenticators`) in default constructor arguments.
The gauge is instantiated eagerly in `config/initializers/prometheus.rb`,
before constants under `app/db`/`app/domain` are autoloadable, so the first
constant raised `NameError` (and the second would raise next — a masked
instance of the same problem). Regression introduced in 8382ff39, shipped in
1.24.0 alongside the Rails 7 upgrade.

This PR defaults both kwargs to `nil` and resolves the constants in `update()`
via `||=`. `update` only runs through the initializer's existing `lazy_init`
path (on the first request), when autoloading is ready — consistent with the
lazy-setup pattern already used in that initializer. Dependency injection via
kwargs is unaffected.

**How to review/verify** (no dev environment needed — stock image with the
patched file bind-mounted):

```sh
docker network create repro
docker run -d --name pg --network repro -e POSTGRES_HOST_AUTH_METHOD=trust postgres:15
docker run -d --name conjur --network repro \
  -v "$PWD/lib/monitoring/metrics/authenticator_gauge.rb":/opt/conjur-server/lib/monitoring/metrics/authenticator_gauge.rb:ro \
  -e DATABASE_URL=postgres://postgres@pg/postgres \
  -e CONJUR_DATA_KEY="$(openssl rand -base64 32)" \
  -e CONJUR_TELEMETRY_ENABLED=true \
  cyberark/conjur:1.24.0 server
# wait ~60s, then:
docker exec conjur curl -s localhost:80/metrics | grep conjur_server_authenticator
```

Verified results: with telemetry enabled the server boots, `/metrics` returns
200 and `conjur_server_authenticator` reports enabled/installed/configured
authenticators; with telemetry disabled behaviour is identical to stock
(no `/metrics` route). 
Unpatched 1.24.0 crashes | 1.22.3 works — see #3026.

### Connected Issue/Story

Resolves #3026

CyberArk internal issue ID: N/A (community report)

### Definition of Done

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

*Note: the entry was added as a new version section per the note at the top of
CHANGELOG.md — happy to move it under `Unreleased` if you prefer.*

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

*Note: the existing request specs in
`spec/lib/monitoring/metrics/authenticator_metrics_spec.rb` already exercise
the full path through `update()` (including the new lazy resolution) and
instantiate the gauge without kwargs. The bug itself only manifests during
Rails initialization, which the spec environment does not reproduce (the app
is already booted when specs run) — this is also why CI did not catch the
regression.*

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

*Note: TELEMETRY.md already documents the intended behaviour; this PR restores it.*

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

*Note: bug fix restoring the documented behaviour of an existing feature;
the default (telemetry disabled) path is untouched.*

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes

*Note: the change only defers constant resolution; both lazily-resolved classes
are read-only, no authn/authz logic is touched, and the existing `/metrics`
exposure model is unchanged. The `||=` lazy assignment matches the existing
unsynchronized `lazy_init` pattern in `PrometheusCollector#call`.*
